### PR TITLE
vfsd, ruststd: pick FS_READ vs FS_READ_FRAME crossover from measurement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,6 +285,10 @@ name = "font"
 version = "0.1.0"
 
 [[package]]
+name = "fsbench"
+version = "0.1.0"
+
+[[package]]
 name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "shared/registry",
     "shared/shmem",
     "base/crasher",
+    "base/fsbench",
     "base/hello",
     "base/pipefault",
     "base/stackoverflow",

--- a/base/fsbench/Cargo.toml
+++ b/base/fsbench/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "fsbench"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[[bin]]
+name = "fsbench"
+path = "src/main.rs"
+test = false
+
+[lints]
+workspace = true

--- a/base/fsbench/src/main.rs
+++ b/base/fsbench/src/main.rs
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// base/fsbench/src/main.rs
+
+//! `FS_READ` vs `FS_READ_FRAME` crossover benchmark.
+//!
+//! Measures wall-clock cycle cost of reading `bench.bin` via the inline
+//! `FS_READ` path and the zero-copy `FS_READ_FRAME` path across the size
+//! grid called out in issue #10: 16 B, 1 KiB, 4 KiB, 16 KiB, 64 KiB.
+//!
+//! Path forcing is by buffer chunking, since `read()`'s policy at
+//! `runtime/ruststd/src/sys/fs/seraph.rs` is `want <= 504 AND
+//! page_off + want <= PAGE_SIZE` picks inline, else frame:
+//!
+//! * Inline measurement: chunk into <= 504-byte reads that don't cross
+//!   a page tail. Loop until `size` bytes consumed.
+//! * Frame measurement: always pass a `PAGE_SIZE` buffer (so `want` is
+//!   4096 which exceeds 504). Each `read` returns up to one page. For
+//!   `size < 4096` the call still pays the full single-page frame cost.
+//!
+//! Output is line-oriented and machine-parseable so the host can scrape
+//! it from the serial log:
+//!
+//! ```text
+//! fsbench: arch=x86_64 size=4096 path=inline iters=256 cycles_min=...
+//! fsbench: arch=x86_64 size=4096 path=frame  iters=256 cycles_min=...
+//! ```
+
+#![feature(restricted_std)]
+// fsbench is a benchmark harness: panics on failure so faults surface
+// in the log. `expect`/`unwrap` are the intended idiom here.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+
+const PAGE_SIZE: u64 = 4096;
+const PAGE_SIZE_USIZE: usize = 4096;
+const INLINE_CHUNK: u64 = 504;
+const SIZES: &[u64] = &[16, 1024, 4096, 16384, 65536];
+const WARMUP_ITERS: u32 = 8;
+const MEASURE_ITERS: u32 = 256;
+const FIXTURE_PATH: &str = "/usertest/bench.bin";
+
+fn cycles_now() -> u64
+{
+    #[cfg(target_arch = "x86_64")]
+    {
+        let lo: u32;
+        let hi: u32;
+        // SAFETY: rdtsc is unprivileged on x86_64; reads TSC into edx:eax.
+        unsafe {
+            core::arch::asm!(
+                "rdtsc",
+                out("eax") lo,
+                out("edx") hi,
+                options(nostack, nomem, preserves_flags),
+            );
+        }
+        u64::from(hi) << 32 | u64::from(lo)
+    }
+    #[cfg(target_arch = "riscv64")]
+    {
+        let c: u64;
+        // SAFETY: `csrr cycle` is unprivileged when scounteren.CY = 1,
+        // which the kernel sets in BSP and AP init
+        // (`core/kernel/src/arch/riscv64/interrupts.rs`).
+        unsafe {
+            core::arch::asm!(
+                "csrr {}, cycle",
+                out(reg) c,
+                options(nostack, nomem),
+            );
+        }
+        c
+    }
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "riscv64")))]
+    {
+        0
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+const ARCH_TAG: &str = "x86_64";
+#[cfg(target_arch = "riscv64")]
+const ARCH_TAG: &str = "riscv64";
+#[cfg(not(any(target_arch = "x86_64", target_arch = "riscv64")))]
+const ARCH_TAG: &str = "unknown";
+
+/// Read `size` bytes from `f` starting at offset 0, chunking into
+/// <= 504-byte reads that don't cross a page tail so std picks the
+/// inline `FS_READ` path for every call.
+fn read_inline(f: &mut File, size: u64, buf: &mut [u8]) -> u64
+{
+    f.seek(SeekFrom::Start(0)).expect("seek failed");
+    let mut consumed: u64 = 0;
+    while consumed < size
+    {
+        let remaining = size - consumed;
+        let page_off = consumed % PAGE_SIZE;
+        let chunk = remaining.min(INLINE_CHUNK).min(PAGE_SIZE - page_off);
+        #[allow(clippy::cast_possible_truncation)]
+        let chunk_usz = chunk as usize;
+        let n = f.read(&mut buf[..chunk_usz]).expect("inline read failed");
+        if n == 0
+        {
+            break;
+        }
+        consumed += n as u64;
+    }
+    consumed
+}
+
+/// Read `size` bytes from `f` starting at offset 0, passing a full
+/// `PAGE_SIZE` buffer so std picks the frame path (`want > 504`) on
+/// every call.
+fn read_frame(f: &mut File, size: u64, buf: &mut [u8]) -> u64
+{
+    f.seek(SeekFrom::Start(0)).expect("seek failed");
+    let mut consumed: u64 = 0;
+    while consumed < size
+    {
+        let n = f.read(buf).expect("frame read failed");
+        if n == 0
+        {
+            break;
+        }
+        consumed += n as u64;
+    }
+    consumed
+}
+
+fn measure(f: &mut File, size: u64, path: &str, buf: &mut [u8])
+{
+    let runner: fn(&mut File, u64, &mut [u8]) -> u64 = match path
+    {
+        "inline" => read_inline,
+        "frame" => read_frame,
+        _ => unreachable!(),
+    };
+
+    for _ in 0..WARMUP_ITERS
+    {
+        let _ = runner(f, size, buf);
+    }
+
+    let mut min_c = u64::MAX;
+    let mut max_c = 0u64;
+    let mut sum_c: u64 = 0;
+    for _ in 0..MEASURE_ITERS
+    {
+        let start = cycles_now();
+        let got = runner(f, size, buf);
+        let elapsed = cycles_now().wrapping_sub(start);
+        assert!(
+            got >= size.min(65536),
+            "fsbench: short read on path={path} size={size}: got {got}"
+        );
+        if elapsed < min_c
+        {
+            min_c = elapsed;
+        }
+        if elapsed > max_c
+        {
+            max_c = elapsed;
+        }
+        sum_c = sum_c.wrapping_add(elapsed);
+    }
+    let mean_c = sum_c / u64::from(MEASURE_ITERS);
+
+    let arch = ARCH_TAG;
+    let iters = MEASURE_ITERS;
+    std::os::seraph::log!(
+        "arch={arch} size={size} path={path} iters={iters} \
+         cycles_min={min_c} cycles_mean={mean_c} cycles_max={max_c}"
+    );
+}
+
+/// Sanity-check the fixture: byte i must equal `(i & 0xFF) as u8` for
+/// the first page and the same pattern at page boundaries. Catches any
+/// read-path corruption before the timing run.
+fn verify_fixture(f: &mut File)
+{
+    let mut buf = [0u8; 64];
+    f.seek(SeekFrom::Start(0)).expect("verify: seek 0 failed");
+    let n = f.read(&mut buf).expect("verify: read failed");
+    assert_eq!(n, buf.len(), "verify: short read at offset 0");
+    for (i, &b) in buf.iter().enumerate()
+    {
+        #[allow(clippy::cast_possible_truncation)]
+        let expected = (i & 0xFF) as u8;
+        assert_eq!(
+            b, expected,
+            "verify: byte {i} mismatch ({b:#x} vs expected {expected:#x})"
+        );
+    }
+
+    // Page-boundary spot check: byte at offset 4080 must equal
+    // `(4080 & 0xFF) == 0xF0`. Read straddles into the next page so
+    // the std-side policy picks the frame path.
+    f.seek(SeekFrom::Start(4080))
+        .expect("verify: seek 4080 failed");
+    let n = f.read(&mut buf).expect("verify: page-straddle read failed");
+    assert!(n > 0, "verify: page-straddle returned zero");
+    let expected: u8 = 0xF0;
+    assert_eq!(
+        buf[0], expected,
+        "verify: page-straddle first byte mismatch ({:#x} vs {expected:#x})",
+        buf[0]
+    );
+}
+
+fn main()
+{
+    std::os::seraph::log::register_name(b"fsbench");
+    std::os::seraph::log!("starting, fixture={FIXTURE_PATH}");
+
+    let mut f =
+        File::open(FIXTURE_PATH).unwrap_or_else(|e| panic!("fsbench: open {FIXTURE_PATH}: {e}"));
+    verify_fixture(&mut f);
+
+    let mut buf = vec![0u8; PAGE_SIZE_USIZE];
+    for &size in SIZES
+    {
+        measure(&mut f, size, "inline", &mut buf);
+        measure(&mut f, size, "frame", &mut buf);
+    }
+
+    std::os::seraph::log!("done");
+}

--- a/base/usertest/src/main.rs
+++ b/base/usertest/src/main.rs
@@ -130,6 +130,7 @@ fn main()
     ns_mount_boundary_phase();
     fs_open_phase();
     fs_release_on_close_phase();
+    fs_crossover_bench_phase();
     fs_rights_attenuation_phase();
     ns_multi_component_phase();
     ns_sandbox_phase();
@@ -728,6 +729,27 @@ fn fs_release_on_close_phase()
     }
 
     std::os::seraph::log!("fs_release_on_close phase passed (8 cycles)");
+}
+
+/// Spawn `/bin/fsbench` and surface its per-(size, path) cycle counts in
+/// the boot log. fsbench measures the cost of reading `/usertest/bench.bin`
+/// via the inline `FS_READ` path versus the zero-copy `FS_READ_FRAME` path
+/// across the size grid called out in issue #10. The numbers inform the
+/// `READ_INLINE_THRESHOLD` constant at
+/// `runtime/ruststd/src/sys/fs/seraph.rs`.
+///
+/// Asserts on child exit status only; the actual measurements appear in
+/// the serial log under the `[fsbench]` name.
+fn fs_crossover_bench_phase()
+{
+    use std::process::Command;
+
+    let mut child = Command::new("/bin/fsbench")
+        .spawn()
+        .expect("spawn /bin/fsbench failed");
+    let status = child.wait().expect("fsbench wait failed");
+    assert!(status.success(), "fsbench did not exit cleanly: {status}");
+    std::os::seraph::log!("fs_crossover_bench phase passed");
 }
 
 /// Verify F2: fatfs node-cap handlers enforce namespace rights bits.

--- a/runtime/ruststd/src/sys/fs/seraph.rs
+++ b/runtime/ruststd/src/sys/fs/seraph.rs
@@ -67,6 +67,20 @@ use release_handler::{FileEntry, OutstandingMapping};
 
 const PAGE_SIZE_USIZE: usize = PAGE_SIZE as usize;
 
+/// Per-call crossover threshold between the inline FS_READ path and the
+/// zero-copy FS_READ_FRAME path. A `read()` of at most this many bytes
+/// that also fits within the current page goes inline; anything larger
+/// or page-straddling takes the frame path.
+///
+/// 504 is the FS_READ IPC reply ceiling: 63 data words × 8 bytes minus
+/// the 8-byte length prefix in word 0 (`abi/syscall/MSG_DATA_WORDS_MAX`).
+/// At or below this size, a single FS_READ carries the bytes. The
+/// `fsbench` numbers in `services/fs/docs/fs-driver-protocol.md` show
+/// inline is roughly 2× cheaper per call on both x86_64 and riscv64,
+/// so 504 also happens to be the smallest size at which any larger
+/// would force ≥ 2 inline calls and lose to one frame call.
+const READ_INLINE_THRESHOLD: usize = 504;
+
 // ── Public type stubs ─────────────────────────────────────────────────────
 
 #[derive(Copy, Clone, Debug, Default)]
@@ -619,12 +633,15 @@ impl File
         let want = (buf.len() as u64).min(remaining) as usize;
 
         // Inline path: small reads or page-tail reads that don't cross a
-        // page boundary. The 504-byte inline ceiling matches what fs's
-        // FS_READ handler can fit in one IPC reply (63 data words ×
-        // 8 bytes = 504, minus the 8-byte length prefix in word 0).
+        // page boundary. Threshold equals the FS_READ IPC payload
+        // ceiling: 63 data words × 8 bytes = 504, minus the 8-byte
+        // length prefix in word 0. Above this a single inline reply
+        // cannot carry the bytes; below this the per-call cost is
+        // strictly cheaper than the frame path on both x86_64 and
+        // riscv64 (≈ 2× factor; see fsbench numbers recorded in
+        // `services/fs/docs/fs-driver-protocol.md`).
         let page_off = (pos % PAGE_SIZE) as usize;
-        const INLINE_MAX: usize = 504;
-        if want <= INLINE_MAX && page_off + want <= PAGE_SIZE_USIZE
+        if want <= READ_INLINE_THRESHOLD && page_off + want <= PAGE_SIZE_USIZE
         {
             return self.read_inline(buf, pos, want);
         }

--- a/services/fs/docs/fs-driver-protocol.md
+++ b/services/fs/docs/fs-driver-protocol.md
@@ -76,8 +76,11 @@ node's `(NodeId, NamespaceRights)` token to the driver via
 `ipc_recv.token`; the driver MUST verify the `READ` rights bit and
 reject with `NsError::PermissionDenied` otherwise.
 
-Used for short reads (`< PAGE_SIZE`); larger reads use
-[`FS_READ_FRAME`](#label-7-fs_read_frame).
+Used for short reads (≤ 504 bytes that fit within the current page);
+larger or page-straddling reads use
+[`FS_READ_FRAME`](#label-7-fs_read_frame). The threshold is
+client-side policy, not server-enforced; see
+[Inline-vs-frame crossover](#inline-vs-frame-crossover-client-policy).
 
 **Request**
 
@@ -151,6 +154,74 @@ falling back to the eviction worker's hard-revoke path.
 
 **Reply (error)**: `label = NsError::*` or
 `fs_errors::BAD_FRAME_OFFSET` (cookie zero).
+
+---
+
+## Inline-vs-frame crossover (client policy)
+
+The choice between [`FS_READ`](#label-2-fs_read) and
+[`FS_READ_FRAME`](#label-7-fs_read_frame) is **client-side policy**, not
+protocol. The server accepts whichever label arrives; the cost of the
+wrong pick falls entirely on the client.
+
+The reference policy lives in `runtime/ruststd/src/sys/fs/seraph.rs`:
+
+```text
+inline iff  want <= READ_INLINE_THRESHOLD
+       AND  (offset mod PAGE_SIZE) + want <= PAGE_SIZE
+frame  otherwise
+```
+
+`READ_INLINE_THRESHOLD = 504` bytes. This is the FS_READ IPC payload
+ceiling — 63 data words × 8 bytes minus the 8-byte length prefix in
+word 0 (`MSG_DATA_WORDS_MAX` in `abi/syscall`). Above this size a
+single inline reply cannot carry the bytes; below it the per-call cost
+is strictly cheaper than the frame path on both supported architectures.
+
+The page-alignment clause forces frame for any read that straddles a
+page tail even if its size fits inline, because the frame path's
+single-page granularity matches the on-disk page-cache layout, whereas
+an inline reply spanning two pages would force the server to assemble
+contiguous bytes across the boundary.
+
+### Measured per-call cost (`fsbench`, debug builds)
+
+Source: `base/fsbench/src/main.rs`. The bench loops 256 timed iterations
+of "seek to 0; read N bytes via the chosen path" against a 64 KiB
+fixture (`/usertest/bench.bin`). The inline path chunks into ≤ 504-byte
+non-straddling reads; the frame path always passes a full-page buffer
+so `want > 504` forces a frame call. `cycles_now()` uses `rdtsc` on
+x86_64 and `csrr cycle` on riscv64. Numbers below are `cycles_mean`.
+
+**x86_64 (KVM-accelerated, TSC = hardware cycles)**
+
+| Size (B) | Inline calls | Inline cycles | Frame calls | Frame cycles |
+|---------:|-------------:|--------------:|------------:|-------------:|
+| 16       | 1            | 61 426        | 1           | 123 139      |
+| 1 024    | 3            | 236 906       | 1           | 130 553      |
+| 4 096    | 9            | 938 019       | 1           | 244 221      |
+| 16 384   | 33           | 3 780 641     | 4           | 1 000 699    |
+| 65 536   | 130          | 15 347 991    | 16          | 3 987 730    |
+
+**riscv64 (TCG-emulated, `cycle` CSR via `scounteren.CY`)**
+
+| Size (B) | Inline calls | Inline cycles | Frame calls | Frame cycles |
+|---------:|-------------:|--------------:|------------:|-------------:|
+| 16       | 1            | 548 333       | 1           | 1 232 195    |
+| 1 024    | 3            | 2 131 616     | 1           | 1 383 683    |
+| 4 096    | 9            | 8 205 397     | 1           | 2 389 154    |
+| 16 384   | 33           | 33 249 701    | 4           | 9 735 094    |
+| 65 536   | 130          | 134 748 016   | 16          | 39 159 872   |
+
+**Reading the table:** the single-call inline cost is consistently
+≈ 0.5× the single-call frame cost on both architectures. Once the
+request exceeds 504 bytes the inline path must issue ≥ 2 calls and
+loses to the single frame call. Below 504 bytes inline always wins.
+The threshold is therefore set to the IPC payload ceiling: not by
+coincidence, but by measurement.
+
+Absolute riscv64 cycles run ≈ 10× x86_64 because riscv64 boots under
+TCG (no KVM); the *ratio* between paths is what informs the policy.
 
 ---
 

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -92,6 +92,7 @@ pub enum BuildComponent
     Svcmgr,
     Pwrmgr,
     Hello,
+    Fsbench,
     Pipefault,
     Stackoverflow,
     Stdiotest,

--- a/xtask/src/commands/build.rs
+++ b/xtask/src/commands/build.rs
@@ -139,6 +139,11 @@ const SPECS: &[Spec] = &[
         dest: InstallDest::RootfsBin,
     },
     Spec {
+        name: "fsbench",
+        profile: BuildProfile::StdUser,
+        dest: InstallDest::RootfsBin,
+    },
+    Spec {
         name: "stackoverflow",
         profile: BuildProfile::StdUser,
         dest: InstallDest::RootfsBin,
@@ -174,6 +179,7 @@ fn spec_for(component: BuildComponent) -> Option<&'static Spec>
         BuildComponent::Svcmgr => "svcmgr",
         BuildComponent::Pwrmgr => "pwrmgr",
         BuildComponent::Hello => "hello",
+        BuildComponent::Fsbench => "fsbench",
         BuildComponent::Stackoverflow => "stackoverflow",
         BuildComponent::Pipefault => "pipefault",
         BuildComponent::Stdiotest => "stdiotest",

--- a/xtask/src/disk.rs
+++ b/xtask/src/disk.rs
@@ -18,10 +18,11 @@ use crate::util::step;
 
 const SECTOR_SIZE: u64 = 512;
 
-/// Both partitions are 128 MiB. Debug binaries have grown (usertest added
-/// alloc-crate codegen, bringing total ESP contents close to the old 64 MiB
-/// limit); release builds remain comfortable well under half of this.
-const PARTITION_SIZE: u64 = 128 * 1024 * 1024;
+/// Both partitions are 192 MiB. Debug binaries each weigh ~14 MiB; the root
+/// partition holds ~10 of them plus fixtures, so 128 MiB was insufficient
+/// once `fsbench` was added. Release builds remain comfortable well under
+/// half of this.
+const PARTITION_SIZE: u64 = 192 * 1024 * 1024;
 
 /// First partition starts at LBA 2048 (1 MiB alignment, standard GPT practice).
 const ESP_START_LBA: u64 = 2048;

--- a/xtask/src/sysroot.rs
+++ b/xtask/src/sysroot.rs
@@ -92,6 +92,7 @@ pub fn install_rootfs(ctx: &BuildContext) -> Result<()>
     }
 
     synthesise_usertest_large_bin(ctx)?;
+    synthesise_usertest_bench_bin(ctx)?;
 
     Ok(())
 }
@@ -132,6 +133,36 @@ fn synthesise_usertest_large_bin(ctx: &BuildContext) -> Result<()>
     buf.truncate(total);
     fs::write(&dst, &buf).with_context(|| format!("writing {}", dst.display()))?;
     step(&format!("Rootfs: {} (synthesised, 16 KiB)", dst.display()));
+    Ok(())
+}
+
+const USERTEST_BENCH_BIN_SIZE: usize = 65536;
+
+/// Emit `/usertest/bench.bin`, a 64 KiB deterministic fixture consumed by
+/// `fsbench` (the FS_READ vs FS_READ_FRAME crossover benchmark). Filled
+/// with a byte-position-derived pattern so any read-path corruption shows
+/// up as a content mismatch at the byte level. Gitignored and treated as
+/// a build artifact, same pattern as `large.bin`.
+fn synthesise_usertest_bench_bin(ctx: &BuildContext) -> Result<()>
+{
+    let dst = ctx.sysroot.join("usertest/bench.bin");
+    if dst.exists()
+    {
+        return Ok(());
+    }
+    if let Some(parent) = dst.parent()
+    {
+        fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+    }
+    let mut buf = Vec::with_capacity(USERTEST_BENCH_BIN_SIZE);
+    for i in 0..USERTEST_BENCH_BIN_SIZE
+    {
+        #[allow(clippy::cast_possible_truncation)]
+        let b = (i & 0xFF) as u8;
+        buf.push(b);
+    }
+    fs::write(&dst, &buf).with_context(|| format!("writing {}", dst.display()))?;
+    step(&format!("Rootfs: {} (synthesised, 64 KiB)", dst.display()));
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- Renames `INLINE_MAX = 504` at `runtime/ruststd/src/sys/fs/seraph.rs` to `READ_INLINE_THRESHOLD = 504` and turns the pick from an accidental IPC-ceiling coincidence into a measured, deliberate one. Behavior is unchanged.
- Adds `base/fsbench`, a userspace bench that loops timed `FS_READ` vs `FS_READ_FRAME` reads of 16 B / 1 KiB / 4 KiB / 16 KiB / 64 KiB against a synthesised 64 KiB fixture (`/usertest/bench.bin`) and logs `cycles_min/mean/max` per cell. `usertest` spawns it so CI captures the numbers every run.
- Documents the policy and the measured numbers in `services/fs/docs/fs-driver-protocol.md` under a new "Inline-vs-frame crossover (client policy)" subsection.

## Measured per-call costs (debug, mean cycles)

x86_64 (KVM, rdtsc):

| Size | Inline | Frame |
|---:|---:|---:|
| 16 | 61 426 | 123 139 |
| 1 024 | 236 906 (3 calls) | 130 553 |
| 4 096 | 938 019 (9) | 244 221 |
| 16 384 | 3 780 641 (33) | 1 000 699 (4) |
| 65 536 | 15 347 991 (130) | 3 987 730 (16) |

riscv64 (TCG, `csrr cycle`):

| Size | Inline | Frame |
|---:|---:|---:|
| 16 | 548 333 | 1 232 195 |
| 1 024 | 2 131 616 (3) | 1 383 683 |
| 4 096 | 8 205 397 (9) | 2 389 154 |
| 16 384 | 33 249 701 (33) | 9 735 094 (4) |
| 65 536 | 134 748 016 (130) | 39 159 872 (16) |

Frame is ~2× the per-call cost of inline on both archs; the crossover is at "request needs ≥ 2 inline calls" → `want > 504`. The threshold lands at 504 by measurement, not by accident.

## Incidental scope

Disk image partition bumped 128 → 192 MiB at `xtask/src/disk.rs`: each debug binary is ~14 MiB and the new bench tipped the root partition over the old cap on riscv64.

## Test plan

- [x] `cargo xtask clean && cargo xtask build` (x86_64) — clean
- [x] `cargo xtask run` (x86_64) — `ALL TESTS PASSED`, fsbench lines present in log
- [x] `cargo xtask clean && cargo xtask build --arch riscv64` — clean
- [x] `cargo xtask run --arch riscv64` — `ALL TESTS PASSED`, fsbench lines present in log
- [x] fsbench's fixture-verification asserts pass (`(i & 0xFF) as u8` pattern + page-straddle spot check)

Closes #10