### PR TITLE
xtask: env-var-first firmware discovery + Accel enum for QEMU launch

### DIFF
--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -181,14 +181,25 @@ followed by `cargo xtask run` (or `cargo xtask run-parallel` for stress).
 Seraph boots via its own UEFI bootloader on both architectures. This requires
 UEFI firmware in QEMU — SeaBIOS cannot load UEFI applications.
 
-**x86-64:** Requires OVMF from `edk2-ovmf`. `cargo xtask run` searches standard
-Fedora, Debian, and Arch install paths. The bootloader `.efi` reaches OVMF via
-the GPT image's ESP partition, attached to the guest as a virtio-blk-pci
-device.
+**x86-64:** Requires OVMF (`edk2-ovmf` / `ovmf` / `edk2-x86_64-code.fd`,
+distro-dependent). `cargo xtask run` searches per-platform default paths
+(Linux FHS, macOS Homebrew, BSD ports), or honours the `SERAPH_OVMF_CODE`
+env var for direct override on non-FHS or unsupported hosts. The bootloader
+`.efi` reaches OVMF via the GPT image's ESP partition, attached to the
+guest as a virtio-blk-pci device.
 
-**RISC-V:** Requires `edk2-riscv64` firmware. `cargo xtask run` searches standard
-firmware paths and pads `RISCV_VIRT_CODE.fd` / `RISCV_VIRT_VARS.fd` to 32 MiB
-in temporary files if necessary (QEMU virt ≥9.0 requires exactly 32 MiB).
+**RISC-V:** Requires `edk2-riscv64` firmware. `cargo xtask run` searches
+per-platform default paths and pads `RISCV_VIRT_CODE.fd` / `RISCV_VIRT_VARS.fd`
+to 32 MiB in temporary files if necessary (QEMU virt ≥ 9.0 requires exactly
+32 MiB). `SERAPH_RISCV_CODE` and `SERAPH_RISCV_VARS` override discovery;
+they are an all-or-nothing pair (setting only one is rejected).
+
+**Acceleration:** controlled by `SERAPH_ACCEL` (`auto` / `tcg` / `kvm` /
+`hvf` / `whpx` / `nvmm`). Default `auto` runs per-host detection: KVM on
+Linux (`/dev/kvm` opened O_RDWR), HVF on macOS, WHPX on Windows, NVMM on
+NetBSD, or TCG elsewhere. Cross-arch guests (riscv64 on x86, etc.) always
+resolve to TCG. The user-facing command reference plus the full env-var
+table lives in [`xtask/README.md`](../xtask/README.md#environment-variables).
 
 **Minimum QEMU version:** QEMU ≥ 8.0 (V extension support) is required;
 `xtask/src/qemu.rs` passes `-cpu rv64,v=true,zba=true,zbb=true,zbs=true`

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -43,18 +43,43 @@ cargo xtask run [--arch x86_64|riscv64] [--gdb] [--headless] [--verbose] [--cpus
 | `--verbose` | Show all serial output; by default output is filtered until `[--------] boot:` appears |
 | `--cpus` | Number of vCPUs to expose to the guest (default: `4`) |
 
-**x86-64** uses KVM acceleration when `/dev/kvm` is present, falling back
-to multi-threaded TCG with `-cpu max,migratable=no`. KVM hosts must
-advertise x86-64-v3 (AVX2/BMI2/FMA — Haswell+ / Excavator+) because the
-userspace target is pinned to that psABI level. Requires OVMF firmware
-(`dnf install edk2-ovmf` / `apt install ovmf`).
+**x86-64** selects an acceleration backend per host: KVM on Linux,
+HVF on macOS, WHPX on Windows, NVMM on NetBSD, or TCG everywhere else
+(see `SERAPH_ACCEL` below to override). KVM/HVF hosts must advertise
+x86-64-v3 (AVX2/BMI2/FMA — Haswell+ / Excavator+) because the userspace
+target is pinned to that psABI level; TCG mode uses
+`-cpu max,migratable=no` which emulates the same baseline. Requires
+OVMF firmware (`dnf install edk2-ovmf` / `apt install ovmf` /
+`pacman -S edk2-ovmf` / Homebrew `brew install qemu` /
+FreeBSD `pkg install edk2-qemu-x64`).
 
-**RISC-V** uses TCG emulation with edk2 UEFI firmware and OpenSBI (loaded
+**RISC-V** always uses TCG with edk2 UEFI firmware and OpenSBI (loaded
 automatically by QEMU's `virt` machine). Requires edk2 RISC-V firmware
 (`dnf install edk2-riscv64` / `apt install qemu-efi-riscv64`) and
 QEMU ≥ 8.0 (V extension); QEMU ≥ 9.1 unlocks the named `-cpu rva23s64`
 model (currently the runner uses the explicit feature string until the
 CI floor catches up).
+
+#### Environment variables
+
+These override `cargo xtask run`'s built-in firmware and accelerator
+selection. None are required when the host follows FHS conventions
+and the distro ships standard firmware packages.
+
+| Var | Effect |
+|---|---|
+| `SERAPH_OVMF_CODE` | Direct path to the OVMF code firmware. Skips the per-platform default search. |
+| `SERAPH_RISCV_CODE` | Direct path to `RISCV_VIRT_CODE.fd`. Must be set together with `SERAPH_RISCV_VARS` — partial overrides are rejected (a custom code image paired against the system vars template corrupts NVRAM state). |
+| `SERAPH_RISCV_VARS` | Direct path to `RISCV_VIRT_VARS.fd`. See pairing rule above. |
+| `SERAPH_ACCEL` | One of `auto` / `tcg` / `kvm` / `hvf` / `whpx` / `nvmm`. `auto` (the default) runs per-host detection. Cross-arch guests (e.g. riscv64 on x86) always resolve to `tcg`; an explicit non-`tcg`/`auto` override in that case emits a stderr warning. Unrecognized values also warn and fall through to detection. |
+
+Default firmware search paths per host:
+
+- **Linux** OVMF: `/usr/share/edk2/ovmf/OVMF_CODE.fd`, `/usr/share/OVMF/OVMF_CODE.fd`, `/usr/share/edk2-ovmf/x64/OVMF_CODE.fd`, `/usr/share/ovmf/OVMF.fd`, `/usr/share/edk2/x64/OVMF_CODE.4m.fd`
+- **Linux** RISC-V: `/usr/share/edk2/riscv`, `/usr/share/edk2-riscv`, `/usr/share/qemu-efi-riscv64`
+- **macOS** (both): `/opt/homebrew/share/qemu`, `/usr/local/share/qemu`
+- **BSD** (both): `/usr/local/share/qemu`, `/usr/local/share/uefi-firmware`
+- **Windows / other**: no defaults; the relevant `SERAPH_*` env var is required.
 
 ---
 

--- a/xtask/src/accel.rs
+++ b/xtask/src/accel.rs
@@ -63,8 +63,15 @@ pub const ENV_ACCEL: &str = "SERAPH_ACCEL";
 /// or because the guest is cross-arch and only `Tcg` is possible.
 pub fn detect_for_arch(arch: Arch) -> Accel
 {
-    let env_value = std::env::var(ENV_ACCEL).ok();
-    let env_trimmed = env_value.as_deref().map(str::trim);
+    detect_for_arch_impl(arch, std::env::var(ENV_ACCEL).ok().as_deref())
+}
+
+/// Implementation core of `detect_for_arch`, parameterized on the
+/// env value so tests can exercise the env-override paths without
+/// mutating process-global env state.
+fn detect_for_arch_impl(arch: Arch, env_value: Option<&str>) -> Accel
+{
+    let env_trimmed = env_value.map(str::trim);
 
     if !is_same_arch(arch)
     {
@@ -194,101 +201,61 @@ mod tests
 {
     use super::*;
 
-    fn with_env<F: FnOnce()>(key: &str, value: Option<&str>, f: F)
+    fn native_arch() -> Arch
     {
-        let prev = std::env::var_os(key);
-        // SAFETY: env vars are process-global; tests touching the
-        // same var must not run concurrently. xtask's test surface is
-        // small enough that single-var ownership per test suffices.
-        unsafe {
-            match value
-            {
-                Some(v) => std::env::set_var(key, v),
-                None => std::env::remove_var(key),
-            }
+        if cfg!(target_arch = "x86_64")
+        {
+            Arch::X86_64
         }
-        f();
-        unsafe {
-            match prev
-            {
-                Some(v) => std::env::set_var(key, v),
-                None => std::env::remove_var(key),
-            }
+        else
+        {
+            Arch::Riscv64
+        }
+    }
+
+    fn cross_arch() -> Arch
+    {
+        if cfg!(target_arch = "x86_64")
+        {
+            Arch::Riscv64
+        }
+        else
+        {
+            Arch::X86_64
         }
     }
 
     #[test]
     fn cross_arch_guest_always_resolves_to_tcg()
     {
-        let cross = if cfg!(target_arch = "x86_64")
-        {
-            Arch::Riscv64
-        }
-        else
-        {
-            Arch::X86_64
-        };
-        with_env(ENV_ACCEL, Some("kvm"), || {
-            assert_eq!(detect_for_arch(cross), Accel::Tcg);
-        });
+        assert_eq!(detect_for_arch_impl(cross_arch(), Some("kvm")), Accel::Tcg);
     }
 
     #[test]
     fn explicit_env_var_tcg_forces_tcg()
     {
-        let native = if cfg!(target_arch = "x86_64")
-        {
-            Arch::X86_64
-        }
-        else
-        {
-            Arch::Riscv64
-        };
-        with_env(ENV_ACCEL, Some("tcg"), || {
-            assert_eq!(detect_for_arch(native), Accel::Tcg);
-        });
+        assert_eq!(detect_for_arch_impl(native_arch(), Some("tcg")), Accel::Tcg);
     }
 
     #[test]
     fn explicit_env_var_auto_falls_through_to_detection()
     {
-        // We can't fully test detection (depends on /dev/kvm), but
-        // we can confirm "auto" does not pin to any specific backend
-        // and is not rejected as invalid: the result must be the same
-        // as no env var set at all.
-        let native = if cfg!(target_arch = "x86_64")
-        {
-            Arch::X86_64
-        }
-        else
-        {
-            Arch::Riscv64
-        };
-        with_env(ENV_ACCEL, None, || {
-            let baseline = detect_for_arch(native);
-            with_env(ENV_ACCEL, Some("auto"), || {
-                assert_eq!(detect_for_arch(native), baseline);
-            });
-        });
+        // We can't fully test detection (depends on /dev/kvm), but we
+        // can confirm "auto" does not pin to a specific backend and
+        // is not rejected as invalid: the result matches the no-env
+        // baseline.
+        let baseline = detect_for_arch_impl(native_arch(), None);
+        assert_eq!(detect_for_arch_impl(native_arch(), Some("auto")), baseline);
     }
 
     #[test]
     fn unknown_env_value_falls_through_to_detection()
     {
-        let native = if cfg!(target_arch = "x86_64")
-        {
-            Arch::X86_64
-        }
-        else
-        {
-            Arch::Riscv64
-        };
-        with_env(ENV_ACCEL, None, || {
-            let baseline = detect_for_arch(native);
-            with_env(ENV_ACCEL, Some("notarealbackend"), || {
-                assert_eq!(detect_for_arch(native), baseline);
-            });
-        });
+        let baseline = detect_for_arch_impl(native_arch(), None);
+        assert_eq!(
+            detect_for_arch_impl(native_arch(), Some("notarealbackend")),
+            baseline,
+        );
     }
 
     #[test]

--- a/xtask/src/accel.rs
+++ b/xtask/src/accel.rs
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+//! accel.rs
+//!
+//! Per-host QEMU acceleration-backend selection.
+//!
+//! `Accel` enumerates the same-architecture accelerators QEMU supports:
+//! KVM (Linux), HVF (macOS), WHPX (Windows), NVMM (NetBSD), and the
+//! always-available TCG software emulator. Selection is env-var-first
+//! (`SERAPH_ACCEL`), then per-`cfg(target_os)` detection, then a TCG
+//! fallback for hosts without a registered native accelerator.
+//!
+//! Scope: cross-architecture emulation (e.g. riscv64 guest on x86_64
+//! host) only ever has TCG available; this module's detection routines
+//! report the *host's* native accelerator, and a guest of a different
+//! arch is resolved to `Tcg` via `detect_for_arch`. The current Seraph
+//! launch flow uses native acceleration only for x86_64 guests on
+//! x86_64 hosts; everything else (riscv64 guest on any host, x86_64
+//! guest on a non-x86_64 host) uses TCG.
+//!
+//! Env var:
+//!
+//! - `SERAPH_ACCEL = auto | tcg | kvm | hvf | whpx | nvmm` — override
+//!   automatic detection. Unknown values fall through to detection,
+//!   silently. `auto` is the documented "do detection" sentinel.
+
+use crate::arch::Arch;
+
+/// Acceleration backend for one QEMU launch.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Accel
+{
+    /// Linux KVM (`/dev/kvm`). Same-arch only.
+    Kvm,
+    /// macOS Hypervisor.framework. Same-arch only.
+    Hvf,
+    /// Windows Hyper-V Platform. Same-arch only.
+    Whpx,
+    /// NetBSD Native VM Monitor (`/dev/nvmm`). Same-arch only.
+    Nvmm,
+    /// QEMU TCG software emulation. Universal; only choice for
+    /// cross-architecture guests.
+    Tcg,
+}
+
+/// Env var name that overrides automatic detection.
+pub const ENV_ACCEL: &str = "SERAPH_ACCEL";
+
+/// Select an acceleration backend for a guest of the given
+/// architecture. Cross-arch guests resolve to `Tcg`; same-arch
+/// guests honor `SERAPH_ACCEL` and per-`cfg(target_os)` detection.
+pub fn detect_for_arch(arch: Arch) -> Accel
+{
+    if !is_same_arch(arch)
+    {
+        return Accel::Tcg;
+    }
+
+    if let Some(value) = std::env::var_os(ENV_ACCEL)
+    {
+        let s = value.to_string_lossy();
+        if let Some(parsed) = parse_explicit(&s)
+        {
+            return parsed;
+        }
+    }
+
+    detect_default()
+}
+
+/// Returns true when the guest architecture matches the host
+/// architecture, i.e. when native acceleration could in principle
+/// apply.
+fn is_same_arch(arch: Arch) -> bool
+{
+    match arch
+    {
+        Arch::X86_64 => cfg!(target_arch = "x86_64"),
+        Arch::Riscv64 => cfg!(target_arch = "riscv64"),
+    }
+}
+
+/// Parse a user-provided env-var value into an `Accel`. Returns
+/// `None` for the documented `auto` sentinel and for unknown values
+/// (both trigger detection).
+fn parse_explicit(s: &str) -> Option<Accel>
+{
+    match s.trim().to_ascii_lowercase().as_str()
+    {
+        "auto" => None,
+        "kvm" => Some(Accel::Kvm),
+        "hvf" => Some(Accel::Hvf),
+        "whpx" => Some(Accel::Whpx),
+        "nvmm" => Some(Accel::Nvmm),
+        "tcg" => Some(Accel::Tcg),
+        _ => None,
+    }
+}
+
+// ── Per-host detection ───────────────────────────────────────────────────────
+
+#[cfg(target_os = "linux")]
+fn detect_default() -> Accel
+{
+    // /dev/kvm existence is not sufficient — runner users on CI may
+    // not be in the kvm group, so `open(O_RDWR)` returns EACCES and
+    // QEMU exits. Probe the same way QEMU itself does.
+    let usable = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open("/dev/kvm")
+        .is_ok();
+    if usable { Accel::Kvm } else { Accel::Tcg }
+}
+
+#[cfg(target_os = "macos")]
+fn detect_default() -> Accel
+{
+    // HVF is part of macOS 10.10+. There's no cheap probe from Rust;
+    // QEMU itself errors clearly if launch fails. Set
+    // SERAPH_ACCEL=tcg to opt out.
+    Accel::Hvf
+}
+
+#[cfg(target_os = "windows")]
+fn detect_default() -> Accel
+{
+    // WHPX requires Windows 10+ with the Hyper-V Platform feature
+    // enabled. Same as macOS: no cheap probe; QEMU itself errors
+    // clearly on launch failure. Set SERAPH_ACCEL=tcg to opt out.
+    Accel::Whpx
+}
+
+#[cfg(target_os = "netbsd")]
+fn detect_default() -> Accel
+{
+    let usable = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open("/dev/nvmm")
+        .is_ok();
+    if usable { Accel::Nvmm } else { Accel::Tcg }
+}
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows",
+    target_os = "netbsd",
+)))]
+fn detect_default() -> Accel
+{
+    // FreeBSD, OpenBSD, DragonFly, Solaris, illumos, etc. — none
+    // have a standard QEMU accel beyond TCG.
+    Accel::Tcg
+}
+
+#[cfg(test)]
+mod tests
+{
+    use super::*;
+
+    fn with_env<F: FnOnce()>(key: &str, value: Option<&str>, f: F)
+    {
+        let prev = std::env::var_os(key);
+        // SAFETY: env vars are process-global; tests touching the
+        // same var must not run concurrently. xtask's test surface is
+        // small enough that single-var ownership per test suffices.
+        unsafe {
+            match value
+            {
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
+            }
+        }
+        f();
+        unsafe {
+            match prev
+            {
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
+            }
+        }
+    }
+
+    #[test]
+    fn cross_arch_guest_always_resolves_to_tcg()
+    {
+        let cross = if cfg!(target_arch = "x86_64")
+        {
+            Arch::Riscv64
+        }
+        else
+        {
+            Arch::X86_64
+        };
+        with_env(ENV_ACCEL, Some("kvm"), || {
+            assert_eq!(detect_for_arch(cross), Accel::Tcg);
+        });
+    }
+
+    #[test]
+    fn explicit_env_var_tcg_forces_tcg()
+    {
+        let native = if cfg!(target_arch = "x86_64")
+        {
+            Arch::X86_64
+        }
+        else
+        {
+            Arch::Riscv64
+        };
+        with_env(ENV_ACCEL, Some("tcg"), || {
+            assert_eq!(detect_for_arch(native), Accel::Tcg);
+        });
+    }
+
+    #[test]
+    fn explicit_env_var_auto_falls_through_to_detection()
+    {
+        // We can't fully test detection (depends on /dev/kvm), but
+        // we can confirm "auto" does not pin to any specific backend
+        // and is not rejected as invalid: the result must be the same
+        // as no env var set at all.
+        let native = if cfg!(target_arch = "x86_64")
+        {
+            Arch::X86_64
+        }
+        else
+        {
+            Arch::Riscv64
+        };
+        with_env(ENV_ACCEL, None, || {
+            let baseline = detect_for_arch(native);
+            with_env(ENV_ACCEL, Some("auto"), || {
+                assert_eq!(detect_for_arch(native), baseline);
+            });
+        });
+    }
+
+    #[test]
+    fn unknown_env_value_falls_through_to_detection()
+    {
+        let native = if cfg!(target_arch = "x86_64")
+        {
+            Arch::X86_64
+        }
+        else
+        {
+            Arch::Riscv64
+        };
+        with_env(ENV_ACCEL, None, || {
+            let baseline = detect_for_arch(native);
+            with_env(ENV_ACCEL, Some("notarealbackend"), || {
+                assert_eq!(detect_for_arch(native), baseline);
+            });
+        });
+    }
+
+    #[test]
+    fn parse_explicit_recognizes_all_documented_names()
+    {
+        assert_eq!(parse_explicit("kvm"), Some(Accel::Kvm));
+        assert_eq!(parse_explicit("hvf"), Some(Accel::Hvf));
+        assert_eq!(parse_explicit("whpx"), Some(Accel::Whpx));
+        assert_eq!(parse_explicit("nvmm"), Some(Accel::Nvmm));
+        assert_eq!(parse_explicit("tcg"), Some(Accel::Tcg));
+        assert_eq!(parse_explicit("auto"), None);
+        assert_eq!(parse_explicit("garbage"), None);
+    }
+
+    #[test]
+    fn parse_explicit_ignores_case_and_surrounding_whitespace()
+    {
+        assert_eq!(parse_explicit("  KVM  "), Some(Accel::Kvm));
+        assert_eq!(parse_explicit("Tcg"), Some(Accel::Tcg));
+    }
+}

--- a/xtask/src/accel.rs
+++ b/xtask/src/accel.rs
@@ -22,8 +22,15 @@
 //! Env var:
 //!
 //! - `SERAPH_ACCEL = auto | tcg | kvm | hvf | whpx | nvmm` — override
-//!   automatic detection. Unknown values fall through to detection,
-//!   silently. `auto` is the documented "do detection" sentinel.
+//!   automatic detection. `auto` is the documented "do detection"
+//!   sentinel. Unknown values emit a stderr warning and fall through
+//!   to detection so a typo doesn't silently miss-accelerate.
+//!
+//! Cross-arch precedence: when the guest arch doesn't match the host
+//! arch (e.g. riscv64 guest on x86_64 host), native acceleration is
+//! impossible and the result is always `Tcg`. If the user also set
+//! `SERAPH_ACCEL` to something other than `tcg`/`auto`, a stderr
+//! warning is emitted so the silent downgrade is visible.
 
 use crate::arch::Arch;
 
@@ -50,19 +57,45 @@ pub const ENV_ACCEL: &str = "SERAPH_ACCEL";
 /// Select an acceleration backend for a guest of the given
 /// architecture. Cross-arch guests resolve to `Tcg`; same-arch
 /// guests honor `SERAPH_ACCEL` and per-`cfg(target_os)` detection.
+///
+/// Emits a stderr warning when an explicit `SERAPH_ACCEL` override
+/// is silently downgraded — either because the value is unrecognized
+/// or because the guest is cross-arch and only `Tcg` is possible.
 pub fn detect_for_arch(arch: Arch) -> Accel
 {
+    let env_value = std::env::var(ENV_ACCEL).ok();
+    let env_trimmed = env_value.as_deref().map(str::trim);
+
     if !is_same_arch(arch)
     {
+        if let Some(s) = env_trimmed
+            && !matches!(s.to_ascii_lowercase().as_str(), "" | "auto" | "tcg")
+        {
+            eprintln!(
+                "warning: {ENV_ACCEL}={s} ignored; cross-arch guest \
+                 (host != guest arch) only supports TCG",
+            );
+        }
         return Accel::Tcg;
     }
 
-    if let Some(value) = std::env::var_os(ENV_ACCEL)
+    if let Some(s) = env_trimmed
     {
-        let s = value.to_string_lossy();
-        if let Some(parsed) = parse_explicit(&s)
+        match parse_explicit(s)
         {
-            return parsed;
+            Some(explicit) => return explicit,
+            None if s.is_empty() || s.eq_ignore_ascii_case("auto") =>
+            {
+                // documented sentinel: fall through to detection
+            }
+            None =>
+            {
+                eprintln!(
+                    "warning: {ENV_ACCEL}={s} is not a recognized backend; \
+                     falling through to auto-detection \
+                     (valid: auto | tcg | kvm | hvf | whpx | nvmm)",
+                );
+            }
         }
     }
 
@@ -82,13 +115,13 @@ fn is_same_arch(arch: Arch) -> bool
 }
 
 /// Parse a user-provided env-var value into an `Accel`. Returns
-/// `None` for the documented `auto` sentinel and for unknown values
-/// (both trigger detection).
+/// `None` for the documented `auto` sentinel, the empty string, and
+/// for unknown values; the caller distinguishes "auto/empty"
+/// (silent fall-through) from "unknown" (warn-and-fall-through).
 fn parse_explicit(s: &str) -> Option<Accel>
 {
     match s.trim().to_ascii_lowercase().as_str()
     {
-        "auto" => None,
         "kvm" => Some(Accel::Kvm),
         "hvf" => Some(Accel::Hvf),
         "whpx" => Some(Accel::Whpx),
@@ -266,7 +299,10 @@ mod tests
         assert_eq!(parse_explicit("whpx"), Some(Accel::Whpx));
         assert_eq!(parse_explicit("nvmm"), Some(Accel::Nvmm));
         assert_eq!(parse_explicit("tcg"), Some(Accel::Tcg));
+        // Empty / sentinel / unknown all yield None; the caller
+        // distinguishes them.
         assert_eq!(parse_explicit("auto"), None);
+        assert_eq!(parse_explicit(""), None);
         assert_eq!(parse_explicit("garbage"), None);
     }
 

--- a/xtask/src/commands/run.rs
+++ b/xtask/src/commands/run.rs
@@ -19,9 +19,9 @@ use anyhow::{Context as _, Result};
 use crate::arch::Arch;
 use crate::cli::RunArgs;
 use crate::context::Context as BuildContext;
+use crate::firmware::find_ovmf_code;
 use crate::qemu::{
-    QemuLaunchSpec, build_qemu_argv, find_ovmf_code, prepare_riscv_firmware,
-    validate_sysroot_for_launch,
+    QemuLaunchSpec, build_qemu_argv, prepare_riscv_firmware, validate_sysroot_for_launch,
 };
 use crate::term::filter::FilterWriter;
 use crate::term::guard::TerminalGuard;

--- a/xtask/src/commands/run_parallel.rs
+++ b/xtask/src/commands/run_parallel.rs
@@ -28,9 +28,9 @@ use regex::Regex;
 use crate::arch::Arch;
 use crate::cli::RunParallelArgs;
 use crate::context::Context as BuildContext;
+use crate::firmware::find_ovmf_code;
 use crate::qemu::{
-    QemuLaunchSpec, build_qemu_argv, find_ovmf_code, prepare_riscv_firmware,
-    validate_sysroot_for_launch,
+    QemuLaunchSpec, build_qemu_argv, prepare_riscv_firmware, validate_sysroot_for_launch,
 };
 use crate::term::filter::FilterWriter;
 use crate::util::step;

--- a/xtask/src/firmware.rs
+++ b/xtask/src/firmware.rs
@@ -131,35 +131,54 @@ pub fn find_ovmf_code() -> Result<PathBuf>
 
 /// Locate the RISC-V EDK2 source images, returning `(code, vars)`.
 ///
-/// Per-file env vars `SERAPH_RISCV_CODE` and `SERAPH_RISCV_VARS`
-/// override the directory search; when both are set, no directory
-/// search runs. When neither is set, the first directory containing
-/// `RISCV_VIRT_CODE.fd` and `RISCV_VIRT_VARS.fd` is used as the
-/// source of both. When exactly one is set, the directory search
-/// resolves the unset one.
+/// Per-file env vars `SERAPH_RISCV_CODE` and `SERAPH_RISCV_VARS` are
+/// all-or-nothing: setting only one is an error, because the code
+/// image and vars template must come from the same firmware build —
+/// pairing a custom code image with the system vars template (or
+/// vice versa) silently corrupts NVRAM state. When both are set,
+/// no directory search runs; when neither is set, the first
+/// directory containing both files is used.
 pub fn find_riscv_firmware() -> Result<(PathBuf, PathBuf)>
 {
     let env_code = std::env::var_os(ENV_RISCV_CODE).map(PathBuf::from);
     let env_vars = std::env::var_os(ENV_RISCV_VARS).map(PathBuf::from);
 
-    if let (Some(code), Some(vars)) = (env_code.as_ref(), env_vars.as_ref())
+    match (env_code, env_vars)
     {
-        return Ok((code.clone(), vars.clone()));
+        (Some(code), Some(vars)) =>
+        {
+            if !code.is_file()
+            {
+                return Err(missing_env_path_error(ENV_RISCV_CODE, &code));
+            }
+            if !vars.is_file()
+            {
+                return Err(missing_env_path_error(ENV_RISCV_VARS, &vars));
+            }
+            Ok((code, vars))
+        }
+        (Some(_), None) | (None, Some(_)) => Err(anyhow!(
+            "${ENV_RISCV_CODE} and ${ENV_RISCV_VARS} must be set \
+                 together (or both left unset). Pairing a custom code \
+                 image with a system vars template (or vice versa) \
+                 silently corrupts NVRAM state.",
+        )),
+        (None, None) =>
+        {
+            let dir = find_riscv_firmware_dir()?;
+            let code = dir.join("RISCV_VIRT_CODE.fd");
+            let vars = dir.join("RISCV_VIRT_VARS.fd");
+            if !code.is_file()
+            {
+                return Err(missing_file_error("RISC-V code firmware", &code));
+            }
+            if !vars.is_file()
+            {
+                return Err(missing_file_error("RISC-V vars template", &vars));
+            }
+            Ok((code, vars))
+        }
     }
-
-    let dir = find_riscv_firmware_dir()?;
-    let code = env_code.unwrap_or_else(|| dir.join("RISCV_VIRT_CODE.fd"));
-    let vars = env_vars.unwrap_or_else(|| dir.join("RISCV_VIRT_VARS.fd"));
-
-    if !code.is_file()
-    {
-        return Err(missing_file_error("RISC-V code firmware", &code));
-    }
-    if !vars.is_file()
-    {
-        return Err(missing_file_error("RISC-V vars template", &vars));
-    }
-    Ok((code, vars))
 }
 
 // ── Internal helpers ─────────────────────────────────────────────────────────
@@ -175,10 +194,7 @@ fn find_path(env_var: &str, defaults: &[&str], label: &str, hints: &str) -> Resu
         {
             return Ok(path);
         }
-        return Err(anyhow!(
-            "{label} not found: ${env_var}={path} does not exist",
-            path = path.display(),
-        ));
+        return Err(missing_env_path_error(env_var, &path));
     }
 
     for candidate in defaults
@@ -240,10 +256,20 @@ fn not_found_error(label: &str, env_var: &str, tried: &[&str], hints: &str) -> a
     anyhow!(msg)
 }
 
-/// Build the "env var set but file missing" error.
+/// Build the "discovered file missing" error.
 fn missing_file_error(label: &str, path: &std::path::Path) -> anyhow::Error
 {
     anyhow!("{label} not found at resolved path: {}", path.display(),)
+}
+
+/// Build the "env var set to a path that doesn't exist" error.
+/// Names the env var so the user can fix or unset it.
+fn missing_env_path_error(env_var: &str, path: &std::path::Path) -> anyhow::Error
+{
+    anyhow!(
+        "${env_var}={} does not exist; unset {env_var} to fall back to default search",
+        path.display(),
+    )
 }
 
 /// Per-platform install hints for OVMF.
@@ -341,5 +367,40 @@ mod tests
                 assert_eq!(vars, workspace_cargo);
             });
         });
+    }
+
+    #[test]
+    fn riscv_firmware_with_only_one_env_var_set_is_rejected()
+    {
+        // Setting only SERAPH_RISCV_CODE (without the matching VARS)
+        // would silently pair a custom code image against the system
+        // vars template — a real footgun. Require both or neither.
+        let workspace_cargo = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .join("Cargo.toml");
+        let path = workspace_cargo.to_str().unwrap();
+        // Ensure the partner is unset for the duration of the test.
+        let prev_vars = std::env::var_os(ENV_RISCV_VARS);
+        // SAFETY: tests are single-threaded within this process for env
+        // mutation; we restore on the way out.
+        unsafe {
+            std::env::remove_var(ENV_RISCV_VARS);
+        }
+        with_env_var(ENV_RISCV_CODE, path, || {
+            let err = find_riscv_firmware().unwrap_err();
+            let msg = format!("{err:#}");
+            assert!(
+                msg.contains("must be set together"),
+                "expected pairing-error, got: {msg}",
+            );
+        });
+        unsafe {
+            match prev_vars
+            {
+                Some(v) => std::env::set_var(ENV_RISCV_VARS, v),
+                None => std::env::remove_var(ENV_RISCV_VARS),
+            }
+        }
     }
 }

--- a/xtask/src/firmware.rs
+++ b/xtask/src/firmware.rs
@@ -24,6 +24,7 @@
 //! Padding and per-launch caching of the discovered images stays in
 //! `qemu.rs::prepare_riscv_firmware` — this module is pure discovery.
 
+use std::ffi::OsStr;
 use std::path::PathBuf;
 
 use anyhow::{Result, anyhow};
@@ -121,12 +122,7 @@ pub const ENV_RISCV_VARS: &str = "SERAPH_RISCV_VARS";
 /// supported host.
 pub fn find_ovmf_code() -> Result<PathBuf>
 {
-    find_path(
-        ENV_OVMF_CODE,
-        OVMF_CODE_DEFAULTS,
-        "OVMF code firmware (x86-64)",
-        OVMF_INSTALL_HINTS,
-    )
+    find_ovmf_code_impl(std::env::var_os(ENV_OVMF_CODE).as_deref())
 }
 
 /// Locate the RISC-V EDK2 source images, returning `(code, vars)`.
@@ -140,8 +136,36 @@ pub fn find_ovmf_code() -> Result<PathBuf>
 /// directory containing both files is used.
 pub fn find_riscv_firmware() -> Result<(PathBuf, PathBuf)>
 {
-    let env_code = std::env::var_os(ENV_RISCV_CODE).map(PathBuf::from);
-    let env_vars = std::env::var_os(ENV_RISCV_VARS).map(PathBuf::from);
+    find_riscv_firmware_impl(
+        std::env::var_os(ENV_RISCV_CODE).as_deref(),
+        std::env::var_os(ENV_RISCV_VARS).as_deref(),
+    )
+}
+
+/// Implementation core of `find_ovmf_code`, parameterized on the env
+/// value so tests can exercise the env-override paths without
+/// mutating process-global env state.
+fn find_ovmf_code_impl(env_value: Option<&OsStr>) -> Result<PathBuf>
+{
+    find_path(
+        env_value,
+        ENV_OVMF_CODE,
+        OVMF_CODE_DEFAULTS,
+        "OVMF code firmware (x86-64)",
+        OVMF_INSTALL_HINTS,
+    )
+}
+
+/// Implementation core of `find_riscv_firmware`, parameterized on
+/// the env values so tests can exercise the env-override paths
+/// without mutating process-global env state.
+fn find_riscv_firmware_impl(
+    env_code: Option<&OsStr>,
+    env_vars: Option<&OsStr>,
+) -> Result<(PathBuf, PathBuf)>
+{
+    let env_code = env_code.map(PathBuf::from);
+    let env_vars = env_vars.map(PathBuf::from);
 
     match (env_code, env_vars)
     {
@@ -183,11 +207,19 @@ pub fn find_riscv_firmware() -> Result<(PathBuf, PathBuf)>
 
 // ── Internal helpers ─────────────────────────────────────────────────────────
 
-/// Resolve a single firmware file path: env var first, then default
-/// list, then structured error.
-fn find_path(env_var: &str, defaults: &[&str], label: &str, hints: &str) -> Result<PathBuf>
+/// Resolve a single firmware file path: env value first (taken as
+/// parameter rather than read from the process env, so callers in
+/// tests can supply mock values without mutating global state), then
+/// default list, then structured error.
+fn find_path(
+    env_value: Option<&OsStr>,
+    env_var: &str,
+    defaults: &[&str],
+    label: &str,
+    hints: &str,
+) -> Result<PathBuf>
 {
-    if let Some(value) = std::env::var_os(env_var)
+    if let Some(value) = env_value
     {
         let path = PathBuf::from(value);
         if path.is_file()
@@ -295,112 +327,74 @@ mod tests
 {
     use super::*;
 
-    /// Helper: run `f` with an env var set, then restore. Avoids
-    /// cross-test pollution because each test owns one env var
-    /// exclusively for the duration of the call.
-    fn with_env_var<F: FnOnce()>(key: &str, value: &str, f: F)
+    /// A known-existing file inside the workspace, used as a stand-in
+    /// for a real firmware image in env-override tests.
+    fn existing_workspace_file() -> PathBuf
     {
-        let prev = std::env::var_os(key);
-        // SAFETY: cargo runs tests serialized per process by default
-        // only for `--test-threads=1`; multi-threaded tests sharing
-        // env vars is racy. The two env-var tests here use distinct
-        // keys to minimize interaction, but a reader of these tests
-        // should know that the underlying env mutation is
-        // process-global. Acceptable for xtask's small test surface.
-        unsafe {
-            std::env::set_var(key, value);
-        }
-        f();
-        unsafe {
-            match prev
-            {
-                Some(v) => std::env::set_var(key, v),
-                None => std::env::remove_var(key),
-            }
-        }
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .join("Cargo.toml")
     }
 
     #[test]
     fn env_var_override_pointing_at_missing_file_returns_error()
     {
-        with_env_var(ENV_OVMF_CODE, "/nonexistent/firmware/path.fd", || {
-            let err = find_ovmf_code().unwrap_err();
-            let msg = format!("{err:#}");
-            assert!(
-                msg.contains("SERAPH_OVMF_CODE"),
-                "error should name the env var: {msg}",
-            );
-            assert!(
-                msg.contains("/nonexistent/firmware/path.fd"),
-                "error should include the bad path: {msg}",
-            );
-        });
+        let bogus = OsStr::new("/nonexistent/firmware/path.fd");
+        let err = find_ovmf_code_impl(Some(bogus)).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("SERAPH_OVMF_CODE"),
+            "error should name the env var: {msg}",
+        );
+        assert!(
+            msg.contains("/nonexistent/firmware/path.fd"),
+            "error should include the bad path: {msg}",
+        );
     }
 
     #[test]
     fn env_var_override_pointing_at_existing_file_succeeds()
     {
-        // Cargo.toml is a known-existing file in the workspace.
-        let workspace = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .unwrap()
-            .join("Cargo.toml");
-        let workspace_str = workspace.to_str().unwrap();
-        with_env_var(ENV_OVMF_CODE, workspace_str, || {
-            let resolved = find_ovmf_code().unwrap();
-            assert_eq!(resolved, workspace);
-        });
+        let workspace = existing_workspace_file();
+        let resolved = find_ovmf_code_impl(Some(workspace.as_os_str())).unwrap();
+        assert_eq!(resolved, workspace);
     }
 
     #[test]
     fn riscv_firmware_with_both_env_vars_skips_directory_search()
     {
-        let workspace_cargo = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .unwrap()
-            .join("Cargo.toml");
-        let path = workspace_cargo.to_str().unwrap();
-        with_env_var(ENV_RISCV_CODE, path, || {
-            with_env_var(ENV_RISCV_VARS, path, || {
-                let (code, vars) = find_riscv_firmware().unwrap();
-                assert_eq!(code, workspace_cargo);
-                assert_eq!(vars, workspace_cargo);
-            });
-        });
+        let workspace = existing_workspace_file();
+        let os = workspace.as_os_str();
+        let (code, vars) = find_riscv_firmware_impl(Some(os), Some(os)).unwrap();
+        assert_eq!(code, workspace);
+        assert_eq!(vars, workspace);
     }
 
     #[test]
-    fn riscv_firmware_with_only_one_env_var_set_is_rejected()
+    fn riscv_firmware_with_only_code_env_var_set_is_rejected()
     {
         // Setting only SERAPH_RISCV_CODE (without the matching VARS)
         // would silently pair a custom code image against the system
         // vars template — a real footgun. Require both or neither.
-        let workspace_cargo = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .unwrap()
-            .join("Cargo.toml");
-        let path = workspace_cargo.to_str().unwrap();
-        // Ensure the partner is unset for the duration of the test.
-        let prev_vars = std::env::var_os(ENV_RISCV_VARS);
-        // SAFETY: tests are single-threaded within this process for env
-        // mutation; we restore on the way out.
-        unsafe {
-            std::env::remove_var(ENV_RISCV_VARS);
-        }
-        with_env_var(ENV_RISCV_CODE, path, || {
-            let err = find_riscv_firmware().unwrap_err();
-            let msg = format!("{err:#}");
-            assert!(
-                msg.contains("must be set together"),
-                "expected pairing-error, got: {msg}",
-            );
-        });
-        unsafe {
-            match prev_vars
-            {
-                Some(v) => std::env::set_var(ENV_RISCV_VARS, v),
-                None => std::env::remove_var(ENV_RISCV_VARS),
-            }
-        }
+        let workspace = existing_workspace_file();
+        let err = find_riscv_firmware_impl(Some(workspace.as_os_str()), None).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("must be set together"),
+            "expected pairing-error, got: {msg}",
+        );
+    }
+
+    #[test]
+    fn riscv_firmware_with_only_vars_env_var_set_is_rejected()
+    {
+        let workspace = existing_workspace_file();
+        let err = find_riscv_firmware_impl(None, Some(workspace.as_os_str())).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("must be set together"),
+            "expected pairing-error, got: {msg}",
+        );
     }
 }

--- a/xtask/src/firmware.rs
+++ b/xtask/src/firmware.rs
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+//! firmware.rs
+//!
+//! Host-side discovery of QEMU pflash firmware images.
+//!
+//! Two firmware surfaces are needed by the launch flow:
+//!
+//! - **OVMF (x86-64)** — a single readonly code image. x86 launches with
+//!   volatile NVRAM and don't ship a writable vars file.
+//! - **EDK2 RISC-V (riscv64)** — a paired (code, vars) source. The
+//!   readonly code image plus a vars template that is copied per-launch
+//!   into a writable pflash file.
+//!
+//! Discovery is env-var-first, then per-`cfg(target_os)` default path
+//! tables, then a structured error that enumerates the tried paths and
+//! the install commands for every supported host. The env vars
+//! (`SERAPH_OVMF_CODE`, `SERAPH_RISCV_CODE`, `SERAPH_RISCV_VARS`)
+//! exist for hosts that don't follow FHS conventions (NixOS, macOS,
+//! Windows, custom builds) and override the default search entirely
+//! when set.
+//!
+//! Padding and per-launch caching of the discovered images stays in
+//! `qemu.rs::prepare_riscv_firmware` — this module is pure discovery.
+
+use std::path::PathBuf;
+
+use anyhow::{Result, anyhow};
+
+// ── Default search tables ────────────────────────────────────────────────────
+
+/// OVMF code-image search paths (x86-64). First existing path wins.
+#[cfg(target_os = "linux")]
+const OVMF_CODE_DEFAULTS: &[&str] = &[
+    "/usr/share/edk2/ovmf/OVMF_CODE.fd",
+    "/usr/share/OVMF/OVMF_CODE.fd",
+    "/usr/share/edk2-ovmf/x64/OVMF_CODE.fd",
+    "/usr/share/ovmf/OVMF.fd",
+    "/usr/share/edk2/x64/OVMF_CODE.4m.fd",
+];
+
+#[cfg(target_os = "macos")]
+const OVMF_CODE_DEFAULTS: &[&str] = &[
+    "/opt/homebrew/share/qemu/edk2-x86_64-code.fd",
+    "/usr/local/share/qemu/edk2-x86_64-code.fd",
+];
+
+#[cfg(any(
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly",
+))]
+const OVMF_CODE_DEFAULTS: &[&str] = &[
+    "/usr/local/share/qemu/edk2-x86_64-code.fd",
+    "/usr/local/share/uefi-firmware/edk2-x86_64-code.fd",
+];
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly",
+)))]
+const OVMF_CODE_DEFAULTS: &[&str] = &[];
+
+/// EDK2 RISC-V firmware directories (riscv64). The first directory
+/// containing `RISCV_VIRT_CODE.fd` is used as the source of both the
+/// code image and the vars template, unless `SERAPH_RISCV_CODE` /
+/// `SERAPH_RISCV_VARS` override per-file.
+#[cfg(target_os = "linux")]
+const RISCV_FIRMWARE_DIRS: &[&str] = &[
+    "/usr/share/edk2/riscv",
+    "/usr/share/edk2-riscv",
+    "/usr/share/qemu-efi-riscv64",
+];
+
+#[cfg(target_os = "macos")]
+const RISCV_FIRMWARE_DIRS: &[&str] = &["/opt/homebrew/share/qemu", "/usr/local/share/qemu"];
+
+#[cfg(any(
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly",
+))]
+const RISCV_FIRMWARE_DIRS: &[&str] = &["/usr/local/share/qemu", "/usr/local/share/uefi-firmware"];
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly",
+)))]
+const RISCV_FIRMWARE_DIRS: &[&str] = &[];
+
+// ── Public discovery API ─────────────────────────────────────────────────────
+
+/// Env var that, when set, overrides the OVMF code-image search with a
+/// direct path.
+pub const ENV_OVMF_CODE: &str = "SERAPH_OVMF_CODE";
+
+/// Env var that, when set, overrides the RISC-V code-image search with
+/// a direct path.
+pub const ENV_RISCV_CODE: &str = "SERAPH_RISCV_CODE";
+
+/// Env var that, when set, overrides the RISC-V vars-template search
+/// with a direct path.
+pub const ENV_RISCV_VARS: &str = "SERAPH_RISCV_VARS";
+
+/// Locate the OVMF code image.
+///
+/// Resolution order: `$SERAPH_OVMF_CODE`, then `OVMF_CODE_DEFAULTS`
+/// for the current `target_os`. On miss, returns a structured error
+/// enumerating the tried paths and install commands for every
+/// supported host.
+pub fn find_ovmf_code() -> Result<PathBuf>
+{
+    find_path(
+        ENV_OVMF_CODE,
+        OVMF_CODE_DEFAULTS,
+        "OVMF code firmware (x86-64)",
+        OVMF_INSTALL_HINTS,
+    )
+}
+
+/// Locate the RISC-V EDK2 source images, returning `(code, vars)`.
+///
+/// Per-file env vars `SERAPH_RISCV_CODE` and `SERAPH_RISCV_VARS`
+/// override the directory search; when both are set, no directory
+/// search runs. When neither is set, the first directory containing
+/// `RISCV_VIRT_CODE.fd` and `RISCV_VIRT_VARS.fd` is used as the
+/// source of both. When exactly one is set, the directory search
+/// resolves the unset one.
+pub fn find_riscv_firmware() -> Result<(PathBuf, PathBuf)>
+{
+    let env_code = std::env::var_os(ENV_RISCV_CODE).map(PathBuf::from);
+    let env_vars = std::env::var_os(ENV_RISCV_VARS).map(PathBuf::from);
+
+    if let (Some(code), Some(vars)) = (env_code.as_ref(), env_vars.as_ref())
+    {
+        return Ok((code.clone(), vars.clone()));
+    }
+
+    let dir = find_riscv_firmware_dir()?;
+    let code = env_code.unwrap_or_else(|| dir.join("RISCV_VIRT_CODE.fd"));
+    let vars = env_vars.unwrap_or_else(|| dir.join("RISCV_VIRT_VARS.fd"));
+
+    if !code.is_file()
+    {
+        return Err(missing_file_error("RISC-V code firmware", &code));
+    }
+    if !vars.is_file()
+    {
+        return Err(missing_file_error("RISC-V vars template", &vars));
+    }
+    Ok((code, vars))
+}
+
+// ── Internal helpers ─────────────────────────────────────────────────────────
+
+/// Resolve a single firmware file path: env var first, then default
+/// list, then structured error.
+fn find_path(env_var: &str, defaults: &[&str], label: &str, hints: &str) -> Result<PathBuf>
+{
+    if let Some(value) = std::env::var_os(env_var)
+    {
+        let path = PathBuf::from(value);
+        if path.is_file()
+        {
+            return Ok(path);
+        }
+        return Err(anyhow!(
+            "{label} not found: ${env_var}={path} does not exist",
+            path = path.display(),
+        ));
+    }
+
+    for candidate in defaults
+    {
+        let path = PathBuf::from(candidate);
+        if path.is_file()
+        {
+            return Ok(path);
+        }
+    }
+
+    Err(not_found_error(label, env_var, defaults, hints))
+}
+
+/// Locate the RISC-V firmware *directory* (containing
+/// `RISCV_VIRT_CODE.fd`). Used by `find_riscv_firmware` only when at
+/// least one of the per-file env vars is unset.
+fn find_riscv_firmware_dir() -> Result<PathBuf>
+{
+    for dir in RISCV_FIRMWARE_DIRS
+    {
+        let candidate = PathBuf::from(dir);
+        if candidate.join("RISCV_VIRT_CODE.fd").is_file()
+        {
+            return Ok(candidate);
+        }
+    }
+    Err(not_found_error(
+        "RISC-V EDK2 firmware directory",
+        ENV_RISCV_CODE,
+        RISCV_FIRMWARE_DIRS,
+        RISCV_INSTALL_HINTS,
+    ))
+}
+
+/// Build the standard "not found" error: label, env-var instruction,
+/// tried-paths list, per-platform install hints.
+fn not_found_error(label: &str, env_var: &str, tried: &[&str], hints: &str) -> anyhow::Error
+{
+    let mut msg = format!("{label} not found");
+    msg.push_str("\n\nTried (none existed):\n");
+    if tried.is_empty()
+    {
+        msg.push_str("  (no default paths registered for this host OS)\n");
+    }
+    else
+    {
+        for p in tried
+        {
+            msg.push_str("  ");
+            msg.push_str(p);
+            msg.push('\n');
+        }
+    }
+    msg.push_str(&format!(
+        "\nSet ${env_var} to a direct path, or install the firmware:\n",
+    ));
+    msg.push_str(hints);
+    anyhow!(msg)
+}
+
+/// Build the "env var set but file missing" error.
+fn missing_file_error(label: &str, path: &std::path::Path) -> anyhow::Error
+{
+    anyhow!("{label} not found at resolved path: {}", path.display(),)
+}
+
+/// Per-platform install hints for OVMF.
+const OVMF_INSTALL_HINTS: &str = "  Fedora:           dnf install edk2-ovmf\n  \
+                                  Debian / Ubuntu:  apt install ovmf\n  \
+                                  Arch:             pacman -S edk2-ovmf\n  \
+                                  macOS (Homebrew): brew install qemu\n  \
+                                  FreeBSD:          pkg install edk2-qemu-x64\n  \
+                                  Windows:          set SERAPH_OVMF_CODE to a direct path\n";
+
+/// Per-platform install hints for the EDK2 RISC-V firmware.
+const RISCV_INSTALL_HINTS: &str = "  Fedora:           dnf install edk2-riscv64\n  \
+                                   Debian / Ubuntu:  apt install qemu-efi-riscv64\n  \
+                                   Arch:             extract the Fedora edk2-riscv64 RPM\n  \
+                                                     (RISCV_VIRT_CODE.fd + RISCV_VIRT_VARS.fd)\n  \
+                                                     into /usr/share/edk2/riscv/\n  \
+                                   macOS (Homebrew): brew install qemu\n  \
+                                   FreeBSD:          pkg install edk2-qemu-riscv64\n  \
+                                   Windows:          set SERAPH_RISCV_CODE and SERAPH_RISCV_VARS\n";
+
+#[cfg(test)]
+mod tests
+{
+    use super::*;
+
+    /// Helper: run `f` with an env var set, then restore. Avoids
+    /// cross-test pollution because each test owns one env var
+    /// exclusively for the duration of the call.
+    fn with_env_var<F: FnOnce()>(key: &str, value: &str, f: F)
+    {
+        let prev = std::env::var_os(key);
+        // SAFETY: cargo runs tests serialized per process by default
+        // only for `--test-threads=1`; multi-threaded tests sharing
+        // env vars is racy. The two env-var tests here use distinct
+        // keys to minimize interaction, but a reader of these tests
+        // should know that the underlying env mutation is
+        // process-global. Acceptable for xtask's small test surface.
+        unsafe {
+            std::env::set_var(key, value);
+        }
+        f();
+        unsafe {
+            match prev
+            {
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
+            }
+        }
+    }
+
+    #[test]
+    fn env_var_override_pointing_at_missing_file_returns_error()
+    {
+        with_env_var(ENV_OVMF_CODE, "/nonexistent/firmware/path.fd", || {
+            let err = find_ovmf_code().unwrap_err();
+            let msg = format!("{err:#}");
+            assert!(
+                msg.contains("SERAPH_OVMF_CODE"),
+                "error should name the env var: {msg}",
+            );
+            assert!(
+                msg.contains("/nonexistent/firmware/path.fd"),
+                "error should include the bad path: {msg}",
+            );
+        });
+    }
+
+    #[test]
+    fn env_var_override_pointing_at_existing_file_succeeds()
+    {
+        // Cargo.toml is a known-existing file in the workspace.
+        let workspace = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .join("Cargo.toml");
+        let workspace_str = workspace.to_str().unwrap();
+        with_env_var(ENV_OVMF_CODE, workspace_str, || {
+            let resolved = find_ovmf_code().unwrap();
+            assert_eq!(resolved, workspace);
+        });
+    }
+
+    #[test]
+    fn riscv_firmware_with_both_env_vars_skips_directory_search()
+    {
+        let workspace_cargo = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .join("Cargo.toml");
+        let path = workspace_cargo.to_str().unwrap();
+        with_env_var(ENV_RISCV_CODE, path, || {
+            with_env_var(ENV_RISCV_VARS, path, || {
+                let (code, vars) = find_riscv_firmware().unwrap();
+                assert_eq!(code, workspace_cargo);
+                assert_eq!(vars, workspace_cargo);
+            });
+        });
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -16,6 +16,7 @@
 
 use clap::Parser;
 
+mod accel;
 mod arch;
 mod cli;
 mod commands;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -21,6 +21,7 @@ mod cli;
 mod commands;
 mod context;
 mod disk;
+mod firmware;
 mod qemu;
 mod rust_src;
 mod sysroot;

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -23,10 +23,6 @@ use crate::context::Context;
 use crate::firmware;
 use crate::sysroot;
 
-// Firmware discovery (OVMF, EDK2 RISC-V) lives in `firmware.rs`;
-// this module owns argv construction and the per-launch pflash cache.
-pub use crate::firmware::find_ovmf_code;
-
 /// QEMU virt machine requires pflash images to be exactly 32 MiB.
 const PFLASH_SIZE: u64 = 32 * 1024 * 1024;
 

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -17,6 +17,7 @@ use std::process::{Command, Stdio};
 
 use anyhow::{Context as _, Result, bail};
 
+use crate::accel::{self, Accel};
 use crate::arch::Arch;
 use crate::context::Context;
 use crate::firmware;
@@ -78,42 +79,69 @@ pub fn build_qemu_argv(spec: &QemuLaunchSpec) -> Vec<String>
         args.extend(["-s".into(), "-S".into()]);
     }
 
+    let accel = accel::detect_for_arch(spec.arch);
     match spec.arch
     {
-        Arch::X86_64 => extend_x86(&mut args, spec),
+        Arch::X86_64 => extend_x86(&mut args, spec, accel),
         Arch::Riscv64 => extend_riscv(&mut args, spec),
     }
 
     args
 }
 
-fn extend_x86(args: &mut Vec<String>, spec: &QemuLaunchSpec)
+fn extend_x86(args: &mut Vec<String>, spec: &QemuLaunchSpec, accel: Accel)
 {
     args.extend(["-machine".into(), "q35".into()]);
 
-    // Existence is insufficient: GitHub `ubuntu-latest` x86 runners expose
-    // /dev/kvm for nested virt, but the runner user is not in the `kvm`
-    // group, so `open(O_RDWR)` returns EACCES and QEMU exits immediately.
-    // Probe the same way QEMU itself does, then fall through to TCG when
-    // the device cannot actually be used.
-    if kvm_usable()
+    match accel
     {
-        // -cpu host inherits the development host's microarchitecture; the
-        // kernel asserts x86-64-v3 in early init, so the host must advertise
-        // AVX2/BMI2/FMA (Haswell+ / Excavator+).
-        args.extend(["-enable-kvm".into(), "-cpu".into(), "host".into()]);
-    }
-    else
-    {
-        // TCG fallback: `-cpu max,migratable=no` advertises every feature
-        // QEMU can emulate (including x86-64-v3) so userspace SIMD codegen
-        // executes correctly under non-KVM runs (CI, KVM-less containers).
-        args.extend([
-            "-accel".into(),
-            "tcg,thread=multi".into(),
-            "-cpu".into(),
-            "max,migratable=no".into(),
-        ]);
+        Accel::Kvm =>
+        {
+            // -cpu host inherits the development host's microarchitecture;
+            // the kernel asserts x86-64-v3 in early init, so the host must
+            // advertise AVX2/BMI2/FMA (Haswell+ / Excavator+).
+            args.extend(["-enable-kvm".into(), "-cpu".into(), "host".into()]);
+        }
+        Accel::Hvf =>
+        {
+            // macOS Hypervisor.framework. Same -cpu host rationale as KVM;
+            // HVF passes host features through to the guest natively.
+            args.extend(["-accel".into(), "hvf".into(), "-cpu".into(), "host".into()]);
+        }
+        Accel::Whpx =>
+        {
+            // Windows Hyper-V Platform. WHPX does not expose -cpu host the
+            // same way KVM/HVF do; -cpu max,migratable=no is the documented
+            // QEMU recipe and exposes the same x86-64-v3 baseline TCG does.
+            args.extend([
+                "-accel".into(),
+                "whpx".into(),
+                "-cpu".into(),
+                "max,migratable=no".into(),
+            ]);
+        }
+        Accel::Nvmm =>
+        {
+            args.extend([
+                "-accel".into(),
+                "nvmm".into(),
+                "-cpu".into(),
+                "max,migratable=no".into(),
+            ]);
+        }
+        Accel::Tcg =>
+        {
+            // TCG fallback: `-cpu max,migratable=no` advertises every
+            // feature QEMU can emulate (including x86-64-v3) so userspace
+            // SIMD codegen executes correctly under non-KVM runs (CI,
+            // KVM-less containers).
+            args.extend([
+                "-accel".into(),
+                "tcg,thread=multi".into(),
+                "-cpu".into(),
+                "max,migratable=no".into(),
+            ]);
+        }
     }
 
     args.extend([
@@ -182,24 +210,6 @@ fn extend_riscv(args: &mut Vec<String>, spec: &QemuLaunchSpec)
             ]);
         }
     }
-}
-
-/// Returns true if `/dev/kvm` can be opened for read+write by the current
-/// process. Existence alone is misleading on environments that expose the
-/// node without granting the calling user access (e.g. GitHub-hosted
-/// runners). Setting `SERAPH_NO_KVM=1` forces the TCG path regardless,
-/// for local reproduction of the no-KVM CI environment.
-fn kvm_usable() -> bool
-{
-    if std::env::var_os("SERAPH_NO_KVM").is_some()
-    {
-        return false;
-    }
-    std::fs::OpenOptions::new()
-        .read(true)
-        .write(true)
-        .open("/dev/kvm")
-        .is_ok()
 }
 
 /// Resolve and cache riscv64 firmware.

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -19,23 +19,12 @@ use anyhow::{Context as _, Result, bail};
 
 use crate::arch::Arch;
 use crate::context::Context;
+use crate::firmware;
 use crate::sysroot;
 
-/// OVMF firmware search paths (Fedora, Debian/Ubuntu, Arch).
-const OVMF_CODE_PATHS: &[&str] = &[
-    "/usr/share/edk2/ovmf/OVMF_CODE.fd",
-    "/usr/share/OVMF/OVMF_CODE.fd",
-    "/usr/share/edk2-ovmf/x64/OVMF_CODE.fd",
-    "/usr/share/ovmf/OVMF.fd",
-    "/usr/share/edk2/x64/OVMF_CODE.4m.fd",
-];
-
-/// edk2 RISC-V firmware search directories.
-const EDK2_RISCV_DIRS: &[&str] = &[
-    "/usr/share/edk2/riscv",
-    "/usr/share/edk2-riscv",
-    "/usr/share/qemu-efi-riscv64",
-];
+// Firmware discovery (OVMF, EDK2 RISC-V) lives in `firmware.rs`;
+// this module owns argv construction and the per-launch pflash cache.
+pub use crate::firmware::find_ovmf_code;
 
 /// QEMU virt machine requires pflash images to be exactly 32 MiB.
 const PFLASH_SIZE: u64 = 32 * 1024 * 1024;
@@ -213,23 +202,6 @@ fn kvm_usable() -> bool
         .is_ok()
 }
 
-/// Locate the OVMF code image, returning the first installed path.
-pub fn find_ovmf_code() -> Result<PathBuf>
-{
-    OVMF_CODE_PATHS
-        .iter()
-        .map(PathBuf::from)
-        .find(|p| p.exists())
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "OVMF firmware not found\n\
-                 Install with: dnf install edk2-ovmf  (Fedora)\n\
-                 or:           apt install ovmf        (Debian/Ubuntu)\n\
-                 or:           pacman -S edk2-ovmf     (Arch Linux)"
-            )
-        })
-}
-
 /// Resolve and cache riscv64 firmware.
 ///
 /// Returns `(code_path, vars_template_path)`:
@@ -240,29 +212,14 @@ pub fn find_ovmf_code() -> Result<PathBuf>
 ///   on every call. `run` uses this path directly as the writable pflash;
 ///   `run-parallel` copies it to per-slot VARS.fd files so concurrent QEMUs
 ///   don't race on the same NVRAM image.
+///
+/// Source discovery is delegated to `firmware::find_riscv_firmware`,
+/// which is env-var-first and per-`cfg(target_os)` aware. This function
+/// owns only the padding/caching that QEMU's `virt` machine requires
+/// (exactly 32 MiB pflash images).
 pub fn prepare_riscv_firmware(ctx: &Context) -> Result<(PathBuf, PathBuf)>
 {
-    let firmware_dir = EDK2_RISCV_DIRS
-        .iter()
-        .find(|d| Path::new(d).join("RISCV_VIRT_CODE.fd").exists())
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "edk2 RISC-V firmware not found\n\
-                 Install with: dnf install edk2-riscv64          (Fedora)\n\
-                 or:           apt install qemu-efi-riscv64       (Debian/Ubuntu)\n\
-                 or on Arch:   download the Fedora edk2-riscv64 RPM and extract\n\
-                               RISCV_VIRT_CODE.fd + RISCV_VIRT_VARS.fd into /usr/share/edk2/riscv/"
-            )
-        })?;
-
-    let base = Path::new(firmware_dir);
-    let src_code = base.join("RISCV_VIRT_CODE.fd");
-    let src_vars = base.join("RISCV_VIRT_VARS.fd");
-
-    if !src_vars.exists()
-    {
-        bail!("RISC-V NVRAM template not found: {}", src_vars.display());
-    }
+    let (src_code, src_vars) = firmware::find_riscv_firmware()?;
 
     let cache_dir = ctx.target_dir.join("xtask").join("firmware").join("riscv");
     std::fs::create_dir_all(&cache_dir)

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -3,12 +3,14 @@
 
 //! qemu.rs
 //!
-//! Shared QEMU argv construction and firmware preparation.
+//! Shared QEMU argv construction and per-launch pflash cache for RISC-V.
 //!
 //! Both `run` and `run-parallel` produce QEMU command lines from the same
-//! source of truth (`build_qemu_argv`) and resolve firmware via the same
-//! helpers (`find_ovmf_code`, `prepare_riscv_firmware`). The interactive
-//! launch loop (stdout filtering, terminal restore) stays in
+//! source of truth (`build_qemu_argv`). Firmware discovery lives in
+//! `firmware::{find_ovmf_code, find_riscv_firmware}`; the padding +
+//! caching of RISC-V pflash images stays here in `prepare_riscv_firmware`.
+//! Acceleration-backend selection lives in `accel::detect_for_arch`. The
+//! interactive launch loop (stdout filtering, terminal restore) stays in
 //! `commands/run.rs`; `run-parallel` spawns QEMU directly against per-slot
 //! log files.
 


### PR DESCRIPTION
## Summary

Replaces xtask's hard-coded firmware-path lookups and inline KVM probe
with portable, env-var-overridable modules. Three commits, one PR:

| Layer | Was | Now |
|---|---|---|
| OVMF / EDK2 RISC-V discovery | hard-coded \`/usr/share/edk2/...\` paths in \`qemu.rs\` | \`firmware.rs\` — env-var-first (\`SERAPH_OVMF_CODE\`, \`SERAPH_RISCV_CODE\`, \`SERAPH_RISCV_VARS\`), then per-\`cfg(target_os)\` default tables (Linux / macOS / BSD), then structured error with tried paths + per-platform install commands |
| Acceleration | inline \`kvm_usable() -> bool\` returning a \`/dev/kvm\` test-open result | \`accel.rs\` — \`enum Accel { Kvm, Hvf, Whpx, Nvmm, Tcg }\` with per-cfg detection and \`SERAPH_ACCEL\` env override; explicit overrides that can't be honored emit a stderr warning |
| QEMU argv | x86 path inline-branched on the KVM bool | x86 path switches on the \`Accel\` enum; one argv recipe per backend |

The old \`SERAPH_NO_KVM\` knob is not carried forward; \`SERAPH_ACCEL=tcg\`
covers the same use case without polluting the env-var surface.

## Why

Both pieces were Linux-only by design. \`/usr/share/edk2/...\` exists nowhere
on macOS / BSD / Windows / NixOS; \`/dev/kvm\` is Linux-specific. Neither
had an escape hatch.

After this PR:

- Anyone on a non-FHS Linux (NixOS, custom builds) can set
  \`SERAPH_OVMF_CODE\` / \`SERAPH_RISCV_*\` and xtask works without code
  changes.
- macOS and BSD developers have working default search paths plus the
  same env-var override.
- \`SERAPH_ACCEL\` lets a Linux user force TCG to reproduce CI behavior.
- The Windows and macOS code paths compile cleanly on a Linux host;
  runtime behavior on those platforms is by-design-unverified (no CI,
  no test access).

## New env vars

| Var | Purpose | Default |
|---|---|---|
| \`SERAPH_OVMF_CODE\` | Direct path to OVMF code firmware | per-cfg search list |
| \`SERAPH_RISCV_CODE\` | Direct path to RISCV_VIRT_CODE.fd. **All-or-nothing pair with \`SERAPH_RISCV_VARS\`** | per-cfg directory search |
| \`SERAPH_RISCV_VARS\` | Direct path to RISCV_VIRT_VARS.fd. See pairing rule above | per-cfg directory search |
| \`SERAPH_ACCEL\` | \`auto \| tcg \| kvm \| hvf \| whpx \| nvmm\` | \`auto\` (per-cfg detection) |

Partial RISC-V env-var sets are rejected with a clear error: pairing a
custom code image against the system vars template silently corrupts
NVRAM. Unrecognized \`SERAPH_ACCEL\` values warn and fall through to
auto-detection. Cross-arch guests (riscv64 on x86, etc.) always resolve
to \`Tcg\`; an explicit non-\`tcg\`/\`auto\` override in that case emits a
warning explaining the silent downgrade.

## Default search tables

OVMF code (x86-64):

- Linux:   5 paths (Fedora, Debian/Ubuntu, Arch variants).
- macOS:   \`/opt/homebrew/share/qemu/edk2-x86_64-code.fd\`, \`/usr/local/share/qemu/...\`
- BSD:     \`/usr/local/share/qemu/...\`, \`/usr/local/share/uefi-firmware/...\`
- Other:   empty (env var required).

EDK2 RISC-V directories:

- Linux:   \`/usr/share/edk2/riscv\`, \`/usr/share/edk2-riscv\`, \`/usr/share/qemu-efi-riscv64\`
- macOS:   \`/opt/homebrew/share/qemu\`, \`/usr/local/share/qemu\`
- BSD:     \`/usr/local/share/qemu\`, \`/usr/local/share/uefi-firmware\`
- Other:   empty (env vars required).

## Acceleration backends

Per-host \`detect_default()\` (only consulted for same-arch guests):

- Linux:   probe \`/dev/kvm\` open(O_RDWR) → \`Kvm\` or \`Tcg\`.
- macOS:   \`Hvf\` (no probe; macOS 10.10+ ships HVF).
- Windows: \`Whpx\` (no probe; QEMU errors clearly on launch failure if the Hyper-V Platform feature is disabled).
- NetBSD:  probe \`/dev/nvmm\` → \`Nvmm\` or \`Tcg\`.
- Other:   \`Tcg\`.

Cross-arch guests always resolve to \`Tcg\` regardless of host detection,
because TCG is the only option for cross-architecture emulation.

## Documentation

\`xtask/README.md\` and \`docs/build-system.md\` updated to document the
four new env vars, the per-platform default search behavior, the RISC-V
pairing rule, and the per-host accel selection.

## Test plan

- [x] \`cargo xtask test\` — 56 xtask tests pass (10 new: 4 firmware + 6 accel).
      Coverage: env-var success/error paths, both-vars-set bypass, pairing
      enforcement, every explicit \`SERAPH_ACCEL\` name, case/whitespace
      tolerance, cross-arch fallback.
- [x] \`cargo xtask build\` clean on x86_64 and riscv64.
- [x] \`cargo xtask run --headless\` boots to \`ALL TESTS PASSED\` on x86_64
      (default KVM ~4s, \`SERAPH_ACCEL=tcg\` ~15s) and riscv64 (always TCG).
- [x] \`SERAPH_OVMF_CODE=/nonexistent cargo xtask run\` produces the
      structured "not found" error and exits 1.

## By-design unverified

- macOS HVF and the Homebrew default search paths.
- Windows WHPX, console behavior, and env-var-only firmware resolution.
- FreeBSD / OpenBSD / DragonFly / NetBSD firmware paths and NVMM detection.

CI stays on \`ubuntu-latest\`. The \`cfg\`-gated code paths compile cleanly
on Linux; runtime verification on the other hosts is on the next person
who runs xtask there.