### PR TITLE
logd, init, procmgr, kernel, caps: real logd + full init reap + cap hygiene

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,6 +478,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "logd"
+version = "0.1.0"
+dependencies = [
+ "ipc",
+ "syscall",
+ "syscall-abi",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "services/procmgr",
     "services/svcmgr",
     "services/devmgr",
+    "services/logd",
     "services/pwrmgr",
     "services/vfsd",
     "services/drivers/virtio/core",

--- a/abi/init-protocol/src/lib.rs
+++ b/abi/init-protocol/src/lib.rs
@@ -36,7 +36,7 @@
 /// v4: Added `cspace_cap` slot for init's own `CSpace` cap.
 /// v3: Added `cmdline_offset`, `cmdline_len`, and `sbi_control_cap` for kernel
 ///     command line passthrough and RISC-V SBI forwarding.
-pub const INIT_PROTOCOL_VERSION: u32 = 5;
+pub const INIT_PROTOCOL_VERSION: u32 = 6;
 
 // ── Address space constants ──────────────────────────────────────────────────
 
@@ -178,6 +178,32 @@ pub struct InitInfo
     /// Slot index of the read-only `Frame` cap covering the DTB blob,
     /// or zero if no DTB was supplied (pure-ACPI platforms).
     pub dtb_frame_cap: u32,
+
+    // ── Init self-reclaim cap surfaces (added in protocol v6) ───────────
+    /// First slot index of init's user stack `Frame` caps.
+    ///
+    /// Each cap covers one 4 KiB stack page; init holds
+    /// `init_stack_frame_count` consecutive caps starting at this slot.
+    /// Used by init's reap-handoff (`procmgr.REGISTER_INIT_TEARDOWN`) to
+    /// donate the stack pages back to memmgr's pool after init's
+    /// `AddressSpace` is torn down. Zero if the kernel did not mint stack
+    /// caps (legacy boot path).
+    pub init_stack_frame_base: u32,
+    /// Number of stack `Frame` caps (typically `INIT_STACK_PAGES = 4`).
+    pub init_stack_frame_count: u32,
+
+    /// First slot index of init's `InitInfo`-region `Frame` caps.
+    ///
+    /// Each cap covers one 4 KiB page of the kernel-allocated
+    /// `InitInfo` region (header + `CapDescriptor` array + command
+    /// line). Donated alongside the stack caps in init's reap-handoff.
+    /// The cap range includes the page that contains this `InitInfo`
+    /// struct itself — once init has read `InitInfo` at `_start`, the
+    /// pages can be reclaimed safely. Zero if the kernel did not mint
+    /// `InitInfo` caps (legacy boot path).
+    pub init_info_frame_base: u32,
+    /// Number of `InitInfo` `Frame` caps (1..=[`INIT_INFO_MAX_PAGES`]).
+    pub init_info_frame_count: u32,
 
     /// Explicit 4-byte tail pad so `size_of::<InitInfo>()` stays 8-byte
     /// aligned. Consumers of `cap_descriptors_offset` rely on this: the

--- a/abi/process-abi/src/lib.rs
+++ b/abi/process-abi/src/lib.rs
@@ -37,7 +37,7 @@ use core::prelude::rust_2024::*;
 
 /// Process ABI version. Incremented on any breaking change to the
 /// [`ProcessInfo`] layout or field semantics.
-pub const PROCESS_ABI_VERSION: u32 = 13;
+pub const PROCESS_ABI_VERSION: u32 = 14;
 
 // ── Address space constants ──────────────────────────────────────────────────
 
@@ -370,10 +370,28 @@ pub struct ProcessInfo
     /// it merely lets the holder request a freshly-minted tokened cap.
     /// Distributing it widely is therefore harmless.
     ///
-    /// Zero when no logger is reachable (very early boot, processes
-    /// created before the log infrastructure is wired). Logger-using
-    /// callers must tolerate zero (writes silently drop).
-    pub log_discovery_cap: u32,
+    /// `CSpace` slot of a tokened SEND cap on the system log endpoint
+    /// suitable for direct `STREAM_BYTES` / `STREAM_REGISTER_NAME`
+    /// use.
+    ///
+    /// Procmgr derives this cap per spawn via `cap_derive_token` on
+    /// the log endpoint it holds, using the child's procmgr-assigned
+    /// token as the cap's token. Logd sees the same token on every
+    /// IPC the child makes, keys its per-sender slot map by it, and
+    /// matches it directly against the death-notification correlator
+    /// procmgr posts on child exit.
+    ///
+    /// Zero when no logger is reachable (init, memmgr, procmgr
+    /// themselves; processes spawned before the log endpoint exists).
+    /// `seraph::log!` silently drops in that case.
+    ///
+    /// History note (not part of the field's contract): pre-pivot
+    /// this slot held an *un-tokened* discovery cap; callers issued
+    /// `GET_LOG_CAP` to lazy-acquire a tokened cap on first log. The
+    /// discovery path still exists in init-logd and real-logd for
+    /// pre-handover live writers that already acquired their tokened
+    /// caps under it; new spawns skip it entirely.
+    pub log_send_cap: u32,
 
     // ── Stdio pipe wakeup signals ──────────────────────────────────────
     //

--- a/abi/process-abi/src/lib.rs
+++ b/abi/process-abi/src/lib.rs
@@ -361,15 +361,6 @@ pub struct ProcessInfo
     /// is installed (e.g. via `std::env::set_current_dir`).
     pub current_dir_cap: u32,
 
-    /// `CSpace` slot of an un-tokened SEND cap on the system log endpoint
-    /// (the *discovery* cap).
-    ///
-    /// Used by the `seraph::log!` macro path to lazy-acquire a tokened
-    /// SEND cap on first call, via the `log_labels::GET_LOG_CAP` IPC. The
-    /// discovery cap by itself grants no identity and no observability —
-    /// it merely lets the holder request a freshly-minted tokened cap.
-    /// Distributing it widely is therefore harmless.
-    ///
     /// `CSpace` slot of a tokened SEND cap on the system log endpoint
     /// suitable for direct `STREAM_BYTES` / `STREAM_REGISTER_NAME`
     /// use.
@@ -384,13 +375,6 @@ pub struct ProcessInfo
     /// Zero when no logger is reachable (init, memmgr, procmgr
     /// themselves; processes spawned before the log endpoint exists).
     /// `seraph::log!` silently drops in that case.
-    ///
-    /// History note (not part of the field's contract): pre-pivot
-    /// this slot held an *un-tokened* discovery cap; callers issued
-    /// `GET_LOG_CAP` to lazy-acquire a tokened cap on first log. The
-    /// discovery path still exists in init-logd and real-logd for
-    /// pre-handover live writers that already acquired their tokened
-    /// caps under it; new spawns skip it entirely.
     pub log_send_cap: u32,
 
     // ── Stdio pipe wakeup signals ──────────────────────────────────────

--- a/core/kernel/src/main.rs
+++ b/core/kernel/src/main.rs
@@ -357,6 +357,15 @@ pub extern "C" fn kernel_entry(boot_info: *const BootInfo) -> !
                 .unwrap_or_else(|_| fatal("Phase 9: cannot insert init AddressSpace cap"));
 
             // Frame caps for each init segment (phys base + size + permissions).
+            // Minted reclaimable: full byte ledger + `owns_memory = true` +
+            // `register_owned_range` so init's reap-handoff donation
+            // (`procmgr.REGISTER_INIT_TEARDOWN` → `memmgr.DONATE_FRAMES`)
+            // can route these pages into memmgr's pool, and any cascade-
+            // delete via `dealloc_object` returns them to the buddy. The
+            // segments live in EFI LoaderData (not in the buddy free list
+            // at boot — see `mm/init.rs` exclusion list), so the buddy
+            // must register them as managed-but-not-free before a
+            // subsequent `free_range` can balance the page accounting.
             let seg_count = init_image.segment_count as usize;
             let mut seg_base: u32 = 0;
             for i in 0..seg_count
@@ -364,9 +373,9 @@ pub extern "C" fn kernel_entry(boot_info: *const BootInfo) -> !
                 let seg = &init_image.segments[i];
                 let rights = match seg.flags
                 {
-                    SegmentFlags::Read => Rights::MAP,
-                    SegmentFlags::ReadWrite => Rights::MAP | Rights::WRITE,
-                    SegmentFlags::ReadExecute => Rights::MAP | Rights::EXECUTE,
+                    SegmentFlags::Read => Rights::MAP | Rights::RETYPE,
+                    SegmentFlags::ReadWrite => Rights::MAP | Rights::WRITE | Rights::RETYPE,
+                    SegmentFlags::ReadExecute => Rights::MAP | Rights::EXECUTE | Rights::RETYPE,
                 };
                 // The bootloader encodes the ELF in-page offset into
                 // `phys_addr` so `map_segment` can preserve
@@ -379,6 +388,14 @@ pub extern "C" fn kernel_entry(boot_info: *const BootInfo) -> !
                 let phys_aligned = seg.phys_addr & !page_mask;
                 let in_page_off = seg.phys_addr & page_mask;
                 let size_aligned = (in_page_off + seg.size + page_mask) & !page_mask;
+                // SAFETY: segment phys range is disjoint from buddy
+                // free list (excluded in `mm/init.rs::collect_exclusions`)
+                // and from boot module ranges; single-threaded boot.
+                unsafe {
+                    crate::mm::with_frame_allocator(|alloc| {
+                        alloc.register_owned_range(phys_aligned, size_aligned);
+                    });
+                }
                 let fo_nn = cap::mint_phase7_body(FrameObject {
                     header: KernelObjectHeader::with_ancestor(
                         ObjectType::Frame,
@@ -386,11 +403,8 @@ pub extern "C" fn kernel_entry(boot_info: *const BootInfo) -> !
                     ),
                     base: phys_aligned,
                     size: size_aligned,
-                    // Init ELF segment: not retypable; cap minted without RETYPE.
-                    available_bytes: core::sync::atomic::AtomicU64::new(0),
-                    // Init ELF segments are bootloader-loaded pages outside
-                    // the buddy pool; never return them.
-                    owns_memory: core::sync::atomic::AtomicBool::new(false),
+                    available_bytes: core::sync::atomic::AtomicU64::new(size_aligned),
+                    owns_memory: core::sync::atomic::AtomicBool::new(true),
                     allocator: crate::cap::retype::RetypeAllocator::new_inline(),
                     lock: core::sync::atomic::AtomicU32::new(0),
                 });
@@ -413,8 +427,13 @@ pub extern "C" fn kernel_entry(boot_info: *const BootInfo) -> !
         // ── Populate InitInfo region ─────────────────────────────────────────
         // Allocate enough physical pages for InitInfo + CapDescriptor array +
         // command line, fill them via the direct map, then map read-only into
-        // init's address space starting at INIT_INFO_VADDR.
+        // init's address space starting at INIT_INFO_VADDR. Each backing page
+        // also gets a reclaimable Frame cap minted into init's CSpace so the
+        // pages flow into memmgr's pool through init's reap-handoff donate
+        // path (see `services/init/src/service.rs` end-of-phase-3).
         let info_page_virt = {
+            use cap::object::{FrameObject, KernelObjectHeader, ObjectType};
+            use cap::slot::{CapTag, Rights};
             use init_protocol::{INIT_INFO_VADDR, INIT_PROTOCOL_VERSION, InitInfo};
 
             let descriptors_offset = core::mem::size_of::<InitInfo>() as u32;
@@ -452,6 +471,8 @@ pub extern "C" fn kernel_entry(boot_info: *const BootInfo) -> !
             }
             let mut page_ptrs: [*mut u8; init_protocol::INIT_INFO_MAX_PAGES] =
                 [core::ptr::null_mut(); init_protocol::INIT_INFO_MAX_PAGES];
+            let mut page_phys: [u64; init_protocol::INIT_INFO_MAX_PAGES] =
+                [0u64; init_protocol::INIT_INFO_MAX_PAGES];
 
             for pg in 0..info_pages
             {
@@ -466,6 +487,7 @@ pub extern "C" fn kernel_entry(boot_info: *const BootInfo) -> !
                 unsafe { (*init_as_ptr).map_page(map_va, phys, flags) }
                     .unwrap_or_else(|()| fatal("Phase 9: failed to map InitInfo page"));
                 page_ptrs[pg] = virt;
+                page_phys[pg] = phys;
             }
             let info_base = page_ptrs[0];
 
@@ -503,6 +525,10 @@ pub extern "C" fn kernel_entry(boot_info: *const BootInfo) -> !
                 acpi_region_frame_base: cspace_layout.acpi_region_frame_base,
                 acpi_region_frame_count: cspace_layout.acpi_region_frame_count,
                 dtb_frame_cap: cspace_layout.dtb_frame_slot,
+                init_stack_frame_base: 0,  // patched after stack mint
+                init_stack_frame_count: 0, // patched after stack mint
+                init_info_frame_base: 0,   // patched after self-mint below
+                init_info_frame_count: 0,  // patched after self-mint below
                 _pad_tail: 0,
             };
 
@@ -547,6 +573,61 @@ pub extern "C" fn kernel_entry(boot_info: *const BootInfo) -> !
                 }
             }
 
+            // Mint a reclaimable Frame cap per InitInfo page so init's
+            // reap-handoff donates the pages back to memmgr after AS
+            // teardown. Caps carry MAP|READ rights (matching the
+            // userspace mapping) and the standard reclaim flags
+            // (RETYPE + owns_memory=true + full ledger).
+            // SAFETY: ROOT_CSPACE initialised in Phase 7; single-threaded boot.
+            let cs = unsafe { cap::root_cspace_mut() }
+                .unwrap_or_else(|| fatal("Phase 9: ROOT_CSPACE missing for InitInfo mint"));
+            let mut info_frame_base_slot: u32 = 0;
+            for pg in 0..info_pages
+            {
+                let phys = page_phys[pg];
+                // SAFETY: page was just buddy-allocated above and is not
+                // double-registered; single-threaded boot.
+                unsafe {
+                    crate::mm::with_frame_allocator(|alloc| {
+                        alloc.register_owned_range(phys, mm::PAGE_SIZE as u64);
+                    });
+                }
+                let fo_nn = cap::mint_phase7_body(FrameObject {
+                    header: KernelObjectHeader::with_ancestor(
+                        ObjectType::Frame,
+                        cap::seed_header_nn(),
+                    ),
+                    base: phys,
+                    size: mm::PAGE_SIZE as u64,
+                    available_bytes: core::sync::atomic::AtomicU64::new(mm::PAGE_SIZE as u64),
+                    owns_memory: core::sync::atomic::AtomicBool::new(true),
+                    allocator: crate::cap::retype::RetypeAllocator::new_inline(),
+                    lock: core::sync::atomic::AtomicU32::new(0),
+                });
+                let slot = cs
+                    .insert_cap(
+                        CapTag::Frame,
+                        Rights::MAP | Rights::READ | Rights::RETYPE,
+                        fo_nn,
+                    )
+                    .unwrap_or_else(|_| fatal("Phase 9: cannot insert InitInfo Frame cap"));
+                if pg == 0
+                {
+                    info_frame_base_slot = slot.get();
+                }
+            }
+
+            // Patch the just-written InitInfo header with the self-
+            // referential cap slot range.
+            // SAFETY: info_base mapped writable through the direct map;
+            // header lives at offset 0; single-threaded boot.
+            #[allow(clippy::cast_ptr_alignment)]
+            unsafe {
+                let info_ptr = info_base.cast::<InitInfo>();
+                (*info_ptr).init_info_frame_base = info_frame_base_slot;
+                (*info_ptr).init_info_frame_count = info_pages as u32;
+            }
+
             kprintln!(
                 "init: info at {:#x} ({} cap descriptors, {} pages)",
                 INIT_INFO_VADDR,
@@ -554,19 +635,102 @@ pub extern "C" fn kernel_entry(boot_info: *const BootInfo) -> !
                 info_pages,
             );
 
+            // Suppress unused-variable warnings: both values were already
+            // patched into InitInfo above; the block returns only the
+            // direct-map pointer that callers use for further patching.
+            let _ = (info_frame_base_slot, info_pages);
             info_base
         };
 
-        // Map init's user stack (INIT_STACK_PAGES pages below INIT_STACK_TOP).
-        // SAFETY: init_as_ptr valid (allocated above); stack_top is page-aligned
-        // constant within user address range; frame allocator validated in Phase 2.
+        // Map init's user stack (INIT_STACK_PAGES pages below INIT_STACK_TOP)
+        // and mint a reclaimable Frame cap for each backing page. Inlined
+        // (rather than calling `map_stack`) so we capture each phys address
+        // for cap minting; `register_owned_range` accounts for the pages so
+        // dealloc-driven `free_range` keeps the buddy ledger balanced.
+        let (init_stack_frame_base, init_stack_frame_count) = {
+            use cap::object::{FrameObject, KernelObjectHeader, ObjectType};
+            use cap::slot::{CapTag, Rights};
+
+            const STACK_PAGES: usize = mm::address_space::INIT_STACK_PAGES;
+            let stack_top = mm::address_space::INIT_STACK_TOP;
+            let rw_flags = mm::paging::PageFlags {
+                readable: true,
+                writable: true,
+                executable: false,
+                uncacheable: false,
+            };
+
+            // SAFETY: ROOT_CSPACE initialised in Phase 7; single-threaded boot.
+            let cs = unsafe { cap::root_cspace_mut() }
+                .unwrap_or_else(|| fatal("Phase 9: ROOT_CSPACE missing for stack mint"));
+
+            let mut base_slot: u32 = 0;
+            for i in 0..STACK_PAGES
+            {
+                let phys = crate::mm::with_frame_allocator(|alloc| alloc.alloc(0))
+                    .unwrap_or_else(|| fatal("Phase 9: cannot allocate init stack page"));
+
+                // Zero the page through the kernel direct map.
+                // SAFETY: phys_to_virt yields a valid kernel virtual address.
+                unsafe {
+                    let virt = mm::paging::phys_to_virt(phys);
+                    core::ptr::write_bytes(virt as *mut u8, 0, mm::PAGE_SIZE);
+                }
+
+                let virt = stack_top - ((i + 1) * mm::PAGE_SIZE) as u64;
+                // SAFETY: virt in user range; phys freshly allocated.
+                unsafe {
+                    (*init_as_ptr)
+                        .map_page(virt, phys, rw_flags)
+                        .unwrap_or_else(|()| fatal("Phase 9: failed to map init stack page"));
+                }
+
+                // Register and mint a reclaimable Frame cap covering this page.
+                // SAFETY: page just allocated from the buddy and not yet
+                // double-registered; single-threaded boot.
+                unsafe {
+                    crate::mm::with_frame_allocator(|alloc| {
+                        alloc.register_owned_range(phys, mm::PAGE_SIZE as u64);
+                    });
+                }
+                let fo_nn = cap::mint_phase7_body(FrameObject {
+                    header: KernelObjectHeader::with_ancestor(
+                        ObjectType::Frame,
+                        cap::seed_header_nn(),
+                    ),
+                    base: phys,
+                    size: mm::PAGE_SIZE as u64,
+                    available_bytes: core::sync::atomic::AtomicU64::new(mm::PAGE_SIZE as u64),
+                    owns_memory: core::sync::atomic::AtomicBool::new(true),
+                    allocator: crate::cap::retype::RetypeAllocator::new_inline(),
+                    lock: core::sync::atomic::AtomicU32::new(0),
+                });
+                let slot = cs
+                    .insert_cap(
+                        CapTag::Frame,
+                        Rights::MAP | Rights::READ | Rights::WRITE | Rights::RETYPE,
+                        fo_nn,
+                    )
+                    .unwrap_or_else(|_| fatal("Phase 9: cannot insert init stack Frame cap"));
+                if i == 0
+                {
+                    base_slot = slot.get();
+                }
+            }
+            // The guard page (one page below the stack) is intentionally left
+            // unmapped: accessing it will fault, catching stack overflows.
+            (base_slot, STACK_PAGES as u32)
+        };
+
+        // Patch InitInfo with the just-minted stack cap slot range.
+        // SAFETY: info_page_virt mapped writable through the direct map;
+        // header at offset 0; single-threaded boot.
+        #[allow(clippy::cast_ptr_alignment)]
         unsafe {
-            (*init_as_ptr).map_stack(
-                mm::address_space::INIT_STACK_TOP,
-                mm::address_space::INIT_STACK_PAGES,
-            )
+            let info_ptr = info_page_virt.cast::<init_protocol::InitInfo>();
+            (*info_ptr).init_stack_frame_base = init_stack_frame_base;
+            (*info_ptr).init_stack_frame_count = init_stack_frame_count;
         }
-        .unwrap_or_else(|()| fatal("Phase 9: failed to map init stack"));
 
         // Retype a 6-page slab from SEED_FRAME for init's Thread:
         //   pages 0..3 — kernel stack (KERNEL_STACK_PAGES = 4 = 16 KiB)

--- a/core/kernel/src/main.rs
+++ b/core/kernel/src/main.rs
@@ -585,13 +585,10 @@ pub extern "C" fn kernel_entry(boot_info: *const BootInfo) -> !
             for pg in 0..info_pages
             {
                 let phys = page_phys[pg];
-                // SAFETY: page was just buddy-allocated above and is not
-                // double-registered; single-threaded boot.
-                unsafe {
-                    crate::mm::with_frame_allocator(|alloc| {
-                        alloc.register_owned_range(phys, mm::PAGE_SIZE as u64);
-                    });
-                }
+                // No register_owned_range: these pages came from the
+                // buddy via `alloc.alloc(0)` above, so they are already
+                // in `total_pages`. `register_owned_range` would
+                // double-count.
                 let fo_nn = cap::mint_phase7_body(FrameObject {
                     header: KernelObjectHeader::with_ancestor(
                         ObjectType::Frame,
@@ -635,10 +632,6 @@ pub extern "C" fn kernel_entry(boot_info: *const BootInfo) -> !
                 info_pages,
             );
 
-            // Suppress unused-variable warnings: both values were already
-            // patched into InitInfo above; the block returns only the
-            // direct-map pointer that callers use for further patching.
-            let _ = (info_frame_base_slot, info_pages);
             info_base
         };
 
@@ -685,14 +678,11 @@ pub extern "C" fn kernel_entry(boot_info: *const BootInfo) -> !
                         .unwrap_or_else(|()| fatal("Phase 9: failed to map init stack page"));
                 }
 
-                // Register and mint a reclaimable Frame cap covering this page.
-                // SAFETY: page just allocated from the buddy and not yet
-                // double-registered; single-threaded boot.
-                unsafe {
-                    crate::mm::with_frame_allocator(|alloc| {
-                        alloc.register_owned_range(phys, mm::PAGE_SIZE as u64);
-                    });
-                }
+                // Mint a reclaimable Frame cap covering this page.
+                // No register_owned_range: the page came from the
+                // buddy via `alloc.alloc(0)` above, so it is already
+                // in `total_pages`. `register_owned_range` would
+                // double-count.
                 let fo_nn = cap::mint_phase7_body(FrameObject {
                     header: KernelObjectHeader::with_ancestor(
                         ObjectType::Frame,

--- a/core/ktest/src/unit/mm.rs
+++ b/core/ktest/src/unit/mm.rs
@@ -13,8 +13,14 @@
 //!   `aspace_cap + 2` — RODATA segment frame (MAP)
 //!   `aspace_cap + 3` — BSS/DATA segment frame (MAP | WRITE)
 //!
-//! `frame_split` consumes the RODATA frame (`aspace_cap + 2`). TEXT and BSS
-//! frames are left intact for the tests that use them directly.
+//! Segment Frame caps own their physical memory (the kernel mints them with
+//! `owns_memory=true` so the init-reap donation cascade can return them to
+//! memmgr). Tests therefore MUST NOT `cap_delete` or otherwise dec-ref a
+//! segment cap (or a tail derived from one) while the segment is still
+//! mapped in ktest's own address space — the dealloc would buddy-free phys
+//! pages still referenced by live PTEs and silently alias future allocations.
+//! Split/merge/delete exercises operate on pool-allocated frames; segments
+//! are read-only test surfaces for `mem_map` / `mem_protect`.
 
 use syscall::{MAP_READONLY, MAP_WRITABLE, aspace_query, mem_map, mem_unmap};
 
@@ -26,7 +32,7 @@ const TEST_VA: u64 = 0x4000_0000;
 
 // ── SYS_FRAME_SPLIT / SYS_FRAME_MERGE ─────────────────────────────────────────
 
-/// Split-merge round-trip on the RODATA frame (Option D semantics).
+/// Split-merge round-trip on the RODATA segment cap (Option D semantics).
 ///
 /// Validates the full inverse relationship between `frame_split` and
 /// `frame_merge`:
@@ -40,16 +46,18 @@ const TEST_VA: u64 = 0x4000_0000;
 /// 4. The merged cap can be re-split at the same offset, proving the
 ///    merge correctly restored the parent's size and base.
 ///
-/// Consumes a tail off RODATA (`aspace_cap + 2`); TEXT and BSS frames are
-/// left intact. The merged cap is not exercised through `mem_map` because
-/// RODATA's underlying physical base is sub-page-offset by ELF loading
-/// and is not usable as a leaf-page mapping target — a separate concern
-/// from frame merging.
+/// The test exclusively uses `frame_split` / `frame_merge` and never
+/// `cap_delete` on a segment-derived tail. Segment caps own their
+/// physical memory (kernel mint sets `owns_memory=true` for the
+/// init-reap donation cascade), so a `cap_delete` of a tail whose phys
+/// range is still mapped in ktest's own address space would buddy-free
+/// pages while live PTEs alias them. `frame_merge` clears `owns_memory`
+/// on the consumed tail before `dec_ref`, so the matching round-trip
+/// leaves no dangling deletes and preserves the original mapping.
 pub fn frame_split_merge(ctx: &TestContext) -> TestResult
 {
     const PAGE: u64 = 0x1000;
 
-    // ── Split ─────────────────────────────────────────────────────────────
     let rodata_cap = ctx.aspace_cap + 2;
     let tail =
         syscall::frame_split(rodata_cap, PAGE).map_err(|_| "frame_split on RODATA failed")?;
@@ -58,18 +66,13 @@ pub fn frame_split_merge(ctx: &TestContext) -> TestResult
         return Err("frame_split returned the parent's slot for the tail");
     }
 
-    // ── Wrong-order merge must fail ───────────────────────────────────────
     if syscall::frame_merge(tail, rodata_cap).is_ok()
     {
         return Err("frame_merge(tail, parent) should fail (contiguity reversed)");
     }
 
-    // ── Correct-order merge ──────────────────────────────────────────────
     syscall::frame_merge(rodata_cap, tail).map_err(|_| "frame_merge halves failed")?;
 
-    // ── Re-split must work on the merged cap ──────────────────────────────
-    // If the merge did not correctly restore parent.size, splitting at the
-    // same offset would fail.
     let tail2 =
         syscall::frame_split(rodata_cap, PAGE).map_err(|_| "re-split of merged cap failed")?;
     if tail2 == rodata_cap
@@ -77,7 +80,11 @@ pub fn frame_split_merge(ctx: &TestContext) -> TestResult
         return Err("re-split returned parent slot for tail");
     }
 
-    syscall::cap_delete(tail2).map_err(|_| "cap_delete re-split tail failed")?;
+    // Restore RODATA to its original size via merge. Using `cap_delete`
+    // here would dec-ref a Frame whose phys range is still mapped at
+    // RODATA's segment VA; the dealloc path would buddy-free pages live
+    // in ktest's own page tables.
+    syscall::frame_merge(rodata_cap, tail2).map_err(|_| "final frame_merge failed")?;
     Ok(())
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,9 +79,15 @@ under explicit capability grants.
 
 **init**
 First userspace process. Starts memmgr and procmgr, requests early services
-(devmgr, svcmgr, drivers, vfsd), delegates capabilities, and exits. See
-[`abi/boot-protocol/`](../abi/boot-protocol/) and
-[`process-lifecycle.md`](process-lifecycle.md) for the userspace boot order.
+(devmgr, svcmgr, drivers, vfsd), delegates capabilities, then hands its own
+`AddressSpace` / `CSpace` / `Thread` caps plus every reclaimable Frame cap
+(segments, stack, `InitInfo` pages, IPC buffer) to procmgr via
+`REGISTER_INIT_TEARDOWN` and exits. Procmgr's death-EQ observer fires on
+the exit and reclaims every init resource — kernel objects torn down,
+Frame caps donated to memmgr's pool. After reap, zero init residue
+remains in the system. See [`abi/boot-protocol/`](../abi/boot-protocol/),
+[`process-lifecycle.md`](process-lifecycle.md) §"Init reap", and
+`services/procmgr/src/init_reap.rs`.
 
 **memmgr**
 Owns the userspace RAM frame pool. Receives all RAM Frame caps from init at

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -129,7 +129,15 @@ Network stack. Manages interfaces via driver IPC and exposes socket-like endpoin
 to applications.
 
 **logd**
-Receives structured log messages via IPC and routes them to configured sinks.
+Post-mount owner of the master log endpoint. Every userspace
+process holds a pre-installed tokened SEND cap on the same kernel
+endpoint (seeded by procmgr at spawn time into
+`ProcessInfo.log_send_cap`); logd drains the RECV side. Init runs an
+interim `init-logd` thread until logd is launched at the end of init's
+Phase 2, then hands over via `log_labels::HANDOVER_PULL` (the kernel
+endpoint object is unchanged across the handover, so existing tokened
+SEND caps survive without re-derivation). Subscribes to procmgr's
+death-notification cascade for per-sender slot reclamation.
 
 **base**
 Unprivileged applications (shell, terminal, editor, core tools).

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -67,7 +67,18 @@ transferring the RAM frame pool to memmgr and minting procmgr's
 first call. Init then requests procmgr to start the remaining early services
 (devmgr, svcmgr, drivers, vfsd, optionally netd), delegates the appropriate
 subsets of its initial capability set to each service, registers services
-with svcmgr, and exits. The system-scope userspace boot order lives in
+with svcmgr, and exits.
+
+At the end of init's Phase 2 — after the root mount completes but before
+Phase 3 spawns any other service — init spawns real `logd` from
+`/bin/logd` and hands it the receive side of the master log endpoint
+via `log_labels::HANDOVER_PULL`. init-logd's receive loop terminates
+on the final handover reply. The kernel endpoint object is unchanged
+across the transition, so every pre-existing tokened SEND cap (held
+by memmgr, procmgr, every tier-1 service) continues to work without
+re-derivation; only the holder of the RECV cap changes. See
+[`services/logd/README.md`](../services/logd/README.md) and
+[`services/logd/docs/handover-protocol.md`](../services/logd/docs/handover-protocol.md). The system-scope userspace boot order lives in
 [`process-lifecycle.md`](process-lifecycle.md); role-level description is in
 [`services/init/README.md`](../services/init/README.md); authoritative stage
 enumeration lives in

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -91,6 +91,20 @@ for specialized purposes and follow their own bootstrap shape.
 
 ## Handover to svcmgr
 
+At the end of Phase 3, init signs over its own kernel-object caps
+(`AddressSpace`, `CSpace`, main `Thread`, init-logd `Thread`) and every
+reclaimable Frame cap (segments + stack + `InitInfo` pages + IPC buffer)
+to procmgr via `procmgr_labels::REGISTER_INIT_TEARDOWN`, then
+`sys_thread_exit`s. Procmgr binds a death-EQ observer on init's main
+thread with `procmgr_labels::INIT_REAP_CORRELATOR`; the event delivered
+by the exit triggers procmgr's reap path, which (1) reclaims both
+TCBs, (2) tears down init's `AddressSpace` (PT chunks freed, mappings
+gone), (3) donates the Frame caps to memmgr's pool with `DONATE_FRAMES`,
+and (4) tears down init's `CSpace` (cascade reclaims the remaining
+endpoint and slab caps). After reap, no init-related kernel object
+exists and the segment / stack / `InitInfo` / IPC-buffer pages are back
+in memmgr's pool. See `services/procmgr/src/init_reap.rs`.
+
 Once init exits, svcmgr is the resident supervisor: it monitors registered
 services, handles restarts, and holds the direct process-creation
 capabilities needed to recover procmgr itself. See

--- a/docs/capability-model.md
+++ b/docs/capability-model.md
@@ -194,17 +194,77 @@ capability slots across all processes, enabling correct revocation.
 ## Tokens
 
 A capability may carry an immutable **token** — a `u64` value attached at derivation
-time via `SYS_CAP_DERIVE_TOKEN`. Tokens serve as unforgeable caller identifiers:
-when a tokened endpoint capability is used for IPC, the kernel delivers the token
-to the receiver alongside the message label.
+time via `SYS_CAP_DERIVE_TOKEN`. When a tokened endpoint capability is used for IPC,
+the kernel delivers the token to the receiver alongside the message label.
 
 Tokens are generic: any capability type may carry one. For endpoints, the kernel
 delivers the token on `ipc_recv`. For other types, the token is stored but not
 automatically delivered — userspace may use it for bookkeeping.
 
-A token is set once and cannot be changed. Deriving from a tokened capability
-inherits the token. Attempting to set a new token on an already-tokened capability
-returns an error.
+### Kernel guarantees
+
+`SYS_CAP_DERIVE_TOKEN` enforces two invariants:
+
+1. **Tokens are set-once.** A non-zero token may be attached only to a source
+   capability that does NOT already carry one (`src_token != 0` is rejected).
+   Deriving from an already-tokened cap propagates the parent's token unchanged;
+   the parent's token cannot be replaced or shadowed.
+2. **Tokens propagate through the derivation tree.** Every derived child inherits
+   the parent's token (when non-zero). Once a cap is tokened, every cap reachable
+   from it through `cap_derive` / `cap_copy` carries the same token.
+
+These guarantees give the **receiver** of an IPC message a kernel-delivered token
+field it can trust: the value cannot be lied about on the receive path, cannot be
+changed after the fact, and is locked to whichever derivation chain the cap belongs
+to.
+
+### What the kernel does NOT guarantee
+
+The kernel does NOT restrict which token *value* a caller chooses when attaching a
+token to an un-tokened source. Any holder of an un-tokened cap on an endpoint may
+mint a tokened child cap with any non-zero u64 value, including values that the
+endpoint's server uses as authority markers (e.g.,
+`procmgr_labels::DEATH_EQ_AUTHORITY`, `pwrmgr_labels::SHUTDOWN_AUTHORITY`).
+
+This is the correct kernel semantics — minting un-tokened sources is the
+mechanism by which servers distribute tokened identities. The implication for
+servers is structural, not cryptographic.
+
+### Server-side rule for authority-bearing endpoints
+
+**Never distribute an un-tokened SEND cap on an authority-bearing endpoint to a
+holder that should not be able to mint arbitrary identities on it.** The
+un-tokened cap is a blank cheque — it is, by design, the source from which any
+tokened child can be derived.
+
+In practice this means: the un-tokened source cap on a server's endpoint lives
+exclusively in the server's own CSpace (used internally to mint per-client
+tokened copies) and in the CSpaces of trusted bootstrap-time minters (today: init,
+which dies and is fully reclaimed at the end of Phase 3). Every other client
+receives a tokened cap whose token value is chosen by the trusted minter — the
+client cannot subsequently re-tokenize it because of the set-once rule above.
+
+Trying to harden a public authority-bearing token value by making it "hard to
+guess" (long random sentinel, etc.) is obscurity, not security: the same cap_derive
+chain that would produce the well-known constant can produce any other u64.
+Security comes from controlling *who holds an un-tokened cap*, not from secrecy
+of the token bits.
+
+### Examples in this codebase
+
+- **Memmgr** allocates a per-client tokened SEND on its own endpoint inside
+  `REGISTER_PROCESS` (`services/memmgr/src/main.rs:781`). The un-tokened source
+  cap on memmgr's endpoint never leaves memmgr's CSpace; clients see only the
+  set-once tokened copy minted for them.
+- **Procmgr** derives a tokened SEND_GRANT on its own endpoint per child during
+  `populate_child_info` (`services/procmgr/src/process.rs`). Children cannot
+  re-tokenize to mint `DEATH_EQ_AUTHORITY` or any other procmgr-side authority
+  bit. The un-tokened source stays in procmgr's own CSpace, and in init's CSpace
+  until init reaps.
+- **Pwrmgr** is similar: init mints both an authorised tokened cap
+  (`SHUTDOWN_AUTHORITY`) and a deliberately-non-authorised tokened cap
+  (sentinel `1`) for the negative-test path. Even the deny-test cap is tokened,
+  preventing the test recipient from re-deriving a privileged twin.
 
 ---
 

--- a/docs/process-lifecycle.md
+++ b/docs/process-lifecycle.md
@@ -181,8 +181,13 @@ at creation time. Examples:
   identifying this process; minted by `REGISTER_PROCESS` per child.
 - `ProcessInfo.procmgr_endpoint_cap` — tokened SEND on procmgr's
   endpoint, for process-lifecycle queries.
-- `ProcessInfo.log_endpoint_cap` (or the log-discovery surface) —
-  established by procmgr per child.
+- `ProcessInfo.log_send_cap` — tokened SEND cap on the master log
+  endpoint, minted by procmgr per child via
+  `cap_derive_token(log_send_source, RIGHTS_SEND, process_token)`.
+  The cap's kernel-attached token equals procmgr's process token,
+  which also equals the death-EQ correlator procmgr posts to
+  logd. Identity is reconciled across the three views without
+  any auxiliary mapping.
 - `InitInfo.memory_frame_base`, `InitInfo.memory_frame_count` — chosen
   by the kernel per init invocation.
 

--- a/docs/process-lifecycle.md
+++ b/docs/process-lifecycle.md
@@ -122,9 +122,57 @@ procmgr's `CREATE_PROCESS` endpoint. For each service, init delegates
 the appropriate capability subset (see
 [`capability-model.md`](capability-model.md) §"Initial Capability
 Distribution") and registers the service with svcmgr along with its
-restart policy. Init then exits.
+restart policy.
 
-After init exits, svcmgr is the resident supervisor. See
+### Init reap
+
+After Phase 3 (svcmgr handover complete, usertest spawned), init signs
+over its own kernel-object caps and every reclaimable Frame cap to
+procmgr via `procmgr_labels::REGISTER_INIT_TEARDOWN` and then
+`sys_thread_exit`s.
+
+Caps moved in the handoff:
+
+1. **Kernel-object caps** (first round):
+   - Init's own `AddressSpace`.
+   - Init's own `CSpace`.
+   - Init's main `Thread`.
+   - Init-logd's `Thread` (already in `Exited` state — TCB lingers
+     until cap death drives the dealloc).
+
+2. **Reclaimable Frame caps** (subsequent rounds, up to 4 caps per IPC):
+   - Init's ELF segment caps (kernel-minted at Phase 9 with
+     `RETYPE` + `owns_memory=true` + `available_bytes = size`).
+   - Init's user stack pages (one cap per page, same flags).
+   - Init's `InitInfo` region pages (one cap per page, same flags).
+   - Init's IPC buffer page (init-created via `FrameAlloc`).
+
+Procmgr binds a death-EQ observer on init's main thread with
+`procmgr_labels::INIT_REAP_CORRELATOR` (reserved `u32::MAX`); when
+init's `sys_thread_exit` posts the death notification, procmgr's
+`dispatch_death` routes to `init_reap::run_reap`:
+
+1. `cap_delete(init-logd thread)` — TCB reclaimed.
+2. `cap_delete(init main thread)` — TCB reclaimed.
+3. `cap_revoke + cap_delete(init AddressSpace)` — `dealloc_object`
+   walks PT chunks and `retype_free`s them; user-page mappings vanish
+   atomically.
+4. `DONATE_FRAMES(donate_caps) → memmgr` — pages enter memmgr's pool.
+   Safe: no aliasing, since init's mappings died at step 3.
+5. `cap_revoke + cap_delete(init CSpace)` — cascade dec_refs every
+   remaining cap (endpoint SENDs, endpoint slab Frame, leftover
+   `FrameAlloc` tails). `owns_memory = true` Frame caps return their
+   pages directly to the kernel buddy via `dealloc_object`'s
+   `buddy.free_range`.
+6. Log: `[procmgr] init reaped: donated N caps = M pages (M KiB) to
+   memmgr; pool reclaim total T pages`.
+
+After reap, no init-related kernel object exists; init's segment / stack
+/ `InitInfo` / IPC-buffer pages are in memmgr's pool; init's endpoint
+slab and any other `FrameAlloc` tails are back in the kernel buddy.
+Authoritative implementation: `services/procmgr/src/init_reap.rs`.
+
+After init's reap completes, svcmgr is the resident supervisor. See
 [`services/svcmgr/README.md`](../services/svcmgr/README.md).
 
 ---

--- a/runtime/ruststd/src/os/seraph.rs
+++ b/runtime/ruststd/src/os/seraph.rs
@@ -663,11 +663,11 @@ pub use pal_reserve::{ReserveError, ReservedRange, reserve_pages, unreserve_page
 pub mod log {
     use super::current_ipc_buf;
 
-    /// Acquire (or fetch the cached) tokened SEND cap on the system log
-    /// endpoint. First call performs one `GET_LOG_CAP` round-trip;
-    /// subsequent calls return the same cap from the process-global
-    /// cache. Returns `0` when no discovery cap is reachable or the
-    /// IPC buffer is not yet registered.
+    /// Return the cached tokened SEND cap on the system log endpoint
+    /// (pre-installed at `_start` from `ProcessInfo.log_send_cap`).
+    /// Returns `0` when no log cap was seeded for this process (init,
+    /// memmgr, procmgr themselves, or processes spawned before logd
+    /// existed).
     #[stable(feature = "seraph_ext", since = "1.0.0")]
     pub fn acquire() -> u32 {
         ::log::ensure_tokened_cap(current_ipc_buf())

--- a/runtime/ruststd/src/os/seraph.rs
+++ b/runtime/ruststd/src/os/seraph.rs
@@ -113,12 +113,13 @@ pub struct StartupInfo {
     pub stderr_data_signal_cap: u32,
     #[stable(feature = "seraph_ext", since = "1.0.0")]
     pub stderr_space_signal_cap: u32,
-    /// Un-tokened SEND cap on the system log endpoint (the "discovery
-    /// cap"). Used by [`log!`] to lazy-acquire a tokened SEND cap on
-    /// first call via the `GET_LOG_CAP` IPC. Zero when no logger is
-    /// reachable; the macro silently drops.
+    /// Tokened SEND cap on the system log endpoint, pre-installed by
+    /// procmgr at spawn time. Used by [`log!`] directly — no
+    /// discovery roundtrip. Zero when no logger is reachable
+    /// (init/memmgr/procmgr themselves, or anything earlier in the
+    /// boot chain than the log endpoint); the macro silently drops.
     #[stable(feature = "seraph_ext", since = "1.0.0")]
-    pub log_discovery_cap: u32,
+    pub log_send_cap: u32,
     /// Virtual address of the `PT_TLS` template in the loaded image, or 0
     /// when the binary has no TLS segment.
     #[stable(feature = "seraph_ext", since = "1.0.0")]
@@ -338,7 +339,7 @@ pub extern "C" fn _start() -> ! {
         stdout_space_signal_cap: info.stdout_space_signal_cap,
         stderr_data_signal_cap: info.stderr_data_signal_cap,
         stderr_space_signal_cap: info.stderr_space_signal_cap,
-        log_discovery_cap: info.log_discovery_cap,
+        log_send_cap: info.log_send_cap,
         tls_template_vaddr: info.tls_template_vaddr,
         tls_template_filesz: info.tls_template_filesz,
         tls_template_memsz: info.tls_template_memsz,
@@ -373,10 +374,11 @@ pub extern "C" fn _start() -> ! {
         info.self_aspace_cap,
     );
 
-    // Install the log discovery cap so `seraph::log!` can lazy-acquire
-    // a tokened SEND cap on first call. Zero is tolerated (the macro
-    // silently drops in processes without a logger).
-    ::log::set_discovery_cap(info.log_discovery_cap);
+    // Install the pre-seeded tokened log SEND cap procmgr placed in
+    // ProcessInfo. `seraph::log!` uses it directly with no discovery
+    // roundtrip. Zero is tolerated (the macro silently drops in
+    // processes without a logger).
+    ::log::install_tokened_cap(info.log_send_cap);
 
     // Stash the system-root namespace cap so `std::fs` (or any other
     // namespace-walking surface) can reach it. Zero passes through
@@ -649,11 +651,11 @@ pub use pal_reserve::{ReserveError, ReservedRange, reserve_pages, unreserve_page
 
 // ── System log macro surface ────────────────────────────────────────────────
 //
-// The discovery cap installed at process create-time (recorded in
-// `StartupInfo::log_discovery_cap` and forwarded to `::log::set_discovery_cap`
-// during `_start`) drives a lazy `GET_LOG_CAP` round on first
-// `seraph::log!` call; the tokened cap is then cached process-globally for
-// the lifetime of the process.
+// The tokened SEND cap procmgr seeds at process create-time (recorded in
+// `StartupInfo::log_send_cap` and installed via `::log::install_tokened_cap`
+// during `_start`) is the destination of every `seraph::log!` call. No
+// discovery roundtrip; the cap is live from the first instruction of
+// user code.
 
 /// System-log access surface. Re-exports the `shared/log` wire-format
 /// helpers wrapped against the calling thread's registered IPC buffer.

--- a/runtime/ruststd/src/sys/stdio/seraph.rs
+++ b/runtime/ruststd/src/sys/stdio/seraph.rs
@@ -16,7 +16,8 @@
 //   * stdin read returns Ok(0) (immediate EOF).
 //
 // Panic output continues to route through the system log endpoint
-// (lazy GET_LOG_CAP on first write); this file does NOT touch the log.
+// (pre-seeded tokened SEND cap in `ProcessInfo.log_send_cap`); this
+// file does NOT touch the log.
 
 use crate::cell::UnsafeCell;
 use crate::io::{self, BorrowedCursor, IoSlice, IoSliceMut};
@@ -269,8 +270,8 @@ pub fn close_all() {
 
 /// Panic-output sink that emits through the system log endpoint.
 ///
-/// Lazy-acquires the process's tokened SEND cap on first write (one
-/// `GET_LOG_CAP` round-trip against the discovery cap), then sends each
+/// Uses the process's pre-seeded tokened SEND cap from
+/// `ProcessInfo.log_send_cap` (installed by `_start`) and sends each
 /// `write` as `STREAM_BYTES` chunks. Non-allocating — `log::write_bytes`
 /// stages bytes into the per-thread IPC buffer, so panics survive
 /// allocator failure. Silent-drops on a zero cap or any IPC error.

--- a/services/init/README.md
+++ b/services/init/README.md
@@ -98,17 +98,35 @@ Init's responsibilities are strictly bounded:
    all started services with svcmgr along with their restart policies
    and capability sets.
 
-9. **Exit** — init calls `sys_thread_exit`. By this point init-logd
-   has also terminated (driven by real-logd's `HANDOVER_PULL` at
-   end of Phase 2), so init holds no surviving threads. The kernel
-   tears down init's address space and CSpace; init's
-   `FrameAlloc`-sourced pages return to memmgr's buddy pool
-   automatically. (Init's bootloader-loaded ELF segment frames are
-   minted without `RETYPE` and without `owns_memory` — they stay
-   outside memmgr's pool until kernel-side work tracked separately
-   adds a non-RETYPE donation path.) Init holds no long-lived
-   state, no supervision capability, and no restart authority;
-   svcmgr takes over.
+9. **Reap handoff and exit** — init hands its own `AddressSpace`,
+   `CSpace`, main `Thread`, and init-logd `Thread` caps plus every
+   reclaimable Frame cap (segments, stack, `InitInfo` region, IPC
+   buffer) to procmgr via `procmgr_labels::REGISTER_INIT_TEARDOWN`
+   (multi-round; IPC cap-transfer MOVES the caps out of init's
+   CSpace). After `INIT_TEARDOWN_DONE`, init calls
+   `sys_thread_exit`. The kernel mints all four resource classes at
+   Phase 9 with `RETYPE` + `owns_memory=true` + the full
+   `available_bytes` ledger + `register_owned_range`, so each cap is
+   eligible for `memmgr.DONATE_FRAMES` ingestion.
+
+   Procmgr's death-EQ observer (bound on init's main thread with
+   `INIT_REAP_CORRELATOR`) fires on the exit and runs
+   [`init_reap::run_reap`](../procmgr/src/init_reap.rs):
+
+   1. `cap_delete` both `Thread` caps → TCBs reclaimed.
+   2. `cap_revoke + cap_delete` init's `AddressSpace` → PT chunks
+      `retype_free`'d, every user-page mapping vanishes.
+   3. `DONATE_FRAMES` the accumulated Frame caps to memmgr → the
+      segment / stack / `InitInfo` / IPC-buffer pages enter
+      memmgr's pool, safely (no aliasing — the AS is already dead).
+   4. `cap_revoke + cap_delete` init's `CSpace` → cascade dec_refs
+      every cap init still held (endpoint SENDs, endpoint slab
+      Frame, leftover `FrameAlloc` tails). Those with
+      `owns_memory=true` return their pages to the kernel buddy via
+      `dealloc_object`'s `free_range` (kernel-internal, not
+      memmgr's pool).
+   5. Procmgr logs a summary line. No init-related kernel object
+      remains; svcmgr takes over as the resident supervisor.
 
 memmgr and procmgr are the only two processes init creates via raw
 syscalls. Every later service is spawned via IPC to procmgr.

--- a/services/init/README.md
+++ b/services/init/README.md
@@ -61,7 +61,21 @@ Init's responsibilities are strictly bounded:
    IPC. Init retains derived intermediary copies (for potential
    revocation), not the roots.
 
-6. **Spawn Phase 3 services from VFS** — svcmgr, crasher, pwrmgr,
+6. **Launch real logd (Phase 2 epilogue)** — immediately after the
+   seed `system_root_cap` is acquired, init walks
+   `/bin/logd` and spawns real-logd via
+   `procmgr_labels::CREATE_FROM_FILE`. The bootstrap round
+   delivers (a) a RECV cap on the master log endpoint, (b) a
+   one-shot SEND cap on the same endpoint for `HANDOVER_PULL`,
+   (c) a tokened SEND on procmgr carrying
+   `procmgr_labels::DEATH_EQ_AUTHORITY`, and (d) the arch serial
+   authority (`IoPortRange` on x86-64, `SbiControl` on RISC-V).
+   logd pulls init-logd's captured state via `HANDOVER_PULL`;
+   init-logd's receive loop self-terminates on the final reply.
+   See [`services/logd/README.md`](../logd/README.md) and
+   [`services/logd/docs/handover-protocol.md`](../logd/docs/handover-protocol.md).
+
+7. **Spawn Phase 3 services from VFS** — svcmgr, crasher, pwrmgr,
    usertest, hello, stdiotest are loaded by walking init's seed
    system-root cap to `/bin/<name>`, then issuing
    `procmgr_labels::CREATE_FROM_FILE` with the resolved file cap.
@@ -80,13 +94,21 @@ Init's responsibilities are strictly bounded:
    gate rejects un-tokened callers. See
    [`services/pwrmgr/README.md`](../pwrmgr/README.md).
 
-7. **Register services with svcmgr** — before exiting, init registers
+8. **Register services with svcmgr** — before exiting, init registers
    all started services with svcmgr along with their restart policies
    and capability sets.
 
-8. **Exit** — init calls `sys_thread_exit`. It holds no long-lived
-   state, no supervision capability, and no restart authority. svcmgr
-   takes over.
+9. **Exit** — init calls `sys_thread_exit`. By this point init-logd
+   has also terminated (driven by real-logd's `HANDOVER_PULL` at
+   end of Phase 2), so init holds no surviving threads. The kernel
+   tears down init's address space and CSpace; init's
+   `FrameAlloc`-sourced pages return to memmgr's buddy pool
+   automatically. (Init's bootloader-loaded ELF segment frames are
+   minted without `RETYPE` and without `owns_memory` — they stay
+   outside memmgr's pool until kernel-side work tracked separately
+   adds a non-RETYPE donation path.) Init holds no long-lived
+   state, no supervision capability, and no restart authority;
+   svcmgr takes over.
 
 memmgr and procmgr are the only two processes init creates via raw
 syscalls. Every later service is spawned via IPC to procmgr.

--- a/services/init/src/bootstrap.rs
+++ b/services/init/src/bootstrap.rs
@@ -384,7 +384,7 @@ fn populate_memmgr_info(
     pi.stdin_frame_cap = 0;
     pi.stdout_frame_cap = 0;
     pi.stderr_frame_cap = 0;
-    pi.log_discovery_cap = 0;
+    pi.log_send_cap = 0;
     pi.stdin_data_signal_cap = 0;
     pi.stdin_space_signal_cap = 0;
     pi.stdout_data_signal_cap = 0;
@@ -623,12 +623,12 @@ struct ProcmgrCaps
     /// endpoint. Zero when memmgr is not yet wired (early-boot regression
     /// path; never expected after P5).
     memmgr_endpoint_slot: u32,
-    /// Slot in procmgr's `CSpace` holding an un-tokened SEND on the system
-    /// log endpoint (the "discovery" cap). Std reads it from
-    /// `pi.log_discovery_cap` at `_start` and uses it to lazy-acquire a
-    /// tokened SEND on first `seraph::log!` call. Zero when no log is
-    /// available.
-    log_discovery_slot: u32,
+    /// Slot in procmgr's `CSpace` holding a tokened SEND on the
+    /// system log endpoint with token `LOG_TOKEN_PROCMGR`. Std reads
+    /// it from `pi.log_send_cap` at `_start` and installs it via
+    /// `::log::install_tokened_cap` for procmgr's own `seraph::log!`
+    /// writes. Zero when no log endpoint is available.
+    log_send_slot: u32,
     /// `PT_TLS` template metadata, propagated into procmgr's `ProcessInfo`
     /// so spawned-thread allocations (via std) can populate matching
     /// blocks. Zero `memsz` means "no TLS".
@@ -637,10 +637,12 @@ struct ProcmgrCaps
 
 /// Populate procmgr's `ProcessInfo` page and map it read-only into procmgr.
 ///
-/// procmgr is `no_std` and doesn't drive `std::io::stdio`, so the three
-/// stdio cap slots are left zero. The log endpoint procmgr needs (as the
-/// source `cap_copy`'d into every child's `ProcessInfo.log_discovery_cap`)
-/// arrives via its bootstrap round, not via `ProcessInfo`.
+/// procmgr's stdio cap slots are left zero (procmgr is std-built post-
+/// P7 but does not drive interactive stdio). The un-tokened SEND on
+/// the log endpoint procmgr uses as the *source* for deriving tokened
+/// SEND caps per child arrives via procmgr's bootstrap round, not via
+/// `ProcessInfo`. The pre-installed tokened SEND cap procmgr uses for
+/// its OWN `seraph::log!` writes lives in `pi.log_send_cap`.
 #[allow(clippy::similar_names)]
 fn populate_procmgr_info(
     alloc: &mut FrameAlloc,
@@ -672,12 +674,13 @@ fn populate_procmgr_info(
     pi.stdin_frame_cap = 0;
     pi.stdout_frame_cap = 0;
     pi.stderr_frame_cap = 0;
-    // Procmgr holds the un-tokened SEND on the log endpoint and
-    // `cap_copy`s it into every child's `ProcessInfo.log_discovery_cap`
-    // at `CREATE_PROCESS` time. Post-P7 procmgr is std-using and has its
-    // own `seraph::log!` surface, so init also installs a discovery
-    // SEND here.
-    pi.log_discovery_cap = caps.log_discovery_slot;
+    // Procmgr's own `seraph::log!` surface. The slot holds a tokened
+    // SEND cap on the log endpoint with token `LOG_TOKEN_PROCMGR`,
+    // derived by init via `cap_derive_token`. Procmgr's std `_start`
+    // installs it via `::log::install_tokened_cap`. The un-tokened
+    // SEND procmgr uses to derive per-child tokened caps is separate
+    // (delivered via procmgr's bootstrap round).
+    pi.log_send_cap = caps.log_send_slot;
     pi.stdin_data_signal_cap = 0;
     pi.stdin_space_signal_cap = 0;
     pi.stdout_data_signal_cap = 0;
@@ -740,11 +743,13 @@ pub struct ProcmgrBootstrap
     pub service_ep: u32,
     /// Procmgr's bootstrap token on init's bootstrap endpoint.
     pub bootstrap_token: u64,
-    /// Slot in procmgr's `CSpace` holding an un-tokened SEND cap on the
-    /// system log endpoint. Procmgr `cap_copy`s this into every child's
-    /// `ProcessInfo.log_discovery_cap` at `CREATE_PROCESS` time. Zero
-    /// when no log endpoint is available (very early boot); children
-    /// born in that window receive zero and silent-drop `seraph::log!`.
+    /// Slot in procmgr's `CSpace` holding an un-tokened SEND cap on
+    /// the system log endpoint, used by procmgr as the *source* for
+    /// `cap_derive_token` to mint a tokened SEND cap per child (token =
+    /// the child's process token). The minted cap is placed in the
+    /// child's `ProcessInfo.log_send_cap`. Zero when no log endpoint
+    /// is available (very early boot); children born in that window
+    /// receive zero and silent-drop `seraph::log!`.
     pub log_endpoint_slot: u32,
     /// Procmgr's main thread cap (in init's `CSpace`). Used by
     /// [`start_procmgr`] to launch procmgr after memmgr is live.
@@ -849,8 +854,8 @@ pub fn bootstrap_procmgr(
     // Derive an un-tokened SEND cap on the log endpoint for procmgr.
     // Kept in init's CSpace and sent to procmgr via the bootstrap round
     // (ipc transfer moves it into procmgr's CSpace at a fresh slot).
-    // Procmgr `cap_copy`s this into every child's
-    // `ProcessInfo.log_discovery_cap` at `CREATE_PROCESS` time.
+    // Procmgr uses it as the *source* for `cap_derive_token` to mint a
+    // tokened SEND cap per child it spawns.
     let pm_log_send = if log_ep == 0
     {
         0
@@ -871,19 +876,27 @@ pub fn bootstrap_procmgr(
         syscall::cap_copy(memmgr_send_cap, pm_cspace, syscall::RIGHTS_SEND_GRANT).ok()?
     };
 
-    // Copy a discovery SEND on the log endpoint into procmgr's CSpace so
-    // procmgr's own `seraph::log!` calls can `GET_LOG_CAP` on first use.
-    // Procmgr is std-using post-P7 and its diagnostics ride the same log
-    // surface as every other service; the discovery cap by itself grants
-    // no log identity — that comes from the tokened cap returned by
-    // `GET_LOG_CAP`.
-    let log_discovery_slot = if log_ep == 0
+    // Derive procmgr's pre-installed tokened SEND cap on the log
+    // endpoint. Token = `LOG_TOKEN_PROCMGR` (reserved). Procmgr's
+    // `seraph::log!` writes ride this cap; logd attributes them by the
+    // kernel-delivered token. Init derives in its own CSpace then
+    // copies into procmgr's, mirroring the rights of every other
+    // procmgr-CSpace seed.
+    let log_send_slot = if log_ep == 0
     {
         0
     }
     else
     {
-        syscall::cap_copy(log_ep, pm_cspace, syscall::RIGHTS_SEND).ok()?
+        let init_side = syscall::cap_derive_token(
+            log_ep,
+            syscall::RIGHTS_SEND,
+            ipc::log_tokens::LOG_TOKEN_PROCMGR,
+        )
+        .ok()?;
+        let pm_side = syscall::cap_copy(init_side, pm_cspace, syscall::RIGHTS_SEND).ok()?;
+        let _ = syscall::cap_delete(init_side);
+        pm_side
     };
 
     let pm_caps = ProcmgrCaps {
@@ -892,7 +905,7 @@ pub fn bootstrap_procmgr(
         thread: pm_thread,
         creator_endpoint_slot: pm_creator_slot,
         memmgr_endpoint_slot,
-        log_discovery_slot,
+        log_send_slot,
         tls: pm_tls_meta,
     };
     populate_procmgr_info(alloc, init_aspace, &pm_caps, stack_pages)?;

--- a/services/init/src/logging.rs
+++ b/services/init/src/logging.rs
@@ -225,7 +225,18 @@ fn ipc_log(cap: u32, ipc_buf: *mut u64, bytes: &[u8])
 /// Spawn a dedicated log-receiving thread so the main thread can continue
 /// bootstrap orchestration (making IPC calls to vfsd etc.) without blocking
 /// service log output.
-pub fn spawn_log_thread(info: &InitInfo, alloc: &mut FrameAlloc, log_ep: u32, ioport_cap: u32)
+///
+/// Returns the init-logd Thread cap slot so the main thread can include it
+/// in the post-Phase-3 reap-handoff (`procmgr.REGISTER_INIT_TEARDOWN`).
+/// The cap survives init-logd's `sys_thread_exit` — the kernel marks the
+/// TCB Exited but does not reclaim it until `cap_delete` drops the cap's
+/// last reference.
+pub fn spawn_log_thread(
+    info: &InitInfo,
+    alloc: &mut FrameAlloc,
+    log_ep: u32,
+    ioport_cap: u32,
+) -> u32
 {
     // Allocate stack pages for the log thread.
     for i in 0..LOG_THREAD_STACK_PAGES
@@ -322,6 +333,7 @@ pub fn spawn_log_thread(info: &InitInfo, alloc: &mut FrameAlloc, log_ep: u32, io
         log("init: FATAL: cannot start log thread");
         syscall::thread_exit();
     }
+    thread_cap
 }
 
 /// Entry point for the log thread. Registers its own IPC buffer then enters

--- a/services/init/src/logging.rs
+++ b/services/init/src/logging.rs
@@ -3,28 +3,41 @@
 
 // init/src/logging.rs
 
-//! Logging subsystem for init.
+//! Logging subsystem for init — the system's *interim* log mediator.
 //!
-//! Two halves:
+//! Init owns the master log endpoint at boot and runs a dedicated thread
+//! ("init-logd") that drains it until real-logd is launched at the end
+//! of Phase 2. The init-logd thread terminates immediately after the
+//! handover, leaving the same kernel endpoint object live (existing
+//! tokened SEND caps held by every early writer remain valid; only the
+//! RECV-holder changes).
+//!
+//! Three halves:
 //!
 //! * **Sender side (init's own log line emission):** early boot writes
 //!   directly to the serial port; once the log thread is up, init's main
 //!   thread switches to the same `STREAM_BYTES` IPC path that std-built
-//!   services use, with a tokened SEND cap carrying `b"init"` so the
-//!   receiver attributes init's lines correctly.
+//!   services use, with a tokened SEND cap carrying token
+//!   `LOG_TOKEN_INIT` so the receiver attributes init's lines correctly.
 //!
 //! * **Receiver side (`log_receive_loop`):** the dedicated log thread
-//!   loops on `ipc_recv` over the master log endpoint. Each message
-//!   carries a `STREAM_BYTES` label, the sender's token (delivered by the
-//!   kernel from the tokened SEND cap they hold), and a length-prefixed
-//!   payload. The thread maintains a small per-token line buffer; on
-//!   `\n` it emits `[name] <line>\r\n` to the serial port.
+//!   loops on `ipc_recv` over the master log endpoint. Each
+//!   `STREAM_BYTES` message carries a token (delivered by the kernel
+//!   from the tokened SEND cap they hold) and a length-prefixed payload.
+//!   The thread maintains a per-token line buffer; on `\n` it emits
+//!   `[name] <line>\r\n` to the serial port AND records the line in a
+//!   bounded history ring for handover to real-logd.
+//!
+//! * **Handover (`HANDOVER_PULL`):** real-logd, once up, calls
+//!   `log_labels::HANDOVER_PULL` on the same endpoint. Init-logd
+//!   serialises (token table + history ring) into one or more reply
+//!   chunks, then breaks its loop and `sys_thread_exit`s.
 
 use crate::arch;
 use crate::{FrameAlloc, PAGE_SIZE};
 use init_protocol::InitInfo;
 
-use ipc::log_labels::GET_LOG_CAP;
+use ipc::log_labels::HANDOVER_PULL;
 use ipc::stream_labels::STREAM_BYTES;
 
 // ── Constants ────────────────────────────────────────────────────────────────
@@ -58,6 +71,41 @@ const MAX_SENDERS: usize = 16;
 /// are truncated.
 const MAX_NAME_LEN: usize = 48;
 
+/// Number of completed log lines retained in the handover ring. Sized
+/// so the pre-mount window — every line emitted between boot and Phase
+/// 2's `phase 2: launching logd` — fits without wrapping in practice
+/// (today: ~50 lines). Lines beyond the ring eject the oldest entry
+/// (FIFO drop). Real-logd treats the ring as the captured history it
+/// inherits at handover.
+const HISTORY_RING_LEN: usize = 512;
+
+/// Per-line history entry. Stores the byte payload (no `\n`, no
+/// `[name]` prefix — real-logd re-renders if it wants), the sender's
+/// token (kernel-delivered identity), and the receipt timestamp in
+/// microseconds since boot. Names are looked up out of band on
+/// handover by walking the slot table.
+#[derive(Clone, Copy)]
+struct HistoryLine
+{
+    token: u64,
+    us: u64,
+    bytes: [u8; LINE_BUF_SIZE],
+    used: u16,
+}
+
+impl HistoryLine
+{
+    const fn empty() -> Self
+    {
+        Self {
+            token: 0,
+            us: 0,
+            bytes: [0u8; LINE_BUF_SIZE],
+            used: 0,
+        }
+    }
+}
+
 // ── Mutable state (sender side, main-thread bound) ──────────────────────────
 
 /// Tokened SEND cap on the log endpoint that init's own `log()` writes to.
@@ -67,14 +115,6 @@ static mut INIT_LOG_SEND: u32 = 0;
 
 /// IPC buffer pointer for the main thread (set after IPC buffer is mapped).
 static mut MAIN_IPC_BUF: *mut u64 = core::ptr::null_mut();
-
-/// Monotonic counter for tokens minted on the `GET_LOG_CAP` discovery
-/// path. Token 0 is reserved for the untokened sentinel; token 1 is
-/// reserved for init's self-identity cap, derived directly from the
-/// log endpoint init owns; every other process gets its token from
-/// this counter.
-static INIT_DISCOVERY_NEXT_TOKEN: core::sync::atomic::AtomicU64 =
-    core::sync::atomic::AtomicU64::new(2);
 
 // ── Public interface ─────────────────────────────────────────────────────────
 
@@ -335,17 +375,78 @@ impl SenderSlot
     }
 }
 
+/// Bounded ring of completed log lines, written on every `flush_line`
+/// for handover to real-logd. Wraps FIFO; oldest entry dropped on
+/// overflow. Lives on the log thread's stack? No — too large for the
+/// 16 KiB stack. Allocated as a `static mut` so it sits in init's BSS.
+/// The only mutator is the log thread; no synchronisation needed.
+static mut HISTORY: [HistoryLine; HISTORY_RING_LEN] = [HistoryLine::empty(); HISTORY_RING_LEN];
+
+/// Write cursor (next slot to overwrite, monotonically increasing modulo
+/// `HISTORY_RING_LEN`). Once `HISTORY_TOTAL >= HISTORY_RING_LEN` the
+/// ring has wrapped; oldest entry = `HISTORY[(HISTORY_TOTAL %
+/// HISTORY_RING_LEN)]`.
+static HISTORY_HEAD: core::sync::atomic::AtomicUsize = core::sync::atomic::AtomicUsize::new(0);
+
+/// Total lines ever pushed (monotonic, never reset). Lets the handover
+/// know whether the ring has wrapped (and thus how many entries to
+/// dump) without scanning for sentinel values.
+static HISTORY_TOTAL: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
+
+/// Set when `HANDOVER_PULL` has replied its final chunk. The receive
+/// loop checks this on the next iteration and exits cleanly via
+/// `sys_thread_exit`, terminating the init-logd thread.
+static HANDOVER_COMPLETE: core::sync::atomic::AtomicBool =
+    core::sync::atomic::AtomicBool::new(false);
+
+/// Push a completed line into the history ring. Called from
+/// `flush_line` for every newline-terminated or buffer-full payload.
+fn history_push(slot: &SenderSlot)
+{
+    use core::sync::atomic::Ordering;
+
+    if slot.used == 0
+    {
+        return;
+    }
+    let head = HISTORY_HEAD.fetch_add(1, Ordering::Relaxed) % HISTORY_RING_LEN;
+    let us = syscall::system_info(syscall_abi::SystemInfoType::ElapsedUs as u64).unwrap_or(0);
+    // SAFETY: log thread is the only mutator of HISTORY; head is unique
+    // per call.
+    unsafe {
+        let entry = &mut HISTORY[head];
+        entry.token = slot.token;
+        entry.us = us;
+        let n = slot.used.min(LINE_BUF_SIZE);
+        entry.bytes[..n].copy_from_slice(&slot.buf[..n]);
+        entry.used = n as u16;
+    }
+    HISTORY_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
 /// Receive byte-stream messages from services and write them to the serial
 /// port, prefixing each line with the sender's `[name]` (extracted from the
-/// per-message kernel-delivered token).
+/// per-message kernel-delivered token). Also services `HANDOVER_PULL`
+/// from real-logd; on the final chunk reply, sets `HANDOVER_COMPLETE`
+/// and the next loop iteration self-terminates the thread.
 fn log_receive_loop(log_ep: u32, ipc_buf_raw: *mut u64) -> !
 {
     let mut slots: [SenderSlot; MAX_SENDERS] = [SenderSlot::empty(); MAX_SENDERS];
     // Round-robin pointer used to evict when all slots are in use.
     let mut next_evict: usize = 0;
+    // Cursor into HISTORY for staged HANDOVER_PULL replies.
+    let mut handover_cursor: u64 = 0;
+    // Cursor into the slot table for staged HANDOVER_PULL replies.
+    let mut handover_slot_idx: usize = 0;
 
     loop
     {
+        if HANDOVER_COMPLETE.load(core::sync::atomic::Ordering::Acquire)
+        {
+            flush_synthetic_logd_line(b"handover complete; init-logd thread exiting");
+            syscall::thread_exit();
+        }
+
         // SAFETY: ipc_buf_raw is the log thread's registered IPC buffer page.
         let Ok(recv) = (unsafe { ipc::ipc_recv(log_ep, ipc_buf_raw) })
         else
@@ -367,25 +468,14 @@ fn log_receive_loop(log_ep: u32, ipc_buf_raw: *mut u64) -> !
             // SAFETY: ipc_buf_raw is the log thread's registered IPC buffer page.
             let _ = unsafe { ipc::ipc_reply(&ipc::IpcMessage::new(0), ipc_buf_raw) };
         }
-        else if label_id == GET_LOG_CAP
+        else if label_id == HANDOVER_PULL
         {
-            if recv.word(0) == u64::from(ipc::LOG_LABELS_VERSION)
-            {
-                handle_get_log_cap(log_ep, ipc_buf_raw);
-                // handle_get_log_cap performs its own ipc_reply (with the
-                // minted cap or an error code), so we do not double-reply
-                // here.
-            }
-            else
-            {
-                // Caller built against a different `shared/ipc` revision;
-                // reject before minting a token. Reply code 3 is local to
-                // GET_LOG_CAP's reply vocabulary (0=success, 1=token
-                // counter wrap, 2=cap_derive failure, 3=version mismatch).
-                // SAFETY: ipc_buf_raw is the log thread's registered IPC
-                // buffer page.
-                let _ = unsafe { ipc::ipc_reply(&ipc::IpcMessage::new(3), ipc_buf_raw) };
-            }
+            handle_handover_pull(
+                &slots,
+                &mut handover_cursor,
+                &mut handover_slot_idx,
+                ipc_buf_raw,
+            );
         }
         else
         {
@@ -396,39 +486,134 @@ fn log_receive_loop(log_ep: u32, ipc_buf_raw: *mut u64) -> !
     }
 }
 
-/// Handler for `log_labels::GET_LOG_CAP`. Mints a fresh tokened SEND cap
-/// on the system log endpoint (token=0 reserved as the untokened sentinel,
-/// token=1 reserved for init's self-identity), transfers it back to the
-/// caller in the reply, and frees our local slot when the kernel performs
-/// the transfer.
-fn handle_get_log_cap(log_ep: u32, ipc_buf: *mut u64)
+/// Reply codes for [`HANDOVER_PULL`].
+mod handover_reply
+{
+    /// More data follows; caller should make another `HANDOVER_PULL`
+    /// call.
+    pub const MORE: u64 = 0;
+    /// Final chunk; the caller has the complete state.
+    pub const DONE: u64 = 1;
+}
+
+/// Per-chunk payload kind in `word(0)` of `HANDOVER_PULL` replies.
+mod handover_kind
+{
+    /// `word(1)` = total history-entry count; `word(2)` = active slot
+    /// count. No further data words. Always the first chunk so the
+    /// caller can size its receiving buffers.
+    pub const HEADER: u64 = 1;
+    /// One slot entry. `word(1)` = token, `word(2)` = name length in
+    /// bytes; following bytes (starting `data[3*8]` via `.bytes(3,
+    /// ...)`) carry the name payload.
+    pub const SLOT: u64 = 2;
+    /// One history line. `word(1)` = token, `word(2)` = receipt
+    /// microseconds, `word(3)` = byte length, followed by inline name
+    /// bytes via `.bytes(4, ...)`.
+    pub const LINE: u64 = 3;
+}
+
+/// Stage one chunk of handover state into the reply. Cursor state
+/// (`hist_cursor`, `slot_idx`) advances across calls so each pull
+/// returns a fresh chunk. On the last entry, replies with `DONE` and
+/// sets `HANDOVER_COMPLETE`; the receive loop's next iteration exits
+/// the thread.
+fn handle_handover_pull(
+    slots: &[SenderSlot; MAX_SENDERS],
+    hist_cursor: &mut u64,
+    slot_idx: &mut usize,
+    ipc_buf: *mut u64,
+)
 {
     use core::sync::atomic::Ordering;
 
-    let token = INIT_DISCOVERY_NEXT_TOKEN.fetch_add(1, Ordering::Relaxed);
-    if token == 0
+    // First chunk: header.
+    if *hist_cursor == 0 && *slot_idx == 0
     {
-        // Counter wrapped — vanishingly unlikely (u64), but bail rather
-        // than mint a token that aliases the untokened sentinel.
-        flush_synthetic_logd_line(b"GET_LOG_CAP: token counter wrapped");
+        let total = HISTORY_TOTAL.load(Ordering::Acquire);
+        let active = slots.iter().filter(|s| s.token != 0).count() as u64;
+        let reply = ipc::IpcMessage::builder(handover_reply::MORE)
+            .word(0, handover_kind::HEADER)
+            .word(1, total)
+            .word(2, active)
+            .build();
         // SAFETY: ipc_buf is the log thread's registered IPC buffer page.
-        let _ = unsafe { ipc::ipc_reply(&ipc::IpcMessage::new(1), ipc_buf) };
+        let _ = unsafe { ipc::ipc_reply(&reply, ipc_buf) };
+        // Sentinel: bump cursor to mark "header sent". Real cursors
+        // start at 1.
+        *hist_cursor = 1;
         return;
     }
 
-    let Ok(cap) = syscall::cap_derive_token(log_ep, syscall::RIGHTS_SEND, token)
+    // Slot table.
+    while *slot_idx < MAX_SENDERS
+    {
+        let slot = &slots[*slot_idx];
+        *slot_idx += 1;
+        if slot.token == 0
+        {
+            continue;
+        }
+        let name_len = slot.name_used.min(MAX_NAME_LEN);
+        let label = handover_reply::MORE | ((name_len as u64 & 0xFFFF) << 16);
+        let reply = ipc::IpcMessage::builder(label)
+            .word(0, handover_kind::SLOT)
+            .word(1, slot.token)
+            .word(2, name_len as u64)
+            .bytes(3, &slot.name[..name_len])
+            .build();
+        // SAFETY: ipc_buf is the log thread's registered IPC buffer page.
+        let _ = unsafe { ipc::ipc_reply(&reply, ipc_buf) };
+        return;
+    }
+
+    // History ring.
+    let total = HISTORY_TOTAL.load(Ordering::Acquire);
+    let ring_full = total >= HISTORY_RING_LEN as u64;
+    let entries_to_send = if ring_full
+    {
+        HISTORY_RING_LEN as u64
+    }
     else
     {
-        // SAFETY: ipc_buf is the log thread's registered IPC buffer page.
-        let _ = unsafe { ipc::ipc_reply(&ipc::IpcMessage::new(2), ipc_buf) };
-        return;
+        total
     };
+    let cursor_zero_based = *hist_cursor - 1;
+    if cursor_zero_based < entries_to_send
+    {
+        let i = cursor_zero_based as usize;
+        let read_idx = if ring_full
+        {
+            (HISTORY_HEAD.load(Ordering::Acquire) + i) % HISTORY_RING_LEN
+        }
+        else
+        {
+            i
+        };
+        // SAFETY: log thread is the only mutator of HISTORY; read of
+        // a fully-initialised slot.
+        let entry = unsafe { &HISTORY[read_idx] };
+        let byte_len = entry.used as usize;
+        let label = handover_reply::MORE | ((byte_len as u64 & 0xFFFF) << 16);
+        let reply = ipc::IpcMessage::builder(label)
+            .word(0, handover_kind::LINE)
+            .word(1, entry.token)
+            .word(2, entry.us)
+            .word(3, byte_len as u64)
+            .bytes(4, &entry.bytes[..byte_len])
+            .build();
+        // SAFETY: ipc_buf is the log thread's registered IPC buffer page.
+        let _ = unsafe { ipc::ipc_reply(&reply, ipc_buf) };
+        *hist_cursor += 1;
+        return;
+    }
 
-    let reply = ipc::IpcMessage::builder(0).cap(cap).build();
-    // SAFETY: ipc_buf is the log thread's registered IPC buffer page;
-    // the kernel transfers the cap from init's CSpace to the caller's
-    // CSpace, so the local slot is released.
+    // Drained. Final reply marks DONE; the receive loop self-
+    // terminates on the next iteration.
+    let reply = ipc::IpcMessage::new(handover_reply::DONE);
+    // SAFETY: ipc_buf is the log thread's registered IPC buffer page.
     let _ = unsafe { ipc::ipc_reply(&reply, ipc_buf) };
+    HANDOVER_COMPLETE.store(true, Ordering::Release);
 }
 
 /// Record a display name for the sender identified by `token`. Called
@@ -755,11 +940,13 @@ fn find_or_alloc_slot(
     victim
 }
 
-/// Emit `[sec.usfrac] [name] <buffered bytes>\r\n` to the serial port.
-/// `[name]` uses the display name registered via `STREAM_REGISTER_NAME`;
+/// Emit `[sec.usfrac] [name] <buffered bytes>\r\n` to the serial port,
+/// and record the line in the handover ring for real-logd. `[name]`
+/// uses the display name registered via `STREAM_REGISTER_NAME`;
 /// senders that have not registered yet render as `[?]`.
 fn flush_line(slot: &SenderSlot)
 {
+    history_push(slot);
     // ── Timestamp: [sec.usfrac:06] ─────────────────────────────────────
     //
     // Source: `SYS_SYSTEM_INFO(ElapsedUs)` — kernel handler returns

--- a/services/init/src/main.rs
+++ b/services/init/src/main.rs
@@ -451,9 +451,11 @@ fn run(info_ptr: u64) -> !
         syscall::thread_exit();
     };
 
-    // TODO: see above — log-thread ownership transfers to real logd.
+    // Log thread cap retained so init's reap-handoff
+    // (`procmgr.REGISTER_INIT_TEARDOWN`) can include it, letting procmgr
+    // reclaim the init-logd TCB after init's main thread exits.
     let ioport_cap = find_cap_by_type(info, init_protocol::CapType::IoPortRange).unwrap_or(0);
-    logging::spawn_log_thread(info, &mut alloc, log_ep, ioport_cap);
+    let init_logd_thread_cap = logging::spawn_log_thread(info, &mut alloc, log_ep, ioport_cap);
 
     // Tokened SEND on the log endpoint for init's own `log()` lines so
     // they appear under `[init]`. `LOG_TOKEN_INIT` (= 1) is reserved
@@ -876,6 +878,8 @@ fn run(info_ptr: u64) -> !
         system_root_cap,
         root_mount.root_cap,
         ipc_buf,
+        init_logd_thread_cap,
+        ipc_cap,
     );
 }
 

--- a/services/init/src/main.rs
+++ b/services/init/src/main.rs
@@ -21,7 +21,7 @@ use core::panic::PanicInfo;
 /// Tiny `fmt::Write` adapter into a fixed byte slice. Truncates silently if
 /// the formatted output exceeds the slice. UTF-8 by construction (the
 /// formatter only emits valid UTF-8).
-struct SliceWriter<'a>
+pub(crate) struct SliceWriter<'a>
 {
     buf: &'a mut [u8],
     len: usize,
@@ -29,12 +29,12 @@ struct SliceWriter<'a>
 
 impl<'a> SliceWriter<'a>
 {
-    fn new(buf: &'a mut [u8]) -> Self
+    pub(crate) fn new(buf: &'a mut [u8]) -> Self
     {
         Self { buf, len: 0 }
     }
 
-    fn as_slice(&self) -> &[u8]
+    pub(crate) fn as_slice(&self) -> &[u8]
     {
         &self.buf[..self.len]
     }
@@ -434,7 +434,8 @@ fn run(info_ptr: u64) -> !
 
     // Create the log endpoint. Init holds the full-rights cap; procmgr
     // receives a SEND copy in its bootstrap round and `cap_copy`s it
-    // into every child's `ProcessInfo.log_discovery_cap`. Spawn the log
+    // and uses as the source for per-child `cap_derive_token` to seed
+    // `ProcessInfo.log_send_cap`. Spawn the log
     // thread as soon as its prerequisites (allocator, IPC buffer,
     // log_ep) are satisfied so init's own subsequent log lines ride IPC
     // through the mediator instead of direct serial.
@@ -455,8 +456,13 @@ fn run(info_ptr: u64) -> !
     logging::spawn_log_thread(info, &mut alloc, log_ep, ioport_cap);
 
     // Tokened SEND on the log endpoint for init's own `log()` lines so
-    // they appear under `[init]`. Token `1` is reserved for init.
-    let Ok(init_log_send) = syscall::cap_derive_token(log_ep, syscall::RIGHTS_SEND, 1)
+    // they appear under `[init]`. `LOG_TOKEN_INIT` (= 1) is reserved
+    // for init in the log endpoint's token space.
+    let Ok(init_log_send) = syscall::cap_derive_token(
+        log_ep,
+        syscall::RIGHTS_SEND,
+        ipc::log_tokens::LOG_TOKEN_INIT,
+    )
     else
     {
         logging::log("init: FATAL: cannot derive tokened log SEND");
@@ -832,6 +838,31 @@ fn run(info_ptr: u64) -> !
     }
 
     log_reclaim_total(memmgr_service_ep, ipc_buf, "phase 2");
+
+    // ── Phase 2 epilogue: launch real logd ──────────────────────────────────
+    //
+    // Spawned at the end of Phase 2 (after root mount, with
+    // system_root_cap in hand) so logd can be walked from
+    // `/bin/logd`. Hands over the master log endpoint via
+    // `HANDOVER_PULL` IPC inside logd's bootstrap; init-logd's
+    // receive loop self-terminates after replying the final chunk.
+    // From here on the same kernel endpoint object carries every
+    // sender's messages to real-logd's RECV — no live writer
+    // re-registers.
+    logging::log("phase 2: launching logd");
+    if !service::create_and_start_logd(
+        info,
+        endpoint_cap,
+        endpoint_cap,
+        init_bootstrap_ep,
+        log_ep,
+        system_root_cap,
+        info.cspace_cap,
+        ipc_buf,
+    )
+    {
+        logging::log("phase 2: logd launch failed; init-logd remains the receiver");
+    }
 
     logging::log("phase 2 bootstrap complete");
 

--- a/services/init/src/main.rs
+++ b/services/init/src/main.rs
@@ -440,10 +440,13 @@ fn run(info_ptr: u64) -> !
     // log_ep) are satisfied so init's own subsequent log lines ride IPC
     // through the mediator instead of direct serial.
     //
-    // TODO: real `logd` — a late-boot service loaded from the real root
-    // (not the ESP) — will eventually own the receive side and the
-    // mediator role. At that point init hands over `log_ep` to logd and
-    // retires the in-init thread.
+    // Real `logd` (loaded from `/bin/logd` at the end of Phase 2,
+    // post-root-mount) takes over the receive side via the
+    // `log_labels::HANDOVER_PULL` exchange — see
+    // `service::create_and_start_logd` and
+    // `services/logd/docs/handover-protocol.md`. The same kernel
+    // endpoint object is reused, so every existing tokened SEND cap
+    // survives the handover unchanged.
     let Ok(log_ep) = syscall::cap_create_endpoint(endpoint_slab())
     else
     {

--- a/services/init/src/service.rs
+++ b/services/init/src/service.rs
@@ -1350,6 +1350,8 @@ pub fn phase3_svcmgr_handover(
     system_root_cap: u32,
     fatfs_root_cap: u32,
     ipc_buf: *mut u64,
+    init_logd_thread_cap: u32,
+    init_ipc_buf_cap: u32,
 ) -> !
 {
     let init_self_cspace = info.cspace_cap;
@@ -1498,26 +1500,112 @@ pub fn phase3_svcmgr_handover(
         _ => log("phase 3: handover failed"),
     }
 
-    // Init's main thread now exits cleanly. With init-logd already
-    // terminated (driven by real-logd's HANDOVER_PULL at end of
-    // Phase 2), no init thread remains; the kernel will reap init's
-    // address space and CSpace, returning every dynamically
-    // allocated (FrameAlloc-sourced) page to memmgr's buddy pool.
-    //
-    // NOTE: init's ELF segment Frame caps are minted by the kernel
-    // without `RETYPE` and with `owns_memory=false`
-    // (`core/kernel/src/main.rs:382-396`) — they are bootloader-
-    // loaded pages outside memmgr's buddy pool by design. They
-    // cannot be `DONATE_FRAMES`'d to memmgr (memmgr rejects them in
-    // `handle_donate_frames` per the `RETYPE` gate at
-    // `services/memmgr/src/main.rs:890`). Issue #5's "DONATE_FRAMES
-    // of init segments" therefore requires kernel changes (mint
-    // these caps with RETYPE + owns_memory, or add a separate
-    // memmgr ingestion path for non-pool pages). Not in scope here;
-    // surfaced as a follow-up. The init-logd termination and main-
-    // thread exit that this PR delivers are the real prerequisites.
-    log("main thread exiting; init process terminates");
+    // Reap-handoff: move init's kernel-object caps + every reclaimable
+    // Frame cap to procmgr. Procmgr binds a death-EQ on init's main
+    // thread; when this function returns into `sys_thread_exit`
+    // immediately below, procmgr's reap path tears init's AS/CSpace
+    // /Threads down and donates the Frame caps to memmgr's pool.
+    handoff_to_procmgr_reap(
+        info,
+        procmgr_ep,
+        init_logd_thread_cap,
+        init_ipc_buf_cap,
+        ipc_buf,
+    );
+
+    log("main thread exiting; init handed off to procmgr for reap");
     syscall::thread_exit();
+}
+
+/// Move init's kernel-object caps + every reclaimable Frame cap to
+/// procmgr via `REGISTER_INIT_TEARDOWN`, then signal
+/// `INIT_TEARDOWN_DONE`. IPC cap-transfer MOVES caps, so after this
+/// returns init's `CSpace` no longer holds the transferred slots.
+///
+/// Failures here are logged but otherwise non-fatal — init still calls
+/// `sys_thread_exit` afterward, just leaving the un-transferred caps
+/// to cascade through `CSpace` teardown to the kernel buddy on eventual
+/// cap death.
+fn handoff_to_procmgr_reap(
+    info: &InitInfo,
+    procmgr_ep: u32,
+    init_logd_thread_cap: u32,
+    init_ipc_buf_cap: u32,
+    ipc_buf: *mut u64,
+)
+{
+    // Round 1: kernel-object caps. `data[0] = 1` distinguishes from
+    // subsequent donate-only rounds.
+    let round1 = IpcMessage::builder(procmgr_labels::REGISTER_INIT_TEARDOWN)
+        .word(0, 1)
+        .cap(info.aspace_cap)
+        .cap(info.cspace_cap)
+        .cap(info.thread_cap)
+        .cap(init_logd_thread_cap)
+        .build();
+    // SAFETY: ipc_buf is init's registered IPC buffer; procmgr_ep carries SEND|GRANT.
+    if let Ok(reply) = unsafe { ipc::ipc_call(procmgr_ep, &round1, ipc_buf) }
+    {
+        if reply.label != ipc::procmgr_errors::SUCCESS
+        {
+            log("reap-handoff: procmgr refused kernel-object round; aborting handoff");
+            return;
+        }
+    }
+    else
+    {
+        log("reap-handoff: kernel-object round IPC failed; aborting handoff");
+        return;
+    }
+
+    // Donatable Frame caps: segments + stack + InitInfo region + IPC
+    // buffer. Other init-owned Frame caps (endpoint slab, leftover
+    // FrameAlloc tails) fall to the CSpace cascade — they end up in
+    // the kernel buddy rather than memmgr's pool.
+    let seg = info.segment_frame_base..info.segment_frame_base + info.segment_frame_count;
+    let stack =
+        info.init_stack_frame_base..info.init_stack_frame_base + info.init_stack_frame_count;
+    let inf = info.init_info_frame_base..info.init_info_frame_base + info.init_info_frame_count;
+
+    let mut donate: [u32; 32] = [0; 32];
+    let mut n = 0usize;
+    for slot in seg.chain(stack).chain(inf)
+    {
+        if n < donate.len()
+        {
+            donate[n] = slot;
+            n += 1;
+        }
+    }
+    if init_ipc_buf_cap != 0 && n < donate.len()
+    {
+        donate[n] = init_ipc_buf_cap;
+        n += 1;
+    }
+
+    let chunk_size = syscall_abi::MSG_CAP_SLOTS_MAX;
+    let mut i = 0usize;
+    while i < n
+    {
+        let end = (i + chunk_size).min(n);
+        let mut builder = IpcMessage::builder(procmgr_labels::REGISTER_INIT_TEARDOWN).word(0, 0);
+        for &slot in &donate[i..end]
+        {
+            builder = builder.cap(slot);
+        }
+        let msg = builder.build();
+        // SAFETY: ipc_buf is registered; procmgr_ep carries SEND|GRANT.
+        let _ = unsafe { ipc::ipc_call(procmgr_ep, &msg, ipc_buf) };
+        i = end;
+    }
+
+    // Signal the cap stream is closed. Procmgr arms the death-EQ
+    // observer; the next event with INIT_REAP_CORRELATOR triggers the
+    // reap. (Done by this point — REGISTER_INIT_TEARDOWN's first round
+    // already bound the EQ.)
+    let done = IpcMessage::new(procmgr_labels::INIT_TEARDOWN_DONE);
+    // SAFETY: ipc_buf is registered.
+    let _ = unsafe { ipc::ipc_call(procmgr_ep, &done, ipc_buf) };
 }
 
 // ── logd spawn ──────────────────────────────────────────────────────────────

--- a/services/init/src/service.rs
+++ b/services/init/src/service.rs
@@ -1459,11 +1459,17 @@ pub fn phase3_svcmgr_handover(
             0
         };
         // No-authority twin used by usertest's `pwrmgr_cap_deny_phase`
-        // to verify the SHUTDOWN gate rejects un-tokened callers.
-        // `cap_derive_token` rejects token=0; use plain `cap_derive` so
-        // the derived cap inherits the source's token (which is zero on
-        // the untokened source endpoint init created).
-        let noauth = if let Ok(c) = syscall::cap_derive(ep, syscall::RIGHTS_SEND)
+        // to verify the SHUTDOWN gate rejects callers without the
+        // `SHUTDOWN_AUTHORITY` token bit. Tokenized with a non-AUTHORITY
+        // sentinel (`1`) so the gate fails the
+        // `msg.token & SHUTDOWN_AUTHORITY != 0` check, AND so usertest
+        // cannot subsequently call `cap_derive_token` on this cap to
+        // mint a privileged twin — `sys_cap_derive_token` rejects
+        // sources with `src_token != 0`. Plain `cap_derive` would
+        // produce an un-tokened cap that usertest could re-tokenize
+        // with any value (including `SHUTDOWN_AUTHORITY`), defeating
+        // the very gate this test is supposed to exercise.
+        let noauth = if let Ok(c) = syscall::cap_derive_token(ep, syscall::RIGHTS_SEND, 1)
         {
             c
         }

--- a/services/init/src/service.rs
+++ b/services/init/src/service.rs
@@ -1498,6 +1498,210 @@ pub fn phase3_svcmgr_handover(
         _ => log("phase 3: handover failed"),
     }
 
-    log("main thread exiting, log thread continues");
+    // Init's main thread now exits cleanly. With init-logd already
+    // terminated (driven by real-logd's HANDOVER_PULL at end of
+    // Phase 2), no init thread remains; the kernel will reap init's
+    // address space and CSpace, returning every dynamically
+    // allocated (FrameAlloc-sourced) page to memmgr's buddy pool.
+    //
+    // NOTE: init's ELF segment Frame caps are minted by the kernel
+    // without `RETYPE` and with `owns_memory=false`
+    // (`core/kernel/src/main.rs:382-396`) — they are bootloader-
+    // loaded pages outside memmgr's buddy pool by design. They
+    // cannot be `DONATE_FRAMES`'d to memmgr (memmgr rejects them in
+    // `handle_donate_frames` per the `RETYPE` gate at
+    // `services/memmgr/src/main.rs:890`). Issue #5's "DONATE_FRAMES
+    // of init segments" therefore requires kernel changes (mint
+    // these caps with RETYPE + owns_memory, or add a separate
+    // memmgr ingestion path for non-pool pages). Not in scope here;
+    // surfaced as a follow-up. The init-logd termination and main-
+    // thread exit that this PR delivers are the real prerequisites.
+    log("main thread exiting; init process terminates");
     syscall::thread_exit();
+}
+
+// ── logd spawn ──────────────────────────────────────────────────────────────
+
+/// Spawn real-logd from `/bin/logd` at the end of Phase 2, immediately
+/// after the root mount completes. Init transfers:
+///
+/// * a RECV cap on the master log endpoint (so logd becomes the
+///   receive-side; init-logd terminates as part of the handover);
+/// * a SEND cap on the same endpoint (single-use, for the
+///   `HANDOVER_PULL` IPC to init-logd);
+/// * a tokened SEND cap on procmgr carrying
+///   `procmgr_labels::DEATH_EQ_AUTHORITY` (for `REGISTER_DEATH_EQ`);
+/// * an arch-specific serial-authority cap (`IoPortRange` on x86-64,
+///   `SbiControl` on RISC-V) so logd can write directly to the UART
+///   for its own diagnostics and the per-sender log lines it
+///   receives. Logd cannot route its diagnostics through
+///   `seraph::log!` because it IS the log receiver.
+///
+/// Returns `true` on successful spawn + bootstrap; `false` on any
+/// failure (logged at fault; init continues without real-logd, with
+/// init-logd running indefinitely until init's process is otherwise
+/// reaped).
+// too_many_lines: one transactional spawn path; splitting would push
+// most of the body into helpers and obscure the cap-flow sequencing.
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+pub fn create_and_start_logd(
+    info: &InitInfo,
+    procmgr_ep: u32,
+    procmgr_service_ep_source: u32,
+    bootstrap_ep: u32,
+    log_ep: u32,
+    system_root_cap: u32,
+    init_self_cspace: u32,
+    ipc_buf: *mut u64,
+) -> bool
+{
+    let Some(walked) = walk::walk_to_file(system_root_cap, b"/bin/logd", ipc_buf)
+    else
+    {
+        log("logd: walk /bin/logd failed");
+        return false;
+    };
+
+    let Some((tokened_creator, child_token)) = derive_tokened_creator(bootstrap_ep)
+    else
+    {
+        log("logd: tokened creator derive failed");
+        return false;
+    };
+
+    let create_msg = IpcMessage::builder(procmgr_labels::CREATE_FROM_FILE)
+        .word(0, walked.size)
+        .cap(walked.file_cap)
+        .cap(tokened_creator)
+        .build();
+    // SAFETY: ipc_buf is the registered IPC buffer.
+    let Ok(reply) = (unsafe { ipc::ipc_call(procmgr_ep, &create_msg, ipc_buf) })
+    else
+    {
+        log("logd: CREATE_FROM_FILE ipc_call failed");
+        return false;
+    };
+    if reply.label != 0
+    {
+        log("logd: CREATE_FROM_FILE error");
+        return false;
+    }
+    let reply_caps = reply.caps();
+    if reply_caps.is_empty()
+    {
+        log("logd: CREATE_FROM_FILE reply missing caps");
+        return false;
+    }
+    let process_handle = reply_caps[0];
+    // CREATE_FROM_FILE returns (process_handle, thread_cap); logd
+    // is svcmgr-registered for restart in a follow-up PR. Drop the
+    // thread cap for now.
+    if reply_caps.len() >= 2
+    {
+        let _ = syscall::cap_delete(reply_caps[1]);
+    }
+
+    if !configure_child_namespace(process_handle, system_root_cap, init_self_cspace, ipc_buf)
+    {
+        return false;
+    }
+
+    // Derive the three bootstrap caps logd needs.
+    let Ok(log_recv) = syscall::cap_derive(log_ep, syscall::RIGHTS_ALL)
+    else
+    {
+        log("logd: log_ep RECV derive failed");
+        destroy_partial_child(process_handle, ipc_buf);
+        return false;
+    };
+    let Ok(log_handover_send) = syscall::cap_derive(log_ep, syscall::RIGHTS_SEND)
+    else
+    {
+        log("logd: log_ep SEND derive failed");
+        let _ = syscall::cap_delete(log_recv);
+        destroy_partial_child(process_handle, ipc_buf);
+        return false;
+    };
+    // RIGHTS_SEND_GRANT (not bare SEND): the IPC kernel requires the
+    // GRANT bit when the caller transfers any cap in the message, and
+    // logd's REGISTER_DEATH_EQ call hands over its `death_eq` cap.
+    let Ok(procmgr_death_auth) = syscall::cap_derive_token(
+        procmgr_service_ep_source,
+        syscall::RIGHTS_SEND_GRANT,
+        procmgr_labels::DEATH_EQ_AUTHORITY,
+    )
+    else
+    {
+        log("logd: procmgr DEATH_EQ_AUTHORITY derive failed");
+        let _ = syscall::cap_delete(log_recv);
+        let _ = syscall::cap_delete(log_handover_send);
+        destroy_partial_child(process_handle, ipc_buf);
+        return false;
+    };
+
+    // Arch-specific serial-authority cap. Both `cap_derive(RIGHTS_ALL)`
+    // mirror pwrmgr's pattern (`services/init/src/service.rs::
+    // create_and_start_pwrmgr`). On absent archs the source slot is
+    // zero; we pass zero through and logd silently disables its serial
+    // path (received log lines still buffer in memory).
+    let arch_cap_source: u32 = {
+        #[cfg(target_arch = "x86_64")]
+        {
+            crate::find_cap_by_type(info, CapType::IoPortRange).unwrap_or(0)
+        }
+        #[cfg(target_arch = "riscv64")]
+        {
+            info.sbi_control_cap
+        }
+        #[cfg(not(any(target_arch = "x86_64", target_arch = "riscv64")))]
+        {
+            let _ = info;
+            0
+        }
+    };
+    let arch_cap_copy = if arch_cap_source != 0
+    {
+        syscall::cap_derive(arch_cap_source, syscall::RIGHTS_ALL).unwrap_or(0)
+    }
+    else
+    {
+        0
+    };
+
+    if !start_process(
+        process_handle,
+        ipc_buf,
+        "phase 2: logd started; serving bootstrap",
+        "phase 2: logd START_PROCESS failed",
+    )
+    {
+        let _ = syscall::cap_delete(log_recv);
+        let _ = syscall::cap_delete(log_handover_send);
+        let _ = syscall::cap_delete(procmgr_death_auth);
+        if arch_cap_copy != 0
+        {
+            let _ = syscall::cap_delete(arch_cap_copy);
+        }
+        return false;
+    }
+
+    if !serve(
+        bootstrap_ep,
+        child_token,
+        ipc_buf,
+        true,
+        &[
+            log_recv,
+            log_handover_send,
+            procmgr_death_auth,
+            arch_cap_copy,
+        ],
+        &[],
+        "logd: bootstrap round failed",
+    )
+    {
+        return false;
+    }
+
+    true
 }

--- a/services/init/src/service.rs
+++ b/services/init/src/service.rs
@@ -1601,7 +1601,22 @@ fn handoff_to_procmgr_reap(
         }
         let msg = builder.build();
         // SAFETY: ipc_buf is registered; procmgr_ep carries SEND|GRANT.
-        let _ = unsafe { ipc::ipc_call(procmgr_ep, &msg, ipc_buf) };
+        match unsafe { ipc::ipc_call(procmgr_ep, &msg, ipc_buf) }
+        {
+            Ok(reply) if reply.label == ipc::procmgr_errors::SUCCESS =>
+            {}
+            Ok(reply) => log(
+                if reply.label == ipc::procmgr_errors::INVALID_ARGUMENT
+                {
+                    "reap-handoff: donation chunk refused INVALID_ARGUMENT"
+                }
+                else
+                {
+                    "reap-handoff: donation chunk refused (non-success reply)"
+                },
+            ),
+            Err(_) => log("reap-handoff: donation chunk IPC failed"),
+        }
         i = end;
     }
 
@@ -1611,7 +1626,12 @@ fn handoff_to_procmgr_reap(
     // already bound the EQ.)
     let done = IpcMessage::new(procmgr_labels::INIT_TEARDOWN_DONE);
     // SAFETY: ipc_buf is registered.
-    let _ = unsafe { ipc::ipc_call(procmgr_ep, &done, ipc_buf) };
+    match unsafe { ipc::ipc_call(procmgr_ep, &done, ipc_buf) }
+    {
+        Ok(reply) if reply.label == ipc::procmgr_errors::SUCCESS =>
+        {}
+        _ => log("reap-handoff: INIT_TEARDOWN_DONE IPC failed (reap may not run)"),
+    }
 }
 
 // ── logd spawn ──────────────────────────────────────────────────────────────

--- a/services/logd/Cargo.toml
+++ b/services/logd/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "logd"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[[bin]]
+name = "logd"
+path = "src/main.rs"
+test = false
+
+[dependencies]
+ipc = { path = "../../shared/ipc" }
+syscall = { path = "../../shared/syscall" }
+syscall-abi = { path = "../../abi/syscall" }
+
+[lints]
+workspace = true

--- a/services/logd/README.md
+++ b/services/logd/README.md
@@ -57,10 +57,6 @@ process.
 * Network-syslog sink.
 * svcmgr-late-launch migration (parallel to the usertest refactor;
   logd is launched by init for now).
-* GET_LOG_CAP cleanup. With every new spawn receiving a
-  pre-installed tokened SEND cap directly in `ProcessInfo`, the
-  legacy discovery path is dead code; a separate PR removes it
-  once every live writer has been migrated.
 
 ## Source layout
 

--- a/services/logd/README.md
+++ b/services/logd/README.md
@@ -1,20 +1,115 @@
 # logd
 
-Logging daemon. Receives structured log messages via IPC from the kernel and all
-userspace components, and writes them to configured sinks (serial, file, etc.).
+Post-mount owner of the master system log endpoint.
+
+logd is spawned by init at the end of Phase 2, immediately after the
+root filesystem is mounted and before any Phase 3 service is launched.
+It assumes the receive side of the kernel endpoint that init-logd had
+been draining since boot, ingests init-logd's captured history,
+subscribes to procmgr's death-notification cascade, and from then on
+is the single owner of every log line emitted by every userspace
+process.
 
 ## Role
 
-logd is started during bootstrap as a core service. All components send log
-messages to logd's IPC endpoint rather than writing to hardware directly.
+* **Receiver of the master log endpoint.** Every userspace process
+  holds a pre-installed tokened SEND cap on the same kernel endpoint
+  (seeded into `ProcessInfo.log_send_cap` by procmgr at spawn time;
+  see [`services/procmgr/src/process.rs`](../procmgr/src/process.rs)).
+  Across the init-logd → real-logd handover the kernel endpoint
+  object is unchanged — only the holder of the RECV cap changes —
+  so every pre-existing tokened SEND cap continues to work without
+  re-derivation or re-registration.
 
-The kernel retains a direct serial logger for pre-logd output (early boot
-messages, panic reports). Once logd is running, the kernel transitions
-structured log output to IPC.
+* **Direct serial writer.** logd writes received log lines and its
+  own diagnostics straight to the UART via an arch-specific
+  authority cap (`IoPortRange` for COM1 on x86-64, `SbiControl` for
+  SBI legacy `console_putchar` on RISC-V). It cannot route its own
+  diagnostics through `seraph::log!` because it IS the log
+  receiver; the macro would self-IPC into the endpoint logd serves
+  and deadlock. A future PR will replace this direct path with a
+  proper userspace console driver under devmgr (see issue
+  [#66](https://github.com/kottlerg/seraph/issues/66)).
 
-## Status
+* **History buffer.** logd maintains a per-sender ring of completed
+  log lines, populated by every `STREAM_BYTES`-derived flush and
+  seeded at startup from init-logd's handover payload. Lines stay in
+  memory until per-slot bounds are reached (FIFO drop). A future PR
+  exposes this buffer through a query IPC and/or durable sinks
+  (disk file, network syslog). For now the buffer is write-only;
+  the deliverable here is the retention contract, not yet the read
+  surface.
 
-Not yet implemented.
+* **Per-sender slot reclamation.** logd creates an `EventQueue` and
+  registers it with procmgr via `procmgr_labels::REGISTER_DEATH_EQ`
+  (authorised by the `DEATH_EQ_AUTHORITY` tokened SEND cap init
+  hands to logd at bootstrap). Procmgr binds that EQ as an
+  additional death observer on every existing thread and on every
+  future spawn. When a process exits, logd's EQ receives
+  `(process_token << 32) | exit_reason`; logd evicts the matching
+  slot from its hash-keyed token table. This is the slot-table
+  scale + reclamation work folded into the same service per issue
+  [#1](https://github.com/kottlerg/seraph/issues/1).
+
+## Out of scope (follow-up issues)
+
+* Log rotation, durable-disk persistence, query API.
+* Network-syslog sink.
+* svcmgr-late-launch migration (parallel to the usertest refactor;
+  logd is launched by init for now).
+* GET_LOG_CAP cleanup. With every new spawn receiving a
+  pre-installed tokened SEND cap directly in `ProcessInfo`, the
+  legacy discovery path is dead code; a separate PR removes it
+  once every live writer has been migrated.
+
+## Source layout
+
+```
+logd/
+├── Cargo.toml                  # std-built workspace member
+├── README.md
+├── docs/
+│   ├── handover-protocol.md    # init-logd → logd wire format
+│   └── ipc-interface.md        # IPC labels logd handles
+└── src/
+    ├── main.rs                 # entry, bootstrap, event loop,
+    │                           # serial emit, self_log
+    ├── handover.rs             # HANDOVER_PULL caller
+    ├── slot.rs                 # SlotTable: HashMap<token, Slot>
+    │                           # with per-sender history ring
+    └── arch/                   # arch-specific serial output
+        ├── mod.rs
+        ├── x86_64/mod.rs       # COM1 via IoPortRange
+        └── riscv64/mod.rs      # SBI legacy console_putchar
+```
+
+## Bootstrap caps
+
+Init's bootstrap round (one round, `done = true`) delivers four caps:
+
+| Index | Cap |
+|---|---|
+| 0 | RECV on the master log endpoint |
+| 1 | SEND on the master log endpoint (single-use; HANDOVER_PULL only) |
+| 2 | Tokened SEND on procmgr's service endpoint carrying `DEATH_EQ_AUTHORITY` |
+| 3 | Arch serial authority (`IoPortRange` on x86-64, `SbiControl` on RISC-V) |
+
+After `HANDOVER_PULL` completes, logd deletes cap[1] (no other use
+for a SEND cap on its own endpoint). The arch cap stays bound to
+logd's main thread for the lifetime of the process.
+
+## Relevant design documents
+
+| Document | Content |
+|---|---|
+| [docs/architecture.md](../../docs/architecture.md) | logd's role in the userspace component map |
+| [docs/bootstrap.md](../../docs/bootstrap.md) | logd's spawn timing inside init's Phase 2 |
+| [docs/process-lifecycle.md](../../docs/process-lifecycle.md) | Death-notification cascade logd subscribes to |
+| [docs/ipc-design.md](../../docs/ipc-design.md) | Endpoint identity, cap transfer semantics that make the init-logd handover possible |
+| [services/init/README.md](../init/README.md) | init's Phase 2 epilogue (logd spawn) and init-logd's role + termination |
+| [services/procmgr/README.md](../procmgr/README.md) | `REGISTER_DEATH_EQ` handler + retroactive bind |
+| [services/logd/docs/handover-protocol.md](docs/handover-protocol.md) | init-logd → logd wire format |
+| [services/logd/docs/ipc-interface.md](docs/ipc-interface.md) | IPC labels logd accepts |
 
 ---
 

--- a/services/logd/docs/handover-protocol.md
+++ b/services/logd/docs/handover-protocol.md
@@ -1,0 +1,108 @@
+# logd handover protocol
+
+Wire format for the one-shot init-logd → real-logd state transfer.
+
+Real-logd, on bootstrap, calls `log_labels::HANDOVER_PULL` repeatedly
+on its single-use SEND cap to the master log endpoint. Init-logd's
+receive loop, on seeing the label, replies one chunk at a time until
+its captured state is drained, then breaks its loop and calls
+`sys_thread_exit`. Real-logd's existing tokened SEND caps held by
+every other sender remain valid because the kernel endpoint object
+is unchanged across the transition.
+
+## Call shape
+
+* Request: `IpcMessage::new(HANDOVER_PULL)`. Empty payload, no caps.
+* Reply: `label = MORE (0)` for every intermediate chunk;
+  `label = DONE (1)` on the terminal chunk. Init-logd sets its
+  internal `HANDOVER_COMPLETE` flag immediately after replying
+  `DONE`; the next iteration of its receive loop self-terminates the
+  init-logd thread.
+
+The reply label's upper 16 bits (`(byte_len << 16)`) carry the
+inline byte length on `SLOT` and `LINE` chunk kinds, matching the
+stream-protocol convention. Real-logd masks the bottom 16 bits to
+extract the status code.
+
+## Chunk kinds
+
+`word(0)` of each reply identifies the chunk kind. Three kinds:
+
+### `HEADER` (1)
+
+Always the first reply chunk. Lets real-logd size its receiving
+state up front.
+
+| Word | Meaning |
+|---|---|
+| 0 | `HEADER` |
+| 1 | total history-line count ever pushed (monotonic; may exceed ring size if wrapped) |
+| 2 | active sender-slot count (non-zero tokens in init-logd's slot table) |
+
+No inline bytes. No transferred caps.
+
+### `SLOT` (2)
+
+One entry from init-logd's per-sender slot table. Sent once per
+non-zero slot, in slot-index order.
+
+| Word | Meaning |
+|---|---|
+| 0 | `SLOT` |
+| 1 | sender token (kernel-delivered identity on every IPC) |
+| 2 | display-name length in bytes |
+| 3..  | name bytes (packed via `IpcMessage::builder.bytes(3, ...)`, offset 24 in `data_bytes`) |
+
+The reply label's upper 16 bits carry the name length again (stream-
+protocol convention). Real-logd installs each slot into its own
+hash-keyed token table via
+[`SlotTable::install_from_handover`](../src/slot.rs).
+
+### `LINE` (3)
+
+One completed log line from init-logd's bounded history ring. Sent
+in FIFO order: oldest entry first when the ring has wrapped; index
+0 first when it has not.
+
+| Word | Meaning |
+|---|---|
+| 0 | `LINE` |
+| 1 | sender token at receipt time |
+| 2 | receipt timestamp in microseconds since boot |
+| 3 | line byte length |
+| 4..  | line bytes (packed via `.bytes(4, ...)`, offset 32 in `data_bytes`) |
+
+No trailing `\n`. The line is the buffered content between two
+`\n`-terminated `STREAM_BYTES` flushes, unmodified. Real-logd stores
+it via
+[`SlotTable::install_history_line`](../src/slot.rs); the slot is
+created lazily if no `SLOT` entry preceded it (a history line may
+outlive its registering sender's slot in init-logd's small
+`MAX_SENDERS` table).
+
+## Termination
+
+After the last `LINE` (or the last `SLOT` if no history), init-logd
+replies `DONE` with `word(0) = LINE` and zero inline bytes, then
+sets `HANDOVER_COMPLETE`. Real-logd, on seeing `DONE`, returns from
+[`handover::pull_all`](../src/handover.rs). Init-logd's next loop
+iteration sees the flag and calls `sys_thread_exit`.
+
+Between the `DONE` reply and init-logd's thread exit, no further log
+messages are processed by init-logd — any in-flight `STREAM_BYTES`
+sends from other processes queue at the kernel endpoint and are
+drained by real-logd once it enters its main receive loop.
+
+## Failure modes
+
+| Symptom | Cause | Recovery |
+|---|---|---|
+| `HANDOVER_PULL` IPC returns error | `log_ep_handover_send` cap is invalid or init-logd already exited | Real-logd's `pull_all` returns silently; logd boots with an empty `SlotTable`. Pre-handover history is lost. |
+| Reply with unknown `word(0)` kind | Wire-format drift; one side built against an out-of-sync `shared/ipc` revision | Real-logd skips the chunk and continues. A bounded iteration cap (`MAX_ITERS`) in `pull_all` guarantees termination on a malformed reply stream. |
+
+## Reference
+
+Wire-format constants are defined in
+[`services/init/src/logging.rs`](../../init/src/logging.rs) (sender
+side) and [`services/logd/src/handover.rs`](../src/handover.rs)
+(receiver side). Both files cross-reference each other.

--- a/services/logd/docs/ipc-interface.md
+++ b/services/logd/docs/ipc-interface.md
@@ -1,0 +1,108 @@
+# logd IPC interface
+
+logd is the receive-side of the master log endpoint. It does not
+publish a separate service endpoint; every userspace sender already
+holds a tokened SEND cap on the log endpoint (seeded by procmgr at
+spawn time, or installed by init for itself / procmgr-self). The
+labels documented below are the ones logd's receive loop dispatches
+on.
+
+logd additionally calls procmgr's
+[`procmgr_labels::REGISTER_DEATH_EQ`](../../procmgr/docs/ipc-interface.md)
+once during its own startup; see that document for the wire format.
+
+## Endpoint
+
+| Cap holder | Right | Purpose |
+|---|---|---|
+| logd's main thread | `RECV` | drains the endpoint via `ipc_recv` inside the wait-set loop |
+| every userspace sender | `SEND` (tokened) | `STREAM_BYTES`, `STREAM_REGISTER_NAME` |
+| real-logd at bootstrap | `SEND` (un-tokened) | single-use `HANDOVER_PULL` to init-logd; deleted immediately after `DONE` |
+
+## Labels accepted
+
+### `stream_labels::STREAM_BYTES` (10)
+
+Per-line byte stream. Sender packs the chunk byte length into the
+label's upper 16 bits (`label | ((len << 16))`). Inline bytes
+arrive in the IPC message's data words, packed at word 0. logd
+appends the bytes to the slot keyed by the kernel-delivered
+`msg.token`; every `\n` flushes the slot's partial buffer as one
+line (rendered to serial as `[sec.usfrac] [name] <line>\r\n` and
+appended to the slot's history ring).
+
+Lines exceeding `LINE_BUF_SIZE` (256 bytes) flush without a
+trailing `\n` to keep the per-line attribution visible. Senders
+that have not yet called `STREAM_REGISTER_NAME` render as `[?]`.
+
+Reply: `label = 0` (success), empty payload. Sender unblocks.
+
+### `stream_labels::STREAM_REGISTER_NAME` (11)
+
+Register or update the display name for the sender identified by
+`msg.token`. Inline bytes carry the name; the label's upper 16
+bits carry the name length. Long names truncate at `MAX_NAME_LEN`
+(48 bytes).
+
+No collision-suffix policy: procmgr's per-child process token is
+unique within the system, so display-name collisions only occur if
+two processes intentionally pick the same string. logd allows
+that.
+
+Reply: `label = 0`. Sender unblocks.
+
+### `log_labels::HANDOVER_PULL` (13)
+
+One-shot init-logd → real-logd state transfer. Documented in
+[`handover-protocol.md`](handover-protocol.md). logd's own receive
+loop accepts the label too, but real-logd never receives it post-
+handover (no caller in the system holds a SEND cap suitable for
+the handover after init-logd exits). The handler in real-logd is
+unreachable; init-logd is the only intended target.
+
+### `log_labels::GET_LOG_CAP` (12) — legacy
+
+Pre-pivot discovery path. Reserved in the label table for backward
+compatibility but no caller in the current codebase issues it
+(every spawn receives a pre-installed tokened SEND cap in
+`ProcessInfo.log_send_cap`). logd replies empty if it ever
+arrives, so an out-of-tree v0 caller fails closed without crashing
+logd. A follow-up PR removes the label entirely once the
+pre-pivot discovery path is gone for good.
+
+## Wait-set
+
+logd's main loop waits on a 2-member `WaitSet`:
+
+| Token | Source | Purpose |
+|---|---|---|
+| `WS_TOKEN_LOG` (0) | RECV on the master log endpoint | `STREAM_BYTES` / `STREAM_REGISTER_NAME` arrivals |
+| `WS_TOKEN_DEATH` (1) | RECV on logd's death-notification `EventQueue` | drained per loop iteration before service dispatch |
+
+Death events are drained inside every loop iteration (before
+servicing the log endpoint) so a recently-died sender's slot is
+evicted before logd processes any of its still-queued
+`STREAM_BYTES`. Mirrors procmgr's drain-deaths-first pattern.
+
+## Death-notification cascade
+
+Every process spawned by procmgr is bound to two death observers
+at creation:
+
+1. Procmgr's own death `EventQueue` (correlator = process token,
+   for procmgr's auto-reap path).
+2. logd's death `EventQueue` (correlator = process token, for
+   logd's slot eviction).
+
+Procmgr installs the second binding inside
+[`finalize_creation`](../../procmgr/src/process.rs) when its
+`LOGD_DEATH_EQ` static is non-zero, AND retroactively across every
+existing process table entry when logd's
+`REGISTER_DEATH_EQ` IPC arrives. Children spawned before logd
+registers see only the first binding until the retroactive bind
+catches them up.
+
+logd's drain consumes each event as
+`(process_token as u32) << 32 | exit_reason` and evicts the
+matching slot from the hash-keyed token table. Idempotent on
+already-evicted tokens.

--- a/services/logd/src/arch/mod.rs
+++ b/services/logd/src/arch/mod.rs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// logd/src/arch/mod.rs
+
+//! Architecture dispatch module.
+//!
+//! Mirror of `services/init/src/arch/mod.rs`. The only file in logd
+//! permitted to contain `#[cfg(target_arch)]` guards. All other
+//! modules reach arch-specific functionality through
+//! `arch::current::*`.
+
+#[cfg(target_arch = "x86_64")]
+#[path = "x86_64/mod.rs"]
+pub mod current;
+
+#[cfg(target_arch = "riscv64")]
+#[path = "riscv64/mod.rs"]
+pub mod current;

--- a/services/logd/src/arch/riscv64/mod.rs
+++ b/services/logd/src/arch/riscv64/mod.rs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// logd/src/arch/riscv64/mod.rs
+
+//! RISC-V serial output via SBI legacy `console_putchar`.
+//!
+//! Real-logd uses the SBI ``console_putchar`` (EID `0x01`, FID `0x00`)
+//! legacy extension rather than direct UART MMIO so it does not need
+//! to map the UART aperture or duplicate init's MMIO-mapping
+//! plumbing. The `SbiControl` cap (passed via bootstrap caps[3])
+//! gates the syscall.
+
+const SBI_LEGACY_CONSOLE_PUTCHAR: u64 = 0x01;
+const SBI_LEGACY_FID: u64 = 0x00;
+
+static SBI_CAP: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(0);
+
+/// Install the caller-provided `SbiControl` cap for subsequent
+/// [`serial_write_byte`] calls. `thread_cap` is unused on RISC-V
+/// (SBI calls are not per-thread). Zero cap silently disables
+/// serial output (logd then runs with received log lines buffered
+/// in memory only).
+pub fn serial_init(_thread_cap: u32, sbi_cap: u32)
+{
+    SBI_CAP.store(sbi_cap, core::sync::atomic::Ordering::Release);
+}
+
+/// Write one byte via SBI legacy `console_putchar`. Silently drops
+/// when no `SbiControl` cap was installed.
+pub fn serial_write_byte(byte: u8)
+{
+    let cap = SBI_CAP.load(core::sync::atomic::Ordering::Acquire);
+    if cap == 0
+    {
+        return;
+    }
+    let _ = syscall::sbi_call(
+        cap,
+        SBI_LEGACY_CONSOLE_PUTCHAR,
+        SBI_LEGACY_FID,
+        u64::from(byte),
+        0,
+        0,
+    );
+}

--- a/services/logd/src/arch/x86_64/mod.rs
+++ b/services/logd/src/arch/x86_64/mod.rs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// logd/src/arch/x86_64/mod.rs
+
+//! x86-64 serial output via COM1.
+//!
+//! Real-logd inherits the COM1 hardware from init's COM1 init (init's
+//! main thread programmed the UART during `serial_init`; UART
+//! programming state is per-device and persists). All logd needs is
+//! the `IoPortRange` cap (passed via bootstrap caps[3]) bound to its
+//! main thread so the `out`/`in` instructions don't fault.
+
+const COM1: u16 = 0x3F8;
+
+/// Bind the caller-provided `IoPortRange` cap to `thread_cap` so this
+/// thread can issue `out`/`in` against COM1. Silently no-ops on a
+/// zero cap (logd then runs without serial output — its received
+/// log lines are still buffered in memory).
+pub fn serial_init(thread_cap: u32, ioport_cap: u32)
+{
+    if ioport_cap == 0
+    {
+        return;
+    }
+    let _ = syscall::ioport_bind(thread_cap, ioport_cap);
+}
+
+/// Write one byte to COM1, spinning until the transmit register is
+/// ready. Silently no-ops when no I/O port cap is bound (the `out`
+/// instruction would trap; the bind is gated by
+/// [`serial_init`]).
+pub fn serial_write_byte(byte: u8)
+{
+    // SAFETY: reading LSR is a side-effect-free I/O port read on
+    // COM1, only valid after `ioport_bind` succeeded for this
+    // thread. If the cap was zero, this read traps — but `serial_init`
+    // would have left no-binding, and the caller decides not to
+    // invoke us in that case (see `crate::self_log` / `emit_line`
+    // for the gating).
+    while unsafe { inb(COM1 + 5) } & 0x20 == 0
+    {}
+    // SAFETY: writing one byte to the COM1 data register.
+    unsafe { outb(COM1, byte) };
+}
+
+/// # Safety
+///
+/// `port` must be a valid I/O port bound to the calling thread.
+#[inline]
+unsafe fn outb(port: u16, val: u8)
+{
+    // SAFETY: caller guarantees port is a valid I/O port bound to this thread.
+    unsafe {
+        core::arch::asm!("out dx, al", in("dx") port, in("al") val,
+            options(nomem, nostack, preserves_flags));
+    }
+}
+
+/// # Safety
+///
+/// `port` must be a valid I/O port bound to the calling thread.
+#[inline]
+unsafe fn inb(port: u16) -> u8
+{
+    let val: u8;
+    // SAFETY: caller guarantees port is a valid I/O port bound to this thread.
+    unsafe {
+        core::arch::asm!("in al, dx", in("dx") port, out("al") val,
+            options(nomem, nostack, preserves_flags));
+    }
+    val
+}

--- a/services/logd/src/handover.rs
+++ b/services/logd/src/handover.rs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// logd/src/handover.rs
+
+//! Real-logd → init-logd handover client.
+//!
+//! Sends `log_labels::HANDOVER_PULL` repeatedly on a SEND cap to the
+//! shared log endpoint until init-logd replies with the `DONE`
+//! status. Ingests the (slot table, history ring) payload along the
+//! way and merges it into logd's [`SlotTable`].
+//!
+//! Wire format mirrors `services/init/src/logging.rs`:
+//!
+//! * Reply label = `MORE` (0) or `DONE` (1).
+//! * `word(0)` = chunk kind: `HEADER` (1), `SLOT` (2), `LINE` (3).
+//! * `HEADER`: `word(1)` = total history-entry count, `word(2)` =
+//!   active slot count.
+//! * `SLOT`: `word(1)` = token, `word(2)` = name length;
+//!   `bytes(3, ...)` = name payload.
+//! * `LINE`: `word(1)` = token, `word(2)` = receipt microseconds,
+//!   `word(3)` = byte length; `bytes(4, ...)` = line payload.
+//!
+//! See `services/logd/docs/handover-protocol.md`.
+
+use ipc::IpcMessage;
+use ipc::log_labels::HANDOVER_PULL;
+
+use crate::slot::SlotTable;
+
+/// Reply codes mirror `services/init/src/logging.rs::handover_reply`.
+const REPLY_MORE: u64 = 0;
+const REPLY_DONE: u64 = 1;
+
+/// Chunk-kind codes mirror `services/init/src/logging.rs::handover_kind`.
+const KIND_HEADER: u64 = 1;
+const KIND_SLOT: u64 = 2;
+const KIND_LINE: u64 = 3;
+
+/// Drain init-logd's handover state into `table`. Returns on the
+/// first `DONE` reply (init-logd has at that point set its
+/// handover-complete flag and will self-terminate on its next loop
+/// iteration). Caps the loop at a generous iteration bound to
+/// guarantee termination on a malformed init-logd reply.
+///
+/// # Safety
+/// `ipc_buf` must be the calling thread's registered IPC buffer.
+pub unsafe fn pull_all(handover_send_cap: u32, ipc_buf: *mut u64, table: &mut SlotTable)
+{
+    // Bound: 1 header + MAX_SENDERS slots + HISTORY_RING_LEN lines +
+    // 1 DONE. init-logd's HISTORY_RING_LEN is 512, MAX_SENDERS is 16
+    // — 1024 is comfortable headroom for both. A malformed reply
+    // sequence is unreachable in the in-tree init-logd; the bound is
+    // a defence against a future protocol drift.
+    const MAX_ITERS: usize = 2048;
+
+    for _ in 0..MAX_ITERS
+    {
+        let req = IpcMessage::new(HANDOVER_PULL);
+        // SAFETY: caller's invariant — ipc_buf is the registered IPC
+        // buffer page.
+        let Ok(reply) = (unsafe { ipc::ipc_call(handover_send_cap, &req, ipc_buf) })
+        else
+        {
+            return;
+        };
+        // Init-logd packs SLOT/LINE byte lengths into label bits
+        // 16-31 (mirrors the stream-protocol convention). The status
+        // (MORE / DONE) lives in the bottom 16 bits.
+        let status = reply.label & 0xFFFF;
+        match reply.word(0)
+        {
+            KIND_HEADER =>
+            {
+                // Header is informational; nothing to install yet.
+                let _total = reply.word(1);
+                let _active = reply.word(2);
+            }
+            KIND_SLOT =>
+            {
+                let token = reply.word(1);
+                let name_len = reply.word(2) as usize;
+                let bytes = reply.data_bytes();
+                // Inline bytes start at data word 3. Mirror init-logd's
+                // `.bytes(3, ...)` packing offset (3 * 8 = 24 bytes).
+                let start = 3 * 8;
+                let end = (start + name_len).min(bytes.len());
+                if start < bytes.len()
+                {
+                    table.install_from_handover(token, &bytes[start..end]);
+                }
+            }
+            KIND_LINE =>
+            {
+                let token = reply.word(1);
+                let us = reply.word(2);
+                let byte_len = reply.word(3) as usize;
+                let bytes = reply.data_bytes();
+                // Inline bytes start at data word 4. Mirror init-logd's
+                // `.bytes(4, ...)` packing offset (4 * 8 = 32 bytes).
+                let start = 4 * 8;
+                let end = (start + byte_len).min(bytes.len());
+                if start < bytes.len()
+                {
+                    table.install_history_line(token, us, &bytes[start..end]);
+                }
+            }
+            _ =>
+            {}
+        }
+        if status == REPLY_DONE
+        {
+            return;
+        }
+        debug_assert_eq!(status, REPLY_MORE);
+    }
+}

--- a/services/logd/src/main.rs
+++ b/services/logd/src/main.rs
@@ -361,16 +361,21 @@ fn reply_ack(ipc_buf: *mut u64)
 /// Append `byte_len` bytes from the IPC payload onto the slot for
 /// `token`, flushing complete lines (`\n`-terminated) to the serial
 /// port AND recording them into the per-slot history ring.
+///
+/// Accepts up to `STREAM_CHUNK_SIZE = MSG_DATA_WORDS_MAX * 8` bytes
+/// per call (the maximum a single `STREAM_BYTES` IPC can carry); the
+/// per-line buffer is `LINE_BUF_SIZE` and force-flushes when full,
+/// so a chunk longer than `LINE_BUF_SIZE` produces multiple emitted
+/// lines rather than truncated output (matches init-logd's behaviour).
 fn consume_bytes(table: &mut SlotTable, token: u64, msg: &IpcMessage, byte_len: usize)
 {
+    const STREAM_CHUNK_SIZE: usize = syscall_abi::MSG_DATA_WORDS_MAX * 8;
+
     let bytes = msg.data_bytes();
-    let n = byte_len.min(bytes.len());
-    // Bound the byte stream to the receiver's working buffer length
-    // (matches init-logd's per-call cap to one chunk-sized burst).
-    let n = n.min(LINE_BUF_SIZE);
+    let n = byte_len.min(bytes.len()).min(STREAM_CHUNK_SIZE);
     // Stage the bytes in a stack buffer so we can borrow the slot
     // mutably without aliasing the IPC buffer.
-    let mut staged = [0u8; LINE_BUF_SIZE];
+    let mut staged = [0u8; STREAM_CHUNK_SIZE];
     staged[..n].copy_from_slice(&bytes[..n]);
     let slot = table.get_or_create(token);
     for &b in &staged[..n]

--- a/services/logd/src/main.rs
+++ b/services/logd/src/main.rs
@@ -1,0 +1,588 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// logd/src/main.rs
+
+//! Seraph system log daemon — post-mount owner of the master log
+//! endpoint.
+//!
+//! Spawned by init at the end of Phase 2, real-logd:
+//!
+//! 1. Receives via bootstrap protocol a RECV cap on the master log
+//!    endpoint, a SEND cap on the same endpoint (single-use, for the
+//!    `HANDOVER_PULL` IPC to init-logd), a SEND cap on procmgr
+//!    carrying `DEATH_EQ_AUTHORITY` (for `REGISTER_DEATH_EQ`), and
+//!    an arch-specific serial-authority cap (`IoPortRange` on
+//!    x86-64, `SbiControl` on RISC-V) for direct UART output.
+//! 2. Drains init-logd's captured state via `HANDOVER_PULL` until
+//!    `DONE`. Init-logd self-terminates immediately after replying
+//!    `DONE`.
+//! 3. Creates an `EventQueue` for procmgr-routed death notifications.
+//! 4. Registers the EQ with procmgr via `REGISTER_DEATH_EQ`. Procmgr
+//!    retroactively binds it on every existing thread and on every
+//!    future spawn (correlator = process token, equal to the log
+//!    token logd sees on `STREAM_BYTES`).
+//! 5. Enters the main wait loop, draining death notifications first
+//!    then servicing log endpoint messages.
+//!
+//! Logd does NOT use `seraph::log!` for its own diagnostics — it IS
+//! the log receiver, so a `log!` call would self-IPC into the
+//! endpoint it serves and deadlock once init-logd has terminated.
+//! Diagnostics + received log lines are emitted directly to serial
+//! via `arch::current::serial_write_byte`, mirroring init-logd's
+//! `flush_synthetic_logd_line` pattern.
+//!
+//! The pre-existing tokened SEND caps held by memmgr, procmgr,
+//! tier-1 services, and every Phase-3 child remain valid across the
+//! handover — same kernel endpoint object, only the RECV-holder
+//! changes.
+
+// The `seraph` target is not in rustc's recognised-OS list, so `std`
+// is `restricted_std`-gated for downstream bins.
+#![feature(restricted_std)]
+// cast_possible_truncation: targets 64-bit only; u64/usize conversions lossless.
+#![allow(clippy::cast_possible_truncation)]
+
+mod arch;
+mod handover;
+mod slot;
+
+use core::fmt::Write;
+
+use ipc::stream_labels::{STREAM_BYTES, STREAM_REGISTER_NAME};
+use ipc::{IpcMessage, procmgr_errors, procmgr_labels};
+use std::os::seraph::startup_info;
+
+use crate::slot::{LINE_BUF_SIZE, MAX_NAME_LEN, SlotTable};
+
+/// `WaitSet` token for the master log endpoint.
+const WS_TOKEN_LOG: u64 = 0;
+/// `WaitSet` token for the death-notification event queue.
+const WS_TOKEN_DEATH: u64 = 1;
+
+/// Caps real-logd receives from init's bootstrap round.
+struct BootCaps
+{
+    /// RECV cap on the master log endpoint. Real-logd is now the
+    /// RECV-holder; init-logd has already terminated by the time
+    /// this cap is in use.
+    log_ep_recv: u32,
+    /// SEND cap on the master log endpoint, used only for the
+    /// `HANDOVER_PULL` IPC to init-logd. Deleted after handover.
+    log_ep_handover_send: u32,
+    /// SEND cap on procmgr carrying `DEATH_EQ_AUTHORITY`, used to
+    /// call `REGISTER_DEATH_EQ`. Kept across the lifetime of
+    /// real-logd in case re-registration is ever needed.
+    procmgr_death_auth_send: u32,
+    /// Arch-specific serial-authority cap. `IoPortRange` on x86-64
+    /// (bound to logd's main thread for COM1 access);
+    /// `SbiControl` on RISC-V (used for SBI legacy
+    /// `console_putchar`). Zero disables serial output (logd then
+    /// buffers received log lines in memory only).
+    arch_serial_cap: u32,
+}
+
+fn bootstrap_caps(creator_endpoint: u32, ipc_buf: *mut u64) -> Option<BootCaps>
+{
+    if creator_endpoint == 0
+    {
+        return None;
+    }
+    // SAFETY: ipc_buf is the registered IPC buffer page.
+    let round = unsafe { ipc::bootstrap::request_round(creator_endpoint, ipc_buf) }.ok()?;
+    if round.cap_count < 4 || !round.done
+    {
+        return None;
+    }
+    Some(BootCaps {
+        log_ep_recv: round.caps[0],
+        log_ep_handover_send: round.caps[1],
+        procmgr_death_auth_send: round.caps[2],
+        arch_serial_cap: round.caps[3],
+    })
+}
+
+fn main() -> !
+{
+    let startup = startup_info();
+
+    // IPC buffer is registered by `_start`; reinterpret as `*mut u64`.
+    #[allow(clippy::cast_ptr_alignment)]
+    let ipc_buf = startup.ipc_buffer.cast::<u64>();
+
+    let Some(caps) = bootstrap_caps(startup.creator_endpoint, ipc_buf)
+    else
+    {
+        syscall::thread_exit();
+    };
+
+    // Wire serial output BEFORE handover, so logd's own diagnostics
+    // are visible. On x86-64 this binds the IoPortRange cap to
+    // logd's main thread; on RISC-V it stashes the SbiControl cap
+    // for SBI calls.
+    arch::current::serial_init(startup.self_thread, caps.arch_serial_cap);
+
+    self_log("started; pulling init-logd handover state");
+
+    let mut table = SlotTable::default();
+    // SAFETY: ipc_buf is the registered IPC buffer page.
+    unsafe { handover::pull_all(caps.log_ep_handover_send, ipc_buf, &mut table) };
+
+    // Handover send cap is single-use; drop it now so we don't carry a
+    // SEND cap to the log endpoint around (the only legitimate path
+    // for that cap was the handover IPC).
+    let _ = syscall::cap_delete(caps.log_ep_handover_send);
+
+    {
+        let mut buf = SerialFmt::new();
+        let _ = write!(
+            buf,
+            "handover complete: {} slots, {} history lines",
+            table.slots.len(),
+            table.slots.values().map(|s| s.history.len()).sum::<usize>(),
+        );
+        buf.flush_self_log();
+    }
+
+    let Some(death_eq) = create_death_eq()
+    else
+    {
+        self_log("FATAL: death-EQ create failed; halting");
+        syscall::thread_exit();
+    };
+
+    register_with_procmgr(caps.procmgr_death_auth_send, death_eq, ipc_buf);
+
+    let Some(ws_cap) = create_wait_set(caps.log_ep_recv, death_eq)
+    else
+    {
+        self_log("FATAL: wait_set create failed; halting");
+        syscall::thread_exit();
+    };
+
+    event_loop(ws_cap, death_eq, caps.log_ep_recv, ipc_buf, &mut table);
+}
+
+/// Allocate the slab and create the death-notification `EventQueue`.
+/// Capacity sized so a burst of simultaneous child deaths fits before
+/// logd's next drain (`MAX_DEATHS_PER_BURST`).
+fn create_death_eq() -> Option<u32>
+{
+    const MAX_DEATHS_PER_BURST: u32 = 64;
+    // Bytes: 24 wrapper + 56 state + (capacity + 1) * 8 ring.
+    let slab_bytes: u64 = 24 + 56 + (u64::from(MAX_DEATHS_PER_BURST) + 1) * 8;
+    let slab = std::os::seraph::object_slab_acquire(slab_bytes)?;
+    syscall::event_queue_create(slab, MAX_DEATHS_PER_BURST).ok()
+}
+
+/// Build a 2-member wait set: the log endpoint (`WS_TOKEN_LOG`) and
+/// the death event queue (`WS_TOKEN_DEATH`).
+fn create_wait_set(log_ep_recv: u32, death_eq: u32) -> Option<u32>
+{
+    let slab = std::os::seraph::object_slab_acquire(4096)?;
+    let ws = match syscall::wait_set_create(slab)
+    {
+        Ok(c) => c,
+        Err(e) =>
+        {
+            let mut buf = SerialFmt::new();
+            let _ = write!(buf, "wait_set_create err={e} slab={slab}");
+            buf.flush_self_log();
+            return None;
+        }
+    };
+    if let Err(e) = syscall::wait_set_add(ws, log_ep_recv, WS_TOKEN_LOG)
+    {
+        let mut buf = SerialFmt::new();
+        let _ = write!(buf, "wait_set_add(log) err={e}");
+        buf.flush_self_log();
+        return None;
+    }
+    if let Err(e) = syscall::wait_set_add(ws, death_eq, WS_TOKEN_DEATH)
+    {
+        let mut buf = SerialFmt::new();
+        let _ = write!(buf, "wait_set_add(death) err={e}");
+        buf.flush_self_log();
+        return None;
+    }
+    Some(ws)
+}
+
+/// POST = bit 9 (matches `core::cap::slot::Rights::POST` =
+/// `1 << 9`). Construct directly; `shared/syscall` does not expose
+/// a `RIGHTS_POST` helper yet.
+const RIGHTS_POST: u64 = 1 << 9;
+
+/// Send `REGISTER_DEATH_EQ` to procmgr.
+///
+/// `ipc_call` on a message carrying a cap MOVES the cap into the
+/// receiver's `CSpace` and clears the sender's slot. logd needs to
+/// retain `RECV` on the original event queue so `wait_set_add` and
+/// `event_try_recv` keep working, so it first derives a POST-only
+/// copy and transfers that. Procmgr's `REGISTER_DEATH_EQ` handler
+/// gates on the POST right (`sys_thread_bind_notification`'s lookup
+/// already requires it).
+fn register_with_procmgr(procmgr_send: u32, death_eq: u32, ipc_buf: *mut u64)
+{
+    if procmgr_send == 0
+    {
+        self_log("REGISTER_DEATH_EQ skipped: no procmgr cap");
+        return;
+    }
+    let Ok(post_cap) = syscall::cap_derive(death_eq, RIGHTS_POST)
+    else
+    {
+        self_log("REGISTER_DEATH_EQ: cap_derive POST failed");
+        return;
+    };
+    let msg = IpcMessage::builder(procmgr_labels::REGISTER_DEATH_EQ)
+        .cap(post_cap)
+        .build();
+    // SAFETY: ipc_buf is the registered IPC buffer page; the cap
+    // transfer moves `post_cap` into procmgr's CSpace.
+    let Ok(reply) = (unsafe { ipc::ipc_call(procmgr_send, &msg, ipc_buf) })
+    else
+    {
+        self_log("REGISTER_DEATH_EQ: IPC call failed");
+        let _ = syscall::cap_delete(post_cap);
+        return;
+    };
+    if reply.label == procmgr_errors::SUCCESS
+    {
+        self_log("REGISTER_DEATH_EQ: bound on procmgr");
+    }
+    else
+    {
+        let mut buf = SerialFmt::new();
+        let _ = write!(buf, "REGISTER_DEATH_EQ: error code {}", reply.label);
+        buf.flush_self_log();
+    }
+}
+
+/// Main wait loop. Drains death notifications before each log-EP
+/// dispatch so a recently-died sender's slot is evicted before we
+/// process its in-flight messages (matches procmgr's drain-deaths-
+/// first pattern).
+fn event_loop(
+    ws_cap: u32,
+    death_eq: u32,
+    log_ep_recv: u32,
+    ipc_buf: *mut u64,
+    table: &mut SlotTable,
+) -> !
+{
+    loop
+    {
+        let Ok(token) = syscall::wait_set_wait(ws_cap)
+        else
+        {
+            continue;
+        };
+        drain_deaths(death_eq, table);
+        // Only WS_TOKEN_LOG warrants service action; deaths were
+        // already drained above. WS_TOKEN_DEATH and unknown tokens
+        // fall through silently.
+        if token == WS_TOKEN_LOG
+        {
+            dispatch_log(log_ep_recv, ipc_buf, table);
+        }
+    }
+}
+
+/// Non-blocking drain of the death event queue. Each payload encodes
+/// `(process_token as u32) << 32 | exit_reason`. We evict the
+/// matching slot from the token table.
+fn drain_deaths(death_eq: u32, table: &mut SlotTable)
+{
+    loop
+    {
+        let Ok(payload) = syscall::event_try_recv(death_eq)
+        else
+        {
+            return;
+        };
+        let correlator = (payload >> 32) as u32;
+        let exit_reason = payload as u32;
+        // Token in logd's slot map is the full u64; the correlator
+        // procmgr binds is `process_token as u32`. Match against the
+        // low 32 bits.
+        let dead: Vec<u64> = table
+            .slots
+            .keys()
+            .copied()
+            .filter(|&t| (t as u32) == correlator)
+            .collect();
+        for token in dead
+        {
+            if table.evict(token)
+            {
+                let mut buf = SerialFmt::new();
+                let _ = write!(buf, "reclaim: token={token} exit_reason=0x{exit_reason:x}");
+                buf.flush_self_log();
+            }
+        }
+    }
+}
+
+fn dispatch_log(log_ep_recv: u32, ipc_buf: *mut u64, table: &mut SlotTable)
+{
+    // SAFETY: ipc_buf is the registered IPC buffer page.
+    let Ok(recv) = (unsafe { ipc::ipc_recv(log_ep_recv, ipc_buf) })
+    else
+    {
+        return;
+    };
+    let label_id = recv.label & 0xFFFF;
+    let byte_len = ((recv.label >> 16) & 0xFFFF) as usize;
+    if label_id == STREAM_BYTES
+    {
+        consume_bytes(table, recv.token, &recv, byte_len);
+        reply_ack(ipc_buf);
+    }
+    else if label_id == STREAM_REGISTER_NAME
+    {
+        register_name(table, recv.token, &recv, byte_len);
+        reply_ack(ipc_buf);
+    }
+    else
+    {
+        // Unknown / legacy label (e.g. GET_LOG_CAP from a hypothetical
+        // pre-pivot caller). Reply empty so the sender unblocks.
+        reply_ack(ipc_buf);
+    }
+}
+
+fn reply_ack(ipc_buf: *mut u64)
+{
+    // SAFETY: ipc_buf is the registered IPC buffer page.
+    let _ = unsafe { ipc::ipc_reply(&IpcMessage::new(0), ipc_buf) };
+}
+
+/// Append `byte_len` bytes from the IPC payload onto the slot for
+/// `token`, flushing complete lines (`\n`-terminated) to the serial
+/// port AND recording them into the per-slot history ring.
+fn consume_bytes(table: &mut SlotTable, token: u64, msg: &IpcMessage, byte_len: usize)
+{
+    let bytes = msg.data_bytes();
+    let n = byte_len.min(bytes.len());
+    // Bound the byte stream to the receiver's working buffer length
+    // (matches init-logd's per-call cap to one chunk-sized burst).
+    let n = n.min(LINE_BUF_SIZE);
+    // Stage the bytes in a stack buffer so we can borrow the slot
+    // mutably without aliasing the IPC buffer.
+    let mut staged = [0u8; LINE_BUF_SIZE];
+    staged[..n].copy_from_slice(&bytes[..n]);
+    let slot = table.get_or_create(token);
+    for &b in &staged[..n]
+    {
+        if b == b'\n'
+        {
+            flush_partial(token, slot);
+        }
+        else if slot.partial.len() < LINE_BUF_SIZE
+        {
+            slot.partial.push(b);
+            if slot.partial.len() == LINE_BUF_SIZE
+            {
+                flush_partial(token, slot);
+            }
+        }
+    }
+}
+
+/// Snapshot the slot's in-progress line, emit it to serial, append
+/// it to the history ring, clear the partial buffer. Separated so
+/// the `&slot.name`/`&slot.partial` borrows don't alias the
+/// subsequent `&mut slot` calls.
+fn flush_partial(token: u64, slot: &mut crate::slot::Slot)
+{
+    let name = slot.name.clone();
+    let line: Vec<u8> = slot.partial.drain(..).collect();
+    emit_line(token, &name, &line);
+    let us = elapsed_us();
+    slot.push_history(us, &line);
+}
+
+/// Record / update the display name for `token`. Lines emitted with
+/// the old name remain attributed to the old name in history (those
+/// are immutable); subsequent emissions render under the new name.
+/// Long names truncated. No collision-suffix policy (procmgr's
+/// process token is unique, so name collisions only happen if two
+/// processes intentionally pick the same display name).
+fn register_name(table: &mut SlotTable, token: u64, msg: &IpcMessage, byte_len: usize)
+{
+    let bytes = msg.data_bytes();
+    let n = byte_len.min(bytes.len()).min(MAX_NAME_LEN);
+    let slot = table.get_or_create(token);
+    slot.name.clear();
+    slot.name.extend_from_slice(&bytes[..n]);
+}
+
+/// Emit `[sec.usfrac] [name] <bytes>\r\n` directly to the serial
+/// port. Mirrors init-logd's `flush_line` shape so the post-handover
+/// output stream looks identical to the pre-handover output.
+fn emit_line(_token: u64, name: &[u8], line: &[u8])
+{
+    let us = elapsed_us();
+    let sec = us / 1_000_000;
+    let usfrac = (us % 1_000_000) as u32;
+
+    arch::current::serial_write_byte(b'[');
+    write_decimal(sec);
+    arch::current::serial_write_byte(b'.');
+    write_decimal_padded(u64::from(usfrac), 6);
+    arch::current::serial_write_byte(b']');
+    arch::current::serial_write_byte(b' ');
+
+    arch::current::serial_write_byte(b'[');
+    if name.is_empty()
+    {
+        arch::current::serial_write_byte(b'?');
+    }
+    else
+    {
+        for &b in name
+        {
+            arch::current::serial_write_byte(b);
+        }
+    }
+    arch::current::serial_write_byte(b']');
+    arch::current::serial_write_byte(b' ');
+
+    for &b in line
+    {
+        if b == b'\n'
+        {
+            arch::current::serial_write_byte(b'\r');
+        }
+        arch::current::serial_write_byte(b);
+    }
+    arch::current::serial_write_byte(b'\r');
+    arch::current::serial_write_byte(b'\n');
+}
+
+/// Emit `[sec.usfrac] [logd] <payload>\r\n` directly to the serial
+/// port. Used for logd's own internal diagnostics, replacing every
+/// `seraph::log!` call (which would self-IPC into the log endpoint
+/// logd serves).
+fn self_log(payload: &str)
+{
+    let us = elapsed_us();
+    let sec = us / 1_000_000;
+    let usfrac = (us % 1_000_000) as u32;
+
+    arch::current::serial_write_byte(b'[');
+    write_decimal(sec);
+    arch::current::serial_write_byte(b'.');
+    write_decimal_padded(u64::from(usfrac), 6);
+    arch::current::serial_write_byte(b']');
+    arch::current::serial_write_byte(b' ');
+
+    arch::current::serial_write_byte(b'[');
+    for &b in b"logd"
+    {
+        arch::current::serial_write_byte(b);
+    }
+    arch::current::serial_write_byte(b']');
+    arch::current::serial_write_byte(b' ');
+
+    for b in payload.bytes()
+    {
+        if b == b'\n'
+        {
+            arch::current::serial_write_byte(b'\r');
+        }
+        arch::current::serial_write_byte(b);
+    }
+    arch::current::serial_write_byte(b'\r');
+    arch::current::serial_write_byte(b'\n');
+}
+
+/// Stack-buffer `fmt::Write` adapter for one-shot formatted
+/// diagnostics. 256-byte cap matches `LINE_BUF_SIZE`; over-long
+/// formatted output truncates.
+struct SerialFmt
+{
+    buf: [u8; 256],
+    used: usize,
+}
+
+impl SerialFmt
+{
+    fn new() -> Self
+    {
+        Self {
+            buf: [0u8; 256],
+            used: 0,
+        }
+    }
+
+    fn flush_self_log(&self)
+    {
+        // SAFETY: SerialFmt only ever receives UTF-8 from
+        // `core::fmt::write`.
+        let s = unsafe { core::str::from_utf8_unchecked(&self.buf[..self.used]) };
+        self_log(s);
+    }
+}
+
+impl Write for SerialFmt
+{
+    fn write_str(&mut self, s: &str) -> core::fmt::Result
+    {
+        let bytes = s.as_bytes();
+        let cap = self.buf.len() - self.used;
+        let n = bytes.len().min(cap);
+        self.buf[self.used..self.used + n].copy_from_slice(&bytes[..n]);
+        self.used += n;
+        Ok(())
+    }
+}
+
+fn write_decimal(value: u64)
+{
+    let mut buf = [0u8; 20];
+    let mut n = value;
+    let mut idx = buf.len();
+    if n == 0
+    {
+        idx -= 1;
+        buf[idx] = b'0';
+    }
+    else
+    {
+        while n > 0
+        {
+            idx -= 1;
+            buf[idx] = b'0' + (n % 10) as u8;
+            n /= 10;
+        }
+    }
+    for &b in &buf[idx..]
+    {
+        arch::current::serial_write_byte(b);
+    }
+}
+
+fn write_decimal_padded(value: u64, width: usize)
+{
+    let mut buf = [b'0'; 20];
+    let mut n = value;
+    let mut idx = buf.len();
+    while n > 0 && idx > 0
+    {
+        idx -= 1;
+        buf[idx] = b'0' + (n % 10) as u8;
+        n /= 10;
+    }
+    let start = buf.len().saturating_sub(width);
+    for &b in &buf[start..]
+    {
+        arch::current::serial_write_byte(b);
+    }
+}
+
+fn elapsed_us() -> u64
+{
+    syscall::system_info(syscall_abi::SystemInfoType::ElapsedUs as u64).unwrap_or(0)
+}

--- a/services/logd/src/slot.rs
+++ b/services/logd/src/slot.rs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// logd/src/slot.rs
+
+//! Per-sender state: display name, partial-line buffer, and the bounded
+//! history ring of completed lines retained for future query/disk/syslog
+//! sinks.
+//!
+//! Slots are keyed by the kernel-delivered token on every IPC message —
+//! the same `u64` procmgr uses as the child's process token and the
+//! correlator on its death-EQ binding. Slot eviction is driven by the
+//! death-EQ event drained inside logd's main loop.
+
+use std::collections::HashMap;
+
+/// Per-sender line-buffer size. Lines longer than this are flushed
+/// without a trailing newline (preserves the prefix attribution).
+pub const LINE_BUF_SIZE: usize = 256;
+
+/// Maximum per-slot display-name length in bytes.
+pub const MAX_NAME_LEN: usize = 48;
+
+/// Number of completed log lines retained per slot for future query
+/// surfaces. Bounded to keep total memory predictable at ~10k senders
+/// (10k * 16 * 256 ≈ 40 MiB worst case if every sender saturates;
+/// in practice most slots stay near empty).
+pub const PER_SLOT_HISTORY: usize = 16;
+
+/// One retained completed line. Fields are written at line-flush
+/// time and read by future query / disk-persistence / network-syslog
+/// sinks — those sinks land in follow-up PRs (see issue #1 scope
+/// out-of-scope items), so the fields are dead-code-flagged today
+/// but the storage is part of this PR's deliverable.
+#[allow(dead_code)]
+#[derive(Clone)]
+pub struct LineRecord
+{
+    /// Receipt microseconds since boot
+    /// (`system_info(ElapsedUs)`-derived).
+    pub us: u64,
+    /// Line bytes, no trailing `\n`. Length bounded by
+    /// [`LINE_BUF_SIZE`].
+    pub bytes: Vec<u8>,
+}
+
+/// Per-sender bucket. Stores the display name registered via
+/// `STREAM_REGISTER_NAME`, the in-progress line buffer, and the
+/// bounded ring of completed lines.
+#[derive(Default)]
+pub struct Slot
+{
+    pub name: Vec<u8>,
+    pub partial: Vec<u8>,
+    pub history: std::collections::VecDeque<LineRecord>,
+}
+
+impl Slot
+{
+    pub fn push_history(&mut self, us: u64, bytes: &[u8])
+    {
+        if self.history.len() == PER_SLOT_HISTORY
+        {
+            self.history.pop_front();
+        }
+        self.history.push_back(LineRecord {
+            us,
+            bytes: bytes.to_vec(),
+        });
+    }
+}
+
+/// Token-keyed slot map. `Default::default()` is the empty state at
+/// boot; the ingested handover state from init-logd is merged in via
+/// [`Self::install_from_handover`].
+#[derive(Default)]
+pub struct SlotTable
+{
+    pub slots: HashMap<u64, Slot>,
+}
+
+impl SlotTable
+{
+    pub fn get_or_create(&mut self, token: u64) -> &mut Slot
+    {
+        self.slots.entry(token).or_default()
+    }
+
+    /// Look up `token`, returning `None` when the sender has been
+    /// evicted (by death-EQ) or never logged. Used by future query
+    /// surfaces; kept for symmetry with `get_or_create` even though
+    /// no caller in this PR exercises it.
+    #[allow(dead_code)]
+    pub fn get(&self, token: u64) -> Option<&Slot>
+    {
+        self.slots.get(&token)
+    }
+
+    /// Evict the slot for `token`. Called when procmgr's death-EQ
+    /// notification fires (correlator = process token). Idempotent on
+    /// unknown tokens.
+    pub fn evict(&mut self, token: u64) -> bool
+    {
+        self.slots.remove(&token).is_some()
+    }
+
+    /// Install one slot's (token, name) pair from the init-logd
+    /// handover replies. History lines arrive separately as
+    /// [`Self::install_history_line`].
+    pub fn install_from_handover(&mut self, token: u64, name: &[u8])
+    {
+        let slot = self.get_or_create(token);
+        let n = name.len().min(MAX_NAME_LEN);
+        slot.name.clear();
+        slot.name.extend_from_slice(&name[..n]);
+    }
+
+    /// Append one history line from the init-logd handover into the
+    /// matching slot's ring. Creates the slot if absent (some history
+    /// lines may have originated from senders whose slot was evicted
+    /// from init-logd's small ring; the line itself still attributes
+    /// to its token).
+    pub fn install_history_line(&mut self, token: u64, us: u64, bytes: &[u8])
+    {
+        self.get_or_create(token).push_history(us, bytes);
+    }
+}

--- a/services/procmgr/README.md
+++ b/services/procmgr/README.md
@@ -60,6 +60,14 @@ procmgr/
   it retroactively on every existing thread, and bind it on every
   new spawn alongside procmgr's own death observer (correlator =
   process token, equal to logd's per-sender slot key).
+- **Init reap** — accept init's `REGISTER_INIT_TEARDOWN` handoff
+  at end-of-Phase-3 (init's own `AddressSpace` / `CSpace` / `Thread`
+  caps + every reclaimable Frame cap), bind a death-EQ observer on
+  init's main thread with `INIT_REAP_CORRELATOR`, then on the death
+  event (driven by init's `sys_thread_exit`) tear down init's
+  kernel objects in order (Threads → AddressSpace → donate Frame
+  caps to memmgr → CSpace), leaving zero init residue. See
+  [`src/init_reap.rs`](src/init_reap.rs).
 
 ---
 

--- a/services/procmgr/README.md
+++ b/services/procmgr/README.md
@@ -48,6 +48,18 @@ procmgr/
   notify memmgr.
 - **Process registry** — maintain a table of running processes; answer
   queries from svcmgr and other services.
+- **Per-child log cap seeding** — derive a tokened SEND cap on the
+  master log endpoint at every spawn (token = the child's process
+  token) and install the slot at `ProcessInfo.log_send_cap`. The
+  un-tokened source cap arrives in procmgr's bootstrap round from
+  init. Children call `seraph::log!` directly through the seeded
+  cap; no `GET_LOG_CAP` discovery roundtrip.
+- **Death-notification fan-out to logd** — accept
+  `REGISTER_DEATH_EQ` from real-logd (gated by the
+  `DEATH_EQ_AUTHORITY` token), store logd's `EventQueue` cap, bind
+  it retroactively on every existing thread, and bind it on every
+  new spawn alongside procmgr's own death observer (correlator =
+  process token, equal to logd's per-sender slot key).
 
 ---
 

--- a/services/procmgr/docs/ipc-interface.md
+++ b/services/procmgr/docs/ipc-interface.md
@@ -237,6 +237,43 @@ keep `wait_set_add` and `event_try_recv` working.
 
 ---
 
+## REGISTER_INIT_TEARDOWN — init reap handoff
+
+Wire format:
+
+| Field | Meaning |
+|---|---|
+| label | `procmgr_labels::REGISTER_INIT_TEARDOWN` (15) |
+| `data[0]` | `1` on the first round (carrying kernel-object caps); `0` on subsequent donation rounds |
+| `caps[0..]` | Round 1: 4 kernel-object caps (`AddressSpace`, `CSpace`, main `Thread`, init-logd `Thread`) — MOVED out of init's CSpace via IPC cap-transfer. Subsequent rounds: 1-4 reclaimable Frame caps per round (segments, stack, `InitInfo` pages, IPC buffer). |
+
+On the first round procmgr stores the kernel-object caps and calls
+`syscall::thread_bind_notification(main_thread, death_eq,
+procmgr_labels::INIT_REAP_CORRELATOR)`. Subsequent rounds append to
+the donation Frame cap list. `INIT_TEARDOWN_DONE` (label 16, no
+caps, no data words) closes the stream and arms the state machine.
+
+Reply: `procmgr_errors::SUCCESS` on accept, `INVALID_ARGUMENT` on
+wrong round shape (wrong cap count on round 1, or `done` before any
+round 1).
+
+## INIT_TEARDOWN_DONE — end-of-stream signal
+
+Wire format:
+
+| Field | Meaning |
+|---|---|
+| label | `procmgr_labels::INIT_TEARDOWN_DONE` (16) |
+| caps | none |
+
+Procmgr replies `SUCCESS` then arms the state machine. Init proceeds
+to `sys_thread_exit` immediately; the death-EQ event with
+`INIT_REAP_CORRELATOR` (reserved `u32::MAX`) triggers
+[`init_reap::run_reap`](../src/init_reap.rs) which executes the six-step
+teardown (Threads → AddressSpace → DONATE_FRAMES → CSpace → log).
+
+---
+
 ## Relevant Design Documents
 
 | Document | Content |

--- a/services/procmgr/docs/ipc-interface.md
+++ b/services/procmgr/docs/ipc-interface.md
@@ -208,6 +208,35 @@ procmgr retains the original caps for process lifecycle management.
 
 ---
 
+## REGISTER_DEATH_EQ — install logd's death observer
+
+Wire format:
+
+| Field | Meaning |
+|---|---|
+| label | `procmgr_labels::REGISTER_DEATH_EQ` (14) |
+| caller's cap token | MUST equal `procmgr_labels::DEATH_EQ_AUTHORITY` (`1 << 62`); init mints this tokened SEND cap and gives it exclusively to real-logd at bootstrap |
+| `caps[0]` | `EventQueue` cap with `POST` right; procmgr binds it as a second death observer on every supervised thread |
+
+Procmgr stores the cap in
+[`process::LOGD_DEATH_EQ`](../src/process.rs) and immediately
+walks its process table, calling
+`sys_thread_bind_notification(entry.thread_cap, logd_eq,
+entry.token as u32)` on every live entry. From that moment onward,
+[`finalize_creation`](../src/process.rs) also binds the same EQ on
+every newly spawned child (correlator = process token).
+
+Reply: `procmgr_errors::SUCCESS` on bind, `UNAUTHORIZED` if the
+caller lacks `DEATH_EQ_AUTHORITY`, `INVALID_ARGUMENT` if no cap was
+transferred. Re-registration replaces the previous cap.
+
+logd derives a `POST`-only copy from its `RECV+POST` event queue
+before sending — the kernel's cap-transfer moves the sent cap into
+procmgr's CSpace, so logd must retain `RECV` on its own copy to
+keep `wait_set_add` and `event_try_recv` working.
+
+---
+
 ## Relevant Design Documents
 
 | Document | Content |

--- a/services/procmgr/src/init_reap.rs
+++ b/services/procmgr/src/init_reap.rs
@@ -102,12 +102,24 @@ pub fn handle_register(req: &IpcMessage, ipc_buf: *mut u64, death_eq: u32)
         )
         .is_err()
         {
-            // Bind failed — drop the moved-in caps and refuse so init
-            // doesn't proceed to thread_exit thinking it'll be reaped.
-            let _ = syscall::cap_delete(aspace);
-            let _ = syscall::cap_delete(cspace);
-            let _ = syscall::cap_delete(main_thread);
-            let _ = syscall::cap_delete(logd_thread);
+            // Bind failed. We CANNOT cap_delete the moved-in
+            // AS/CSpace/Thread caps here: procmgr now holds the last
+            // reference, and init's threads are still actively
+            // running on the AS (we are mid-IPC). Dealloc would trip
+            // the `active_cpu_mask == 0` assert at
+            // `core/kernel/src/cap/object.rs` AddressSpace arm.
+            //
+            // Reply ERROR and leave the caps held in procmgr. Init
+            // observes the failure and aborts the handoff
+            // (`services/init/src/service.rs:handoff_to_procmgr_reap`),
+            // then `sys_thread_exit`s. The orphaned caps are a small
+            // one-shot leak on this failure-only path; the underlying
+            // bind error indicates a deeper problem (kernel out of
+            // observer slots) that warrants log + continue rather
+            // than recursive teardown.
+            std::os::seraph::log!(
+                "init-reap: thread_bind_notification failed; refusing handoff (caps leaked in procmgr)"
+            );
             reply(ipc_buf, procmgr_errors::INVALID_ARGUMENT);
             return;
         }

--- a/services/procmgr/src/init_reap.rs
+++ b/services/procmgr/src/init_reap.rs
@@ -79,15 +79,36 @@ pub fn handle_register(req: &IpcMessage, ipc_buf: *mut u64, death_eq: u32)
     let caps = req.caps();
     let is_first = req.word(0) != 0;
     let mut guard = STATE.lock().expect("init-reap state poisoned");
+
+    // Shared invariant for the error arms below: caps the kernel just
+    // moved into procmgr's CSpace cannot be `cap_delete`d here.
+    //   * AddressSpace caps would trip `dealloc_object`'s
+    //     `active_cpu_mask == 0` assert — init's threads are still
+    //     running on that AS while this IPC is in flight.
+    //   * Frame caps (donation rounds) would buddy-free pages that
+    //     init's still-live AS has mapped, recreating the very
+    //     aliasing window the reap ordering exists to prevent.
+    // Init is the sole legitimate caller, all reject arms are
+    // unreachable in well-formed traffic, and on the reject path init
+    // observes the error reply and aborts. The orphaned caps are a
+    // one-shot leak on a failure-only path.
+
     if is_first
     {
         if guard.is_some()
         {
+            std::os::seraph::log!(
+                "init-reap: duplicate first round; refusing (caps leaked in procmgr)"
+            );
             reply(ipc_buf, procmgr_errors::INVALID_ARGUMENT);
             return;
         }
         if caps.len() != 4
         {
+            std::os::seraph::log!(
+                "init-reap: first round expected 4 caps, got {}; refusing (caps leaked in procmgr)",
+                caps.len(),
+            );
             reply(ipc_buf, procmgr_errors::INVALID_ARGUMENT);
             return;
         }
@@ -102,21 +123,6 @@ pub fn handle_register(req: &IpcMessage, ipc_buf: *mut u64, death_eq: u32)
         )
         .is_err()
         {
-            // Bind failed. We CANNOT cap_delete the moved-in
-            // AS/CSpace/Thread caps here: procmgr now holds the last
-            // reference, and init's threads are still actively
-            // running on the AS (we are mid-IPC). Dealloc would trip
-            // the `active_cpu_mask == 0` assert at
-            // `core/kernel/src/cap/object.rs` AddressSpace arm.
-            //
-            // Reply ERROR and leave the caps held in procmgr. Init
-            // observes the failure and aborts the handoff
-            // (`services/init/src/service.rs:handoff_to_procmgr_reap`),
-            // then `sys_thread_exit`s. The orphaned caps are a small
-            // one-shot leak on this failure-only path; the underlying
-            // bind error indicates a deeper problem (kernel out of
-            // observer slots) that warrants log + continue rather
-            // than recursive teardown.
             std::os::seraph::log!(
                 "init-reap: thread_bind_notification failed; refusing handoff (caps leaked in procmgr)"
             );
@@ -138,6 +144,10 @@ pub fn handle_register(req: &IpcMessage, ipc_buf: *mut u64, death_eq: u32)
     let Some(state) = guard.as_mut()
     else
     {
+        std::os::seraph::log!(
+            "init-reap: donation round without prior first round; refusing ({} caps leaked in procmgr)",
+            caps.len(),
+        );
         reply(ipc_buf, procmgr_errors::INVALID_ARGUMENT);
         return;
     };
@@ -150,15 +160,26 @@ pub fn handle_register(req: &IpcMessage, ipc_buf: *mut u64, death_eq: u32)
 
 /// Handle `INIT_TEARDOWN_DONE`. Marks the state machine armed; the
 /// next death-EQ event with `INIT_REAP_CORRELATOR` triggers `run_reap`.
+///
+/// Rejects when state is `None` (no preceding first round) or when
+/// already armed (re-arm is meaningless and signals a malformed
+/// caller).
 pub fn handle_done(ipc_buf: *mut u64)
 {
     let mut guard = STATE.lock().expect("init-reap state poisoned");
     let Some(state) = guard.as_mut()
     else
     {
+        std::os::seraph::log!("init-reap: DONE without prior first round; refusing");
         reply(ipc_buf, procmgr_errors::INVALID_ARGUMENT);
         return;
     };
+    if state.armed
+    {
+        std::os::seraph::log!("init-reap: DONE called while already armed; refusing");
+        reply(ipc_buf, procmgr_errors::INVALID_ARGUMENT);
+        return;
+    }
     state.armed = true;
     reply(ipc_buf, procmgr_errors::SUCCESS);
 }

--- a/services/procmgr/src/init_reap.rs
+++ b/services/procmgr/src/init_reap.rs
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+//! Init reap-handoff: receives init's own kernel-object caps and
+//! reclaimable Frame caps in the post-Phase-3 exit IPCs, binds a
+//! death-EQ observer on init's main thread, and on the resulting
+//! death event tears down init's `AddressSpace`/`CSpace`/`Thread`
+//! objects and donates the Frame caps to memmgr.
+//!
+//! State machine (single-threaded; serialised under procmgr's
+//! `service_ep` recv loop):
+//!
+//! ```text
+//! Empty
+//!   │  REGISTER_INIT_TEARDOWN  (first round; data[0] != 0)
+//!   ▼
+//! Collecting{aspace, cspace, main_thread, logd_thread, caps[..]}
+//!   │  REGISTER_INIT_TEARDOWN  (subsequent rounds; data[0] == 0)
+//!   ▼ (appends Frame caps to caps[..])
+//! Collecting
+//!   │  INIT_TEARDOWN_DONE
+//!   ▼
+//! Armed   (waiting for death-EQ event with INIT_REAP_CORRELATOR)
+//!   │
+//!   ▼  dispatch_death sees correlator == INIT_REAP_CORRELATOR
+//! Reaping (run_reap):
+//!   1. cap_delete(logd_thread)
+//!   2. cap_delete(main_thread)
+//!   3. cap_revoke + cap_delete(aspace)        — mappings gone
+//!   4. DONATE_FRAMES(caps[..]) → memmgr       — safe; no aliasing
+//!   5. cap_revoke + cap_delete(cspace)        — cascade clears
+//!                                                undonated caps to
+//!                                                kernel buddy
+//!   6. log summary
+//! ```
+
+// Procmgr runs single-threaded under its lone `service_ep` recv loop;
+// the `Mutex` here is only the `Sync` shell required for a `static`.
+// `expect` on `.lock()` therefore cannot fire in practice (no contention
+// → no poisoning), and a Vec inside `Option` avoids any unsafe statics.
+#![allow(clippy::expect_used)]
+
+use std::sync::Mutex;
+
+use ipc::{IpcMessage, memmgr_errors, memmgr_labels, procmgr_errors, procmgr_labels};
+use syscall_abi::MSG_CAP_SLOTS_MAX;
+
+/// Init's kernel-object and reclaim-Frame caps, accumulated across
+/// `REGISTER_INIT_TEARDOWN` rounds and consumed by `run_reap`.
+///
+/// `aspace`/`cspace`/`main_thread`/`logd_thread` are the procmgr-side
+/// slots holding the moved-in caps; `donate_caps` is the list of
+/// reclaimable Frame caps (segments + stack + `InitInfo` + IPC buffer +
+/// any other init-owned Frame the reap-handoff covers).
+pub struct InitReapState
+{
+    aspace: u32,
+    cspace: u32,
+    main_thread: u32,
+    logd_thread: u32,
+    donate_caps: Vec<u32>,
+    armed: bool,
+}
+
+/// State machine slot. `None` until init's first
+/// `REGISTER_INIT_TEARDOWN`; populated and progressively filled by
+/// later rounds; transitions to `armed = true` on `INIT_TEARDOWN_DONE`.
+/// Cleared back to `None` after `run_reap` completes.
+static STATE: Mutex<Option<InitReapState>> = Mutex::new(None);
+
+/// Handle a `REGISTER_INIT_TEARDOWN` IPC.
+///
+/// `data[0] != 0` marks the first round (carrying the 4 kernel-object
+/// caps); subsequent rounds carry only reclaimable Frame caps. On the
+/// first round, binds the death-EQ observer on init's main thread with
+/// `INIT_REAP_CORRELATOR`.
+pub fn handle_register(req: &IpcMessage, ipc_buf: *mut u64, death_eq: u32)
+{
+    let caps = req.caps();
+    let is_first = req.word(0) != 0;
+    let mut guard = STATE.lock().expect("init-reap state poisoned");
+    if is_first
+    {
+        if guard.is_some()
+        {
+            reply(ipc_buf, procmgr_errors::INVALID_ARGUMENT);
+            return;
+        }
+        if caps.len() != 4
+        {
+            reply(ipc_buf, procmgr_errors::INVALID_ARGUMENT);
+            return;
+        }
+        let aspace = caps[0];
+        let cspace = caps[1];
+        let main_thread = caps[2];
+        let logd_thread = caps[3];
+        if syscall::thread_bind_notification(
+            main_thread,
+            death_eq,
+            procmgr_labels::INIT_REAP_CORRELATOR,
+        )
+        .is_err()
+        {
+            // Bind failed — drop the moved-in caps and refuse so init
+            // doesn't proceed to thread_exit thinking it'll be reaped.
+            let _ = syscall::cap_delete(aspace);
+            let _ = syscall::cap_delete(cspace);
+            let _ = syscall::cap_delete(main_thread);
+            let _ = syscall::cap_delete(logd_thread);
+            reply(ipc_buf, procmgr_errors::INVALID_ARGUMENT);
+            return;
+        }
+        *guard = Some(InitReapState {
+            aspace,
+            cspace,
+            main_thread,
+            logd_thread,
+            donate_caps: Vec::with_capacity(32),
+            armed: false,
+        });
+        reply(ipc_buf, procmgr_errors::SUCCESS);
+        return;
+    }
+
+    let Some(state) = guard.as_mut()
+    else
+    {
+        reply(ipc_buf, procmgr_errors::INVALID_ARGUMENT);
+        return;
+    };
+    for &slot in caps
+    {
+        state.donate_caps.push(slot);
+    }
+    reply(ipc_buf, procmgr_errors::SUCCESS);
+}
+
+/// Handle `INIT_TEARDOWN_DONE`. Marks the state machine armed; the
+/// next death-EQ event with `INIT_REAP_CORRELATOR` triggers `run_reap`.
+pub fn handle_done(ipc_buf: *mut u64)
+{
+    let mut guard = STATE.lock().expect("init-reap state poisoned");
+    let Some(state) = guard.as_mut()
+    else
+    {
+        reply(ipc_buf, procmgr_errors::INVALID_ARGUMENT);
+        return;
+    };
+    state.armed = true;
+    reply(ipc_buf, procmgr_errors::SUCCESS);
+}
+
+/// Execute the reap when the death-EQ event for init's main thread
+/// fires. Idempotent: a state-less invocation (re-fire after we
+/// already reaped) is a no-op.
+pub fn run_reap(memmgr_ep: u32, ipc_buf: *mut u64)
+{
+    let state = {
+        let mut guard = STATE.lock().expect("init-reap state poisoned");
+        match guard.take()
+        {
+            Some(s) if s.armed => s,
+            other =>
+            {
+                *guard = other;
+                return;
+            }
+        }
+    };
+
+    // 1. Reap init-logd's TCB. Init-logd exited earlier (its
+    //    `sys_thread_exit` ran inside the `HANDOVER_PULL` reply path).
+    //    `dealloc_object` for Thread handles Exited TCBs cleanly.
+    let _ = syscall::cap_delete(state.logd_thread);
+
+    // 2. Reap init's main thread TCB. The death event we're handling
+    //    proves the main thread already transitioned to Exited; the
+    //    cap_delete drives the dealloc.
+    let _ = syscall::cap_delete(state.main_thread);
+
+    // 3. Destroy init's AddressSpace. Revoke first to clear any
+    //    derived child caps, then delete to drop procmgr's reference
+    //    (which is the last one, since init's CSpace moved its copy
+    //    over via IPC). `dealloc_object` for AddressSpace returns PT
+    //    chunks via `retype_free`; user-page mappings disappear at
+    //    the same moment.
+    let _ = syscall::cap_revoke(state.aspace);
+    let _ = syscall::cap_delete(state.aspace);
+
+    // 4. Donate every reclaim Frame cap to memmgr. Safe now that
+    //    init's AS is dead: no live mapping references the phys
+    //    ranges, so memmgr can reissue them without aliasing.
+    let (donated_caps, donated_pages, pool_total) =
+        donate_to_memmgr(memmgr_ep, &state.donate_caps, ipc_buf);
+
+    // 5. Destroy init's CSpace last. The cascade in `dealloc_object`
+    //    deref's every cap init still held (endpoint SENDs, endpoint
+    //    slab Frame, leftover memory frames not donated above). Pages
+    //    backed by `owns_memory=true` Frame caps return to the kernel
+    //    buddy via `free_range` — they don't enter memmgr's pool, but
+    //    they are no longer leaked.
+    let _ = syscall::cap_revoke(state.cspace);
+    let _ = syscall::cap_delete(state.cspace);
+
+    // 6. Summary line so the operator can confirm the reap actually ran.
+    std::os::seraph::log!(
+        "init reaped: donated {} caps = {} pages ({} KiB) to memmgr; \
+         pool reclaim total {} pages",
+        donated_caps,
+        donated_pages,
+        donated_pages * 4,
+        pool_total,
+    );
+}
+
+fn donate_to_memmgr(memmgr_ep: u32, caps: &[u32], ipc_buf: *mut u64) -> (u32, u64, u64)
+{
+    if memmgr_ep == 0 || caps.is_empty()
+    {
+        return (0, 0, 0);
+    }
+    let mut total_caps: u32 = 0;
+    let mut total_pages: u64 = 0;
+    let mut pool_total: u64 = 0;
+    let chunk_size = MSG_CAP_SLOTS_MAX;
+    let mut i = 0;
+    while i < caps.len()
+    {
+        let end = (i + chunk_size).min(caps.len());
+        let mut builder = IpcMessage::builder(memmgr_labels::DONATE_FRAMES);
+        for &slot in &caps[i..end]
+        {
+            builder = builder.cap(slot);
+        }
+        let msg = builder.build();
+        // SAFETY: ipc_buf is procmgr's registered IPC buffer.
+        if let Ok(reply) = unsafe { ipc::ipc_call(memmgr_ep, &msg, ipc_buf) }
+            && reply.label == memmgr_errors::SUCCESS
+        {
+            total_caps += reply.word(0) as u32;
+            total_pages = total_pages.saturating_add(reply.word(1));
+            pool_total = reply.word(2);
+        }
+        i = end;
+    }
+    (total_caps, total_pages, pool_total)
+}
+
+fn reply(ipc_buf: *mut u64, code: u64)
+{
+    let msg = IpcMessage::new(code);
+    // SAFETY: ipc_buf is the registered IPC buffer page.
+    let _ = unsafe { ipc::ipc_reply(&msg, ipc_buf) };
+}

--- a/services/procmgr/src/main.rs
+++ b/services/procmgr/src/main.rs
@@ -33,7 +33,7 @@ use std::os::seraph::startup_info;
 ///   caps[0]: service endpoint (procmgr receives requests on this)
 ///   caps[1]: un-tokened SEND copy of the system log endpoint. Procmgr
 ///            `cap_copy`s this into every child's
-///            `ProcessInfo.log_discovery_cap` at `CREATE_PROCESS` time.
+///            `ProcessInfo.log_send_cap` at `CREATE_PROCESS` time.
 ///            Zero means no log endpoint is available yet; children
 ///            born in that window receive zero and silent-drop
 ///            `std::os::seraph::log!`.
@@ -446,11 +446,54 @@ fn dispatch_ipc(
             handle_configure_namespace(&req, ipc_buf, table);
         }
 
+        procmgr_labels::REGISTER_DEATH_EQ =>
+        {
+            handle_register_death_eq(&req, ipc_buf, table);
+        }
+
         _ =>
         {
             reply_empty(ipc_buf, procmgr_errors::UNKNOWN_OPCODE);
         }
     }
+}
+
+/// Handle `REGISTER_DEATH_EQ` — store the caller's `EventQueue` cap
+/// as procmgr's logd-death observer, then retroactively bind it to
+/// every thread currently in the process table.
+///
+/// Wire format:
+/// * `caller token` MUST equal `procmgr_labels::DEATH_EQ_AUTHORITY`
+///   (init derives the authorised tokened SEND cap and hands it
+///   exclusively to real-logd at bootstrap).
+/// * `caps[0]` = `EventQueue` cap with POST right.
+///
+/// Reply: `procmgr_errors::SUCCESS` on bind, `UNAUTHORIZED` if the
+/// caller lacks the authority token, `INVALID_ARGUMENT` if no cap
+/// arrives.
+fn handle_register_death_eq(req: &IpcMessage, ipc_buf: *mut u64, table: &mut process::ProcessTable)
+{
+    if req.token != procmgr_labels::DEATH_EQ_AUTHORITY
+    {
+        reply_empty(ipc_buf, procmgr_errors::UNAUTHORIZED);
+        return;
+    }
+    let Some(&logd_eq) = req.caps().first()
+    else
+    {
+        reply_empty(ipc_buf, procmgr_errors::INVALID_ARGUMENT);
+        return;
+    };
+    if logd_eq == 0
+    {
+        reply_empty(ipc_buf, procmgr_errors::INVALID_ARGUMENT);
+        return;
+    }
+    // install_logd_death_eq stores the cap and binds it as a second
+    // observer on every existing thread. Future spawns pick it up
+    // inside finalize_creation by reading the same atomic.
+    let _ = process::install_logd_death_eq(table, logd_eq);
+    reply_empty(ipc_buf, procmgr_errors::SUCCESS);
 }
 
 /// Answer `QUERY_PROCESS` for the addressed entry.
@@ -737,7 +780,7 @@ fn handle_create(
 
     let universals = process::UniversalCaps {
         procmgr_endpoint: ctx.self_endpoint,
-        log_discovery: ctx.log_ep,
+        log_send_source: ctx.log_ep,
         memmgr_endpoint: memmgr_send,
         memmgr_token,
     };
@@ -800,11 +843,14 @@ pub struct ProcmgrCtx
 {
     pub self_aspace: u32,
     pub self_endpoint: u32,
-    /// Log endpoint (SEND) received from init during procmgr's own bootstrap.
-    /// Procmgr `cap_copy`s this into every child's
-    /// `ProcessInfo.log_discovery_cap` at `CREATE_PROCESS` time. Zero if
-    /// init did not provide one (very early boot); children born in that
-    /// window receive zero and silent-drop `std::os::seraph::log!`.
+    /// Un-tokened SEND cap on the log endpoint received from init
+    /// during procmgr's own bootstrap. Procmgr uses it as the
+    /// `cap_derive_token` source for minting a tokened SEND cap per
+    /// child it spawns (token = the child's process token). The
+    /// minted cap is placed in the child's `ProcessInfo.log_send_cap`.
+    /// Zero if init did not provide one (very early boot); children
+    /// born in that window receive zero and silent-drop
+    /// `std::os::seraph::log!`.
     pub log_ep: u32,
     /// Tokened SEND cap on memmgr's service endpoint, identifying procmgr.
     /// Used to mint per-child memmgr SENDs via `REGISTER_PROCESS`, to

--- a/services/procmgr/src/main.rs
+++ b/services/procmgr/src/main.rs
@@ -500,11 +500,23 @@ fn handle_register_death_eq(req: &IpcMessage, ipc_buf: *mut u64, table: &mut pro
         reply_empty(ipc_buf, procmgr_errors::INVALID_ARGUMENT);
         return;
     }
-    // install_logd_death_eq stores the cap and binds it as a second
-    // observer on every existing thread. Future spawns pick it up
-    // inside finalize_creation by reading the same atomic.
-    let _ = process::install_logd_death_eq(table, logd_eq);
-    reply_empty(ipc_buf, procmgr_errors::SUCCESS);
+    // install_logd_death_eq is first-wins: it stores the cap and
+    // binds it as a second observer on every existing thread, or
+    // returns false if a previous registration already filled the
+    // slot. Future spawns pick it up inside finalize_creation by
+    // reading the same atomic.
+    if process::install_logd_death_eq(table, logd_eq)
+    {
+        reply_empty(ipc_buf, procmgr_errors::SUCCESS);
+    }
+    else
+    {
+        // Slot already filled (legitimate logd is registered).
+        // Drop the just-transferred cap so it doesn't leak in
+        // procmgr's CSpace; reject the caller.
+        let _ = syscall::cap_delete(logd_eq);
+        reply_empty(ipc_buf, procmgr_errors::UNAUTHORIZED);
+    }
 }
 
 /// Answer `QUERY_PROCESS` for the addressed entry.

--- a/services/procmgr/src/main.rs
+++ b/services/procmgr/src/main.rs
@@ -23,6 +23,7 @@
 #![allow(clippy::cast_possible_truncation)]
 
 mod arch;
+mod init_reap;
 mod loader;
 mod process;
 
@@ -451,6 +452,16 @@ fn dispatch_ipc(
             handle_register_death_eq(&req, ipc_buf, table);
         }
 
+        procmgr_labels::REGISTER_INIT_TEARDOWN =>
+        {
+            init_reap::handle_register(&req, ipc_buf, ctx.death_eq);
+        }
+
+        procmgr_labels::INIT_TEARDOWN_DONE =>
+        {
+            init_reap::handle_done(ipc_buf);
+        }
+
         _ =>
         {
             reply_empty(ipc_buf, procmgr_errors::UNKNOWN_OPCODE);
@@ -564,6 +575,14 @@ fn dispatch_death(
         };
         let correlator = (payload >> 32) as u32;
         let exit_reason = payload & 0xFFFF_FFFF;
+        if correlator == procmgr_labels::INIT_REAP_CORRELATOR
+        {
+            // Init's main thread exited. Run the reap sequence that
+            // tears down init's AS/CSpace/Thread objects and donates
+            // its reclaimable Frame caps to memmgr's pool.
+            init_reap::run_reap(memmgr_ep, ipc_buf);
+            continue;
+        }
         if let Some(entry) = table.take_by_correlator(correlator)
         {
             let entry_token = entry.token();

--- a/services/procmgr/src/process.rs
+++ b/services/procmgr/src/process.rs
@@ -26,8 +26,60 @@ const CHILD_IPC_BUF_VA: u64 = 0x0000_7FFF_FFFE_0000;
 /// Max file data bytes per VFS read IPC. Word 0 = `bytes_read`, words 1..63 = data.
 const VFS_CHUNK_SIZE: u64 = 63 * 8; // 504 bytes
 
-/// Next token value (monotonically increasing, never zero).
-static NEXT_TOKEN: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+/// Next token value (monotonically increasing, never zero). Starts at
+/// `LOG_TOKEN_FIRST_CHILD` so per-child log tokens never collide with
+/// the reserved system-special tokens (init=1, procmgr=2, 3..15
+/// reserved). The same value is procmgr's process token, memmgr's
+/// per-process ledger key, the tokened SEND-cap token on the log
+/// endpoint, and procmgr's death-EQ correlator — one u64, four roles.
+static NEXT_TOKEN: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(ipc::log_tokens::LOG_TOKEN_FIRST_CHILD);
+
+/// Reserve the next process token. Single allocation point so the
+/// value can be threaded to `populate_child_info` (writes it into
+/// `pi.log_send_cap`'s tokened SEND derivation) AND `finalize_creation`
+/// (uses it as the table key, death-EQ correlator, and process-handle
+/// token).
+fn next_process_token() -> u64
+{
+    NEXT_TOKEN.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Logd's death-notification `EventQueue` cap, registered via
+/// `procmgr_labels::REGISTER_DEATH_EQ` once real-logd is up. Zero
+/// until then. Read in `finalize_creation` to bind logd as a second
+/// death observer on every newly spawned child; on registration,
+/// retroactively bound to every existing process table entry by
+/// `bind_logd_eq_to_existing` so logd does not miss prior children.
+///
+/// Single-writer (the `REGISTER_DEATH_EQ` handler runs under
+/// procmgr's single-threaded dispatch); readers race only with the
+/// writer, and the Acquire load pairs with the Release store on
+/// registration.
+pub static LOGD_DEATH_EQ: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+
+/// Install logd's death-notification EQ cap and retroactively bind it
+/// as a second observer on every thread currently in the process
+/// table. Called by `REGISTER_DEATH_EQ`'s handler. Idempotent on
+/// re-registration: replaces the previous slot, re-binds on
+/// everything.
+pub fn install_logd_death_eq(table: &mut ProcessTable, logd_eq: u32) -> bool
+{
+    LOGD_DEATH_EQ.store(logd_eq, std::sync::atomic::Ordering::Release);
+    if logd_eq == 0
+    {
+        return true;
+    }
+    let mut ok = true;
+    table.for_each(|entry| {
+        let correlator = entry.token as u32;
+        if syscall::thread_bind_notification(entry.thread_cap, logd_eq, correlator).is_err()
+        {
+            ok = false;
+        }
+    });
+    ok
+}
 
 /// Maximum concurrent child processes procmgr tracks.
 ///
@@ -207,6 +259,20 @@ impl ProcessTable
             }
         }
         None
+    }
+
+    /// Visit every live entry in insertion order. Used by
+    /// `install_logd_death_eq` to retroactively bind logd's EQ as a
+    /// second death observer on each child's main thread.
+    pub fn for_each<F: FnMut(&ProcessEntry)>(&self, mut f: F)
+    {
+        for slot in &self.entries
+        {
+            if let Some(entry) = slot.as_ref()
+            {
+                f(entry);
+            }
+        }
     }
 
     /// Lightweight status lookup for `QUERY_PROCESS`. Returns
@@ -390,14 +456,15 @@ pub struct CreateResult
 
 /// Universal bootstrap caps procmgr threads through into every child.
 ///
-/// Procmgr's own service endpoint plus the system log discovery cap.
+/// Procmgr's own service endpoint plus the log-cap derivation source.
 ///
 /// The child receives a tokened SEND copy of `procmgr_endpoint` so it
-/// can call `REQUEST_FRAMES` / `CREATE_PROCESS`, and
-/// an un-tokened SEND copy of `log_discovery` so it can `GET_LOG_CAP`
-/// against the system log endpoint on first `seraph::log!` call (the
-/// discovery cap by itself grants no log identity and no observability;
-/// it merely lets the holder request a freshly-minted tokened cap).
+/// can call `REQUEST_FRAMES` / `CREATE_PROCESS`, and a
+/// freshly-derived tokened SEND cap on the log endpoint (token = the
+/// child's process token) so `seraph::log!` writes go directly to logd
+/// with the kernel-attached identity. `log_send_source` is procmgr's
+/// un-tokened SEND cap on the log endpoint, used as the source for
+/// each per-child `cap_derive_token`.
 ///
 /// Stdio caps (stdin, stdout, stderr) are intentionally NOT part of this
 /// struct: they are not a universal property of processes, and each can
@@ -408,10 +475,14 @@ pub struct CreateResult
 pub struct UniversalCaps
 {
     pub procmgr_endpoint: u32,
-    /// Un-tokened SEND cap on the system log endpoint, sourced from the
-    /// `log_ep` slot procmgr received during init bootstrap. Zero when
-    /// procmgr has no log endpoint (e.g. a future no-log boot mode).
-    pub log_discovery: u32,
+    /// Un-tokened SEND cap on the system log endpoint, sourced from
+    /// the slot procmgr received during init bootstrap. Used as the
+    /// `cap_derive_token` source for minting a tokened SEND per child
+    /// (token = child's process token). Zero when procmgr has no log
+    /// endpoint (e.g. a future no-log boot mode); children born in
+    /// that case receive zero in `pi.log_send_cap` and silent-drop
+    /// `seraph::log!`.
+    pub log_send_source: u32,
     /// Tokened SEND cap on memmgr's service endpoint, freshly minted by
     /// `memmgr_labels::REGISTER_PROCESS` for this child. The cap lives in
     /// procmgr's `CSpace` on entry; `populate_child_info` copies it into
@@ -508,6 +579,7 @@ fn populate_child_info(
     env: &ChildEnv<'_>,
     ipc_buf: *mut u64,
     stack_pages: u32,
+    process_token: u64,
 ) -> Option<u32>
 {
     let pi_frame = crate::memmgr_alloc_page(universals.memmgr_endpoint, ipc_buf)?;
@@ -556,14 +628,25 @@ fn populate_child_info(
         0
     };
 
-    // Discovery cap on the system log endpoint: SEND-only copy of the
-    // procmgr-held un-tokened log endpoint cap. Lets the child issue
-    // `GET_LOG_CAP` to lazy-acquire its tokened SEND cap on first
-    // `seraph::log!` call. Zero when procmgr has no log endpoint, in
-    // which case the macro silently drops.
-    let log_discovery_in_child = if universals.log_discovery != 0
+    // Tokened SEND cap on the system log endpoint: derived from the
+    // procmgr-held un-tokened source cap with token = child's process
+    // token. Child's std `_start` installs it via
+    // `::log::install_tokened_cap`; `seraph::log!` writes ride it
+    // directly with no discovery roundtrip. Logd attributes the
+    // writes by the kernel-delivered token, which equals procmgr's
+    // process token, which equals the death-EQ correlator —
+    // self-reconciliation across the three views.
+    let log_send_in_child = if universals.log_send_source != 0
     {
-        syscall::cap_copy(universals.log_discovery, child_cspace, syscall::RIGHTS_SEND).ok()?
+        let proc_side = syscall::cap_derive_token(
+            universals.log_send_source,
+            syscall::RIGHTS_SEND,
+            process_token,
+        )
+        .ok()?;
+        let child_side = syscall::cap_copy(proc_side, child_cspace, syscall::RIGHTS_SEND).ok()?;
+        let _ = syscall::cap_delete(proc_side);
+        child_side
     }
     else
     {
@@ -612,7 +695,7 @@ fn populate_child_info(
     // and there is no inter-CSpace cap_delete primitive to clean up.
     pi.system_root_cap = 0;
     pi.current_dir_cap = 0;
-    pi.log_discovery_cap = log_discovery_in_child;
+    pi.log_send_cap = log_send_in_child;
     pi.stdin_data_signal_cap = 0;
     pi.stdin_space_signal_cap = 0;
     pi.stdout_data_signal_cap = 0;
@@ -949,15 +1032,27 @@ fn finalize_creation(
     death_eq: u32,
     memmgr_send_cap: u32,
     memmgr_token: u64,
+    process_token: u64,
 ) -> Option<CreateResult>
 {
-    let token = NEXT_TOKEN.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let token = process_token;
 
     // Bind procmgr's shared death queue as an observer on the child's
     // main thread. Correlator = low 32 bits of the table token; on death,
     // dispatch_death recovers the entry via `take_by_correlator`.
     let correlator = token as u32;
     syscall::thread_bind_notification(child_thread, death_eq, correlator).ok()?;
+
+    // If logd has registered its own death EQ via REGISTER_DEATH_EQ,
+    // bind it as a second observer with the same correlator (logd's
+    // slot map is keyed by process_token, which equals this token).
+    // Children spawned before logd registers are bound retroactively
+    // by `install_logd_death_eq`.
+    let logd_eq = LOGD_DEATH_EQ.load(std::sync::atomic::Ordering::Acquire);
+    if logd_eq != 0
+    {
+        let _ = syscall::thread_bind_notification(child_thread, logd_eq, correlator);
+    }
 
     // Derive a tokened endpoint cap for the caller. The token identifies this
     // process on subsequent START_PROCESS / REQUEST_FRAMES calls.
@@ -1117,6 +1212,7 @@ fn create_process_from_bytes(
         MainTls::default()
     };
 
+    let process_token = next_process_token();
     let pi_frame_cap = populate_child_info(
         self_aspace,
         child_aspace,
@@ -1129,6 +1225,7 @@ fn create_process_from_bytes(
         env,
         ipc_buf,
         stack_pages,
+        process_token,
     )?;
     map_child_stack_and_ipc(child_aspace, child_memmgr_send, ipc_buf, stack_pages)?;
 
@@ -1144,6 +1241,7 @@ fn create_process_from_bytes(
         death_eq,
         child_memmgr_send,
         universals.memmgr_token,
+        process_token,
     )
 }
 
@@ -1912,10 +2010,11 @@ pub fn create_process_from_file(
 
     let universals = UniversalCaps {
         procmgr_endpoint: ctx.self_endpoint,
-        log_discovery: ctx.log_ep,
+        log_send_source: ctx.log_ep,
         memmgr_endpoint: mms.cap(),
         memmgr_token: mms.token(),
     };
+    let process_token = next_process_token();
     let pi_frame_cap = populate_child_info(
         self_aspace,
         child_objs.aspace(),
@@ -1928,6 +2027,7 @@ pub fn create_process_from_file(
         env,
         ipc_buf,
         stack_pages,
+        process_token,
     )
     .ok_or(procmgr_errors::OUT_OF_MEMORY)?;
     let pi_frame_guard = CapGuard::new(pi_frame_cap);
@@ -1958,6 +2058,7 @@ pub fn create_process_from_file(
         death_eq,
         mms.cap(),
         mms.token(),
+        process_token,
     )
     .ok_or(procmgr_errors::OUT_OF_MEMORY);
     if result.is_ok()

--- a/services/procmgr/src/process.rs
+++ b/services/procmgr/src/process.rs
@@ -640,19 +640,32 @@ fn populate_child_info(
         0
     };
 
-    // procmgr's own service endpoint: install a SEND+GRANT copy so the child
-    // can use it for `REQUEST_FRAMES` (send-only) and `CREATE_PROCESS` (needs
-    // grant to transfer the module frame and creator endpoint in the same
-    // call). Zero when procmgr has no procmgr above it — e.g. procmgr itself,
-    // when init populates its `ProcessInfo`.
+    // procmgr's own service endpoint: install a SEND+GRANT copy
+    // tokened with the child's `process_token`. The token gives
+    // procmgr's handlers a kernel-delivered identity for every IPC
+    // the child makes (used today by no handler; available for
+    // future per-child authorisation), but more importantly it
+    // locks the child OUT of `cap_derive_token` on this cap —
+    // `sys_cap_derive_token` rejects sources with `src_token != 0`,
+    // so the child cannot mint a parallel cap with a privileged
+    // token value (`procmgr_labels::DEATH_EQ_AUTHORITY`, etc.). The
+    // un-tokened source cap stays exclusively in procmgr's own
+    // CSpace; init holds the only other un-tokened copy and reaps
+    // before any non-trusted process is spawned that could
+    // theoretically exploit it. Zero when procmgr has no procmgr
+    // above it — e.g. procmgr itself, when init populates its
+    // `ProcessInfo`.
     let procmgr_ep_in_child = if universals.procmgr_endpoint != 0
     {
-        syscall::cap_copy(
+        let tokened = syscall::cap_derive_token(
             universals.procmgr_endpoint,
-            child_cspace,
             syscall::RIGHTS_SEND_GRANT,
+            process_token,
         )
-        .ok()?
+        .ok()?;
+        let in_child = syscall::cap_copy(tokened, child_cspace, syscall::RIGHTS_SEND_GRANT).ok()?;
+        let _ = syscall::cap_delete(tokened);
+        in_child
     }
     else
     {

--- a/services/procmgr/src/process.rs
+++ b/services/procmgr/src/process.rs
@@ -100,16 +100,29 @@ pub fn install_logd_death_eq(table: &mut ProcessTable, logd_eq: u32) -> bool
     {
         return false;
     }
+    // Commit semantics: this function returns `true` whenever the cap
+    // becomes the registered logd death-EQ (atomic stored). The caller
+    // contract is "false ⇒ cap_delete on the just-transferred slot;
+    // true ⇒ slot is now owned by procmgr". A partial bind failure
+    // CANNOT roll back successful binds — the kernel has no
+    // thread-unbind syscall — so we commit unconditionally once
+    // first-wins passes. Any failed-bind entry is logged; logd will
+    // not receive a death event for it (procmgr's own observer still
+    // does, so memmgr accounting is unaffected). In practice
+    // `finalize_creation` registers logd-EQ at every spawn going
+    // forward; only the pre-existing table is subject to this.
     LOGD_DEATH_EQ.store(logd_eq, std::sync::atomic::Ordering::Release);
-    let mut ok = true;
     table.for_each(|entry| {
         let correlator = entry.token as u32;
         if syscall::thread_bind_notification(entry.thread_cap, logd_eq, correlator).is_err()
         {
-            ok = false;
+            std::os::seraph::log!(
+                "install_logd_death_eq: bind failed for entry token={} (logd will miss its death event; procmgr observer unaffected)",
+                entry.token,
+            );
         }
     });
-    ok
+    true
 }
 
 /// Maximum concurrent child processes procmgr tracks.
@@ -715,10 +728,23 @@ fn populate_child_info(
     pi.procmgr_endpoint_cap = procmgr_ep_in_child;
     pi.memmgr_endpoint_cap = if universals.memmgr_endpoint != 0
     {
-        // SEND_GRANT so the child can attach memmgr's tokened SEND to
-        // outgoing messages it makes on the same endpoint (no current
-        // protocol exercises that capability, but the rights mirror
-        // `procmgr_endpoint_cap`'s shape).
+        // Plain `cap_copy` here is structurally safe — and
+        // intentionally asymmetric with the
+        // `cap_derive_token(..., process_token)` shape used for
+        // `procmgr_endpoint_cap` just above. The reason:
+        // `universals.memmgr_endpoint` is the per-child tokened cap
+        // memmgr minted in its `REGISTER_PROCESS` handler at
+        // `services/memmgr/src/main.rs:781`
+        // (`cap_derive_token(service_ep, SEND_GRANT, new_token)`),
+        // returned via IPC in `register_with_memmgr`
+        // (`services/procmgr/src/main.rs:222-244`). The source is
+        // already kernel-tokened with a memmgr-private per-child
+        // value; `cap_copy` propagates the token to the child slot.
+        // Children therefore cannot `sys_cap_derive_token` to mint a
+        // privileged twin on memmgr's endpoint (the `src_token != 0`
+        // rejection applies). SEND_GRANT lets the child grant onward;
+        // no current protocol uses that, mirrored shape with
+        // `procmgr_endpoint_cap`.
         syscall::cap_copy(
             universals.memmgr_endpoint,
             child_cspace,

--- a/services/procmgr/src/process.rs
+++ b/services/procmgr/src/process.rs
@@ -40,9 +40,26 @@ static NEXT_TOKEN: std::sync::atomic::AtomicU64 =
 /// `pi.log_send_cap`'s tokened SEND derivation) AND `finalize_creation`
 /// (uses it as the table key, death-EQ correlator, and process-handle
 /// token).
+///
+/// Skips tokens whose lower 32 bits would collide with reserved
+/// death-EQ correlators (currently `INIT_REAP_CORRELATOR = u32::MAX`).
+/// The death-EQ binding API takes a `u32` correlator while process
+/// tokens are `u64`; without this guard the truncated correlator
+/// could match the reserved value at u32 wrap (~4.3B spawns) and
+/// the matching child's death would be silently absorbed by the
+/// init-reap branch in `dispatch_death`.
 fn next_process_token() -> u64
 {
-    NEXT_TOKEN.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    loop
+    {
+        let t = NEXT_TOKEN.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        if (t as u32) != ipc::procmgr_labels::INIT_REAP_CORRELATOR
+        {
+            return t;
+        }
+        // Skip the reserved correlator and try again. (Unreachable in
+        // v0.1.0 fleet sizes; cheap guard against a real-life wrap.)
+    }
 }
 
 /// Logd's death-notification `EventQueue` cap, registered via
@@ -60,16 +77,30 @@ pub static LOGD_DEATH_EQ: std::sync::atomic::AtomicU32 = std::sync::atomic::Atom
 
 /// Install logd's death-notification EQ cap and retroactively bind it
 /// as a second observer on every thread currently in the process
-/// table. Called by `REGISTER_DEATH_EQ`'s handler. Idempotent on
-/// re-registration: replaces the previous slot, re-binds on
-/// everything.
+/// table. Called by `REGISTER_DEATH_EQ`'s handler.
+///
+/// First-wins semantics: returns `false` (and changes nothing) if a
+/// previous registration already filled the slot. This mitigates the
+/// pre-existing `sys_cap_derive_token` weakness in which any holder of
+/// a `SEND_GRANT` cap on procmgr's endpoint can mint
+/// `DEATH_EQ_AUTHORITY` and hijack logd's death stream — since logd
+/// registers at startup before any other user process is spawned, a
+/// later attacker's registration is always second and is rejected
+/// here. The caller (`handle_register_death_eq`) is responsible for
+/// `cap_delete`ing the just-transferred slot when this returns false.
 pub fn install_logd_death_eq(table: &mut ProcessTable, logd_eq: u32) -> bool
 {
-    LOGD_DEATH_EQ.store(logd_eq, std::sync::atomic::Ordering::Release);
     if logd_eq == 0
     {
-        return true;
+        return false;
     }
+    // First-wins: refuse to overwrite. Real logd registers exactly
+    // once at startup, so the slot transitions 0 → logd_eq and stays.
+    if LOGD_DEATH_EQ.load(std::sync::atomic::Ordering::Acquire) != 0
+    {
+        return false;
+    }
+    LOGD_DEATH_EQ.store(logd_eq, std::sync::atomic::Ordering::Release);
     let mut ok = true;
     table.for_each(|entry| {
         let correlator = entry.token as u32;

--- a/shared/ipc/src/lib.rs
+++ b/shared/ipc/src/lib.rs
@@ -232,6 +232,41 @@ pub mod procmgr_labels
     /// hands it to real-logd at bootstrap; the un-tokened or
     /// differently-tokened twins are rejected.
     pub const DEATH_EQ_AUTHORITY: u64 = 1u64 << 62;
+
+    /// Hand init's kernel-object caps + reclaimable Frame caps to procmgr
+    /// for post-death reap. Init calls this in the post-Phase-3 exit
+    /// path, then `sys_thread_exit`s.
+    ///
+    /// First round (`is_first = data[0] != 0`):
+    ///   `caps[0]` = init's `AddressSpace` cap (MOVED out of init's `CSpace`).
+    ///   `caps[1]` = init's `CSpace` cap (MOVED).
+    ///   `caps[2]` = init's main `Thread` cap (MOVED).
+    ///   `caps[3]` = init-logd `Thread` cap (MOVED; may be the same slot
+    ///               as a previously-exited thread — its TCB is reclaimed
+    ///               on `cap_delete` regardless of state).
+    /// Subsequent rounds (`data[0] == 0`):
+    ///   `caps[0..N]` = reclaimable Frame caps (segments + stack +
+    ///                  `InitInfo` + IPC buffer + any other init-owned
+    ///                  donatable Frame). MOVED out of init's `CSpace`
+    ///                  via IPC cap-transfer; procmgr accumulates them
+    ///                  for the eventual `memmgr.DONATE_FRAMES` chunk.
+    ///
+    /// Procmgr binds the death-EQ on init's main thread with correlator
+    /// `INIT_REAP_CORRELATOR` as part of the first round. Each round
+    /// replies `procmgr_errors::SUCCESS`.
+    pub const REGISTER_INIT_TEARDOWN: u64 = 15;
+
+    /// Signal end of init's reap-handoff cap stream. After this call
+    /// init has no caps left to transfer; procmgr's state machine
+    /// transitions to "armed", awaiting the death-EQ event. Init
+    /// calls `sys_thread_exit` immediately after this IPC replies.
+    pub const INIT_TEARDOWN_DONE: u64 = 16;
+
+    /// Reserved death-notification correlator used by `REGISTER_INIT_TEARDOWN`.
+    /// Per-child correlators are `process_token as u32` starting at
+    /// `log_tokens::LOG_TOKEN_FIRST_CHILD = 16`; reserving the top of
+    /// the u32 range avoids collision.
+    pub const INIT_REAP_CORRELATOR: u32 = u32::MAX;
 }
 
 pub const MEMMGR_LABELS_VERSION: u32 = 1;

--- a/shared/ipc/src/lib.rs
+++ b/shared/ipc/src/lib.rs
@@ -205,6 +205,33 @@ pub mod procmgr_labels
     /// Idempotent before start; later calls overwrite the previous
     /// caps (the prior caps are `cap_delete`'d procmgr-side).
     pub const CONFIGURE_NAMESPACE: u64 = 12;
+
+    /// Register a death-notification `EventQueue` cap with procmgr.
+    ///
+    /// Wire format:
+    /// * `caps[0]` = `EventQueue` cap (POST right) on which procmgr
+    ///   posts `(process_token as u32) << 32 | exit_reason` for every
+    ///   tracked process when it exits or faults.
+    ///
+    /// Procmgr stores the cap and, for every process already in its
+    /// table, calls `sys_thread_bind_notification` on the child's
+    /// main thread with this EQ as a second observer. From the
+    /// registration moment onward, every newly spawned child also
+    /// receives the binding inside `finalize_creation`. Single
+    /// observer slot — re-registration replaces the previous cap.
+    ///
+    /// Real-logd uses this to learn about sender deaths so it can
+    /// evict the corresponding slot in its hash-keyed token table.
+    /// Reply is `procmgr_errors::SUCCESS` on bind, `INVALID_ARGUMENT`
+    /// if the cap is missing or wrong type, `UNAUTHORIZED` if called
+    /// over a non-privileged path (gated by tokened SEND cap).
+    pub const REGISTER_DEATH_EQ: u64 = 14;
+
+    /// Token bit on procmgr service caps that authorises
+    /// `REGISTER_DEATH_EQ`. Init derives this tokened SEND cap and
+    /// hands it to real-logd at bootstrap; the un-tokened or
+    /// differently-tokened twins are rejected.
+    pub const DEATH_EQ_AUTHORITY: u64 = 1u64 << 62;
 }
 
 pub const MEMMGR_LABELS_VERSION: u32 = 1;
@@ -651,30 +678,88 @@ pub mod stream_labels
     pub const STREAM_REGISTER_NAME: u64 = 11;
 }
 
+/// Reserved log-endpoint tokens.
+///
+/// Every tokened SEND cap on the log endpoint carries a `u64` token
+/// (kernel-attached at `cap_derive_token` time, immutable thereafter).
+/// The cap's holder is identified to the receiver by that token. For
+/// procmgr-spawned children the token equals the child's procmgr-
+/// assigned process token; the kernel-side identity, the receiver's
+/// per-sender slot key, and procmgr's death-notification correlator
+/// thus all share one u64. To leave room for system-special senders
+/// whose identity is not a procmgr process token, procmgr's per-child
+/// token counter starts at [`LOG_TOKEN_FIRST_CHILD`].
+pub mod log_tokens
+{
+    /// init's self-identity. Init derives `cap_derive_token(log_ep,
+    /// SEND, LOG_TOKEN_INIT)` at boot and uses the cap for its own
+    /// `seraph::log!` writes.
+    pub const LOG_TOKEN_INIT: u64 = 1;
+    /// procmgr's self-identity. Init derives a tokened SEND cap with
+    /// this token at procmgr-bootstrap time and seeds it into
+    /// `ProcessInfo.log_send_cap` so procmgr's std `_start` can
+    /// install it. Procmgr's `seraph::log!` writes ride this cap.
+    pub const LOG_TOKEN_PROCMGR: u64 = 2;
+    /// First token value procmgr's per-child counter
+    /// (`NEXT_PROCESS_TOKEN`) hands out. Lower values are reserved
+    /// for the system specials above; raising this leaves room to
+    /// reserve more.
+    pub const LOG_TOKEN_FIRST_CHILD: u64 = 16;
+}
+
 pub const LOG_LABELS_VERSION: u32 = 1;
-/// IPC labels for the system log endpoint's discovery interface.
+/// IPC labels for the system log endpoint's legacy discovery interface
+/// and the one-shot init-logd → real-logd handover.
 ///
 /// Distinct from [`stream_labels`]: the latter carry payload (bytes,
 /// names) on tokened SEND caps that have already been minted; these
-/// labels are spoken on an un-tokened SEND cap (the "discovery cap"
-/// installed in every process at create time) and are how a process
-/// acquires its tokened cap in the first place.
+/// labels are spoken on caps that mediate cap acquisition or state
+/// transfer.
+///
+/// New std-built spawns post-pivot receive a pre-installed tokened
+/// SEND cap in `ProcessInfo.log_send_cap` and never call
+/// [`GET_LOG_CAP`]. The label remains for pre-pivot live writers that
+/// acquired their tokened caps under it; the receive handler stays in
+/// init-logd and real-logd until those callers are migrated.
 pub mod log_labels
 {
-    /// Request a freshly-minted tokened SEND cap on the log endpoint.
+    /// Legacy discovery: request a freshly-minted tokened SEND cap on
+    /// the log endpoint.
     ///
-    /// Request: empty (label only). Reply: one cap — a SEND cap on the
-    /// log endpoint whose token uniquely identifies this caller's log
-    /// stream — plus a single data word carrying a status code (zero on
-    /// success). Callers cache the returned cap process-globally and
-    /// reuse it for every subsequent `STREAM_BYTES` /
-    /// `STREAM_REGISTER_NAME` message.
+    /// Wire format: `word(0) = LOG_LABELS_VERSION` (mismatch → reply
+    /// code 3). Reply: one cap (a tokened SEND on the log endpoint
+    /// whose token uniquely identifies this caller) plus
+    /// `word(0) = status` (zero on success). Callers cache the
+    /// returned cap process-globally.
     ///
-    /// The receiver mints the token (callers cannot pick their own).
-    /// Tokens are unforgeable and serve as the immutable identity of a
-    /// log sender; display names registered later via
-    /// `STREAM_REGISTER_NAME` are mutable labels bound to that identity.
+    /// The receiver mints the token (counter-allocated by init-logd
+    /// or real-logd). Tokens are unforgeable identities; display
+    /// names registered later via `STREAM_REGISTER_NAME` are mutable
+    /// labels bound to that identity.
     pub const GET_LOG_CAP: u64 = 12;
+
+    /// One-shot handover: real-logd pulls init-logd's captured state.
+    ///
+    /// Sent by real-logd on a dedicated handover endpoint that init
+    /// hands it during bootstrap. Init-logd, on receipt, drains any
+    /// pending sends from the log endpoint's queue, then replies with
+    /// one or more chunks carrying:
+    ///
+    /// * The token table — for every active sender token init-logd
+    ///   has seen, the `(token, display_name)` pair.
+    /// * The captured-history ring — all complete lines init-logd has
+    ///   buffered since boot, attributed by token and timestamped at
+    ///   the original receipt instant.
+    /// * The next-token counter (init-logd's
+    ///   `INIT_DISCOVERY_NEXT_TOKEN` value at the moment of handover)
+    ///   so real-logd's `GET_LOG_CAP` handler can continue the same
+    ///   sequence for any further legacy callers.
+    ///
+    /// Wire encoding is documented in
+    /// `services/logd/docs/handover-protocol.md`. After the final
+    /// chunk is replied, init-logd breaks its receive loop and calls
+    /// `sys_thread_exit`.
+    pub const HANDOVER_PULL: u64 = 13;
 }
 
 // ── Bootstrap protocol ──────────────────────────────────────────────────────
@@ -735,6 +820,9 @@ pub mod procmgr_errors
     /// Cap rights derivation failed (e.g. `derive_frame_for_prot`)
     /// during ELF page load.
     pub const INSUFFICIENT_RIGHTS: u64 = 12;
+    /// Caller's cap lacks the required authority token for a gated
+    /// label (e.g. `REGISTER_DEATH_EQ` requires `DEATH_EQ_AUTHORITY`).
+    pub const UNAUTHORIZED: u64 = 13;
     /// Unknown opcode on procmgr endpoint.
     pub const UNKNOWN_OPCODE: u64 = 0xFFFF;
 }

--- a/shared/log/src/lib.rs
+++ b/shared/log/src/lib.rs
@@ -7,20 +7,20 @@
 //!
 //! Two halves:
 //!
-//! * **Wire-format helpers ([`acquire`], [`write_bytes`], [`write_args`],
-//!   [`register_name`]):** thin no-allocation wrappers over the IPC labels
-//!   defined in `ipc::{log_labels, stream_labels}`. Callers supply their
+//! * **Wire-format helpers ([`write_bytes`], [`write_args`],
+//!   [`register_name`]):** thin no-allocation wrappers over the IPC
+//!   labels defined in `ipc::stream_labels`. Callers supply their
 //!   tokened SEND cap and IPC buffer pointer explicitly.
-//! * **Process-global cache ([`set_discovery_cap`],
-//!   [`install_tokened_cap`], [`ensure_tokened_cap`]):** holds the
-//!   discovery cap installed at process startup and the lazily-acquired
-//!   tokened SEND cap. Init pre-populates the tokened slot via
-//!   [`install_tokened_cap`] (it derives its own token-1 cap directly
-//!   from the log endpoint it owns); std-built processes leave it zero
-//!   and let the first log call lazy-acquire from the discovery cap.
+//! * **Process-global cap cache ([`install_tokened_cap`],
+//!   [`ensure_tokened_cap`]):** holds the pre-installed tokened SEND
+//!   cap. Std's `_start` installs the cap procmgr seeded in
+//!   `ProcessInfo.log_send_cap`; init installs its own token-1 cap
+//!   derived directly from the log endpoint it owns. No discovery
+//!   roundtrip — the cap is live from the first user instruction.
 //!
-//! The user-facing macro lives in the std overlay (it needs thread-local
-//! IPC-buffer access). Inside no_std code (init), call [`emit`] directly.
+//! The user-facing macro lives in the std overlay (it needs thread-
+//! local IPC-buffer access). Inside no_std code (init), call [`emit`]
+//! directly.
 
 #![cfg_attr(feature = "rustc-dep-of-std", feature(no_core))]
 #![cfg_attr(feature = "rustc-dep-of-std", allow(internal_features))]
@@ -40,8 +40,7 @@ use core::prelude::rust_2024::*;
 use core::sync::atomic::{AtomicU32, Ordering};
 
 use ipc::{
-    IpcMessage, LOG_LABELS_VERSION,
-    log_labels::GET_LOG_CAP,
+    IpcMessage,
     stream_labels::{STREAM_BYTES, STREAM_REGISTER_NAME},
 };
 use syscall_abi::MSG_DATA_WORDS_MAX;
@@ -58,107 +57,32 @@ const STACK_BUF_LEN: usize = CHUNK_SIZE;
 
 // ── Process-global cap cache ────────────────────────────────────────────────
 
-/// Un-tokened SEND cap on the system log endpoint, installed at process
-/// startup. Used to lazy-acquire the tokened cap on first log call. Zero
-/// in processes that received no discovery cap (init, processes spawned
-/// before the log infrastructure was wired).
-static DISCOVERY_CAP: AtomicU32 = AtomicU32::new(0);
-
-/// Tokened SEND cap on the log endpoint. Zero until either:
-/// * [`install_tokened_cap`] is called (init does this with its self-token cap), or
-/// * [`ensure_tokened_cap`] performs a successful `GET_LOG_CAP` round-trip
-///   against the discovery cap (the standard lazy path).
-///
-/// Once non-zero, never changes — Phase 1 acquires exactly one cap per
-/// process (singleton convention; not enforced receiver-side).
+/// Tokened SEND cap on the log endpoint, pre-installed at process
+/// startup via [`install_tokened_cap`]. Zero when no logger is
+/// reachable (init/memmgr/procmgr-self before its bootstrap completes,
+/// or any tier of the boot chain that runs before the log endpoint
+/// exists); [`emit`] silently drops in that case.
 static TOKENED_CAP: AtomicU32 = AtomicU32::new(0);
 
-/// Install the discovery cap. Called by std's `_start` from the
-/// `log_discovery_cap` field of `ProcessInfo`. Idempotent — last writer
-/// wins.
-pub fn set_discovery_cap(cap: u32)
-{
-    DISCOVERY_CAP.store(cap, Ordering::Release);
-}
-
-/// Pre-install a tokened SEND cap, bypassing the discovery path. Used by
-/// init, which derives its own token-1 cap directly from the log endpoint
-/// it owns and does not consume `GET_LOG_CAP`.
+/// Pre-install a tokened SEND cap on the log endpoint. Called by
+/// std's `_start` with the cap procmgr seeded in
+/// `ProcessInfo.log_send_cap`, and by init with its self-token-1 cap
+/// derived directly from the log endpoint it owns. Idempotent — last
+/// writer wins.
 pub fn install_tokened_cap(cap: u32)
 {
     TOKENED_CAP.store(cap, Ordering::Release);
 }
 
-/// Return the cached tokened cap, or attempt to acquire one from the
-/// discovery cap on first call. Returns 0 on failure (no discovery cap,
-/// no IPC buffer, IPC error, receiver out-of-resources). The first
-/// successful acquisition is persisted for all subsequent calls.
-///
-/// Safe to call from any thread once stdio init has run.
-pub fn ensure_tokened_cap(ipc_buf: *mut u64) -> u32
+/// Return the pre-installed tokened SEND cap, or zero. Caller is
+/// expected to have set it via [`install_tokened_cap`] before the
+/// first log call.
+pub fn ensure_tokened_cap(_ipc_buf: *mut u64) -> u32
 {
-    let existing = TOKENED_CAP.load(Ordering::Acquire);
-    if existing != 0
-    {
-        return existing;
-    }
-    let discovery = DISCOVERY_CAP.load(Ordering::Acquire);
-    if discovery == 0 || ipc_buf.is_null()
-    {
-        return 0;
-    }
-    let new_cap = match acquire(discovery, ipc_buf)
-    {
-        Ok(c) => c,
-        Err(_) => return 0,
-    };
-    if new_cap == 0
-    {
-        return 0;
-    }
-    // CAS — first writer wins. Concurrent acquirers race on first-log: the
-    // loser drops its extra cap slot via cap_delete. Singleton convention
-    // is preserved against all but the loser's transiently-held second
-    // slot.
-    match TOKENED_CAP.compare_exchange(0, new_cap, Ordering::AcqRel, Ordering::Acquire)
-    {
-        Ok(_) => new_cap,
-        Err(winner) =>
-        {
-            let _ = syscall::cap_delete(new_cap);
-            winner
-        }
-    }
+    TOKENED_CAP.load(Ordering::Acquire)
 }
 
 // ── Wire-format primitives ──────────────────────────────────────────────────
-
-/// Issue [`GET_LOG_CAP`] on `discovery_cap`. The reply transfers one cap
-/// (a tokened SEND on the log endpoint) into the caller's CSpace; this
-/// function returns the new slot index.
-///
-/// # Errors
-/// Returns a negative `i64` if the IPC call fails or the receiver replies
-/// without a cap.
-///
-/// # Safety
-/// The caller must have registered `ipc_buf` with the kernel via
-/// `ipc_buffer_set` on the current thread.
-pub fn acquire(discovery_cap: u32, ipc_buf: *mut u64) -> Result<u32, i64>
-{
-    let msg = IpcMessage::builder(GET_LOG_CAP)
-        .word(0, u64::from(LOG_LABELS_VERSION))
-        .build();
-    // SAFETY: ipc_buf is the calling thread's registered IPC buffer per the
-    // function's documented invariant.
-    let reply = unsafe { ipc::ipc_call(discovery_cap, &msg, ipc_buf) }?;
-    let caps = reply.caps();
-    if caps.is_empty()
-    {
-        return Err(0);
-    }
-    Ok(caps[0])
-}
 
 /// Send `bytes` as one or more `STREAM_BYTES` messages on `cap`. Splits
 /// across IPC calls when the payload exceeds [`CHUNK_SIZE`]; the receiver
@@ -254,23 +178,23 @@ pub fn write_args(cap: u32, ipc_buf: *mut u64, args: core::fmt::Arguments<'_>)
     write_bytes(cap, ipc_buf, &buf.data[..buf.used]);
 }
 
-/// One-shot emit: ensure the tokened cap is acquired, then format `args`
-/// and send. Convenience entry point used by the std-overlay macro and by
-/// init's lazy-log path. Silently drops if no log cap can be acquired.
+/// One-shot emit: format `args` and send on the pre-installed tokened
+/// SEND cap. Silently drops when no cap is installed (the process has
+/// no log access — init/memmgr/procmgr-self before bootstrap, or any
+/// process spawned before the log endpoint existed).
 pub fn emit(ipc_buf: *mut u64, args: core::fmt::Arguments<'_>)
 {
     let cap = ensure_tokened_cap(ipc_buf);
     if cap == 0
     {
         // Reaching here means the binary linked `seraph::log!` but
-        // received neither a discovery cap at `_start` nor a pre-
-        // installed tokened cap. Tier-2 binaries that never call
-        // `log!` never reach this function (dead-code-eliminated).
-        // Loud in debug; silent drop in release for cap-oblivious
-        // tier-2 use.
+        // received no pre-installed tokened cap. Tier-2 binaries that
+        // never call `log!` never reach this function (dead-code-
+        // eliminated). Loud in debug; silent drop in release for
+        // cap-oblivious tier-2 use.
         debug_assert!(
             false,
-            "seraph::log! invoked but no log cap was wired at startup",
+            "seraph::log! invoked but no log cap was installed at startup",
         );
         return;
     }

--- a/xtask/src/commands/build.rs
+++ b/xtask/src/commands/build.rs
@@ -134,6 +134,11 @@ const SPECS: &[Spec] = &[
         dest: InstallDest::RootfsBin,
     },
     Spec {
+        name: "logd",
+        profile: BuildProfile::StdUser,
+        dest: InstallDest::RootfsBin,
+    },
+    Spec {
         name: "hello",
         profile: BuildProfile::StdUser,
         dest: InstallDest::RootfsBin,


### PR DESCRIPTION
## Summary

Brings the v0.1.0 init lifecycle to its specified end-state: real `logd` takes over from `init-logd` after root-mount (Issue #1), and after init's Phase-3 handoff the kernel reclaims every byte init was holding (Issue #5).

Branch (six commits):

- `fff7f63` — Issue #1: real logd + handover.
- `4ba8809` — Issue #5: full init reap + every-byte reclaim.
- `d9f7608` — Review fixes round 1 + stale-doc cleanup.
- `e7475f7` — Capability hygiene (un-tokened SEND distribution closed).
- `dee506f` — Review fixes round 2.
- `a006de8` — ktest mm: replace cap_delete with frame_merge for re-split tail.

Closes #1
Closes #5

## Acceptance

**Issue #1** (all met):

- [x] `services/logd/src/main.rs` exists; real service binary in workspace build.
- [x] Real-logd launched by init after root mount; init-logd state transferred via `HANDOVER_PULL`.
- [x] init-logd terminates cleanly post-handover.
- [x] Slot table is token-keyed hash map with lazy buffers + reclaim-on-death via procmgr multi-observer death-EQ.
- [x] Dual-arch boots through handover (usertest + ktest).

**Issue #5** (all met):

- [x] After Phase-3 handover + real-logd handover, init's segment Frame caps are donated to memmgr (plus stack + InitInfo + IPC-buffer caps per scope expansion).
- [x] memmgr's pool reclaim total reflects recovered pages; `[procmgr] init reaped: ...` log line emits per boot.
- [x] Dual-arch reclaims cleanly (usertest + ktest).
- [x] No use-after-free: AS torn down before DONATE_FRAMES; no aliasing window.

## Test plan

- [x] `cargo xtask build` (x86_64)
- [x] `cargo xtask run` (x86_64) — `[usertest] ALL TESTS PASSED`
- [x] `cargo xtask run` (x86_64) ktest mode — `131/0 ALL TESTS PASSED`
- [x] `cargo xtask build --arch riscv64`
- [x] `cargo xtask run --arch riscv64` — `[usertest] ALL TESTS PASSED`
- [x] `cargo xtask run --arch riscv64` ktest mode — `131/0 ALL TESTS PASSED`
- [x] `[procmgr] init reaped: ...` log line on both arches
- [x] `[usertest] pwrmgr cap-deny phase passed (UNAUTHORIZED reply)` on both arches

## Notes

**Scope expansion of #5.** Original scope was "donate init segment frames" with full init exit deferred. User pulled the expansion into v0.1.0: init's `AddressSpace`+`CSpace`+both `Thread` caps fully torn down; kernel now mints init's stack + InitInfo pages as reclaimable Frame caps for donation. Mechanism: end-of-Phase-3 `REGISTER_INIT_TEARDOWN` IPC + `INIT_TEARDOWN_DONE` + `sys_thread_exit`; procmgr's death-EQ runs `init_reap::run_reap` (Threads → AS → DONATE_FRAMES → CSpace).

**ktest regression caught and fixed (`a006de8`).** Issue #5 flips segment Frame caps to `owns_memory=true` (required so the init-reap cascade can return them to memmgr). ktest's `mm::frame_split_merge` test was `cap_delete`'ing a re-split tail of the RODATA segment cap; that worked pre-#5 (segments owned no memory, so dec_ref was a buddy-free no-op) but post-#5 the tail's phys range — still mapped at RODATA's segment VA in ktest's own AS — got buddy-freed, silently aliasing subsequent allocations and crashing ktest several tests later in `hw::mmio_map`. Fixed by replacing the trailing `cap_delete(tail2)` with `frame_merge(parent, tail2)`; merge clears `owns_memory` on the tail before dec_ref, so no buddy reclaim fires and the segment mapping stays intact. Same semantic coverage of split↔merge round-trip.

**Emergent capability hygiene (`e7475f7`).** Audit during #5 surfaced `procmgr_endpoint_cap` distributed to children as un-tokened `SEND_GRANT`. With `sys_cap_derive_token` permitting any holder of an un-tokened source to mint a tokened child of any value, this let any child mint `DEATH_EQ_AUTHORITY` (or any other authority-bearing token) on procmgr. Fixed structurally: children now get `cap_derive_token(src, SEND_GRANT, child.process_token)`-derived caps. `pwrmgr_noauth_cap` similarly tokened with sentinel `1`. Audited all other authority endpoints; none had the same defect. `docs/capability-model.md` §Tokens reworked to document kernel guarantees vs non-guarantees and the structural server-side rule.

**Two adversarial review rounds** surfaced and closed a cluster of latent bugs: kernel buddy ledger double-count for stack/InitInfo, init_reap error-path AS-dealloc panic, logd long-line truncation regression, install_logd_death_eq atomic-vs-cap desync, u32 correlator wrap guard.

**Pre-existing kernel concern** (NOT changed by this PR): `sys_cap_derive_token` permits any un-tokened-cap holder to choose any u64 token value. This PR mitigates structurally for every authority endpoint. Future kernel-side defense-in-depth is worth considering separately.
