### PR TITLE
ruststd: std::env cwd bridge to seraph-native cap

### DIFF
--- a/base/usertest/src/main.rs
+++ b/base/usertest/src/main.rs
@@ -119,6 +119,7 @@ fn main()
     command_cwd_missing_phase();
     command_invalid_elf_loop_phase();
     stdio_file_unsupported_phase();
+    env_cwd_unset_phase();
     // Keep `fs_open_relative_phase` last: it installs a process-global
     // `current_dir_cap()` that persists across phases. Subsequent
     // phases that walk the same fs with high cap pressure (e.g.
@@ -2176,9 +2177,32 @@ fn fs_open_relative_phase()
     let pre_err = File::open("test.txt").expect_err("relative open without cwd must fail");
     assert_eq!(pre_err.kind(), std::io::ErrorKind::Unsupported);
 
-    // Install /srv as cwd. The walk goes through vfsd's synthetic root.
+    // Install /srv as cwd via the cap-native primitive. The walk goes
+    // through vfsd's synthetic root.
     std::os::seraph::set_current_dir("/srv").expect("set_current_dir(/srv) failed");
     assert_ne!(std::os::seraph::current_dir_cap(), 0);
+
+    // Cap-native `set_current_dir` also records the path string under
+    // the same Mutex as the cap, so `std::env::current_dir` sees `/srv`
+    // immediately afterwards. The two writers (cap-native and std-env)
+    // converge on the same backing store.
+    assert_eq!(
+        std::env::current_dir().expect("std::env::current_dir after cap-native set"),
+        std::path::PathBuf::from("/srv"),
+        "std::env::current_dir disagrees with cap-native set_current_dir",
+    );
+
+    // The std-portable `std::env::set_current_dir` path: same lockstep
+    // result, observable through both surfaces. Re-target /srv (same
+    // directory) so we can compare against the prior assertions
+    // without disturbing the cap-pressure expectations of subsequent
+    // assertions in this phase.
+    std::env::set_current_dir("/srv").expect("std::env::set_current_dir(/srv) failed");
+    assert_ne!(std::os::seraph::current_dir_cap(), 0);
+    assert_eq!(
+        std::env::current_dir().expect("std::env::current_dir after std-env set"),
+        std::path::PathBuf::from("/srv"),
+    );
 
     // Relative open now succeeds and reads the same bytes the absolute
     // path would yield.
@@ -2199,6 +2223,35 @@ fn fs_open_relative_phase()
     );
 
     std::os::seraph::log!("fs_open_relative phase passed");
+}
+
+/// `std::env::current_dir` returns `Unsupported` until something calls
+/// `set_current_dir` in this process. The startup cap installed from
+/// `ProcessInfo.current_dir_cap` does not carry a path string, and the
+/// namespace protocol forbids `..` / `.` as name components
+/// (`shared/namespace-protocol/src/name.rs`), so seraph has no
+/// FS-walking way to recover a string from a bare cap. The shape
+/// surfaces as `io::ErrorKind::Unsupported` rather than `NotFound`
+/// because the cwd directory *exists*; only its string label is
+/// absent.
+///
+/// MUST run before `fs_open_relative_phase`: that phase installs the
+/// path string permanently via `set_current_dir("/srv")`.
+fn env_cwd_unset_phase()
+{
+    assert_eq!(
+        std::os::seraph::current_dir_cap(),
+        0,
+        "env_cwd_unset_phase pre-condition: cwd cap should still be zero",
+    );
+    let err = std::env::current_dir()
+        .expect_err("std::env::current_dir() with no recorded path must fail");
+    assert_eq!(
+        err.kind(),
+        std::io::ErrorKind::Unsupported,
+        "std::env::current_dir() pre-set should be Unsupported, got {err:?}",
+    );
+    std::os::seraph::log!("env_cwd_unset phase passed");
 }
 
 /// `Stdio::from(File)` is rejected at spawn on seraph rather than

--- a/runtime/ruststd/src/os/seraph.rs
+++ b/runtime/ruststd/src/os/seraph.rs
@@ -23,6 +23,8 @@
 
 use crate::cell::{Cell, UnsafeCell};
 use crate::mem::MaybeUninit;
+use crate::path::PathBuf;
+use crate::sync::Mutex;
 use crate::sync::atomic::{AtomicBool, Ordering};
 use crate::sys::alloc::seraph as pal_alloc;
 use crate::sys::reserve as pal_reserve;
@@ -494,6 +496,17 @@ static ROOT_DIR_CAP: crate::sync::atomic::AtomicU32 =
 static CURRENT_DIR_CAP: crate::sync::atomic::AtomicU32 =
     crate::sync::atomic::AtomicU32::new(0);
 
+// String-form mirror of the cwd cap. Held under a Mutex so that
+// `set_current_dir` updates the cap and the path atomically (readers
+// of the pair never see a torn (new cap, old path) intermediate).
+//
+// `None` is the startup state: `_start` installs `CURRENT_DIR_CAP`
+// from `ProcessInfo.current_dir_cap`, but the cap does not carry a
+// path string — the spawner has no obligation to label it. Until a
+// process calls `set_current_dir`, `current_dir_path()` returns
+// `None` and `std::env::current_dir()` reports `Unsupported`.
+static CURRENT_DIR_PATH: Mutex<Option<PathBuf>> = Mutex::new(None);
+
 /// Install the process-wide root-directory namespace cap. Called by
 /// `_start` from `ProcessInfo.system_root_cap`. Demoted to crate-internal
 /// visibility because the only legitimate writer is std's own startup
@@ -528,15 +541,35 @@ pub fn current_dir_cap() -> u32 {
     CURRENT_DIR_CAP.load(crate::sync::atomic::Ordering::Acquire)
 }
 
-/// Walk `path` from `root_dir_cap()` and install the resolved
-/// directory cap as the process-wide current-directory cap.
+/// Snapshot of the cwd path string recorded by the most recent
+/// successful `set_current_dir`. Returns `None` until `set_current_dir`
+/// has been called in this process — the startup cap installed from
+/// `ProcessInfo.current_dir_cap` carries no string label.
 ///
-/// The seraph-native cwd primitive: cwd is a held cap, not a string.
+/// Backs `std::env::current_dir()` on seraph through
+/// `crate::sys::env::seraph::getcwd`.
+pub(crate) fn current_dir_path() -> Option<PathBuf> {
+    CURRENT_DIR_PATH
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .clone()
+}
+
+/// Walk `path` from `root_dir_cap()` and install the resolved
+/// directory cap as the process-wide current-directory cap. Also
+/// records `path` as the string mirror returned by
+/// [`current_dir_path`]; the cap and the path are updated under one
+/// held lock so concurrent readers never observe a (new cap, old
+/// path) intermediate.
+///
+/// The seraph-native cwd primitive: cwd is a held cap, with a path
+/// string kept alongside only for `std::env::current_dir()` to echo.
 /// The existing cap (if any) is `cap_delete`'d and replaced.
 ///
-/// `std::env::set_current_dir` is `Unsupported` on seraph because the
-/// upstream API is path-as-string-only and cannot express the cap
-/// model directly; this function is the seraph-specific shape.
+/// `std::env::set_current_dir(impl AsRef<Path>)` delegates to this
+/// function on seraph via the env-imp dispatch overlay; this remains
+/// the direct entry point for cap-native callers who already hold a
+/// `&str` path.
 ///
 /// # Errors
 /// - `Unsupported` if `root_dir_cap()` is zero.
@@ -558,7 +591,10 @@ pub fn set_current_dir(path: &str) -> crate::io::Result<()> {
         ));
     }
     let walked = crate::sys::fs::walk_path_to_dir(root, path, ipc_buf)?;
+    let mut guard = CURRENT_DIR_PATH.lock().unwrap_or_else(|p| p.into_inner());
     let prev = CURRENT_DIR_CAP.swap(walked.dir_cap, crate::sync::atomic::Ordering::AcqRel);
+    *guard = Some(PathBuf::from(path));
+    drop(guard);
     if prev != 0 {
         let _ = syscall::cap_delete(prev);
     }

--- a/runtime/ruststd/src/sys/env/seraph.rs
+++ b/runtime/ruststd/src/sys/env/seraph.rs
@@ -19,6 +19,7 @@ use crate::collections::BTreeMap;
 use crate::ffi::{OsStr, OsString};
 use crate::io;
 use crate::os::seraph::try_startup_info;
+use crate::path::{Path, PathBuf};
 use crate::sync::{Mutex, OnceLock};
 
 static ENV: OnceLock<Mutex<BTreeMap<OsString, OsString>>> = OnceLock::new();
@@ -101,4 +102,41 @@ pub unsafe fn unsetenv(key: &OsStr) -> io::Result<()> {
     let mut guard = env_map().lock().unwrap_or_else(|p| p.into_inner());
     guard.remove(key);
     Ok(())
+}
+
+// Cwd surface backing `std::env::current_dir` / `std::env::set_current_dir`
+// on seraph. Wired up by the `apply_env_dispatch_overlay` patch to
+// `library/std/src/env.rs`, which adds a `target_os = "seraph"` cfg arm
+// dispatching here instead of through `os_imp::*` (seraph has no PAL
+// under `sys/pal/seraph/`).
+//
+// `chdir` is a thin shim over `crate::os::seraph::set_current_dir`,
+// which performs the namespace walk from `root_dir_cap()` and stores
+// both the cap and the path string in lockstep. `getcwd` reads the
+// recorded path string back.
+//
+// Relative-path inputs (`"../foo"`, `"./bar"`) are NOT supported here:
+// the namespace protocol forbids `..`/`.` as name components
+// (`shared/namespace-protocol/src/name.rs` `NameError::DotOrDotDot`),
+// and seraph has no client-side lexical resolver yet. Tracked
+// separately; do not paper over with a pseudo-resolver.
+
+pub fn getcwd() -> io::Result<PathBuf> {
+    crate::os::seraph::current_dir_path().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::Unsupported,
+            "seraph: current_dir() called before set_current_dir() — \
+             the startup cap does not carry a path string",
+        )
+    })
+}
+
+pub fn chdir(p: &Path) -> io::Result<()> {
+    let s = p.to_str().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "seraph: set_current_dir requires a UTF-8 path",
+        )
+    })?;
+    crate::os::seraph::set_current_dir(s)
 }

--- a/xtask/src/rust_src.rs
+++ b/xtask/src/rust_src.rs
@@ -556,6 +556,7 @@ fn apply_all_overlays(mirror: &Path, overlay_root: &Path) -> Result<()>
     apply_time_overlay(&rust_src, overlay_root).context("time overlay")?;
     apply_args_overlay(&rust_src, overlay_root).context("args overlay")?;
     apply_env_overlay(&rust_src, overlay_root).context("env overlay")?;
+    apply_env_dispatch_overlay(&rust_src).context("env dispatch overlay")?;
     apply_process_overlay(&rust_src, overlay_root).context("process overlay")?;
     apply_pipe_overlay(&rust_src, overlay_root).context("pipe overlay")?;
     apply_fs_overlay(&rust_src, overlay_root).context("fs overlay")?;
@@ -851,6 +852,53 @@ fn apply_env_overlay(rust_src: &Path, overlay_root: &Path) -> Result<()>
          target_os = \"seraph\" => {\n        mod seraph;\n        \
          pub use seraph::*;\n    }\n",
     )
+}
+
+/// Route `std::env::current_dir` / `std::env::set_current_dir` through
+/// the seraph env-imp module on seraph. Upstream dispatches both to
+/// `os_imp::*` (= `sys::pal::*::os`), but seraph has no PAL under
+/// `sys/pal/seraph/` — `os_imp` resolves to `sys::pal::unsupported::os`,
+/// which returns `Unsupported`. The two functions delegate to
+/// `crate::sys::env::seraph::{getcwd, chdir}` instead, which bridge to
+/// the cap-native cwd surface in `crate::os::seraph`.
+fn apply_env_dispatch_overlay(rust_src: &Path) -> Result<()>
+{
+    let env_rs = rust_src.join("library/std/src/env.rs");
+    let orig =
+        fs::read_to_string(&env_rs).with_context(|| format!("reading {}", env_rs.display()))?;
+    if orig.contains(MARKER)
+    {
+        return Ok(());
+    }
+
+    let a1 = "pub fn current_dir() -> io::Result<PathBuf> {\n    os_imp::getcwd()\n}";
+    let a1r = "pub fn current_dir() -> io::Result<PathBuf> {\n    \
+               // seraph-overlay: dispatch through sys::env for cwd-cap bridge\n    \
+               #[cfg(target_os = \"seraph\")]\n    \
+               { env_imp::getcwd() }\n    \
+               #[cfg(not(target_os = \"seraph\"))]\n    \
+               { os_imp::getcwd() }\n}";
+
+    let a2 = "pub fn set_current_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {\n    \
+              os_imp::chdir(path.as_ref())\n}";
+    let a2r = "pub fn set_current_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {\n    \
+               // seraph-overlay: dispatch through sys::env for cwd-cap bridge\n    \
+               #[cfg(target_os = \"seraph\")]\n    \
+               { env_imp::chdir(path.as_ref()) }\n    \
+               #[cfg(not(target_os = \"seraph\"))]\n    \
+               { os_imp::chdir(path.as_ref()) }\n}";
+
+    if !orig.contains(a1) || !orig.contains(a2)
+    {
+        bail!(
+            "env.rs anchors not found — upstream layout likely changed at {}",
+            env_rs.display()
+        );
+    }
+    let patched = orig.replace(a1, a1r).replace(a2, a2r);
+    write_new_file(&env_rs, &patched)?;
+    step(&format!("seraph-toolchain: patched {}", env_rs.display()));
+    Ok(())
 }
 
 fn apply_stdio_overlay(rust_src: &Path, overlay_root: &Path) -> Result<()>


### PR DESCRIPTION
## Summary

- Bridge `std::env::current_dir` / `set_current_dir` to the seraph-native cwd-cap surface in `std::os::seraph` so processes can use the std-portable API.
- Store the cwd path string in a `Mutex<Option<PathBuf>>` alongside `CURRENT_DIR_CAP`; updates happen under one held lock so the (cap, path) pair is never torn for concurrent readers.
- Patch `library/std/src/env.rs` via a new xtask overlay (`apply_env_dispatch_overlay`) so the two functions dispatch through `crate::sys::env::seraph::{getcwd, chdir}` on seraph rather than the unsupported `os_imp::*` PAL fallback.
- New `env_cwd_unset_phase` in usertest asserts the documented startup behaviour (`current_dir()` is `Unsupported` until the first `set_current_dir`, since the startup cap carries no path string); the std-env round-trip assertions are folded into `fs_open_relative_phase` to avoid re-installing the cwd cap.

Closes #9. Deferred follow-up tracked in #54 (lexical client-side resolver needed for relative-path / `..` inputs; namespace protocol forbids `..` / `.` as name components by design).

## Test plan

- [x] `cargo xtask build --arch x86_64` succeeds
- [x] `cargo xtask run` reaches `ALL TESTS PASSED` on x86_64 (`env_cwd_unset phase passed`, `fs_open_relative phase passed` both fire)
- [x] `cargo xtask build --arch riscv64` succeeds
- [x] `cargo xtask run --arch riscv64` reaches `ALL TESTS PASSED` (both new phases fire)
- [x] CI build-test.yml passes both arches
