### PR TITLE
xtask, ci, boot, kernel: x86_64 CI honesty and TCG correctness

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           cargo xtask run-parallel \
             --arch ${{ matrix.arch }} \
-            --parallel 1 --runs 1 --timeout 60
+            --parallel 1 --runs 1 --timeout 180
 
       - name: Swap boot.conf to init=ktest and rebuild
         run: |
@@ -108,7 +108,7 @@ jobs:
         run: |
           cargo xtask run-parallel \
             --arch ${{ matrix.arch }} \
-            --parallel 1 --runs 1 --timeout 60
+            --parallel 1 --runs 1 --timeout 180
 
       - name: Upload run-parallel logs
         if: always()

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -110,8 +110,8 @@ jobs:
             --arch ${{ matrix.arch }} \
             --parallel 1 --runs 1 --timeout 60
 
-      - name: Upload run-parallel logs on failure
-        if: failure()
+      - name: Upload run-parallel logs
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: run-parallel-${{ matrix.arch }}-${{ matrix.profile }}

--- a/.github/workflows/burnin.yml
+++ b/.github/workflows/burnin.yml
@@ -66,8 +66,8 @@ jobs:
             --arch ${{ matrix.arch }} \
             --parallel 4 --runs 20 --timeout 60
 
-      - name: Upload usertest logs on failure
-        if: failure() && steps.usertest-burnin.outcome == 'failure'
+      - name: Upload usertest logs
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: burnin-usertest-${{ matrix.arch }}-${{ matrix.profile }}
@@ -95,8 +95,8 @@ jobs:
             --arch ${{ matrix.arch }} \
             --parallel 4 --runs 20 --timeout 60
 
-      - name: Upload ktest logs on failure
-        if: failure() && steps.ktest-burnin.outcome == 'failure'
+      - name: Upload ktest logs
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: burnin-ktest-${{ matrix.arch }}-${{ matrix.profile }}

--- a/core/boot/src/acpi.rs
+++ b/core/boot/src/acpi.rs
@@ -466,12 +466,16 @@ pub unsafe fn parse_aperture_seed(rsdp_addr: u64, out: &mut [MmioAperture]) -> u
                     let num_buses = u64::from(end_bus).saturating_sub(u64::from(start_bus)) + 1;
                     let ecam_size = num_buses * 256 * 4096;
                     push!(base, ecam_size);
-                    // PCI BAR windows: QEMU-layout heuristic selected by
-                    // ECAM base. The 32-bit window sits below ECAM on q35
-                    // and at a fixed 0x4000_0000 on virt; the 64-bit
-                    // window is a fixed high range on each. Real hardware
-                    // advertises these through the host bridge's `_CRS`,
-                    // which the bootloader does not evaluate.
+                    // PCI BAR windows. Real hardware advertises these
+                    // through the host bridge's `_CRS`, which the
+                    // bootloader does not evaluate (no AML interpreter).
+                    // We seed conservatively: the 32-bit window is the
+                    // chipset-conventional band below 4 GiB; the 64-bit
+                    // window is `[4 GiB, 1 << MAXPHYADDR)` — wide enough
+                    // to cover any firmware/hypervisor placement on the
+                    // architecture without per-machine tuning. Apertures
+                    // are permission checks, not allocations, so a wide
+                    // upper bound is harmless.
                     let (lo_base, lo_size) = if base < 0x8000_0000
                     {
                         (0x4000_0000u64, 0x4000_0000u64)
@@ -481,14 +485,17 @@ pub unsafe fn parse_aperture_seed(rsdp_addr: u64, out: &mut [MmioAperture]) -> u
                         (0x8000_0000u64, base - 0x8000_0000)
                     };
                     push!(lo_base, lo_size);
-                    let (hi_base, hi_size) = if base < 0x8000_0000
+                    let maxphyaddr = crate::arch::current::max_phys_addr_bits();
+                    let hi_top: u64 = if maxphyaddr >= 64
                     {
-                        (0x4_0000_0000u64, 0x4_0000_0000u64)
+                        u64::MAX
                     }
                     else
                     {
-                        (0x3800_0000_0000u64, 0x1_0000_0000u64)
+                        1u64 << maxphyaddr
                     };
+                    let hi_base: u64 = 1u64 << 32;
+                    let hi_size: u64 = hi_top.saturating_sub(hi_base);
                     push!(hi_base, hi_size);
                 }
                 off += MCFG_ENTRY_SIZE;

--- a/core/boot/src/acpi.rs
+++ b/core/boot/src/acpi.rs
@@ -512,5 +512,19 @@ pub unsafe fn parse_aperture_seed(rsdp_addr: u64, out: &mut [MmioAperture]) -> u
         }
     }
 
+    // Per-arch platform-default PCI apertures.
+    //
+    // Some firmware builds publish ACPI without an MCFG table (e.g. the
+    // EDK2 shipped with Ubuntu's `qemu-efi-riscv64` package observed on
+    // `ubuntu-latest` GitHub runners). When MCFG is absent the loop above
+    // produces no PCI apertures, but devmgr still needs a frame covering
+    // ECAM. Append the arch-defined defaults unconditionally; any overlap
+    // with MCFG-derived entries is collapsed by
+    // `derive_mmio_apertures`'s merge pass.
+    for &(base, size) in crate::arch::current::default_pci_apertures()
+    {
+        push!(base, size);
+    }
+
     n
 }

--- a/core/boot/src/acpi.rs
+++ b/core/boot/src/acpi.rs
@@ -469,13 +469,15 @@ pub unsafe fn parse_aperture_seed(rsdp_addr: u64, out: &mut [MmioAperture]) -> u
                     // PCI BAR windows. Real hardware advertises these
                     // through the host bridge's `_CRS`, which the
                     // bootloader does not evaluate (no AML interpreter).
-                    // We seed conservatively: the 32-bit window is the
-                    // chipset-conventional band below 4 GiB; the 64-bit
-                    // window is `[4 GiB, 1 << MAXPHYADDR)` — wide enough
-                    // to cover any firmware/hypervisor placement on the
-                    // architecture without per-machine tuning. Apertures
-                    // are permission checks, not allocations, so a wide
-                    // upper bound is harmless.
+                    // We seed via an ECAM-base heuristic:
+                    //   ECAM < 2 GiB ⇒ QEMU virt (RISC-V): both windows
+                    //     at stable QEMU-defined offsets.
+                    //   ECAM ≥ 2 GiB ⇒ q35 (x86-64): 32-bit window
+                    //     below ECAM; 64-bit window `[4 GiB, 1<<MAXPHYADDR)`
+                    //     so it covers wherever firmware places it
+                    //     without per-CPU tuning. Apertures are
+                    //     permission checks, not allocations, so a wide
+                    //     upper bound is harmless.
                     let (lo_base, lo_size) = if base < 0x8000_0000
                     {
                         (0x4000_0000u64, 0x4000_0000u64)
@@ -485,17 +487,24 @@ pub unsafe fn parse_aperture_seed(rsdp_addr: u64, out: &mut [MmioAperture]) -> u
                         (0x8000_0000u64, base - 0x8000_0000)
                     };
                     push!(lo_base, lo_size);
-                    let maxphyaddr = crate::arch::current::max_phys_addr_bits();
-                    let hi_top: u64 = if maxphyaddr >= 64
+                    let (hi_base, hi_size) = if base < 0x8000_0000
                     {
-                        u64::MAX
+                        (0x4_0000_0000u64, 0x4_0000_0000u64)
                     }
                     else
                     {
-                        1u64 << maxphyaddr
+                        let maxphyaddr = crate::arch::current::max_phys_addr_bits();
+                        let hi_top: u64 = if maxphyaddr >= 64
+                        {
+                            u64::MAX
+                        }
+                        else
+                        {
+                            1u64 << maxphyaddr
+                        };
+                        let hi_base: u64 = 1u64 << 32;
+                        (hi_base, hi_top.saturating_sub(hi_base))
                     };
-                    let hi_base: u64 = 1u64 << 32;
-                    let hi_size: u64 = hi_top.saturating_sub(hi_base);
                     push!(hi_base, hi_size);
                 }
                 off += MCFG_ENTRY_SIZE;

--- a/core/boot/src/arch/riscv64/mod.rs
+++ b/core/boot/src/arch/riscv64/mod.rs
@@ -160,3 +160,22 @@ pub unsafe fn allocate_ap_trampoline(bs: *mut EfiBootServices) -> Option<u64>
     // SAFETY: bs is valid per the caller's contract.
     unsafe { allocate_pages(bs, 1).ok() }
 }
+
+/// Return the platform's maximum physical address width in bits.
+///
+/// On RISC-V the Privileged spec caps physical addresses at 56 bits
+/// across Sv39, Sv48, and Sv57 page-table modes, and no in-band ISA
+/// mechanism exists for querying the implementation-supported width
+/// (no CPUID analogue). Real implementations can be narrower; 56 is
+/// the safe upper bound.
+///
+/// Provided for arch-dispatch symmetry with x86-64. The current
+/// QEMU virt RISC-V machine has a fixed, well-known PCI MMIO layout
+/// that [`crate::acpi::parse_aperture_seed`] handles via its
+/// virt-machine branch, so this value is not consumed today. When
+/// RISC-V boards diverge from QEMU virt and need MAXPHYADDR-derived
+/// apertures, this function is the dispatch point.
+pub fn max_phys_addr_bits() -> u8
+{
+    56
+}

--- a/core/boot/src/arch/riscv64/mod.rs
+++ b/core/boot/src/arch/riscv64/mod.rs
@@ -161,6 +161,22 @@ pub unsafe fn allocate_ap_trampoline(bs: *mut EfiBootServices) -> Option<u64>
     unsafe { allocate_pages(bs, 1).ok() }
 }
 
+/// QEMU virt RISC-V PCI MMIO layout (ECAM, 32-bit window, 64-bit window).
+///
+/// Seeded unconditionally so devmgr can mint a Frame covering the ECAM
+/// region even on firmware builds that publish ACPI without MCFG and
+/// don't expose the DTB via the UEFI configuration table. Merged with any
+/// MCFG-derived entries in [`crate::memory_map::derive_mmio_apertures`].
+pub fn default_pci_apertures() -> &'static [(u64, u64)]
+{
+    const ENTRIES: &[(u64, u64)] = &[
+        (0x3000_0000, 0x1000_0000),
+        (0x4000_0000, 0x4000_0000),
+        (0x4_0000_0000, 0x4_0000_0000),
+    ];
+    ENTRIES
+}
+
 /// Return the platform's maximum physical address width in bits.
 ///
 /// On RISC-V the Privileged spec caps physical addresses at 56 bits

--- a/core/boot/src/arch/x86_64/mod.rs
+++ b/core/boot/src/arch/x86_64/mod.rs
@@ -115,3 +115,55 @@ pub fn bsp_hardware_id(_boot_hart_id: u64) -> u32
 {
     0
 }
+
+/// Return the platform's maximum physical address width in bits.
+///
+/// Read from CPUID extended leaf `0x80000008`, EAX[7:0]. When the
+/// extended leaf is not advertised by the CPU (very old hardware), fall
+/// back to the IA-32e architectural minimum of 36 bits. The result
+/// determines where firmware and hypervisors place the 64-bit PCI MMIO
+/// window — see [`crate::acpi::parse_aperture_seed`].
+#[cfg(not(test))]
+pub fn max_phys_addr_bits() -> u8
+{
+    let max_ext: u32;
+    // SAFETY: CPUID leaf 0x80000000 is universally available on x86-64;
+    // rbx is callee-saved and reserved by LLVM in some codegen modes, so
+    // we save/restore it manually.
+    unsafe {
+        core::arch::asm!(
+            "push rbx",
+            "cpuid",
+            "pop rbx",
+            inout("eax") 0x8000_0000u32 => max_ext,
+            out("ecx") _,
+            out("edx") _,
+            options(nostack, nomem),
+        );
+    }
+    if max_ext < 0x8000_0008
+    {
+        return 36;
+    }
+    let eax: u32;
+    // SAFETY: leaf 0x80000008 is advertised by the preceding check.
+    unsafe {
+        core::arch::asm!(
+            "push rbx",
+            "cpuid",
+            "pop rbx",
+            inout("eax") 0x8000_0008u32 => eax,
+            out("ecx") _,
+            out("edx") _,
+            options(nostack, nomem),
+        );
+    }
+    let bits = (eax & 0xff) as u8;
+    if bits == 0 { 36 } else { bits }
+}
+
+#[cfg(test)]
+pub fn max_phys_addr_bits() -> u8
+{
+    48
+}

--- a/core/boot/src/arch/x86_64/mod.rs
+++ b/core/boot/src/arch/x86_64/mod.rs
@@ -116,6 +116,15 @@ pub fn bsp_hardware_id(_boot_hart_id: u64) -> u32
     0
 }
 
+/// No platform-default PCI apertures on x86-64.
+///
+/// q35 firmware always publishes MCFG, and BAR placement varies by
+/// machine and CPU MAXPHYADDR, so no single fixed seed makes sense.
+pub fn default_pci_apertures() -> &'static [(u64, u64)]
+{
+    &[]
+}
+
 /// Return the platform's maximum physical address width in bits.
 ///
 /// Read from CPUID extended leaf `0x80000008`, EAX[7:0]. When the

--- a/core/kernel/src/arch/riscv64/fpu.rs
+++ b/core/kernel/src/arch/riscv64/fpu.rs
@@ -326,6 +326,23 @@ pub unsafe fn switch_out_save(tcb: *mut crate::sched::thread::ThreadControlBlock
 #[cfg(test)]
 pub unsafe fn switch_out_save(_tcb: *mut crate::sched::thread::ThreadControlBlock) {}
 
+/// No-op on RISC-V: the trap path's `lazy_restore_fp_v` already restores
+/// extended state on the first U-mode FP/V instruction after switch-in,
+/// and that path is correct under every TCG version currently exercised.
+/// The function exists for arch-dispatch symmetry with x86-64, where
+/// eager restore avoids variation in TCG lazy-FPU emulation.
+///
+/// # Safety
+/// Accepts the unified arch-dispatch signature; ring discipline is
+/// enforced by the caller.
+#[cfg(not(test))]
+#[inline]
+pub unsafe fn switch_in_restore(_tcb: *mut crate::sched::thread::ThreadControlBlock) {}
+
+/// No-op test stub.
+#[cfg(test)]
+pub unsafe fn switch_in_restore(_tcb: *mut crate::sched::thread::ThreadControlBlock) {}
+
 /// Lazy-trap handler body: promote live `sstatus.FS` and `sstatus.VS` from
 /// Off to Initial, restore the F/D and V register files from `area` (when
 /// non-null), then mirror the resulting live FS/VS bits into `frame.sstatus`

--- a/core/kernel/src/arch/x86_64/fpu.rs
+++ b/core/kernel/src/arch/x86_64/fpu.rs
@@ -187,11 +187,17 @@ pub unsafe fn enable_xsave()
 
 /// Save the live x87/SSE/AVX state of the executing CPU into `area`.
 ///
-/// Uses XSAVEOPT to skip components untouched since the last save.
 /// `area` must be 64-byte aligned and point at a writable XSAVE buffer of
 /// at least [`xsave_area_size`] bytes. The component-mask passed in
-/// `EDX:EAX = 0xFFFF_FFFF_FFFF_FFFF` instructs XSAVEOPT to save every
-/// component that XCR0 currently enables.
+/// `EDX:EAX = 0xFFFF_FFFF_FFFF_FFFF` instructs XSAVE to write every
+/// component XCR0 currently enables; hardware intersects with XCR0, so
+/// the actual written set is exactly the OS-enabled components.
+///
+/// Plain XSAVE (not XSAVEOPT) is intentional: XSAVEOPT may skip writing
+/// components it tracks as "clean" since the last load, and the per-CPU
+/// tracking is only correct when both load and save paths use matching
+/// instructions consistently. XSAVE is unconditional and works the same
+/// on every implementation (hardware, KVM, TCG).
 ///
 /// # Safety
 /// Must execute at ring 0. `area` must satisfy the alignment and size
@@ -201,12 +207,12 @@ pub unsafe fn enable_xsave()
 #[inline]
 pub unsafe fn save_to(area: *mut u8)
 {
-    // SAFETY: caller's contract; XSAVEOPT requires OSXSAVE which the boot
+    // SAFETY: caller's contract; XSAVE requires OSXSAVE which the boot
     // path established. The component mask `0xFFFF_FFFF` (low 32 bits) is
     // intersected with XCR0 by hardware, so it saves exactly the enabled set.
     unsafe {
         core::arch::asm!(
-            "xsaveopt [{area}]",
+            "xsave [{area}]",
             area = in(reg) area,
             in("eax") 0xFFFF_FFFFu32,
             in("edx") 0xFFFF_FFFFu32,
@@ -266,6 +272,16 @@ pub unsafe fn switch_out_save(tcb: *mut crate::sched::thread::ThreadControlBlock
     // TCB's lifetime when non-null.
     let area = unsafe { (*tcb).extended.area };
     if area.is_null()
+    {
+        return;
+    }
+    // CR0.TS is the architected dirty bit for the extended-state register
+    // file: cleared by the `#NM` handler when this thread loads its area,
+    // set again here on switch-out. If it is still set, the thread has
+    // not touched FP/SIMD since the last switch-in, so the live registers
+    // belong to whichever thread last cleared TS — saving them into this
+    // thread's area would clobber it with another thread's state. Skip.
+    if read_cr0() & CR0_TS != 0
     {
         return;
     }

--- a/core/kernel/src/arch/x86_64/fpu.rs
+++ b/core/kernel/src/arch/x86_64/fpu.rs
@@ -275,23 +275,56 @@ pub unsafe fn switch_out_save(tcb: *mut crate::sched::thread::ThreadControlBlock
     {
         return;
     }
-    // CR0.TS is the architected dirty bit for the extended-state register
-    // file: cleared by the `#NM` handler when this thread loads its area,
-    // set again here on switch-out. If it is still set, the thread has
-    // not touched FP/SIMD since the last switch-in, so the live registers
-    // belong to whichever thread last cleared TS — saving them into this
-    // thread's area would clobber it with another thread's state. Skip.
-    if read_cr0() & CR0_TS != 0
+    // Eager save: the live extended-state register file always belongs to
+    // the outgoing thread because [`switch_in_restore`] reloaded it on
+    // switch-in. CR0.TS dirty-tracking is intentionally not used; the
+    // lazy-trap path varies in correctness across TCG versions
+    // (observed on QEMU 8.2 under `ubuntu-latest`).
+    // CR0.TS may already be clear (the matching switch_in_restore cleared
+    // it); ensure it is for XSAVE, which faults on TS=1.
+    // SAFETY: ring 0.
+    unsafe {
+        cr0_clear_ts();
+        save_to(area);
+    }
+}
+
+/// Context-switch hook called on switch-in of a user thread (the caller
+/// supplies a TCB whose `extended.area` is non-null): XRSTOR the saved
+/// register file into the live x87/SSE/AVX registers and clear CR0.TS so
+/// the thread resumes without an `#NM` trap.
+///
+/// Paired with [`switch_out_save`] to form an eager save/restore
+/// discipline that does not depend on `#NM`/CR0.TS lazy-trap semantics.
+///
+/// # Safety
+/// Must execute at ring 0 with interrupts disabled, after this thread's
+/// preceding `switch_out_save` has completed. `tcb` must be a valid TCB
+/// pointer; when its `extended.area` is non-null the area must satisfy
+/// the alignment and size requirements of [`restore_from`].
+#[cfg(not(test))]
+#[inline]
+pub unsafe fn switch_in_restore(tcb: *mut crate::sched::thread::ThreadControlBlock)
+{
+    // SAFETY: caller guarantees tcb is valid; the area is allocated for the
+    // TCB's lifetime when non-null.
+    let area = unsafe { (*tcb).extended.area };
+    if area.is_null()
     {
         return;
     }
-    // SAFETY: caller's contract.
+    // SAFETY: caller's contract; XRSTOR requires OSXSAVE which the boot
+    // path established.
     unsafe {
-        save_to(area);
-        cr0_set_ts();
+        cr0_clear_ts();
+        restore_from(area);
     }
 }
 
 /// No-op test stub.
 #[cfg(test)]
 pub unsafe fn switch_out_save(_tcb: *mut crate::sched::thread::ThreadControlBlock) {}
+
+/// No-op test stub.
+#[cfg(test)]
+pub unsafe fn switch_in_restore(_tcb: *mut crate::sched::thread::ThreadControlBlock) {}

--- a/core/kernel/src/sched/mod.rs
+++ b/core/kernel/src/sched/mod.rs
@@ -1604,18 +1604,26 @@ pub unsafe fn schedule(requeue_current: bool)
     }
 
     // Save the current thread's extended FPU/SIMD/V state to its per-TCB
-    // area before any other CPU can observe this thread as no-longer-current.
-    // switch_out_save is a no-op when the TCB has no extended-state area
-    // (kernel-only / idle threads, which the soft-float-everywhere kernel
-    // discipline never dirties).
+    // area before any other CPU can observe this thread as no-longer-current,
+    // then load the incoming thread's state into the live registers. The
+    // x86-64 path is eager (unconditional XSAVE + XRSTOR here); the RISC-V
+    // path keeps lazy FS/VS trap restore so `switch_in_restore` is a no-op
+    // there. Both calls no-op for kernel-only / idle threads (extended.area
+    // is null on those TCBs).
     if !current.is_null()
     {
-        // SAFETY: ring-0 with interrupts disabled and the scheduler
-        // lock held; arch fpu::switch_out_save handles the per-arch
-        // save discipline (XSAVEOPT on x86-64, FS/VS-dirty checks plus
-        // trap-frame FS/VS clear on RISC-V) and re-arms the lazy trap.
+        // SAFETY: ring-0 with interrupts disabled and the scheduler lock
+        // held; arch fpu::switch_out_save handles the per-arch save.
         unsafe {
             crate::arch::current::fpu::switch_out_save(current);
+        }
+    }
+    if !next.is_null()
+    {
+        // SAFETY: ring-0 with interrupts disabled and the scheduler lock
+        // held; arch fpu::switch_in_restore handles the per-arch restore.
+        unsafe {
+            crate::arch::current::fpu::switch_in_restore(next);
         }
     }
 

--- a/services/devmgr/src/main.rs
+++ b/services/devmgr/src/main.rs
@@ -286,6 +286,42 @@ fn discover_ecam(caps: &caps::DevmgrCaps) -> Option<firmware::EcamLocation>
     {
         return Some(loc);
     }
+    platform_default_ecam()
+}
+
+/// Platform-default ECAM when neither ACPI MCFG nor a DTB exposes one.
+///
+/// On RISC-V the QEMU `virt` machine has a stable, well-known PCI ECAM
+/// at `[0x3000_0000, 0x4000_0000)` for buses 0..=255. Some EDK2 builds
+/// shipped with distro packages (Ubuntu's `qemu-efi-riscv64`, observed
+/// on `ubuntu-latest` GitHub runners) publish ACPI but omit MCFG and do
+/// not re-expose the `OpenSBI` DTB through the UEFI configuration table,
+/// leaving both discovery paths empty. Falling back to the QEMU virt
+/// constants here keeps devmgr functional on those firmware builds.
+///
+/// On x86-64 no comparable single-target fallback exists; the function
+/// returns `None` so the boot halts and the missing firmware is
+/// surfaced explicitly. New RISC-V hardware that diverges from QEMU
+/// virt will need real `_CRS` parsing or a DTB published by its
+/// firmware — replace this stub at that point.
+// The `Option` return is the unified call-site shape; the riscv64
+// arm always succeeds, but `discover_ecam` chains it after two
+// fallible firmware probes that may also yield `Some(...)`.
+#[allow(clippy::unnecessary_wraps)]
+#[cfg(target_arch = "riscv64")]
+fn platform_default_ecam() -> Option<firmware::EcamLocation>
+{
+    Some(firmware::EcamLocation {
+        phys_base: 0x3000_0000,
+        size: 0x1000_0000,
+        start_bus: 0,
+        end_bus: 255,
+    })
+}
+
+#[cfg(not(target_arch = "riscv64"))]
+fn platform_default_ecam() -> Option<firmware::EcamLocation>
+{
     None
 }
 

--- a/xtask/src/commands/run_parallel.rs
+++ b/xtask/src/commands/run_parallel.rs
@@ -239,8 +239,30 @@ pub fn run(ctx: &BuildContext, args: &RunParallelArgs) -> Result<()>
         dispatched += wave_size;
     }
 
-    print_summary(args, &workdir, &outcomes);
+    let summary = print_summary(args, &workdir, &outcomes);
+    print_failing_tails(&workdir, &outcomes);
+    if summary.pass != args.runs
+    {
+        bail!(
+            "run-parallel: {}/{} runs passed (ok={} fail={} hang={} err={})",
+            summary.pass,
+            args.runs,
+            summary.ok,
+            summary.fail,
+            summary.hang,
+            summary.err,
+        );
+    }
     Ok(())
+}
+
+struct Summary
+{
+    pass: u32,
+    ok: u32,
+    fail: u32,
+    hang: u32,
+    err: u32,
 }
 
 fn validate_args(args: &RunParallelArgs) -> Result<()>
@@ -440,23 +462,25 @@ fn format_outcome_line(outcome: &RunOutcome) -> String
     }
 }
 
-fn print_summary(args: &RunParallelArgs, workdir: &Path, outcomes: &[RunOutcome])
+fn print_summary(args: &RunParallelArgs, workdir: &Path, outcomes: &[RunOutcome]) -> Summary
 {
-    let mut pass = 0u32;
-    let mut ok = 0u32;
-    let mut fail = 0u32;
-    let mut hang = 0u32;
-    let mut err = 0u32;
+    let mut summary = Summary {
+        pass: 0,
+        ok: 0,
+        fail: 0,
+        hang: 0,
+        err: 0,
+    };
     let mut non_hang_us: Vec<u128> = Vec::with_capacity(outcomes.len());
     for o in outcomes
     {
         match o.status
         {
-            Status::Pass => pass += 1,
-            Status::Ok => ok += 1,
-            Status::Fail => fail += 1,
-            Status::Hang => hang += 1,
-            Status::Err(_) => err += 1,
+            Status::Pass => summary.pass += 1,
+            Status::Ok => summary.ok += 1,
+            Status::Fail => summary.fail += 1,
+            Status::Hang => summary.hang += 1,
+            Status::Err(_) => summary.err += 1,
         }
         if !matches!(o.status, Status::Hang)
         {
@@ -472,7 +496,7 @@ fn print_summary(args: &RunParallelArgs, workdir: &Path, outcomes: &[RunOutcome]
     );
     println!(
         "pass={}  ok={}  fail={}  hang={}  err={}",
-        pass, ok, fail, hang, err
+        summary.pass, summary.ok, summary.fail, summary.hang, summary.err,
     );
     if let (Some(&min_us), Some(&max_us)) = (non_hang_us.first(), non_hang_us.last())
     {
@@ -485,6 +509,71 @@ fn print_summary(args: &RunParallelArgs, workdir: &Path, outcomes: &[RunOutcome]
         );
     }
     println!("logs preserved under {}", workdir.display());
+    summary
+}
+
+/// Per-run log tail: last `TAIL_LINES` lines, hard-capped at `TAIL_BYTES`.
+///
+/// Surfacing failing logs inline lets a CI step's own stdout convey the
+/// proximate failure without requiring an artifact download. The cap
+/// guards against multi-megabyte QEMU traces dominating job output.
+const TAIL_LINES: usize = 20;
+const TAIL_BYTES: usize = 4096;
+
+fn print_failing_tails(workdir: &Path, outcomes: &[RunOutcome])
+{
+    let failing: Vec<&RunOutcome> = outcomes
+        .iter()
+        .filter(|o| !matches!(o.status, Status::Pass | Status::Ok))
+        .collect();
+    if failing.is_empty()
+    {
+        return;
+    }
+    println!("===== failing-run tails =====");
+    for o in failing
+    {
+        let Some(prefix) = o.status.log_prefix()
+        else
+        {
+            continue;
+        };
+        let log_path = workdir.join(format!("{}-{}.log", prefix, o.run));
+        println!(
+            "--- run={} status={} log={}",
+            o.run,
+            o.status.label(),
+            log_path.display(),
+        );
+        let body = read_log(&log_path).unwrap_or_default();
+        let tail = tail_text(&body, TAIL_LINES, TAIL_BYTES);
+        if tail.is_empty()
+        {
+            println!("(no log content captured)");
+        }
+        else
+        {
+            println!("{}", tail);
+        }
+    }
+}
+
+fn tail_text(body: &str, max_lines: usize, max_bytes: usize) -> String
+{
+    let lines: Vec<&str> = body.lines().collect();
+    let start = lines.len().saturating_sub(max_lines);
+    let mut tail: String = lines[start..].join("\n");
+    if tail.len() > max_bytes
+    {
+        let drop = tail.len() - max_bytes;
+        let mut cut = drop;
+        while !tail.is_char_boundary(cut) && cut < tail.len()
+        {
+            cut += 1;
+        }
+        tail = tail.split_off(cut);
+    }
+    tail
 }
 
 fn us_to_s(us: u128) -> f64

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -102,11 +102,12 @@ fn extend_x86(args: &mut Vec<String>, spec: &QemuLaunchSpec)
 {
     args.extend(["-machine".into(), "q35".into()]);
 
-    // KVM acceleration when /dev/kvm is present (local dev); fall back to
-    // multi-threaded TCG otherwise (CI runners, KVM-less containers). The
-    // riscv64 path is always TCG; this mirrors its `-accel tcg,thread=multi`
-    // shape when KVM is unavailable.
-    if Path::new("/dev/kvm").exists()
+    // Existence is insufficient: GitHub `ubuntu-latest` x86 runners expose
+    // /dev/kvm for nested virt, but the runner user is not in the `kvm`
+    // group, so `open(O_RDWR)` returns EACCES and QEMU exits immediately.
+    // Probe the same way QEMU itself does, then fall through to TCG when
+    // the device cannot actually be used.
+    if kvm_usable()
     {
         // -cpu host inherits the development host's microarchitecture; the
         // kernel asserts x86-64-v3 in early init, so the host must advertise
@@ -192,6 +193,24 @@ fn extend_riscv(args: &mut Vec<String>, spec: &QemuLaunchSpec)
             ]);
         }
     }
+}
+
+/// Returns true if `/dev/kvm` can be opened for read+write by the current
+/// process. Existence alone is misleading on environments that expose the
+/// node without granting the calling user access (e.g. GitHub-hosted
+/// runners). Setting `SERAPH_NO_KVM=1` forces the TCG path regardless,
+/// for local reproduction of the no-KVM CI environment.
+fn kvm_usable() -> bool
+{
+    if std::env::var_os("SERAPH_NO_KVM").is_some()
+    {
+        return false;
+    }
+    std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open("/dev/kvm")
+        .is_ok()
 }
 
 /// Locate the OVMF code image, returning the first installed path.


### PR DESCRIPTION
## Summary

x86_64 CI was silently green while QEMU exited rc=1 in ~50ms without ever booting the kernel. Three layered defects compounded; surfaced two more once the silent-pass bug was fixed.

- **CI integrity**: `xtask run-parallel` returned `Ok(())` regardless of outcome; failures were unobservable to GitHub Actions and per-run logs were uploaded only `if: failure()`, so they were never preserved.
- **KVM probe**: `extend_x86` gated `-enable-kvm -cpu host` on `Path::exists("/dev/kvm")`. `ubuntu-latest` x86 runners expose `/dev/kvm` for nested virt but deny `O_RDWR` to the `runner` user, so QEMU bailed pre-boot.
- **Bootloader 64-bit PCI aperture (x86-64)**: hardcoded `[16 GiB, 32 GiB)` did not cover where firmware places the BAR on `-cpu max` TCG. Now derived from CPUID MAXPHYADDR; the riscv64 branch keeps its known-good QEMU virt offsets.
- **Bootloader PCI apertures (riscv64)**: Ubuntu's `qemu-efi-riscv64` EDK2 publishes ACPI without MCFG and doesn't expose the DTB through the UEFI configuration table, so no PCI apertures were seeded. The bootloader now appends the known QEMU virt PCI windows unconditionally on riscv64.
- **devmgr ECAM discovery (riscv64)**: same firmware gap — devmgr now falls back to the QEMU virt ECAM constants when both ACPI MCFG and DTB discovery come up empty.
- **Kernel x86-64 FPU save/restore**: lazy CR0.TS-gated `XSAVE`/`XRSTOR` worked under QEMU 11 TCG and KVM but reliably crashed with `rip=0` under QEMU 8.2.2 TCG (the version on `ubuntu-latest`). Switched x86-64 to eager save/restore. Proper long-term lazy fix tracked in #65 against the v0.1.0 milestone.

Closes #62

## Acceptance

- [x] `xtask run-parallel` exits non-zero when not every run passes the `--pass` regex.
- [x] When `fail + hang + err > 0`, run-parallel prints a post-summary block tailing each failing run's log inline on stdout.
- [x] `xtask/src/qemu.rs::extend_x86` probes `/dev/kvm` by attempting `OpenOptions::new().read(true).write(true).open(...)` instead of `Path::exists`.
- [x] `.github/workflows/build-test.yml` run-parallel log artifact uploaded `if: always()`.
- [x] `.github/workflows/burnin.yml` both run-parallel log artifacts uploaded `if: always()`.
- [x] Post-fix CI run for x86_64 (`validate (x86_64, debug)` and `validate (x86_64, release)`) is honestly green, having executed under TCG.

## Test plan

- [x] `cargo xtask build` (x86_64) — clippy `-D warnings` clean
- [x] `cargo xtask build --arch riscv64` — clippy clean
- [x] `cargo xtask run-parallel --arch x86_64` (KVM path, usertest + ktest) — PASS
- [x] `SERAPH_NO_KVM=1 cargo xtask run-parallel --arch x86_64` (TCG path, usertest + ktest) — PASS (was: ERR rc=1 then HANG)
- [x] `cargo xtask run-parallel --arch riscv64` (usertest + ktest) — PASS, no regression
- [x] `xtask run-parallel` correctly bails non-zero on synthetic failure and prints the failing-log tail inline
- [x] PR CI: all five jobs green (host-tests, validate x86_64 debug/release, validate riscv64 debug/release).

## Notes

`SERAPH_NO_KVM=1` is a documented test knob to force the TCG path locally; intended for reproducing the CI environment.

The riscv64 ECAM/aperture fallbacks are explicitly platform-coupled to QEMU virt; rustdoc on both sites states that real RISC-V hardware diverging from QEMU virt will need to publish PCIE info via `_CRS` or a DTB and these stubs replaced.

#65 tracks the eager-FPU follow-up for v0.1.0: restore the lazy-save optimization once the QEMU 8.2 TCG behavior is understood (or via a per-CPU `fpu_owner` cache that doesn't depend on CR0.TS).