### PR TITLE
.github, docs/conventions, .claude: PR workflow hardening

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -44,8 +44,16 @@ truth for "how work is tracked and shipped" on this project.
   `gh pr checks <N> --watch` (or `gh run watch <run-id>`) as a backgrounded
   `Bash` invocation (`run_in_background: true`). Do not poll, do not sleep —
   the harness notifies on completion.
-- On green: confirm the pass to the user in one line, then proceed (or
-  prompt for merge approval if not yet merged).
+- On green: confirm the pass in one line, then run the pre-merge audit
+  before prompting for merge:
+  1. `gh pr view <N> --json body`. Every `- [ ]` in the PR body MUST be
+     `- [x]` or removed with rationale. List any unticked items to the
+     user and resolve them (`gh pr edit`) before continuing.
+  2. For each `Closes #N` / `Fixes #N` in the PR body, `gh issue view <N>
+     --json body`. Every `- [ ]` under `## Acceptance` MUST be `- [x]` or
+     dropped with rationale. Resolve via `gh issue edit`.
+  3. Only after the audit clears, prompt the user for the merge decision.
+     Merge via `gh pr merge <N> --merge --delete-branch`.
 - On red: surface the failing job's tail (`gh run view <run-id> --log-failed`
   or equivalent) so the user can see the actual error without asking.
 - The assistant MUST NOT merge a PR while its CI run is pending or failing.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+<one to three sentences: what changed and why>
+
+Closes #<issue>
+
+## Acceptance
+<copy the Acceptance section of the linked Issue verbatim; tick items completed by this PR>
+- [ ]
+
+## Test plan
+- [ ] `cargo xtask build` (x86_64)
+- [ ] `cargo xtask run` (x86_64), terminal pass marker observed
+- [ ] `cargo xtask build --arch riscv64`
+- [ ] `cargo xtask run --arch riscv64`, terminal pass marker observed
+- [ ] additional component-specific checks: <…>
+
+## Notes
+<design tradeoffs; follow-ups filed as Issues; anything reviewers should see>

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -121,6 +121,34 @@ are forbidden; `master` MUST NOT receive force pushes.
 
 `feature/<slug>`, `fix/<slug>`, `cleanup/<slug>`, `audit/<slug>` — matching the Class labels above.
 
+### Merge method
+
+`master` accepts merge commits only; rebase and squash merge are disabled
+at the repo level. Merge via the GitHub web UI ("Create a merge commit")
+or `gh pr merge <N> --merge --delete-branch`. `git log --first-parent master`
+gives the PR-level linear view.
+
+### Branch protection
+
+`master` is protected by a GitHub branch protection rule enforcing:
+
+- Pull request required before merging.
+- Required status checks (strict, branch up-to-date): `host-tests`,
+  `validate (x86_64, debug)`, `validate (x86_64, release)`,
+  `validate (riscv64, debug)`, `validate (riscv64, release)`.
+- Required signed commits.
+- Force pushes blocked.
+- Branch deletion blocked.
+- Rules enforced for administrators.
+
+### PR-body checklist discipline
+
+- PRs are opened from `.github/pull_request_template.md`.
+- Before merge, every `- [ ]` in the PR body MUST be `- [x]` or removed
+  with a one-line rationale in the same edit. Same shape as the Issue
+  acceptance rule under "Backlog Tracking" above.
+- Edit via `gh pr edit <N> --body "$(cat <<'EOF' …EOF)"` or the web UI.
+
 ## CI Workflows
 
 | Workflow file | Trigger | Purpose |


### PR DESCRIPTION
## Summary

Switch `master` to merge-commit-only, add a PR template, codify the matching branch protection and pre-merge tickbox audit. Together these restore Verified-by-author badges on every commit landing on `master` (rebase merge had stripped them) and make the acceptance/test-plan discipline run from the template + protection rules rather than memory.

No Issue ticket (workflow-hardening, discussed and decided in chat). Plan file: `~/.claude/plans/i-want-to-explore-serene-wall.md`.

## Acceptance

- [x] Repo merge methods: `mergeCommit=true`, `rebase=false`, `squash=false`.
- [x] Branch protection on `master` enforces required checks (5 contexts, strict), signed commits, no force push, no deletion, admin-enforced.
- [x] `.github/pull_request_template.md` present on `master`.
- [x] `docs/conventions.md` documents merge method, branch protection, and PR-body checklist discipline.
- [x] `.claude/CLAUDE.md` codifies the pre-merge audit (3-step) before prompting for merge.

## Test plan

- [x] `host-tests` green
- [x] `validate (x86_64, debug)` green
- [x] `validate (x86_64, release)` green
- [x] `validate (riscv64, debug)` green
- [x] `validate (riscv64, release)` green

(No code changes; doc + config files only.)

## Notes

GitHub-state changes (merge methods, branch protection) were applied via `gh api` **before** this PR was opened — otherwise it could not have been merged under the new rules. The PR's own merge will be the first to use the merge-commit method under the new protection regime.