### PR TITLE
xtask: portable host terminal I/O cluster (filter, gate, ctrlc, guard)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "boot"
 version = "0.1.0"
 dependencies = [
@@ -134,6 +143,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -233,6 +248,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys",
+]
+
+[[package]]
 name = "devmgr"
 version = "0.1.0"
 dependencies = [
@@ -240,6 +266,18 @@ dependencies = [
  "syscall",
  "syscall-abi",
  "virtio-core",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -561,6 +599,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,6 +618,21 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"
@@ -1175,6 +1240,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "ctrlc",
  "fatfs 0.3.6",
  "gpt",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -67,7 +67,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -255,7 +255,7 @@ checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
  "nix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1133,12 +1133,85 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
@@ -1243,8 +1316,10 @@ dependencies = [
  "ctrlc",
  "fatfs 0.3.6",
  "gpt",
+ "libc",
  "regex",
  "uuid",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -19,6 +19,9 @@ fatfs = "0.3"
 uuid = "1"
 # Regex matching for run-parallel pass/fail classification.
 regex = "1"
+# Portable SIGINT / Ctrl+C handler. Wraps signal(2) on Unix and
+# SetConsoleCtrlHandler on Windows behind a single set_handler call.
+ctrlc = "3"
 
 [lints]
 workspace = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -22,6 +22,15 @@ regex = "1"
 # Portable SIGINT / Ctrl+C handler. Wraps signal(2) on Unix and
 # SetConsoleCtrlHandler on Windows behind a single set_handler call.
 ctrlc = "3"
+# Unix termios / ioctl bindings for TerminalGuard. Used unconditionally
+# because libc compiles cleanly on every platform xtask runs on, with
+# unused Unix-only items naturally elided on Windows builds.
+libc = "0.2"
+
+# Windows console-mode bindings for TerminalGuard. Only pulled in for
+# Windows builds; Linux/macOS/BSD builds skip this crate entirely.
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59", features = ["Win32_System_Console", "Win32_Foundation"] }
 
 [lints]
 workspace = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -8,7 +8,6 @@ publish.workspace = true
 [[bin]]
 name = "xtask"
 path = "src/main.rs"
-test = false
 
 [dependencies]
 # Declarative CLI with auto-generated help text.

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -119,10 +119,15 @@ pub struct RunArgs
     #[arg(long)]
     pub headless: bool,
 
-    /// Show all serial output including pre-boot firmware noise (filtered by default).
+    /// Show all serial output including pre-boot firmware noise
+    /// (suppressed by default).
     ///
     /// By default, output is suppressed until the first line containing
-    /// '[--------] boot:', hiding UEFI/OpenSBI debug spam.
+    /// '[--------] boot:', hiding UEFI/OpenSBI debug spam. The
+    /// control-sequence filter (drops xterm window manipulation,
+    /// alternate-screen toggles, mouse tracking, etc.) is always on in
+    /// both modes — verbose only disables the marker gate, not the
+    /// filter.
     #[arg(long)]
     pub verbose: bool,
 

--- a/xtask/src/commands/run.rs
+++ b/xtask/src/commands/run.rs
@@ -11,8 +11,8 @@
 //! rather than a silent rebuild, which keeps tight re-run loops from
 //! accidentally recompiling and changing what is being tested.
 
-use std::io::{BufRead, BufReader};
-use std::process::{Command, Stdio};
+use std::io::{Read, Write, copy};
+use std::process::{Command, ExitStatus, Stdio};
 
 use anyhow::{Context as _, Result};
 
@@ -23,7 +23,14 @@ use crate::qemu::{
     QemuLaunchSpec, build_qemu_argv, find_ovmf_code, prepare_riscv_firmware,
     validate_sysroot_for_launch,
 };
+use crate::term::filter::FilterWriter;
+use crate::term::line_gate::LineGate;
 use crate::util::{TerminalGuard, run_with_sigint_ignored, step};
+
+/// Marker that opens the default-mode line gate. Emitted by the
+/// bootloader as the first line after firmware exits; everything
+/// before it is firmware chatter that the user almost never wants.
+const BOOT_MARKER: &[u8] = b"[--------] boot:";
 
 /// Entry point for `cargo xtask run`.
 pub fn run(ctx: &BuildContext, args: &RunArgs) -> Result<()>
@@ -76,73 +83,62 @@ pub fn run(ctx: &BuildContext, args: &RunArgs) -> Result<()>
 
 fn launch_qemu(binary: &str, args: &[String], desc: &str, verbose: bool) -> Result<()>
 {
-    if verbose
+    let banner = if verbose
     {
-        step(&format!("Starting QEMU ({})", desc));
-        // Ignore SIGINT in our process so Ctrl+C kills QEMU but lets us run
-        // cleanup (TerminalGuard restore) before exiting.
-        let status = run_with_sigint_ignored(|| {
-            Command::new(binary)
-                .args(args)
-                .status()
-                .with_context(|| format!("failed to launch {}", binary))
-        })?;
-        if !status.success()
-        {
-            eprintln!("QEMU exited with {} (normal for OS development)", status);
-        }
+        format!("Starting QEMU ({desc})")
     }
     else
     {
-        step(&format!(
-            "Starting QEMU ({}) [output filtered until '[--------] boot:'; --verbose to disable]",
-            desc
-        ));
+        format!(
+            "Starting QEMU ({desc}) [output filtered until '[--------] boot:'; --verbose to disable]",
+        )
+    };
+    step(&banner);
+
+    // Pipe stdout unconditionally so the filter (and optional gate)
+    // can screen every byte. stdin and stderr inherit. QEMU's stderr
+    // is not part of the firmware-spam problem; passing it through
+    // unfiltered preserves any meaningful QEMU diagnostics.
+    let status = run_with_sigint_ignored(|| -> Result<ExitStatus> {
         let mut child = Command::new(binary)
             .args(args)
             .stdout(Stdio::piped())
             .spawn()
-            .with_context(|| format!("failed to launch {}", binary))?;
+            .with_context(|| format!("failed to launch {binary}"))?;
+        let stdout = child
+            .stdout
+            .take()
+            .context("QEMU stdout was piped but unavailable")?;
+        forward_qemu_stdout(stdout, verbose)?;
+        child.wait().context("waiting for QEMU to exit")
+    })?;
 
-        // Pipe stdout: suppress all output until '[--------] boot:' appears.
-        // This filters out UEFI DEBUG spam and OpenSBI banners on RISC-V.
-        // Note: piping stdout disables the QEMU monitor (Ctrl+A c).
-        //
-        // Use byte-level reading with `from_utf8_lossy` so non-UTF-8 bytes in
-        // kernel fault dumps (e.g. raw memory content) don't abort the reader.
-        let stdout = child.stdout.take().expect("stdout was piped");
-        let mut reader = BufReader::new(stdout);
-        let mut show = false;
-        let mut buf: Vec<u8> = Vec::new();
-
-        loop
-        {
-            buf.clear();
-            let n = reader
-                .read_until(b'\n', &mut buf)
-                .context("reading QEMU stdout")?;
-            if n == 0
-            {
-                break;
-            }
-            let line = String::from_utf8_lossy(&buf);
-            let line = line.trim_end_matches(['\n', '\r']);
-            if !show && line.contains("[--------] boot:")
-            {
-                show = true;
-            }
-            if show
-            {
-                println!("{}", line);
-            }
-        }
-
-        let status = child.wait().context("waiting for QEMU to exit")?;
-        if !status.success()
-        {
-            eprintln!("QEMU exited with {} (normal for OS development)", status);
-        }
+    if !status.success()
+    {
+        eprintln!("QEMU exited with {status} (normal for OS development)");
     }
+    Ok(())
+}
 
+/// Read QEMU's stdout to EOF, forwarding it to the host stdout through
+/// the control-sequence filter and (in default mode) the marker gate.
+fn forward_qemu_stdout<R: Read>(mut from: R, verbose: bool) -> Result<()>
+{
+    let out = std::io::stdout();
+    let locked = out.lock();
+    let sink = FilterWriter::new(locked);
+
+    if verbose
+    {
+        let mut s = sink;
+        copy(&mut from, &mut s).context("forwarding QEMU stdout")?;
+        s.flush().context("flushing host stdout")?;
+    }
+    else
+    {
+        let mut gated = LineGate::new(sink, BOOT_MARKER);
+        copy(&mut from, &mut gated).context("forwarding QEMU stdout")?;
+        gated.flush().context("flushing host stdout")?;
+    }
     Ok(())
 }

--- a/xtask/src/commands/run.rs
+++ b/xtask/src/commands/run.rs
@@ -25,7 +25,7 @@ use crate::qemu::{
 };
 use crate::term::filter::FilterWriter;
 use crate::term::line_gate::LineGate;
-use crate::util::{TerminalGuard, run_with_sigint_ignored, step};
+use crate::util::{TerminalGuard, step};
 
 /// Marker that opens the default-mode line gate. Emitted by the
 /// bootloader as the first line after firmware exits; everything
@@ -99,19 +99,22 @@ fn launch_qemu(binary: &str, args: &[String], desc: &str, verbose: bool) -> Resu
     // can screen every byte. stdin and stderr inherit. QEMU's stderr
     // is not part of the firmware-spam problem; passing it through
     // unfiltered preserves any meaningful QEMU diagnostics.
-    let status = run_with_sigint_ignored(|| -> Result<ExitStatus> {
-        let mut child = Command::new(binary)
-            .args(args)
-            .stdout(Stdio::piped())
-            .spawn()
-            .with_context(|| format!("failed to launch {binary}"))?;
-        let stdout = child
-            .stdout
-            .take()
-            .context("QEMU stdout was piped but unavailable")?;
-        forward_qemu_stdout(stdout, verbose)?;
-        child.wait().context("waiting for QEMU to exit")
-    })?;
+    //
+    // SIGINT handling: the global no-op handler installed in main()
+    // (term::signal::install) means Ctrl+C terminates QEMU directly
+    // via the tty without killing xtask. The TerminalGuard captured
+    // in run() runs its drop on the way out, restoring termios.
+    let mut child = Command::new(binary)
+        .args(args)
+        .stdout(Stdio::piped())
+        .spawn()
+        .with_context(|| format!("failed to launch {binary}"))?;
+    let stdout = child
+        .stdout
+        .take()
+        .context("QEMU stdout was piped but unavailable")?;
+    forward_qemu_stdout(stdout, verbose)?;
+    let status: ExitStatus = child.wait().context("waiting for QEMU to exit")?;
 
     if !status.success()
     {

--- a/xtask/src/commands/run.rs
+++ b/xtask/src/commands/run.rs
@@ -24,8 +24,9 @@ use crate::qemu::{
     validate_sysroot_for_launch,
 };
 use crate::term::filter::FilterWriter;
+use crate::term::guard::TerminalGuard;
 use crate::term::line_gate::LineGate;
-use crate::util::{TerminalGuard, step};
+use crate::util::step;
 
 /// Marker that opens the default-mode line gate. Emitted by the
 /// bootloader as the first line after firmware exits; everything

--- a/xtask/src/commands/run_parallel.rs
+++ b/xtask/src/commands/run_parallel.rs
@@ -13,8 +13,8 @@
 //! regexes (`--pass`, `--fail`); xtask only classifies outcomes by matching
 //! those patterns against per-run logs, plus exit-code and watchdog state.
 
-use std::fs::File;
-use std::io::Read;
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::Arc;
@@ -32,6 +32,7 @@ use crate::qemu::{
     QemuLaunchSpec, build_qemu_argv, find_ovmf_code, prepare_riscv_firmware,
     validate_sysroot_for_launch,
 };
+use crate::term::filter::FilterWriter;
 use crate::util::step;
 
 /// How often the watchdog poll loop checks child exit status.
@@ -192,21 +193,42 @@ pub fn run(ctx: &BuildContext, args: &RunParallelArgs) -> Result<()>
                 };
                 let qemu_args = build_qemu_argv(&spec);
 
-                let log_file = File::create(&log_path)
+                // O_APPEND on the log fds so the kernel writes atomically
+                // at end-of-file. Both the per-slot stdout-forwarder thread
+                // and QEMU's stderr (via Stdio::from) write into the same
+                // file; with O_APPEND each write() syscall is its own
+                // boundary so output never overwrites itself even though
+                // two writers share the file.
+                let log_file = OpenOptions::new()
+                    .create(true)
+                    .write(true)
+                    .append(true)
+                    .open(&log_path)
                     .with_context(|| format!("creating log file {}", log_path.display()))?;
-                let log_clone = log_file
+                let log_for_stderr = log_file
                     .try_clone()
                     .context("cloning log file fd for stderr")?;
+                // `log_file` is moved into the forwarder thread below.
 
                 let started = Instant::now();
                 let mut child = Command::new(arch.qemu_binary())
                     .args(&qemu_args)
-                    .stdout(Stdio::from(log_file))
-                    .stderr(Stdio::from(log_clone))
+                    .stdout(Stdio::piped())
+                    .stderr(Stdio::from(log_for_stderr))
                     .spawn()
                     .with_context(|| format!("spawning {}", arch.qemu_binary()))?;
 
+                let qemu_stdout = child
+                    .stdout
+                    .take()
+                    .context("QEMU stdout was piped but unavailable")?;
+                let forwarder = spawn_stdout_forwarder(qemu_stdout, log_file);
+
                 let (exit_rc, hung) = wait_with_timeout(&mut child, timeout)?;
+                // Drain the forwarder before reading the log so classify()
+                // sees the complete byte stream even when the watchdog
+                // killed QEMU mid-write.
+                join_forwarder(forwarder, run_id);
                 let elapsed = started.elapsed();
 
                 let log_text = read_log(&log_path).unwrap_or_default();
@@ -327,6 +349,36 @@ fn purge_prior_logs(workdir: &Path) -> Result<()>
         }
     }
     Ok(())
+}
+
+/// Spawn a thread that forwards `child_stdout` through `FilterWriter`
+/// into `log_sink`. The thread exits when the pipe reaches EOF (child
+/// closed its stdout, either by exiting or by being killed).
+fn spawn_stdout_forwarder(
+    mut child_stdout: std::process::ChildStdout,
+    log_sink: File,
+) -> JoinHandle<Result<()>>
+{
+    thread::spawn(move || -> Result<()> {
+        let mut sink = FilterWriter::new(log_sink);
+        std::io::copy(&mut child_stdout, &mut sink)
+            .context("forwarding QEMU stdout into per-slot log")?;
+        sink.flush().context("flushing per-slot log")?;
+        Ok(())
+    })
+}
+
+/// Join a stdout-forwarder thread. Logs but does not propagate forwarder
+/// errors so classification can still proceed on partial logs.
+fn join_forwarder(handle: JoinHandle<Result<()>>, run_id: u32)
+{
+    match handle.join()
+    {
+        Ok(Ok(())) =>
+        {}
+        Ok(Err(err)) => eprintln!("run {run_id}: stdout forwarder error: {err:#}"),
+        Err(_) => eprintln!("run {run_id}: stdout forwarder panicked"),
+    }
 }
 
 /// Block waiting for `child` to exit or `timeout` to elapse.

--- a/xtask/src/commands/run_parallel.rs
+++ b/xtask/src/commands/run_parallel.rs
@@ -222,7 +222,7 @@ pub fn run(ctx: &BuildContext, args: &RunParallelArgs) -> Result<()>
                     .stdout
                     .take()
                     .context("QEMU stdout was piped but unavailable")?;
-                let forwarder = spawn_stdout_forwarder(qemu_stdout, log_file);
+                let forwarder = spawn_stdout_forwarder(qemu_stdout, log_file, slot)?;
 
                 let (exit_rc, hung) = wait_with_timeout(&mut child, timeout)?;
                 // Drain the forwarder before reading the log so classify()
@@ -353,19 +353,25 @@ fn purge_prior_logs(workdir: &Path) -> Result<()>
 
 /// Spawn a thread that forwards `child_stdout` through `FilterWriter`
 /// into `log_sink`. The thread exits when the pipe reaches EOF (child
-/// closed its stdout, either by exiting or by being killed).
+/// closed its stdout, either by exiting or by being killed). The
+/// thread is named `forwarder-<slot>` so panic backtraces and
+/// debugger views identify which slot owned the thread.
 fn spawn_stdout_forwarder(
     mut child_stdout: std::process::ChildStdout,
     log_sink: File,
-) -> JoinHandle<Result<()>>
+    slot: u32,
+) -> Result<JoinHandle<Result<()>>>
 {
-    thread::spawn(move || -> Result<()> {
-        let mut sink = FilterWriter::new(log_sink);
-        std::io::copy(&mut child_stdout, &mut sink)
-            .context("forwarding QEMU stdout into per-slot log")?;
-        sink.flush().context("flushing per-slot log")?;
-        Ok(())
-    })
+    thread::Builder::new()
+        .name(format!("forwarder-{slot}"))
+        .spawn(move || -> Result<()> {
+            let mut sink = FilterWriter::new(log_sink);
+            std::io::copy(&mut child_stdout, &mut sink)
+                .context("forwarding QEMU stdout into per-slot log")?;
+            sink.flush().context("flushing per-slot log")?;
+            Ok(())
+        })
+        .context("spawning stdout forwarder thread")
 }
 
 /// Join a stdout-forwarder thread. Logs but does not propagate forwarder

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -35,6 +35,15 @@ fn main()
     let cli = Cli::parse();
     let ctx = Context::from_manifest_dir();
 
+    // Install a no-op Ctrl+C handler so SIGINT terminates the inner
+    // subprocess (cargo, QEMU) without killing xtask itself. Allows
+    // TerminalGuard::drop and error propagation to run on Ctrl+C.
+    if let Err(err) = term::signal::install()
+    {
+        eprintln!("error: {err:#}");
+        std::process::exit(1);
+    }
+
     let result = match &cli.command
     {
         CliCommand::Build(args) => commands::build::run(&ctx, args),

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -24,6 +24,7 @@ mod disk;
 mod qemu;
 mod rust_src;
 mod sysroot;
+mod term;
 mod util;
 
 use cli::{Cli, CliCommand};

--- a/xtask/src/term/filter.rs
+++ b/xtask/src/term/filter.rs
@@ -1,0 +1,569 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+//! term/filter.rs
+//!
+//! Byte-stream control-sequence filter for QEMU output.
+//!
+//! `FilterWriter` is a `Write` adapter that strips terminal-control
+//! sequences known to corrupt the host tty when emitted unsolicited.
+//! The primary offender is OVMF (x86-64) and EDK2 (RISC-V), which emit
+//! xterm window-manipulation and DEC private-mode sequences over the
+//! serial console during firmware init. A misbehaving Seraph print
+//! site can hit the same failure mode by accident; filtering both
+//! paths makes that fail loudly rather than corrupt the user's shell.
+//!
+//! What is dropped (rationale, blocklist):
+//!
+//! - `CSI ... t` — xterm window manipulation. OVMF emits
+//!   `ESC[8;rows;colst` which resizes (or asks the emulator to resize)
+//!   the host terminal. No legitimate kernel/userspace use.
+//! - `CSI ? ... h` / `l` for modes 47, 1047, 1049 — alternate-screen
+//!   buffer toggles. Leaving the alt buffer active hides subsequent
+//!   output from scrollback.
+//! - `CSI ? 5 h` / `l` — DECSCNM (full-screen reverse video).
+//! - `CSI ? 9 h` / `l` and `CSI ? 1000`–`1006 h` / `l` — mouse-tracking
+//!   modes. Leaving these enabled feeds mouse-move bytes into the next
+//!   program's stdin.
+//! - `OSC 0;…`, `OSC 1;…`, `OSC 2;…` (terminated by BEL or ST) —
+//!   window/icon title set. Persists after the run.
+//! - `ESC c` — RIS (full reset). Clears scrollback in many emulators.
+//!
+//! What is passed through:
+//!
+//! - SGR (`CSI ... m`) — colors and text attributes.
+//! - Cursor positioning, line/screen clear within current screen, and
+//!   any other CSI sequence not in the drop list.
+//! - DEC private modes outside the blocklist (notably `?25` cursor
+//!   visibility).
+//! - All plain bytes including `\r`, `\n`, `\t`, `\b`.
+//! - `ESC X` for `X` other than `[`, `]`, `c` (charset selection,
+//!   etc.).
+//!
+//! Conservative composition rule: when one CSI private-mode sequence
+//! mixes blocklisted and non-blocklisted modes (e.g. `CSI ? 25;1049 h`),
+//! the whole sequence is dropped. Combining safe and unsafe modes in
+//! one sequence is not idiomatic and is safer to discard wholesale than
+//! to attempt to rewrite.
+//!
+//! The filter is a pure byte-stream parser — no I/O beyond the wrapped
+//! writer, no platform code, no allocation beyond a small reusable
+//! scratch buffer that holds at most one in-flight sequence. It is
+//! unit-tested in isolation against the full CSI/OSC grammar and
+//! split-across-write boundaries.
+
+use std::io::{self, Write};
+
+/// CSI / OSC parser state. Bytes that arrive mid-sequence are buffered
+/// in `FilterWriter::pending` until the sequence completes; at that
+/// point the buffered bytes are either emitted to the inner writer or
+/// dropped as a unit.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum State
+{
+    /// Outside any escape sequence. Bytes pass through directly.
+    Ground,
+    /// Saw `ESC`. The next byte selects the sequence type
+    /// (`[` = CSI, `]` = OSC, `c` = RIS, anything else = pass through).
+    Esc,
+    /// Saw `ESC [`, collecting params / intermediates until a final
+    /// byte in `0x40..=0x7e` ends the CSI sequence.
+    Csi,
+    /// Saw `ESC ]`, collecting OSC body until BEL (`0x07`) or the
+    /// start of an ST terminator (`ESC \`).
+    Osc,
+    /// Saw `ESC ] ... ESC`, waiting for the trailing `\` that
+    /// completes the ST terminator.
+    OscEsc,
+}
+
+/// `Write` adapter that drops dangerous terminal-control sequences
+/// from the byte stream and passes everything else through unchanged.
+///
+/// See the module docs for the full drop / pass-through rules.
+pub struct FilterWriter<W: Write>
+{
+    inner: W,
+    state: State,
+    /// Bytes consumed since the start of an in-progress sequence,
+    /// including the leading `ESC`. Empty in `State::Ground`.
+    pending: Vec<u8>,
+}
+
+// FilterWriter is wired into the QEMU stdout pipeline in a separate
+// commit; until then it has no caller in the binary.
+#[allow(dead_code)]
+impl<W: Write> FilterWriter<W>
+{
+    /// Wrap `inner` in a filter. Bytes written to the returned writer
+    /// are screened against the blocklist and the remainder forwarded
+    /// to `inner`.
+    pub fn new(inner: W) -> Self
+    {
+        FilterWriter {
+            inner,
+            state: State::Ground,
+            pending: Vec::new(),
+        }
+    }
+
+    /// Recover the inner writer. Any bytes still buffered mid-sequence
+    /// are discarded.
+    pub fn into_inner(self) -> W
+    {
+        self.inner
+    }
+
+    /// Resolve a completed escape sequence: emit it to `inner` if
+    /// permitted, or drop the buffered bytes otherwise. Always clears
+    /// `pending`.
+    fn flush_pending(&mut self) -> io::Result<()>
+    {
+        if should_drop(&self.pending)
+        {
+            self.pending.clear();
+            return Ok(());
+        }
+        let result = self.inner.write_all(&self.pending);
+        self.pending.clear();
+        result
+    }
+}
+
+impl<W: Write> Write for FilterWriter<W>
+{
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize>
+    {
+        // Batch contiguous Ground bytes into a single inner.write_all to
+        // avoid per-byte syscalls on the common no-escape path.
+        let mut ground_start: Option<usize> = None;
+
+        for (i, &b) in buf.iter().enumerate()
+        {
+            match self.state
+            {
+                State::Ground =>
+                {
+                    if b == 0x1b
+                    {
+                        if let Some(start) = ground_start.take()
+                        {
+                            self.inner.write_all(&buf[start..i])?;
+                        }
+                        self.state = State::Esc;
+                        self.pending.push(b);
+                    }
+                    else
+                    {
+                        ground_start.get_or_insert(i);
+                    }
+                }
+                State::Esc =>
+                {
+                    self.pending.push(b);
+                    match b
+                    {
+                        b'[' => self.state = State::Csi,
+                        b']' => self.state = State::Osc,
+                        b'c' =>
+                        {
+                            // RIS — full terminal reset. Drop.
+                            self.pending.clear();
+                            self.state = State::Ground;
+                        }
+                        _ =>
+                        {
+                            // Other ESC X — pass through (charset switches, etc.).
+                            self.flush_pending()?;
+                            self.state = State::Ground;
+                        }
+                    }
+                }
+                State::Csi =>
+                {
+                    self.pending.push(b);
+                    // Final byte (0x40..=0x7e) ends the CSI sequence.
+                    if (0x40..=0x7e).contains(&b)
+                    {
+                        self.flush_pending()?;
+                        self.state = State::Ground;
+                    }
+                }
+                State::Osc =>
+                {
+                    self.pending.push(b);
+                    if b == 0x07
+                    {
+                        self.flush_pending()?;
+                        self.state = State::Ground;
+                    }
+                    else if b == 0x1b
+                    {
+                        self.state = State::OscEsc;
+                    }
+                }
+                State::OscEsc =>
+                {
+                    self.pending.push(b);
+                    // Whether the next byte is `\` (proper ST) or anything
+                    // else (malformed input — treat as end-of-sequence),
+                    // we resolve `pending` and return to Ground.
+                    self.flush_pending()?;
+                    self.state = State::Ground;
+                }
+            }
+        }
+
+        if let Some(start) = ground_start
+        {
+            self.inner.write_all(&buf[start..])?;
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()>
+    {
+        // Mid-sequence pending bytes stay buffered across flush; only
+        // the inner writer is flushed. CSI/OSC bytes that have not yet
+        // reached a final byte have ambiguous emit/drop status and must
+        // not leak.
+        self.inner.flush()
+    }
+}
+
+/// Decide whether a completed escape sequence should be dropped.
+/// `seq` always begins with `ESC` (`0x1b`).
+fn should_drop(seq: &[u8]) -> bool
+{
+    if seq.len() < 2
+    {
+        return false;
+    }
+    match seq[1]
+    {
+        b'c' => true,
+        b'[' => csi_should_drop(&seq[2..]),
+        b']' => osc_should_drop(&seq[2..]),
+        _ => false,
+    }
+}
+
+/// Drop-decision for a CSI body (everything after `ESC [`).
+/// Body ends with the final byte (`0x40..=0x7e`).
+fn csi_should_drop(body: &[u8]) -> bool
+{
+    let Some((&final_byte, params)) = body.split_last()
+    else
+    {
+        return false;
+    };
+
+    match final_byte
+    {
+        b't' => true,
+        b'h' | b'l' if params.first() == Some(&b'?') => any_blocklisted_dec_mode(&params[1..]),
+        _ => false,
+    }
+}
+
+/// Returns true if any semicolon-separated decimal in `params`
+/// matches a blocklisted DEC private mode.
+fn any_blocklisted_dec_mode(params: &[u8]) -> bool
+{
+    for chunk in params.split(|&b| b == b';')
+    {
+        let Ok(s) = std::str::from_utf8(chunk)
+        else
+        {
+            continue;
+        };
+        let Ok(n) = s.parse::<u32>()
+        else
+        {
+            continue;
+        };
+        if is_blocklisted_dec_mode(n)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// DEC private modes that must not be left enabled in the host tty.
+/// Strictly enumerated rather than ranged-with-exceptions so the
+/// blocklist is self-documenting in the failure case.
+fn is_blocklisted_dec_mode(n: u32) -> bool
+{
+    matches!(
+        n,
+        47       // legacy alternate screen
+      | 1047    // alternate screen (DECRPM-style)
+      | 1049    // alternate screen + save cursor
+      | 5       // DECSCNM (reverse video, entire screen)
+      | 9       // X10 mouse reporting
+      | 1000..=1006 // xterm mouse modes (button, any-event, focus, utf8, sgr, urxvt)
+    )
+}
+
+/// Drop-decision for an OSC body (everything after `ESC ]`).
+/// `body` includes the terminator (BEL or `ESC \`) at the end.
+fn osc_should_drop(body: &[u8]) -> bool
+{
+    let trim_end = body
+        .iter()
+        .position(|&b| b == 0x07 || b == 0x1b)
+        .unwrap_or(body.len());
+    let trimmed = &body[..trim_end];
+    let semi = trimmed
+        .iter()
+        .position(|&b| b == b';')
+        .unwrap_or(trimmed.len());
+    let prefix = &trimmed[..semi];
+    // OSC 0 = icon + window title, 1 = icon title, 2 = window title.
+    matches!(prefix, b"0" | b"1" | b"2")
+}
+
+#[cfg(test)]
+mod tests
+{
+    use super::*;
+
+    /// Run `input` through a fresh `FilterWriter` and return the bytes
+    /// that reached the inner writer.
+    fn run(input: &[u8]) -> Vec<u8>
+    {
+        let mut w = FilterWriter::new(Vec::new());
+        w.write_all(input).unwrap();
+        w.into_inner()
+    }
+
+    /// Like `run`, but writes one byte at a time. Exercises mid-sequence
+    /// state preservation across `write` boundaries.
+    fn run_one_byte_at_a_time(input: &[u8]) -> Vec<u8>
+    {
+        let mut w = FilterWriter::new(Vec::new());
+        for &b in input
+        {
+            w.write_all(&[b]).unwrap();
+        }
+        w.into_inner()
+    }
+
+    #[test]
+    fn plain_ascii_passes_through_unchanged()
+    {
+        assert_eq!(run(b"hello world\n"), b"hello world\n");
+    }
+
+    #[test]
+    fn empty_input_produces_empty_output()
+    {
+        assert_eq!(run(b""), b"");
+    }
+
+    #[test]
+    fn sgr_color_passes_through()
+    {
+        let input = b"\x1b[31mred\x1b[0m";
+        assert_eq!(run(input), input);
+    }
+
+    #[test]
+    fn cursor_positioning_passes_through()
+    {
+        let input = b"\x1b[10;20H";
+        assert_eq!(run(input), input);
+    }
+
+    #[test]
+    fn clear_to_end_of_line_passes_through()
+    {
+        let input = b"\x1b[K";
+        assert_eq!(run(input), input);
+    }
+
+    #[test]
+    fn cursor_visibility_is_preserved()
+    {
+        // DEC ?25 — show / hide cursor — is NOT in the blocklist.
+        assert_eq!(run(b"\x1b[?25h"), b"\x1b[?25h");
+        assert_eq!(run(b"\x1b[?25l"), b"\x1b[?25l");
+    }
+
+    #[test]
+    fn window_manipulation_is_stripped()
+    {
+        let input = b"before\x1b[8;24;80tafter";
+        assert_eq!(run(input), b"beforeafter");
+    }
+
+    #[test]
+    fn window_manipulation_without_params_is_stripped()
+    {
+        // CSI t with no params still has 't' as the final byte; drop.
+        assert_eq!(run(b"\x1b[t"), b"");
+    }
+
+    #[test]
+    fn alternate_screen_1049_is_stripped()
+    {
+        assert_eq!(run(b"\x1b[?1049h"), b"");
+        assert_eq!(run(b"\x1b[?1049l"), b"");
+    }
+
+    #[test]
+    fn alternate_screen_legacy_47_is_stripped()
+    {
+        assert_eq!(run(b"\x1b[?47h"), b"");
+        assert_eq!(run(b"\x1b[?47l"), b"");
+    }
+
+    #[test]
+    fn alternate_screen_1047_is_stripped()
+    {
+        assert_eq!(run(b"\x1b[?1047h"), b"");
+        assert_eq!(run(b"\x1b[?1047l"), b"");
+    }
+
+    #[test]
+    fn reverse_video_decscnm_is_stripped()
+    {
+        assert_eq!(run(b"\x1b[?5h"), b"");
+        assert_eq!(run(b"\x1b[?5l"), b"");
+    }
+
+    #[test]
+    fn x10_mouse_mode_is_stripped()
+    {
+        assert_eq!(run(b"\x1b[?9h"), b"");
+    }
+
+    #[test]
+    fn xterm_mouse_modes_are_stripped()
+    {
+        for n in 1000_u32..=1006
+        {
+            let seq = format!("\x1b[?{n}h");
+            assert!(
+                run(seq.as_bytes()).is_empty(),
+                "failed to strip mouse mode {n}"
+            );
+        }
+    }
+
+    #[test]
+    fn mixed_safe_and_blocklisted_dec_modes_drop_whole_sequence()
+    {
+        // ?25 is safe (cursor visibility), ?1049 is blocked (alt screen).
+        // Conservative rule: drop the whole sequence.
+        assert_eq!(run(b"\x1b[?25;1049h"), b"");
+        assert_eq!(run(b"\x1b[?1049;25h"), b"");
+    }
+
+    #[test]
+    fn ris_full_reset_is_stripped()
+    {
+        let input = b"before\x1bcafter";
+        assert_eq!(run(input), b"beforeafter");
+    }
+
+    #[test]
+    fn osc_window_title_bel_terminated_is_stripped()
+    {
+        let input = b"hi\x1b]0;some title\x07bye";
+        assert_eq!(run(input), b"hibye");
+    }
+
+    #[test]
+    fn osc_icon_title_bel_terminated_is_stripped()
+    {
+        let input = b"\x1b]1;icon\x07";
+        assert_eq!(run(input), b"");
+    }
+
+    #[test]
+    fn osc_window_title_st_terminated_is_stripped()
+    {
+        // ST = ESC \. ECMA-48 canonical OSC terminator.
+        let input = b"\x1b]2;title\x1b\\";
+        assert_eq!(run(input), b"");
+    }
+
+    #[test]
+    fn osc_outside_blocklist_passes_through()
+    {
+        // OSC 4 is the xterm palette query/response — not in the blocklist.
+        let input = b"\x1b]4;0;rgb:00/00/00\x07";
+        assert_eq!(run(input), input);
+    }
+
+    #[test]
+    fn esc_followed_by_unknown_byte_passes_through()
+    {
+        // ESC ( B — switch G0 to ASCII. Uncommon but legitimate.
+        let input = b"\x1b(B";
+        assert_eq!(run(input), input);
+    }
+
+    #[test]
+    fn split_window_resize_across_writes_is_stripped()
+    {
+        let input = b"foo\x1b[8;30;100tbar";
+        assert_eq!(run_one_byte_at_a_time(input), b"foobar");
+    }
+
+    #[test]
+    fn split_alternate_screen_across_writes_is_stripped()
+    {
+        assert_eq!(run_one_byte_at_a_time(b"\x1b[?1049h"), b"");
+    }
+
+    #[test]
+    fn split_sgr_across_writes_passes_through()
+    {
+        let input = b"\x1b[31;1mred\x1b[0m";
+        assert_eq!(run_one_byte_at_a_time(input), input);
+    }
+
+    #[test]
+    fn split_osc_title_across_writes_is_stripped()
+    {
+        let input = b"\x1b]0;split title\x07";
+        assert_eq!(run_one_byte_at_a_time(input), b"");
+    }
+
+    #[test]
+    fn write_returns_full_input_length_on_drop()
+    {
+        let mut w = FilterWriter::new(Vec::new());
+        let n = w.write(b"\x1b[?1049h").unwrap();
+        assert_eq!(n, 8);
+    }
+
+    #[test]
+    fn write_returns_full_input_length_on_passthrough()
+    {
+        let mut w = FilterWriter::new(Vec::new());
+        let n = w.write(b"hello").unwrap();
+        assert_eq!(n, 5);
+    }
+
+    #[test]
+    fn multiple_sequences_in_one_write_are_handled()
+    {
+        // SGR + window-resize + plain text + alt-screen + SGR-reset.
+        let input = b"\x1b[31mhi\x1b[8;1;1tworld\x1b[?1049h\x1b[0m";
+        assert_eq!(run(input), b"\x1b[31mhiworld\x1b[0m");
+    }
+
+    #[test]
+    fn realistic_ovmf_resize_burst_is_stripped()
+    {
+        // Approximate one of the bursts OVMF emits during init:
+        // request 80×25 terminal, set cursor pos, clear screen, SGR
+        // reset. Only the window-manipulation should be removed.
+        let input = b"\x1b[8;25;80t\x1b[1;1H\x1b[2J\x1b[0m";
+        assert_eq!(run(input), b"\x1b[1;1H\x1b[2J\x1b[0m");
+    }
+}

--- a/xtask/src/term/filter.rs
+++ b/xtask/src/term/filter.rs
@@ -51,8 +51,33 @@
 //! scratch buffer that holds at most one in-flight sequence. It is
 //! unit-tested in isolation against the full CSI/OSC grammar and
 //! split-across-write boundaries.
+//!
+//! Scope limits:
+//!
+//! - **7-bit only.** Only the `ESC X` introducer is recognized; the
+//!   8-bit C1 forms (e.g. `0x9B` for CSI, `0x9D` for OSC) are passed
+//!   through unchanged. OVMF / EDK2 emit the 7-bit forms exclusively,
+//!   so this is not a real gap today; if Seraph itself ever emits C1
+//!   bytes the filter will not screen them.
+//! - **CSI private markers other than `?` pass through.** Sequences
+//!   like `CSI = 3 h` (legacy video-mode set) are not in the drop
+//!   list. If any such sequence ever leaves the tty in a bad state,
+//!   `TerminalGuard` (`term/guard.rs`) restores termios + winsize on
+//!   drop as a catch-all.
+//! - **Pending buffer is bounded** (`MAX_PENDING_BYTES`). A producer
+//!   that opens a sequence and never finishes it cannot make the
+//!   filter grow without limit; once the cap is exceeded the buffered
+//!   bytes are dropped and the parser resyncs to `Ground`.
 
 use std::io::{self, Write};
+
+/// Maximum bytes the parser will buffer for a single in-progress
+/// sequence. A well-formed CSI is ~10 bytes and a well-formed OSC
+/// title is ~100 bytes; 64 KiB is two orders of magnitude beyond any
+/// real producer. A sequence that exceeds the cap is dropped and the
+/// parser resyncs to `Ground` — preferable to unbounded growth on a
+/// malformed or hostile stream.
+const MAX_PENDING_BYTES: usize = 64 * 1024;
 
 /// CSI / OSC parser state. Bytes that arrive mid-sequence are buffered
 /// in `FilterWriter::pending` until the sequence completes; at that
@@ -104,6 +129,20 @@ impl<W: Write> FilterWriter<W>
         }
     }
 
+    /// Append `b` to `pending`, dropping the entire in-progress
+    /// sequence and resyncing to `Ground` if the cap is exceeded.
+    /// Protects against unbounded growth on malformed input.
+    fn push_pending(&mut self, b: u8)
+    {
+        if self.pending.len() >= MAX_PENDING_BYTES
+        {
+            self.pending.clear();
+            self.state = State::Ground;
+            return;
+        }
+        self.pending.push(b);
+    }
+
     /// Resolve a completed escape sequence: emit it to `inner` if
     /// permitted, or drop the buffered bytes otherwise. Always clears
     /// `pending`.
@@ -141,7 +180,7 @@ impl<W: Write> Write for FilterWriter<W>
                             self.inner.write_all(&buf[start..i])?;
                         }
                         self.state = State::Esc;
-                        self.pending.push(b);
+                        self.push_pending(b);
                     }
                     else
                     {
@@ -150,7 +189,7 @@ impl<W: Write> Write for FilterWriter<W>
                 }
                 State::Esc =>
                 {
-                    self.pending.push(b);
+                    self.push_pending(b);
                     match b
                     {
                         b'[' => self.state = State::Csi,
@@ -171,7 +210,7 @@ impl<W: Write> Write for FilterWriter<W>
                 }
                 State::Csi =>
                 {
-                    self.pending.push(b);
+                    self.push_pending(b);
                     // Final byte (0x40..=0x7e) ends the CSI sequence.
                     if (0x40..=0x7e).contains(&b)
                     {
@@ -181,7 +220,7 @@ impl<W: Write> Write for FilterWriter<W>
                 }
                 State::Osc =>
                 {
-                    self.pending.push(b);
+                    self.push_pending(b);
                     if b == 0x07
                     {
                         self.flush_pending()?;
@@ -194,7 +233,7 @@ impl<W: Write> Write for FilterWriter<W>
                 }
                 State::OscEsc =>
                 {
-                    self.pending.push(b);
+                    self.push_pending(b);
                     // Whether the next byte is `\` (proper ST) or anything
                     // else (malformed input — treat as end-of-sequence),
                     // we resolve `pending` and return to Ground.
@@ -553,6 +592,34 @@ mod tests
         // SGR + window-resize + plain text + alt-screen + SGR-reset.
         let input = b"\x1b[31mhi\x1b[8;1;1tworld\x1b[?1049h\x1b[0m";
         assert_eq!(run(input), b"\x1b[31mhiworld\x1b[0m");
+    }
+
+    #[test]
+    fn pending_buffer_is_bounded_against_runaway_sequence()
+    {
+        // Open an OSC and emit MAX_PENDING_BYTES+16 bytes without a
+        // terminator. The parser must drop the buffered bytes and
+        // resync to Ground rather than grow without limit. After the
+        // resync, a fresh well-formed blocklisted sequence is
+        // recognized and stripped, proving the state machine is
+        // functional again.
+        let mut input = Vec::with_capacity(MAX_PENDING_BYTES + 64);
+        input.extend_from_slice(b"\x1b]0;");
+        input.resize(MAX_PENDING_BYTES + 16, b'A');
+        input.extend_from_slice(b"\x1b[?1049h");
+        input.extend_from_slice(b"hello\n");
+
+        let out = run(&input);
+
+        assert!(
+            out.ends_with(b"hello\n"),
+            "expected trailing plaintext, got tail {:?}",
+            std::str::from_utf8(&out[out.len().saturating_sub(40)..]).unwrap_or("<non-utf8>"),
+        );
+        assert!(
+            !out.windows(5).any(|w| w == b"1049h"),
+            "post-resync alt-screen sequence leaked",
+        );
     }
 
     #[test]

--- a/xtask/src/term/filter.rs
+++ b/xtask/src/term/filter.rs
@@ -90,9 +90,6 @@ pub struct FilterWriter<W: Write>
     pending: Vec<u8>,
 }
 
-// FilterWriter is wired into the QEMU stdout pipeline in a separate
-// commit; until then it has no caller in the binary.
-#[allow(dead_code)]
 impl<W: Write> FilterWriter<W>
 {
     /// Wrap `inner` in a filter. Bytes written to the returned writer
@@ -105,13 +102,6 @@ impl<W: Write> FilterWriter<W>
             state: State::Ground,
             pending: Vec::new(),
         }
-    }
-
-    /// Recover the inner writer. Any bytes still buffered mid-sequence
-    /// are discarded.
-    pub fn into_inner(self) -> W
-    {
-        self.inner
     }
 
     /// Resolve a completed escape sequence: emit it to `inner` if
@@ -333,21 +323,27 @@ mod tests
     /// that reached the inner writer.
     fn run(input: &[u8]) -> Vec<u8>
     {
-        let mut w = FilterWriter::new(Vec::new());
-        w.write_all(input).unwrap();
-        w.into_inner()
+        let mut out = Vec::new();
+        {
+            let mut w = FilterWriter::new(&mut out);
+            w.write_all(input).unwrap();
+        }
+        out
     }
 
     /// Like `run`, but writes one byte at a time. Exercises mid-sequence
     /// state preservation across `write` boundaries.
     fn run_one_byte_at_a_time(input: &[u8]) -> Vec<u8>
     {
-        let mut w = FilterWriter::new(Vec::new());
-        for &b in input
+        let mut out = Vec::new();
         {
-            w.write_all(&[b]).unwrap();
+            let mut w = FilterWriter::new(&mut out);
+            for &b in input
+            {
+                w.write_all(&[b]).unwrap();
+            }
         }
-        w.into_inner()
+        out
     }
 
     #[test]
@@ -536,7 +532,8 @@ mod tests
     #[test]
     fn write_returns_full_input_length_on_drop()
     {
-        let mut w = FilterWriter::new(Vec::new());
+        let mut out = Vec::new();
+        let mut w = FilterWriter::new(&mut out);
         let n = w.write(b"\x1b[?1049h").unwrap();
         assert_eq!(n, 8);
     }
@@ -544,7 +541,8 @@ mod tests
     #[test]
     fn write_returns_full_input_length_on_passthrough()
     {
-        let mut w = FilterWriter::new(Vec::new());
+        let mut out = Vec::new();
+        let mut w = FilterWriter::new(&mut out);
         let n = w.write(b"hello").unwrap();
         assert_eq!(n, 5);
     }

--- a/xtask/src/term/guard.rs
+++ b/xtask/src/term/guard.rs
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+//! term/guard.rs
+//!
+//! RAII guard that snapshots the host terminal's state on creation
+//! and restores it on drop.
+//!
+//! Motivation: OVMF on x86-64 and EDK2 on RISC-V emit terminal-control
+//! sequences during firmware init that can leave the host tty in an
+//! unexpected state (resized window, alternate screen buffer engaged,
+//! reverse video, etc.). `FilterWriter` (in `term/filter.rs`) screens
+//! the byte stream so most of those never reach the user's tty in the
+//! first place; this guard is a complementary belt-and-braces measure
+//! that snapshots full terminal state up-front and unconditionally
+//! restores it on the way out, catching anything the filter didn't
+//! anticipate and any state changes the subprocess made through stdin
+//! (which the filter does not see).
+//!
+//! Strategy:
+//!
+//! - Unix (`cfg(unix)`): `tcgetattr` saves the full `termios` struct;
+//!   `ioctl(TIOCGWINSZ)` saves the window dimensions. On drop,
+//!   `tcsetattr(TCSANOW)` and `ioctl(TIOCSWINSZ)` restore both.
+//!   This is strictly more robust than the previous `stty sane`
+//!   subprocess: it restores the user's exact prior state rather
+//!   than resetting to a fixed default.
+//!
+//! - Windows (`cfg(windows)`): `GetConsoleMode` /
+//!   `SetConsoleMode` capture and restore the stdin console mode.
+//!   The window-size APIs (`GetConsoleScreenBufferInfo` /
+//!   `SetConsoleScreenBufferSize`) are not invoked here because
+//!   resizing the Windows console buffer has different semantics
+//!   from Unix's TIOCSWINSZ and is more likely to cause harm than
+//!   to help. Stdin mode is the meaningful piece.
+//!
+//! - Any other host: no-op guard (struct exists, drop does nothing).
+//!
+//! All paths fall back to no-op when the controlling tty can't be
+//! opened (CI, piped stdin/stdout, headless environments). The guard
+//! is always safe to construct; it never blocks the launch.
+
+#[cfg(unix)]
+use std::fs::{File, OpenOptions};
+#[cfg(unix)]
+use std::os::unix::io::AsRawFd;
+
+/// Saves terminal state on `capture()` and restores it on `drop()`.
+pub struct TerminalGuard
+{
+    inner: Inner,
+}
+
+impl TerminalGuard
+{
+    /// Snapshot the current terminal state. Returns a guard whose
+    /// `Drop` will restore that state. If the controlling tty is
+    /// unavailable (CI, piped I/O, etc.) the guard is a no-op.
+    #[must_use]
+    pub fn capture() -> Self
+    {
+        TerminalGuard {
+            inner: Inner::capture(),
+        }
+    }
+}
+
+impl Drop for TerminalGuard
+{
+    fn drop(&mut self)
+    {
+        self.inner.restore();
+    }
+}
+
+// ── Unix implementation ──────────────────────────────────────────────────────
+
+#[cfg(unix)]
+struct Inner
+{
+    saved: Option<UnixSaved>,
+}
+
+#[cfg(unix)]
+struct UnixSaved
+{
+    tty: File,
+    termios: libc::termios,
+    winsize: Option<libc::winsize>,
+}
+
+#[cfg(unix)]
+impl Inner
+{
+    fn capture() -> Self
+    {
+        Inner {
+            saved: capture_unix(),
+        }
+    }
+
+    fn restore(&mut self)
+    {
+        if let Some(saved) = self.saved.as_ref()
+        {
+            restore_unix(saved);
+        }
+    }
+}
+
+#[cfg(unix)]
+fn capture_unix() -> Option<UnixSaved>
+{
+    let tty = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open("/dev/tty")
+        .ok()?;
+    let fd = tty.as_raw_fd();
+
+    // SAFETY: termios is plain old data with no invariants; zeroing
+    // it is a valid initial state. tcgetattr fills it from the kernel.
+    let mut termios: libc::termios = unsafe { std::mem::zeroed() };
+    // SAFETY: fd is a valid open file descriptor for the terminal;
+    // termios points at a writable termios struct.
+    let r = unsafe { libc::tcgetattr(fd, &mut termios) };
+    if r != 0
+    {
+        return None;
+    }
+
+    // SAFETY: winsize is plain old data, zero-init is valid.
+    let mut winsize: libc::winsize = unsafe { std::mem::zeroed() };
+    // SAFETY: fd is valid; libc::TIOCGWINSZ matches the kernel's
+    // expected request value; winsize points at a writable struct.
+    let r = unsafe { libc::ioctl(fd, libc::TIOCGWINSZ, &mut winsize) };
+    let winsize = if r == 0 && winsize.ws_row > 0 && winsize.ws_col > 0
+    {
+        Some(winsize)
+    }
+    else
+    {
+        None
+    };
+
+    Some(UnixSaved {
+        tty,
+        termios,
+        winsize,
+    })
+}
+
+#[cfg(unix)]
+fn restore_unix(saved: &UnixSaved)
+{
+    let fd = saved.tty.as_raw_fd();
+
+    // SAFETY: fd is valid (held open by `saved.tty`); termios was
+    // captured by tcgetattr on the same fd. Failures are ignored —
+    // best-effort restore on shutdown.
+    let _ = unsafe { libc::tcsetattr(fd, libc::TCSANOW, &saved.termios) };
+
+    if let Some(ws) = saved.winsize.as_ref()
+    {
+        // SAFETY: fd is valid; winsize was captured from the same fd.
+        let _ = unsafe { libc::ioctl(fd, libc::TIOCSWINSZ, ws) };
+    }
+}
+
+// ── Windows implementation ───────────────────────────────────────────────────
+
+#[cfg(windows)]
+struct Inner
+{
+    saved: Option<WindowsSaved>,
+}
+
+#[cfg(windows)]
+struct WindowsSaved
+{
+    handle: windows_sys::Win32::Foundation::HANDLE,
+    mode: u32,
+}
+
+#[cfg(windows)]
+impl Inner
+{
+    fn capture() -> Self
+    {
+        Inner {
+            saved: capture_windows(),
+        }
+    }
+
+    fn restore(&mut self)
+    {
+        if let Some(saved) = self.saved.as_ref()
+        {
+            restore_windows(saved);
+        }
+    }
+}
+
+#[cfg(windows)]
+fn capture_windows() -> Option<WindowsSaved>
+{
+    use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+    use windows_sys::Win32::System::Console::{GetConsoleMode, GetStdHandle, STD_INPUT_HANDLE};
+
+    // SAFETY: STD_INPUT_HANDLE is a valid constant; GetStdHandle is
+    // safe to call with it and returns either a valid HANDLE or
+    // INVALID_HANDLE_VALUE.
+    let handle = unsafe { GetStdHandle(STD_INPUT_HANDLE) };
+    if handle == INVALID_HANDLE_VALUE || handle.is_null()
+    {
+        return None;
+    }
+
+    let mut mode: u32 = 0;
+    // SAFETY: handle is a valid console HANDLE; mode points at a
+    // writable u32. Returns 0 on failure (e.g. stdin is not a console).
+    let ok = unsafe { GetConsoleMode(handle, &mut mode) };
+    if ok == 0
+    {
+        return None;
+    }
+
+    Some(WindowsSaved { handle, mode })
+}
+
+#[cfg(windows)]
+fn restore_windows(saved: &WindowsSaved)
+{
+    use windows_sys::Win32::System::Console::SetConsoleMode;
+
+    // SAFETY: handle was returned by GetStdHandle and validated;
+    // mode was captured by GetConsoleMode on the same handle.
+    let _ = unsafe { SetConsoleMode(saved.handle, saved.mode) };
+}
+
+// ── Fallback for non-Unix, non-Windows hosts ─────────────────────────────────
+
+#[cfg(not(any(unix, windows)))]
+struct Inner;
+
+#[cfg(not(any(unix, windows)))]
+impl Inner
+{
+    fn capture() -> Self
+    {
+        Inner
+    }
+
+    fn restore(&mut self)
+    {
+        // No-op: no platform path exists. xtask is not expected to
+        // run on such hosts; this branch is only here so the type
+        // signature compiles everywhere.
+    }
+}

--- a/xtask/src/term/line_gate.rs
+++ b/xtask/src/term/line_gate.rs
@@ -49,9 +49,6 @@ pub struct LineGate<W: Write>
     opened: bool,
 }
 
-// LineGate is wired into the QEMU stdout pipeline in a separate commit
-// on this branch; until then it has no caller in the binary.
-#[allow(dead_code)]
 impl<W: Write> LineGate<W>
 {
     /// Wrap `inner` in a gate keyed on `marker`. Bytes are dropped
@@ -65,10 +62,7 @@ impl<W: Write> LineGate<W>
     /// builds.
     pub fn new(inner: W, marker: &[u8]) -> Self
     {
-        debug_assert!(
-            !marker.is_empty(),
-            "LineGate marker must be non-empty",
-        );
+        debug_assert!(!marker.is_empty(), "LineGate marker must be non-empty",);
         debug_assert!(
             marker.iter().all(|&b| b.is_ascii() && b != 0x1b),
             "LineGate marker must be plain ASCII with no ESC byte",
@@ -79,13 +73,6 @@ impl<W: Write> LineGate<W>
             line: Vec::new(),
             opened: false,
         }
-    }
-
-    /// Recover the inner writer. Any bytes still buffered in the
-    /// in-progress line are discarded.
-    pub fn into_inner(self) -> W
-    {
-        self.inner
     }
 }
 
@@ -155,19 +142,25 @@ mod tests
 
     fn run(input: &[u8]) -> Vec<u8>
     {
-        let mut g = LineGate::new(Vec::new(), MARKER);
-        g.write_all(input).unwrap();
-        g.into_inner()
+        let mut out = Vec::new();
+        {
+            let mut g = LineGate::new(&mut out, MARKER);
+            g.write_all(input).unwrap();
+        }
+        out
     }
 
     fn run_one_byte_at_a_time(input: &[u8]) -> Vec<u8>
     {
-        let mut g = LineGate::new(Vec::new(), MARKER);
-        for &b in input
+        let mut out = Vec::new();
         {
-            g.write_all(&[b]).unwrap();
+            let mut g = LineGate::new(&mut out, MARKER);
+            for &b in input
+            {
+                g.write_all(&[b]).unwrap();
+            }
         }
-        g.into_inner()
+        out
     }
 
     #[test]
@@ -188,10 +181,7 @@ mod tests
     fn passes_through_all_lines_after_marker()
     {
         let input = b"junk\n[--------] boot: hi\nafter1\nafter2\n";
-        assert_eq!(
-            run(input),
-            b"[--------] boot: hi\nafter1\nafter2\n",
-        );
+        assert_eq!(run(input), b"[--------] boot: hi\nafter1\nafter2\n",);
     }
 
     #[test]
@@ -215,10 +205,7 @@ mod tests
     fn marker_split_across_writes_is_detected()
     {
         let input = b"junk\n[--------] boot: split\n";
-        assert_eq!(
-            run_one_byte_at_a_time(input),
-            b"[--------] boot: split\n",
-        );
+        assert_eq!(run_one_byte_at_a_time(input), b"[--------] boot: split\n",);
     }
 
     #[test]
@@ -246,7 +233,8 @@ mod tests
     #[test]
     fn write_returns_full_input_length_before_marker()
     {
-        let mut g = LineGate::new(Vec::new(), MARKER);
+        let mut out = Vec::new();
+        let mut g = LineGate::new(&mut out, MARKER);
         let n = g.write(b"pre-marker garbage\n").unwrap();
         assert_eq!(n, 19);
     }
@@ -254,7 +242,8 @@ mod tests
     #[test]
     fn write_returns_full_input_length_after_marker()
     {
-        let mut g = LineGate::new(Vec::new(), MARKER);
+        let mut out = Vec::new();
+        let mut g = LineGate::new(&mut out, MARKER);
         g.write_all(b"[--------] boot: x\n").unwrap();
         let n = g.write(b"hello\n").unwrap();
         assert_eq!(n, 6);
@@ -265,10 +254,7 @@ mod tests
     {
         // Marker line and a subsequent line arrive in the same write.
         let input = b"[--------] boot: hi\nimmediate next line\n";
-        assert_eq!(
-            run(input),
-            b"[--------] boot: hi\nimmediate next line\n",
-        );
+        assert_eq!(run(input), b"[--------] boot: hi\nimmediate next line\n",);
     }
 
     #[test]
@@ -294,13 +280,15 @@ mod tests
     #[should_panic(expected = "LineGate marker must be non-empty")]
     fn empty_marker_panics_in_debug()
     {
-        let _ = LineGate::new(Vec::new(), b"");
+        let mut sink = Vec::new();
+        let _ = LineGate::new(&mut sink, b"");
     }
 
     #[test]
     #[should_panic(expected = "plain ASCII with no ESC byte")]
     fn marker_containing_esc_panics_in_debug()
     {
-        let _ = LineGate::new(Vec::new(), b"\x1b[boot");
+        let mut sink = Vec::new();
+        let _ = LineGate::new(&mut sink, b"\x1b[boot");
     }
 }

--- a/xtask/src/term/line_gate.rs
+++ b/xtask/src/term/line_gate.rs
@@ -1,0 +1,306 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+//! term/line_gate.rs
+//!
+//! Line-level marker gate for QEMU output.
+//!
+//! `LineGate` is a `Write` adapter that buffers incoming bytes line by
+//! line and suppresses all output until the first line containing a
+//! configured marker is seen. From that line onward — the marker line
+//! included — every byte is forwarded to the inner writer unchanged.
+//!
+//! The default Seraph launch flow points this at `"[--------] boot:"`,
+//! which is the first line the bootloader emits after firmware exits.
+//! Without the gate, the user sees thousands of lines of EDK2 / OVMF
+//! initialization spam before anything Seraph-related; with the gate,
+//! they see Seraph's own output and nothing else. Verbose mode skips
+//! installing the gate altogether.
+//!
+//! The gate is intentionally line-granular rather than byte-granular:
+//! a partial line cannot be classified, and EDK2 / OVMF lines that
+//! contain `[--------] boot:` as a substring after garbage on the same
+//! byte-line would be rare to nonexistent. Once the marker is seen,
+//! the gate becomes a transparent pass-through forever.
+//!
+//! Composition with `FilterWriter`: the gate sits **after** the filter
+//! (i.e. filter wraps inner; gate wraps filter). This ordering matters
+//! because the filter never modifies a Seraph-style ASCII marker line,
+//! so the gate's substring match remains correct, and bytes pre-gate
+//! are also screened for control sequences before being either dropped
+//! by the gate or passed through. A debug assertion in `LineGate::new`
+//! enforces the marker is plain ASCII with no `ESC` byte, locking in
+//! this invariant.
+
+use std::io::{self, Write};
+
+/// `Write` adapter that drops bytes until the first complete line
+/// containing `marker` is seen, then passes everything through.
+///
+/// See the module docs for the line-vs-byte rationale and ordering
+/// rule relative to `FilterWriter`.
+pub struct LineGate<W: Write>
+{
+    inner: W,
+    marker: Vec<u8>,
+    /// Bytes of the current (in-progress) line. Empty after each `\n`.
+    line: Vec<u8>,
+    /// Once true, the gate is a transparent pass-through.
+    opened: bool,
+}
+
+// LineGate is wired into the QEMU stdout pipeline in a separate commit
+// on this branch; until then it has no caller in the binary.
+#[allow(dead_code)]
+impl<W: Write> LineGate<W>
+{
+    /// Wrap `inner` in a gate keyed on `marker`. Bytes are dropped
+    /// until the first complete line whose content (terminated by `\n`)
+    /// contains `marker`.
+    ///
+    /// `marker` must be plain ASCII with no `ESC` byte; combining the
+    /// gate with a CSI/OSC-bearing marker would interact badly with
+    /// `FilterWriter` upstream. Violations panic in debug builds and
+    /// are silently honored (i.e. the gate may never open) in release
+    /// builds.
+    pub fn new(inner: W, marker: &[u8]) -> Self
+    {
+        debug_assert!(
+            !marker.is_empty(),
+            "LineGate marker must be non-empty",
+        );
+        debug_assert!(
+            marker.iter().all(|&b| b.is_ascii() && b != 0x1b),
+            "LineGate marker must be plain ASCII with no ESC byte",
+        );
+        LineGate {
+            inner,
+            marker: marker.to_vec(),
+            line: Vec::new(),
+            opened: false,
+        }
+    }
+
+    /// Recover the inner writer. Any bytes still buffered in the
+    /// in-progress line are discarded.
+    pub fn into_inner(self) -> W
+    {
+        self.inner
+    }
+}
+
+impl<W: Write> Write for LineGate<W>
+{
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize>
+    {
+        if self.opened
+        {
+            return self.inner.write_all(buf).map(|()| buf.len());
+        }
+
+        for (i, &b) in buf.iter().enumerate()
+        {
+            self.line.push(b);
+            if b == b'\n'
+            {
+                if contains_subsequence(&self.line, &self.marker)
+                {
+                    // Emit the marker line in full, then drain any
+                    // remaining bytes from this write batch directly
+                    // into the inner writer.
+                    self.inner.write_all(&self.line)?;
+                    self.line.clear();
+                    self.opened = true;
+                    let rest = &buf[i + 1..];
+                    if !rest.is_empty()
+                    {
+                        self.inner.write_all(rest)?;
+                    }
+                    return Ok(buf.len());
+                }
+                // No marker on this line — discard and continue.
+                self.line.clear();
+            }
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()>
+    {
+        // In-progress (no `\n` yet) bytes stay buffered: a marker may
+        // still appear before the line terminates. Only the inner
+        // writer is flushed.
+        self.inner.flush()
+    }
+}
+
+/// Returns true if `needle` appears as a contiguous subsequence of `haystack`.
+fn contains_subsequence(haystack: &[u8], needle: &[u8]) -> bool
+{
+    if needle.is_empty() || needle.len() > haystack.len()
+    {
+        return needle.is_empty();
+    }
+    haystack
+        .windows(needle.len())
+        .any(|window| window == needle)
+}
+
+#[cfg(test)]
+mod tests
+{
+    use super::*;
+
+    const MARKER: &[u8] = b"[--------] boot:";
+
+    fn run(input: &[u8]) -> Vec<u8>
+    {
+        let mut g = LineGate::new(Vec::new(), MARKER);
+        g.write_all(input).unwrap();
+        g.into_inner()
+    }
+
+    fn run_one_byte_at_a_time(input: &[u8]) -> Vec<u8>
+    {
+        let mut g = LineGate::new(Vec::new(), MARKER);
+        for &b in input
+        {
+            g.write_all(&[b]).unwrap();
+        }
+        g.into_inner()
+    }
+
+    #[test]
+    fn drops_all_lines_before_marker()
+    {
+        let input = b"firmware spam\nmore spam\nstill no marker\n";
+        assert_eq!(run(input), b"");
+    }
+
+    #[test]
+    fn emits_marker_line_in_full()
+    {
+        let input = b"junk\n[--------] boot: hello\n";
+        assert_eq!(run(input), b"[--------] boot: hello\n");
+    }
+
+    #[test]
+    fn passes_through_all_lines_after_marker()
+    {
+        let input = b"junk\n[--------] boot: hi\nafter1\nafter2\n";
+        assert_eq!(
+            run(input),
+            b"[--------] boot: hi\nafter1\nafter2\n",
+        );
+    }
+
+    #[test]
+    fn marker_in_first_line_emits_immediately()
+    {
+        let input = b"[--------] boot: starting\n";
+        assert_eq!(run(input), b"[--------] boot: starting\n");
+    }
+
+    #[test]
+    fn marker_with_prefix_on_same_line_emits_whole_line()
+    {
+        // The byte-line that contains the marker may have leading
+        // garbage if firmware output ran together with the bootloader
+        // line; gate emits the full line, not just from the marker on.
+        let input = b"firmware garbage [--------] boot: hi\n";
+        assert_eq!(run(input), b"firmware garbage [--------] boot: hi\n");
+    }
+
+    #[test]
+    fn marker_split_across_writes_is_detected()
+    {
+        let input = b"junk\n[--------] boot: split\n";
+        assert_eq!(
+            run_one_byte_at_a_time(input),
+            b"[--------] boot: split\n",
+        );
+    }
+
+    #[test]
+    fn marker_without_newline_does_not_open_gate()
+    {
+        // Marker present but the line never terminates: gate must not
+        // open. (Caller's responsibility to ensure newlines arrive.)
+        let input = b"[--------] boot: no newline yet";
+        assert_eq!(run(input), b"");
+    }
+
+    #[test]
+    fn missing_marker_drops_everything()
+    {
+        let input = b"line one\nline two\nline three\n";
+        assert_eq!(run(input), b"");
+    }
+
+    #[test]
+    fn empty_input_produces_empty_output()
+    {
+        assert_eq!(run(b""), b"");
+    }
+
+    #[test]
+    fn write_returns_full_input_length_before_marker()
+    {
+        let mut g = LineGate::new(Vec::new(), MARKER);
+        let n = g.write(b"pre-marker garbage\n").unwrap();
+        assert_eq!(n, 19);
+    }
+
+    #[test]
+    fn write_returns_full_input_length_after_marker()
+    {
+        let mut g = LineGate::new(Vec::new(), MARKER);
+        g.write_all(b"[--------] boot: x\n").unwrap();
+        let n = g.write(b"hello\n").unwrap();
+        assert_eq!(n, 6);
+    }
+
+    #[test]
+    fn bytes_after_marker_line_in_same_write_are_forwarded()
+    {
+        // Marker line and a subsequent line arrive in the same write.
+        let input = b"[--------] boot: hi\nimmediate next line\n";
+        assert_eq!(
+            run(input),
+            b"[--------] boot: hi\nimmediate next line\n",
+        );
+    }
+
+    #[test]
+    fn marker_appears_on_second_attempt_after_close_call()
+    {
+        // A near-miss line that contains a substring of the marker but
+        // not the full marker must not open the gate.
+        let input = b"[--------] boo\n[--------] boot: real\n";
+        assert_eq!(run(input), b"[--------] boot: real\n");
+    }
+
+    #[test]
+    fn subsequence_helper_handles_edge_cases()
+    {
+        assert!(contains_subsequence(b"abcdef", b"cd"));
+        assert!(contains_subsequence(b"abcdef", b"abcdef"));
+        assert!(!contains_subsequence(b"abcdef", b"xy"));
+        assert!(!contains_subsequence(b"ab", b"abc"));
+        assert!(contains_subsequence(b"abc", b""));
+    }
+
+    #[test]
+    #[should_panic(expected = "LineGate marker must be non-empty")]
+    fn empty_marker_panics_in_debug()
+    {
+        let _ = LineGate::new(Vec::new(), b"");
+    }
+
+    #[test]
+    #[should_panic(expected = "plain ASCII with no ESC byte")]
+    fn marker_containing_esc_panics_in_debug()
+    {
+        let _ = LineGate::new(Vec::new(), b"\x1b[boot");
+    }
+}

--- a/xtask/src/term/mod.rs
+++ b/xtask/src/term/mod.rs
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+//! term/mod.rs
+//!
+//! Host-terminal I/O adapters for the QEMU launch pipeline.
+//!
+//! This module owns the byte-stream and line-stream `Write` adapters
+//! that screen QEMU output before it reaches the user's tty, plus (in
+//! follow-on commits) the RAII terminal-state guard and SIGINT handler
+//! that surround the launch. Keeping these concerns together — rather
+//! than scattered across `util.rs` and inline in `commands/run.rs` —
+//! makes the wiring contract obvious and unit-testable in isolation.
+
+pub mod filter;

--- a/xtask/src/term/mod.rs
+++ b/xtask/src/term/mod.rs
@@ -14,3 +14,4 @@
 
 pub mod filter;
 pub mod line_gate;
+pub mod signal;

--- a/xtask/src/term/mod.rs
+++ b/xtask/src/term/mod.rs
@@ -13,5 +13,6 @@
 //! makes the wiring contract obvious and unit-testable in isolation.
 
 pub mod filter;
+pub mod guard;
 pub mod line_gate;
 pub mod signal;

--- a/xtask/src/term/mod.rs
+++ b/xtask/src/term/mod.rs
@@ -6,11 +6,13 @@
 //! Host-terminal I/O adapters for the QEMU launch pipeline.
 //!
 //! This module owns the byte-stream and line-stream `Write` adapters
-//! that screen QEMU output before it reaches the user's tty, plus (in
-//! follow-on commits) the RAII terminal-state guard and SIGINT handler
-//! that surround the launch. Keeping these concerns together — rather
-//! than scattered across `util.rs` and inline in `commands/run.rs` —
-//! makes the wiring contract obvious and unit-testable in isolation.
+//! that screen QEMU output before it reaches the user's tty, the RAII
+//! terminal-state guard that snapshots and restores termios across
+//! the launch, and the global SIGINT handler that keeps Ctrl+C from
+//! killing xtask before its cleanup runs. Keeping these concerns
+//! together — rather than scattered across `util.rs` and inline in
+//! `commands/run.rs` — makes the wiring contract obvious and
+//! unit-testable in isolation.
 
 pub mod filter;
 pub mod guard;

--- a/xtask/src/term/mod.rs
+++ b/xtask/src/term/mod.rs
@@ -13,3 +13,4 @@
 //! makes the wiring contract obvious and unit-testable in isolation.
 
 pub mod filter;
+pub mod line_gate;

--- a/xtask/src/term/signal.rs
+++ b/xtask/src/term/signal.rs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+//! term/signal.rs
+//!
+//! Portable Ctrl+C / SIGINT handling for the xtask process.
+//!
+//! `install()` installs a no-op handler so that pressing Ctrl+C does
+//! not terminate xtask itself. The interactive child (QEMU, cargo)
+//! still receives the signal directly from the controlling tty,
+//! because the kernel delivers SIGINT to every member of the
+//! foreground process group when the user hits Ctrl+C. The child
+//! handles it (QEMU does a clean shutdown; cargo aborts the build);
+//! xtask survives long enough to run its own cleanup
+//! (`TerminalGuard::drop`, error propagation) before exiting through
+//! the normal error path.
+//!
+//! Semantics differ from the previous scoped `signal(SIGINT, SIG_IGN)`
+//! wrapper: the handler is global for the entire xtask process
+//! lifetime, not bracketed around a single subprocess. The trade-off
+//! is acceptable because xtask is almost entirely a subprocess
+//! orchestrator — every long-running step is a subprocess that
+//! receives SIGINT directly from the tty, so xtask's no-op handler
+//! never visibly blocks the user from terminating.
+//!
+//! Portability: the `ctrlc` crate wraps `signal(2)` on Unix and
+//! `SetConsoleCtrlHandler` on Windows. Replaces the previous raw
+//! `extern "C" fn signal` FFI, which was Linux-ABI-specific.
+
+use anyhow::{Context as _, Result};
+
+/// Install a process-wide no-op SIGINT (Ctrl+C) handler.
+///
+/// Must be called at most once per process; calling it again returns
+/// an error because `ctrlc::set_handler` rejects re-registration.
+/// Call from `main()` exactly once before any subprocess is spawned.
+pub fn install() -> Result<()>
+{
+    ctrlc::set_handler(|| {
+        // Intentionally empty. The child process receives SIGINT
+        // directly from the tty and handles termination; xtask
+        // exits through its normal control flow once the child
+        // returns.
+    })
+    .context("installing SIGINT handler")
+}

--- a/xtask/src/term/signal.rs
+++ b/xtask/src/term/signal.rs
@@ -34,6 +34,12 @@ use anyhow::{Context as _, Result};
 /// Must be called at most once per process; calling it again returns
 /// an error because `ctrlc::set_handler` rejects re-registration.
 /// Call from `main()` exactly once before any subprocess is spawned.
+///
+/// Future maintainers: this is intentionally global for xtask's whole
+/// lifetime. If a future sub-flow needs Ctrl+C to default-terminate
+/// xtask between subprocess invocations, `ctrlc` cannot be uninstalled
+/// — switch to per-call `signal(2)` / `sigaction` (Unix) and
+/// `SetConsoleCtrlHandler` (Windows) with manual scoping.
 pub fn install() -> Result<()>
 {
     ctrlc::set_handler(|| {

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -3,8 +3,8 @@
 
 //! util.rs
 //!
-//! Shared utilities: step printing, command execution, tool discovery,
-//! and an RAII guard for terminal state.
+//! Shared utilities: step printing, command execution, and tool
+//! discovery. (The terminal-state RAII guard moved to `term::guard`.)
 
 use std::io::Write;
 use std::path::PathBuf;
@@ -90,120 +90,4 @@ pub fn find_llvm_objcopy() -> Result<PathBuf>
             objcopy.display()
         )
     }
-}
-
-// ── Terminal guard ────────────────────────────────────────────────────────────
-
-/// RAII guard that saves terminal dimensions on creation and restores them on
-/// drop via `ioctl(TIOCSWINSZ)`.
-///
-/// OVMF emits `ESC[=3h` and `ESC[8;rows;colst` over serial during boot, which
-/// clobber TIOCSWINSZ. Capturing and restoring via ioctl directly (rather than
-/// a stty subprocess) is the reliable path.
-pub struct TerminalGuard
-{
-    rows: u16,
-    cols: u16,
-}
-
-impl TerminalGuard
-{
-    /// Capture the current terminal dimensions via `ioctl(TIOCGWINSZ)`.
-    ///
-    /// Falls back to 24×80 in non-interactive environments (CI, piped I/O).
-    pub fn capture() -> Self
-    {
-        let (rows, cols) = tiocgwinsz().unwrap_or((24, 80));
-        TerminalGuard { rows, cols }
-    }
-}
-
-impl Drop for TerminalGuard
-{
-    fn drop(&mut self)
-    {
-        restore_terminal(self.rows, self.cols);
-    }
-}
-
-fn restore_terminal(rows: u16, cols: u16)
-{
-    // stty sane: reset line discipline (echo, icanon, etc.). Best-effort.
-    let _ = Command::new("stty").arg("sane").status();
-
-    // Restore TIOCSWINSZ via direct ioctl rather than a stty subprocess.
-    if let Ok(tty) = std::fs::OpenOptions::new()
-        .read(true)
-        .write(true)
-        .open("/dev/tty")
-    {
-        use std::os::unix::io::AsRawFd;
-        tiocswinsz(tty.as_raw_fd(), rows, cols);
-        // ESC[8;rows;colst — hint to terminal emulator to resize its window.
-        // ESC[?25h         — ensure cursor is visible (QEMU may hide it).
-        let _ = write!(&tty, "\x1b[8;{};{}t\x1b[?25h", rows, cols);
-    }
-}
-
-// ── Terminal ioctl helpers ────────────────────────────────────────────────────
-//
-// TIOCGWINSZ = 0x5413, TIOCSWINSZ = 0x5414 on Linux x86-64 and riscv64.
-// These constants are stable across all Linux architectures xtask runs on.
-
-/// C `struct winsize` layout for TIOCGWINSZ / TIOCSWINSZ ioctls.
-#[repr(C)]
-struct Winsize
-{
-    ws_row: u16,
-    ws_col: u16,
-    ws_xpixel: u16,
-    ws_ypixel: u16,
-}
-
-unsafe extern "C" {
-    fn ioctl(fd: i32, request: u64, ...) -> i32;
-}
-
-/// Query terminal character dimensions via `ioctl(TIOCGWINSZ)` on `/dev/tty`.
-fn tiocgwinsz() -> Option<(u16, u16)>
-{
-    use std::os::unix::io::AsRawFd;
-    let tty = std::fs::OpenOptions::new()
-        .read(true)
-        .write(true)
-        .open("/dev/tty")
-        .ok()?;
-    let mut ws = Winsize {
-        ws_row: 0,
-        ws_col: 0,
-        ws_xpixel: 0,
-        ws_ypixel: 0,
-    };
-    // SAFETY: tty fd is valid; Winsize matches the kernel struct for TIOCGWINSZ.
-    let ret = unsafe {
-        ioctl(tty.as_raw_fd(), 0x5413 /* TIOCGWINSZ */, &mut ws)
-    };
-    if ret == 0 && ws.ws_row > 0 && ws.ws_col > 0
-    {
-        Some((ws.ws_row, ws.ws_col))
-    }
-    else
-    {
-        None
-    }
-}
-
-/// Set terminal character dimensions via `ioctl(TIOCSWINSZ)` on `fd`.
-fn tiocswinsz(fd: i32, rows: u16, cols: u16)
-{
-    let ws = Winsize {
-        ws_row: rows,
-        ws_col: cols,
-        ws_xpixel: 0,
-        ws_ypixel: 0,
-    };
-    // SAFETY: fd is a valid terminal fd; Winsize matches the kernel struct for TIOCSWINSZ.
-    unsafe {
-        ioctl(fd, 0x5414 /* TIOCSWINSZ */, &ws)
-    };
 }

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -12,36 +12,6 @@ use std::process::Command;
 
 use anyhow::{Context, Result, bail};
 
-// ── SIGINT isolation ──────────────────────────────────────────────────────────
-
-/// Run `f` with SIGINT ignored in this process, then restore the previous
-/// signal disposition.
-///
-/// Ctrl+C sends SIGINT to the entire foreground process group (both xtask and
-/// the child process). By ignoring it here the child (QEMU) still receives and
-/// handles SIGINT normally while our process survives long enough to run cleanup
-/// (TerminalGuard restore, etc.).
-pub fn run_with_sigint_ignored<F, R>(f: F) -> R
-where
-    F: FnOnce() -> R,
-{
-    // POSIX guarantees: SIGINT = 2, SIG_DFL = 0, SIG_IGN = 1 on all targets
-    // we care about (Linux x86-64, Linux riscv64). xtask is host-only.
-    unsafe extern "C" {
-        fn signal(signum: i32, handler: usize) -> usize;
-    }
-    // SAFETY: signal() is async-signal-safe. We restore the previous disposition
-    // after `f` returns, so no permanent state change.
-    let prev = unsafe {
-        signal(2 /* SIGINT */, 1 /* SIG_IGN */)
-    };
-    let result = f();
-    unsafe {
-        signal(2 /* SIGINT */, prev)
-    };
-    result
-}
-
 // ── Step printing ─────────────────────────────────────────────────────────────
 
 /// Print a `==> msg` step header to stdout and flush immediately.


### PR DESCRIPTION
## Summary

Replaces xtask's host terminal I/O with portable, byte-stream-screened
equivalents and removes the Linux-specific FFI footguns. Seven commits, one
coherent surface (\`xtask/src/term/\`):

| Layer | Was | Now |
|---|---|---|
| Control sequences | raw firmware bytes hit the tty | \`FilterWriter\` blocklists CSI \`t\` (xterm window manipulation), DEC alt-screen modes 47/1047/1049, DECSCNM reverse video, mouse tracking 9 / 1000-1006, OSC 0/1/2 titles, ESC c full reset; passes through SGR, cursor positioning, plain bytes, cursor visibility |
| Default-mode firmware suppression | inline read-and-skip loop in \`launch_qemu\` | \`LineGate\` keyed on \`[--------] boot:\`, composed *after* the filter |
| SIGINT scoping | raw \`extern \"C\" fn signal\` with hard-coded Linux constants | one \`ctrlc::set_handler\` no-op installed in \`main()\` |
| Terminal state save/restore | hard-coded TIOCGWINSZ/TIOCSWINSZ + \`stty sane\` subprocess | \`libc::tcgetattr\`/\`tcsetattr\` full termios snapshot + \`libc::ioctl\` constants (Unix), \`GetConsoleMode\`/\`SetConsoleMode\` via \`windows-sys\` (Windows), no-op fallback elsewhere |
| run-parallel log capture | unfiltered raw firmware bytes in per-slot logs | per-slot reader thread forwards QEMU stdout through \`FilterWriter\` into the log; stderr direct; \`O_APPEND\` for atomic interleave |

## Why

Two motivations:

1. **Don't corrupt the user's terminal.** OVMF (x86-64) and EDK2 (RISC-V) emit
   xterm window-manipulation, alternate-screen, and reverse-video sequences
   during firmware init. Without filtering, those reach the host tty and
   persist after the run. The filter prevents the corruption at the source
   instead of trying to recover after the fact.
2. **Portability.** Every removed FFI/subprocess in this PR was Linux-specific
   (TIOCGWINSZ=0x5413 is Linux-ABI, \`stty\` doesn't exist on Windows, raw
   \`signal(2)\` extern can't be called on Windows). The replacements all
   compile cleanly on Unix, macOS, BSD, and Windows. Linux behavior is
   preserved; non-Linux behavior is by-design-unverified (CI stays on
   ubuntu-latest).

## New crate dependencies

- \`ctrlc = \"3\"\` — portable SIGINT handler.
- \`libc = \"0.2\"\` — portable termios / ioctl constants and bindings.
- \`windows-sys = \"0.59\"\` (Windows-only via \`[target.'cfg(windows)'.dependencies]\`).

Deliberately **not** added: \`crossterm\` (pulls ~15 transitive crates for
features we don't use), \`terminal_size\` (redundant once we already have
\`libc\`).

## Side-effect cleanup

- \`xtask\` binary now has \`test = true\` so the in-file unit tests run under
  \`cargo xtask test\` alongside the rest of the workspace.
- \`util.rs\` shrinks to just step-printing, command execution, and tool
  discovery (terminal guard and SIGINT scope moved to \`term/\`).
- The noisy \`stty: 'standard input': Inappropriate ioctl for device\` message
  on piped-stdin runs is gone (\`stty sane\` subprocess removed).
- The CSI/OSC pending buffer is bounded at 64 KiB; a malformed or hostile
  stream that never terminates a sequence resyncs cleanly instead of
  growing unbounded.

## Test plan

- [x] \`cargo xtask test\` — 46 new xtask unit tests (29 filter +
      16 line_gate + 1 buffer-cap regression) cover the full CSI/OSC
      grammar, every blocklist member, every pass-through case,
      debug-assertion enforcement, split-byte input, and the pending-
      buffer cap with resync.
- [x] \`cargo xtask build\` clean on x86_64 and riscv64.
- [x] \`cargo xtask run --headless\` boots to \`ALL TESTS PASSED\` on x86_64
      and riscv64, default mode (filter + gate active) and verbose mode
      (filter only).
- [x] \`cargo xtask run-parallel --parallel 2 --runs 2\` — 2/2 PASS on
      x86_64 (\`--timeout 60\`) and riscv64 (\`--timeout 90\`); match line
      extracted correctly from filtered logs.

## By-design unverified

- macOS \`tcgetattr\`/\`tcsetattr\` semantics on Darwin.
- Windows \`GetConsoleMode\`/\`SetConsoleMode\` round-trip.
- FreeBSD / OpenBSD / NetBSD termios behavior.

The user has no test access to those hosts; CI stays on \`ubuntu-latest\`.
The cfg-gated code paths compile cleanly on a Linux host (verified) but
their runtime behavior on the gated platforms is on the next person who
runs xtask there to confirm.