### PR TITLE
xtask: rust-native toolchain mirror (fs_compat, wrapper shim, which)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,6 +780,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
+name = "seraph-wrapper-shim"
+version = "0.1.0"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1073,6 +1077,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1319,6 +1332,7 @@ dependencies = [
  "libc",
  "regex",
  "uuid",
+ "which",
  "windows-sys 0.59.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ members = [
     "base/stdiotest",
     "base/usertest",
     "xtask",
+    "xtask/wrapper-shim",
 ]
 
 # default-members limits bare `cargo build`/`cargo run` to xtask only.

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -26,6 +26,11 @@ ctrlc = "3"
 # because libc compiles cleanly on every platform xtask runs on, with
 # unused Unix-only items naturally elided on Windows builds.
 libc = "0.2"
+# Portable PATH-lookup. Used to resolve qemu-system-* and llvm-objcopy
+# up-front so missing tools produce a clear error naming the tool and
+# pointing at the install package, rather than the OS's opaque
+# "No such file or directory" from Command::spawn.
+which = "8"
 
 # Windows console-mode bindings for TerminalGuard. Only pulled in for
 # Windows builds; Linux/macOS/BSD builds skip this crate entirely.

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -168,6 +168,14 @@ discarded.
 
 ---
 
+## Sub-crates
+
+| Sub-crate | Purpose |
+|---|---|
+| [wrapper-shim/](wrapper-shim/README.md) | Tiny native binary installed into the seraph toolchain mirror as both `rustc` and `ws-clippy`. Dispatches by argv[0] basename to exec the real rustc / clippy-driver with overlay-aware `--sysroot` flags. Built by `cargo xtask build` as part of StdUser builds; never invoked directly. |
+
+---
+
 ## Adding a new command
 
 1. Add a variant to `CliCommand` in `src/cli.rs` with a corresponding `Args` struct.

--- a/xtask/src/commands/build.rs
+++ b/xtask/src/commands/build.rs
@@ -463,8 +463,7 @@ fn build_group(
     cmd.arg("build").args(&flags_ref);
     if let Some(s) = seraph.as_ref()
     {
-        cmd.env("RUSTC", &s.rustc);
-        cmd.env("RUSTC_BOOTSTRAP", "1");
+        s.apply_env(&mut cmd);
     }
     run_cmd(&mut cmd)?;
 
@@ -665,11 +664,11 @@ fn clippy_check_ext(
         Some(s) =>
         {
             cmd.arg("check").args(flags);
-            cmd.env("RUSTC", &s.rustc);
-            cmd.env("RUSTC_WORKSPACE_WRAPPER", &s.ws_clippy);
-            // Match the `cargo build` env: unlock `restricted_std` +
-            // `rustc_private` gates so service code stays preamble-free.
-            cmd.env("RUSTC_BOOTSTRAP", "1");
+            // Routes RUSTC + RUSTC_WORKSPACE_WRAPPER through the shim,
+            // sets the SERAPH_SHIM_* config, and re-applies
+            // RUSTC_BOOTSTRAP=1 (unlocks restricted_std + rustc_private
+            // so service code stays preamble-free).
+            s.apply_env(&mut cmd);
             // Clippy-driver splits CLIPPY_ARGS on __CLIPPY_HACKERY__; this
             // matches the encoding cargo-clippy uses internally when
             // forwarding post-`--` args.

--- a/xtask/src/commands/build.rs
+++ b/xtask/src/commands/build.rs
@@ -552,16 +552,16 @@ fn build_spec(ctx: &BuildContext, args: &BuildArgs, spec: &Spec) -> Result<()>
     cmd.arg("build").args(&flags_ref);
     if let Some(s) = seraph.as_ref()
     {
-        cmd.env("RUSTC", &s.rustc);
-        // StdUser bins sit on a custom target ("seraph") that rustc does not
-        // recognise in its built-in list, which makes the whole std surface
-        // `restricted_std`-gated. They also see `ProcessInfo`-derived
-        // helpers that feel "sysroot-private" when their backing crates
-        // (process-abi, syscall, ipc, shmem, log) get loaded as std deps.
-        // Setting RUSTC_BOOTSTRAP=1 for the build treats those gates as
-        // unlocked — matches how hermit and other tier-3 custom-std
-        // targets ship. Service code stays free of feature preambles.
-        cmd.env("RUSTC_BOOTSTRAP", "1");
+        // Routes RUSTC + RUSTC_WORKSPACE_WRAPPER through the shim,
+        // sets the SERAPH_SHIM_* config (so the shim knows what to
+        // exec), and applies RUSTC_BOOTSTRAP=1. The latter unlocks
+        // `restricted_std`/`rustc_private` — StdUser bins target a
+        // custom triple ("seraph") that rustc doesn't recognise in
+        // its built-in list, and the std overlay loads workspace
+        // crates (process-abi, syscall, ipc, shmem, log) as std
+        // deps; matches how hermit and other tier-3 custom-std
+        // targets unlock the same gates.
+        s.apply_env(&mut cmd);
     }
     run_cmd(&mut cmd)?;
 

--- a/xtask/src/commands/run.rs
+++ b/xtask/src/commands/run.rs
@@ -26,7 +26,7 @@ use crate::qemu::{
 use crate::term::filter::FilterWriter;
 use crate::term::guard::TerminalGuard;
 use crate::term::line_gate::LineGate;
-use crate::util::step;
+use crate::util::{require_tool, step};
 
 /// Marker that opens the default-mode line gate. Emitted by the
 /// bootloader as the first line after firmware exits; everything
@@ -105,7 +105,8 @@ fn launch_qemu(binary: &str, args: &[String], desc: &str, verbose: bool) -> Resu
     // (term::signal::install) means Ctrl+C terminates QEMU directly
     // via the tty without killing xtask. The TerminalGuard captured
     // in run() runs its drop on the way out, restoring termios.
-    let mut child = Command::new(binary)
+    let resolved = require_tool(binary)?;
+    let mut child = Command::new(&resolved)
         .args(args)
         .stdout(Stdio::piped())
         .spawn()

--- a/xtask/src/commands/run_parallel.rs
+++ b/xtask/src/commands/run_parallel.rs
@@ -33,7 +33,7 @@ use crate::qemu::{
     QemuLaunchSpec, build_qemu_argv, prepare_riscv_firmware, validate_sysroot_for_launch,
 };
 use crate::term::filter::FilterWriter;
-use crate::util::step;
+use crate::util::{require_tool, step};
 
 /// How often the watchdog poll loop checks child exit status.
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
@@ -107,6 +107,11 @@ pub fn run(ctx: &BuildContext, args: &RunParallelArgs) -> Result<()>
 
     validate_sysroot_for_launch(ctx, args.arch)?;
 
+    // Resolve qemu binary once, up front: missing-tool errors should
+    // surface at run-parallel startup, not N times mid-wave inside
+    // worker threads.
+    let qemu_binary = require_tool(args.arch.qemu_binary())?;
+
     let firmware = resolve_firmware(ctx, args.arch)?;
 
     let workdir = ctx.target_dir.join("xtask").join("run-parallel");
@@ -152,6 +157,7 @@ pub fn run(ctx: &BuildContext, args: &RunParallelArgs) -> Result<()>
             let pass_re = pass_re.clone();
             let fail_re = fail_re.clone();
             let workdir = workdir.clone();
+            let qemu_binary = qemu_binary.clone();
 
             handles.push(thread::spawn(move || -> Result<RunOutcome> {
                 std::fs::create_dir_all(&slot_dir)
@@ -211,7 +217,7 @@ pub fn run(ctx: &BuildContext, args: &RunParallelArgs) -> Result<()>
                 // `log_file` is moved into the forwarder thread below.
 
                 let started = Instant::now();
-                let mut child = Command::new(arch.qemu_binary())
+                let mut child = Command::new(&qemu_binary)
                     .args(&qemu_args)
                     .stdout(Stdio::piped())
                     .stderr(Stdio::from(log_for_stderr))

--- a/xtask/src/fs_compat.rs
+++ b/xtask/src/fs_compat.rs
@@ -31,26 +31,15 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 
-/// What `link_or_copy` actually did, for logging / diagnostics.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[allow(dead_code)] // kept for callers that want to log; not all do
-pub enum LinkKind
-{
-    /// Symbolic link from `dst` to `src`.
-    Symlink,
-    /// Hard link (shared inode) — file-only.
-    HardLink,
-    /// Independent physical copy. For dirs, recursive copy.
-    Copy,
-}
-
 /// Materialise `dst` to reference the same content as `src`. Tries
-/// symlink, then hard link (for files), then physical copy. Returns
-/// the kind that actually succeeded.
+/// symlink, then hard link (for files), then physical copy.
 ///
 /// `src` must exist; `dst` must not. The caller is responsible for
-/// removing any prior `dst`.
-pub fn link_or_copy(src: &Path, dst: &Path) -> Result<LinkKind>
+/// removing any prior `dst`. Failure of one fallback is silent; the
+/// only error surfaced is the final-fallback (`fs::copy` for files,
+/// recursive copy for dirs) failure, with the source path in
+/// context.
+pub fn link_or_copy(src: &Path, dst: &Path) -> Result<()>
 {
     let meta = fs::symlink_metadata(src).with_context(|| format!("stat {}", src.display()))?;
     if meta.file_type().is_dir()
@@ -64,31 +53,31 @@ pub fn link_or_copy(src: &Path, dst: &Path) -> Result<LinkKind>
 }
 
 /// File-level materialise: symlink → hard link → copy.
-fn link_or_copy_file(src: &Path, dst: &Path) -> Result<LinkKind>
+fn link_or_copy_file(src: &Path, dst: &Path) -> Result<()>
 {
     if try_symlink_file(src, dst).is_ok()
     {
-        return Ok(LinkKind::Symlink);
+        return Ok(());
     }
     if fs::hard_link(src, dst).is_ok()
     {
-        return Ok(LinkKind::HardLink);
+        return Ok(());
     }
     fs::copy(src, dst)
         .with_context(|| format!("copying {} -> {}", src.display(), dst.display()))?;
-    Ok(LinkKind::Copy)
+    Ok(())
 }
 
 /// Directory-level materialise: dir-symlink → recursive copy. There
 /// is no portable directory hard-link.
-fn link_or_copy_dir(src: &Path, dst: &Path) -> Result<LinkKind>
+fn link_or_copy_dir(src: &Path, dst: &Path) -> Result<()>
 {
     if try_symlink_dir(src, dst).is_ok()
     {
-        return Ok(LinkKind::Symlink);
+        return Ok(());
     }
     copy_dir_recursive(src, dst)?;
-    Ok(LinkKind::Copy)
+    Ok(())
 }
 
 /// Recursive directory copy. Used as the last-resort fallback for
@@ -205,11 +194,7 @@ mod tests
         let src = dir.join("src.txt");
         let dst = dir.join("dst.txt");
         fs::write(&src, b"hello world").unwrap();
-        let kind = link_or_copy(&src, &dst).unwrap();
-        assert!(matches!(
-            kind,
-            LinkKind::Symlink | LinkKind::HardLink | LinkKind::Copy
-        ));
+        link_or_copy(&src, &dst).unwrap();
         let bytes = fs::read(&dst).unwrap();
         assert_eq!(bytes, b"hello world");
         let _ = fs::remove_dir_all(&dir);
@@ -225,8 +210,7 @@ mod tests
         fs::write(src.join("a.txt"), b"one").unwrap();
         fs::create_dir(src.join("sub")).unwrap();
         fs::write(src.join("sub/b.txt"), b"two").unwrap();
-        let kind = link_or_copy(&src, &dst).unwrap();
-        assert!(matches!(kind, LinkKind::Symlink | LinkKind::Copy));
+        link_or_copy(&src, &dst).unwrap();
         assert_eq!(fs::read(dst.join("a.txt")).unwrap(), b"one");
         assert_eq!(fs::read(dst.join("sub/b.txt")).unwrap(), b"two");
         let _ = fs::remove_dir_all(&dir);

--- a/xtask/src/fs_compat.rs
+++ b/xtask/src/fs_compat.rs
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+//! fs_compat.rs
+//!
+//! Portable file-materialisation helpers.
+//!
+//! `link_or_copy` makes `dst` refer to the same content as `src` using
+//! the cheapest mechanism the host supports: symlink first, then hard
+//! link, then physical copy. The chosen mechanism is reported back so
+//! callers can log it; semantics are identical from a reader's
+//! perspective (cargo and rustc resolve all three to the same bytes).
+//!
+//! This replaces the previous Unix-only `std::os::unix::fs::symlink`
+//! call sites in `rust_src.rs`, which were the last hard blocker to
+//! the toolchain-mirror assembly running on Windows. On Unix and
+//! macOS, behavior is unchanged (symlink path always succeeds). On
+//! Windows the symlink attempt requires developer mode or admin
+//! privileges; the function silently falls through to hard-link
+//! (files) or recursive copy (dirs).
+//!
+//! Directory handling: dir symlinks need a distinct API on Windows
+//! (`symlink_dir` vs `symlink_file`), and there is no portable
+//! directory hard-link. `link_or_copy` dispatches on `src`'s metadata
+//! and falls back to recursive copy for directories when symlink
+//! fails.
+
+use std::fs;
+use std::io;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+/// What `link_or_copy` actually did, for logging / diagnostics.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[allow(dead_code)] // kept for callers that want to log; not all do
+pub enum LinkKind
+{
+    /// Symbolic link from `dst` to `src`.
+    Symlink,
+    /// Hard link (shared inode) — file-only.
+    HardLink,
+    /// Independent physical copy. For dirs, recursive copy.
+    Copy,
+}
+
+/// Materialise `dst` to reference the same content as `src`. Tries
+/// symlink, then hard link (for files), then physical copy. Returns
+/// the kind that actually succeeded.
+///
+/// `src` must exist; `dst` must not. The caller is responsible for
+/// removing any prior `dst`.
+pub fn link_or_copy(src: &Path, dst: &Path) -> Result<LinkKind>
+{
+    let meta = fs::symlink_metadata(src).with_context(|| format!("stat {}", src.display()))?;
+    if meta.file_type().is_dir()
+    {
+        link_or_copy_dir(src, dst)
+    }
+    else
+    {
+        link_or_copy_file(src, dst)
+    }
+}
+
+/// File-level materialise: symlink → hard link → copy.
+fn link_or_copy_file(src: &Path, dst: &Path) -> Result<LinkKind>
+{
+    if try_symlink_file(src, dst).is_ok()
+    {
+        return Ok(LinkKind::Symlink);
+    }
+    if fs::hard_link(src, dst).is_ok()
+    {
+        return Ok(LinkKind::HardLink);
+    }
+    fs::copy(src, dst)
+        .with_context(|| format!("copying {} -> {}", src.display(), dst.display()))?;
+    Ok(LinkKind::Copy)
+}
+
+/// Directory-level materialise: dir-symlink → recursive copy. There
+/// is no portable directory hard-link.
+fn link_or_copy_dir(src: &Path, dst: &Path) -> Result<LinkKind>
+{
+    if try_symlink_dir(src, dst).is_ok()
+    {
+        return Ok(LinkKind::Symlink);
+    }
+    copy_dir_recursive(src, dst)?;
+    Ok(LinkKind::Copy)
+}
+
+/// Recursive directory copy. Used as the last-resort fallback for
+/// `link_or_copy_dir` on hosts where directory symlinks aren't
+/// available (Windows without developer mode).
+fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()>
+{
+    fs::create_dir_all(dst).with_context(|| format!("creating {}", dst.display()))?;
+    for entry in fs::read_dir(src).with_context(|| format!("reading {}", src.display()))?
+    {
+        let entry = entry?;
+        let entry_path = entry.path();
+        let entry_dst = dst.join(entry.file_name());
+        let ft = entry.file_type()?;
+        if ft.is_dir()
+        {
+            copy_dir_recursive(&entry_path, &entry_dst)?;
+        }
+        else if ft.is_symlink()
+        {
+            // Resolve and copy the symlink's content rather than
+            // attempting to recreate the symlink — symlink recreation
+            // is itself non-portable, and a copy gives the reader the
+            // same bytes.
+            fs::copy(&entry_path, &entry_dst).with_context(|| {
+                format!(
+                    "copying (via resolved symlink) {} -> {}",
+                    entry_path.display(),
+                    entry_dst.display()
+                )
+            })?;
+        }
+        else
+        {
+            fs::copy(&entry_path, &entry_dst).with_context(|| {
+                format!(
+                    "copying {} -> {}",
+                    entry_path.display(),
+                    entry_dst.display()
+                )
+            })?;
+        }
+    }
+    Ok(())
+}
+
+// ── Per-platform symlink primitives ──────────────────────────────────────────
+
+#[cfg(unix)]
+fn try_symlink_file(src: &Path, dst: &Path) -> io::Result<()>
+{
+    std::os::unix::fs::symlink(src, dst)
+}
+
+#[cfg(unix)]
+fn try_symlink_dir(src: &Path, dst: &Path) -> io::Result<()>
+{
+    std::os::unix::fs::symlink(src, dst)
+}
+
+#[cfg(windows)]
+fn try_symlink_file(src: &Path, dst: &Path) -> io::Result<()>
+{
+    std::os::windows::fs::symlink_file(src, dst)
+}
+
+#[cfg(windows)]
+fn try_symlink_dir(src: &Path, dst: &Path) -> io::Result<()>
+{
+    std::os::windows::fs::symlink_dir(src, dst)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn try_symlink_file(_src: &Path, _dst: &Path) -> io::Result<()>
+{
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "symlinks not supported on this platform",
+    ))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn try_symlink_dir(_src: &Path, _dst: &Path) -> io::Result<()>
+{
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "symlinks not supported on this platform",
+    ))
+}
+
+#[cfg(test)]
+mod tests
+{
+    use super::*;
+
+    fn tmpdir() -> std::path::PathBuf
+    {
+        let dir = std::env::temp_dir().join(format!(
+            "seraph-xtask-fs_compat-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn link_or_copy_file_makes_dst_readable_with_same_bytes()
+    {
+        let dir = tmpdir();
+        let src = dir.join("src.txt");
+        let dst = dir.join("dst.txt");
+        fs::write(&src, b"hello world").unwrap();
+        let kind = link_or_copy(&src, &dst).unwrap();
+        assert!(matches!(
+            kind,
+            LinkKind::Symlink | LinkKind::HardLink | LinkKind::Copy
+        ));
+        let bytes = fs::read(&dst).unwrap();
+        assert_eq!(bytes, b"hello world");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn link_or_copy_dir_replicates_directory_contents()
+    {
+        let dir = tmpdir();
+        let src = dir.join("src");
+        let dst = dir.join("dst");
+        fs::create_dir(&src).unwrap();
+        fs::write(src.join("a.txt"), b"one").unwrap();
+        fs::create_dir(src.join("sub")).unwrap();
+        fs::write(src.join("sub/b.txt"), b"two").unwrap();
+        let kind = link_or_copy(&src, &dst).unwrap();
+        assert!(matches!(kind, LinkKind::Symlink | LinkKind::Copy));
+        assert_eq!(fs::read(dst.join("a.txt")).unwrap(), b"one");
+        assert_eq!(fs::read(dst.join("sub/b.txt")).unwrap(), b"two");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn link_or_copy_missing_source_errors()
+    {
+        let dir = tmpdir();
+        let src = dir.join("nope.txt");
+        let dst = dir.join("out.txt");
+        let err = link_or_copy(&src, &dst).unwrap_err();
+        assert!(format!("{err:#}").contains("stat"));
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn copy_dir_recursive_handles_nested_files_and_dirs()
+    {
+        let dir = tmpdir();
+        let src = dir.join("src");
+        let dst = dir.join("dst");
+        fs::create_dir(&src).unwrap();
+        fs::create_dir(src.join("a")).unwrap();
+        fs::create_dir(src.join("a/b")).unwrap();
+        fs::write(src.join("a/b/leaf.txt"), b"deep").unwrap();
+        copy_dir_recursive(&src, &dst).unwrap();
+        assert_eq!(fs::read(dst.join("a/b/leaf.txt")).unwrap(), b"deep");
+        let _ = fs::remove_dir_all(&dir);
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -23,6 +23,7 @@ mod commands;
 mod context;
 mod disk;
 mod firmware;
+mod fs_compat;
 mod qemu;
 mod rust_src;
 mod sysroot;

--- a/xtask/src/rust_src.rs
+++ b/xtask/src/rust_src.rs
@@ -68,7 +68,7 @@ use anyhow::{Context, Result, bail};
 
 use crate::context::Context as BuildContext;
 use crate::fs_compat::link_or_copy;
-use crate::util::{run_cmd, step};
+use crate::util::{require_tool, run_cmd, step};
 
 /// Substring placed in every patched source file for idempotency
 /// detection. Single marker per file suffices; atomic-per-file edits.
@@ -159,7 +159,7 @@ pub fn ensure_seraph_toolchain(ctx: &BuildContext) -> Result<SeraphToolchain>
             real_clippy.display()
         );
     }
-    install_wrappers(ctx, &real, &mirror).context("installing wrapper shim")?;
+    install_wrappers(ctx, &mirror).context("installing wrapper shim")?;
 
     let real_rustc = real
         .join("bin/rustc")
@@ -305,20 +305,28 @@ fn hard_link_tree(src: &Path, dst: &Path) -> Result<()>
         else if ft.is_symlink()
         {
             // Symlinks inside library/ are vanishingly rare in the
-            // shipped rust-src; if one appears, materialise it via
-            // `link_or_copy` (symlink on Unix, copy on Windows). The
-            // important invariant is that the file resolves to the
-            // same bytes — relative-target preservation isn't
-            // necessary for cargo's purposes.
+            // shipped rust-src today but are not formally forbidden.
+            // Files inside library/ MUST NOT appear as symlinks to
+            // upstream (cargo canonicalises source paths and would
+            // bypass the overlay) so we resolve and physically copy
+            // the linked content into the mirror — the same
+            // invariant the regular-file branch enforces. Hard-link
+            // is the natural choice but the symlink target may live
+            // on a different filesystem; fall through to copy if so.
             if dst_path.symlink_metadata().is_err()
             {
-                link_or_copy(&path, &dst_path).with_context(|| {
-                    format!(
-                        "materialising library/ symlink {} -> {}",
-                        dst_path.display(),
-                        path.display(),
-                    )
-                })?;
+                let target = fs::canonicalize(&path)
+                    .with_context(|| format!("resolving library/ symlink {}", path.display()))?;
+                if fs::hard_link(&target, &dst_path).is_err()
+                {
+                    fs::copy(&target, &dst_path).with_context(|| {
+                        format!(
+                            "copying library/ symlink target {} -> {}",
+                            target.display(),
+                            dst_path.display()
+                        )
+                    })?;
+                }
             }
         }
         else
@@ -492,10 +500,10 @@ const WRAPPER_NAMES: &[&str] = &["rustc", "ws-clippy"];
 /// works on every host with a native executable format. Wrapper
 /// behavior is parameterised via the `SERAPH_SHIM_*` env vars that
 /// `SeraphToolchain::apply_env` sets before invoking cargo.
-fn install_wrappers(ctx: &BuildContext, real: &Path, mirror: &Path) -> Result<()>
+fn install_wrappers(ctx: &BuildContext, mirror: &Path) -> Result<()>
 {
     let bin_dir = mirror.join("bin");
-    materialise_bin_dir(real, &bin_dir).context("materialising mirror bin/")?;
+    materialise_bin_dir(&bin_dir).context("materialising mirror bin/")?;
 
     let shim_binary = build_shim_binary(ctx)?;
     for &name in WRAPPER_NAMES
@@ -541,7 +549,8 @@ fn install_name_for(name: &str) -> String
 /// to the produced binary. cargo is a no-op when nothing changed.
 fn build_shim_binary(ctx: &BuildContext) -> Result<PathBuf>
 {
-    let mut cmd = Command::new("cargo");
+    let cargo = require_tool("cargo")?;
+    let mut cmd = Command::new(cargo);
     cmd.current_dir(&ctx.root)
         .arg("build")
         .arg("--release")
@@ -564,12 +573,12 @@ fn build_shim_binary(ctx: &BuildContext) -> Result<PathBuf>
     Ok(binary)
 }
 
-/// If `bin_dir` is currently a symlink to `real/bin/`, replace it
-/// with a real directory and populate it with mirror entries for
-/// every binary in `real/bin/` (so cargo's `rustc --print sysroot`
-/// path-resolution still finds the rest of the toolchain). If
-/// already a real directory, leave it alone.
-fn materialise_bin_dir(real: &Path, bin_dir: &Path) -> Result<()>
+/// If `bin_dir` is currently a symlink to the real toolchain's
+/// `bin/`, replace it with a real directory and populate it with
+/// mirror entries for every binary in the real `bin/` (so cargo's
+/// `rustc --print sysroot` path-resolution still finds the rest of
+/// the toolchain). If already a real directory, leave it alone.
+fn materialise_bin_dir(bin_dir: &Path) -> Result<()>
 {
     let is_symlink = bin_dir
         .symlink_metadata()
@@ -602,9 +611,6 @@ fn materialise_bin_dir(real: &Path, bin_dir: &Path) -> Result<()>
             )
         })?;
     }
-    // The real_bin path is needed only for the canonicalise+read_dir
-    // walk; nothing else references it after this function returns.
-    let _ = real;
     Ok(())
 }
 

--- a/xtask/src/rust_src.rs
+++ b/xtask/src/rust_src.rs
@@ -20,15 +20,23 @@
 //!      src/sys/`), which is a physical copy.
 //!   2. Apply the seraph overlay to the physical-copy subtree — no
 //!      upstream rust-src is touched.
-//!   3. Install a `bin/rustc` wrapper script at
-//!      `target/seraph-toolchain/bin/rustc` that execs the real rustc
-//!      with `--sysroot=<our path>` prepended, so every rustc invocation
-//!      (including `rustc --print sysroot` which cargo uses internally)
-//!      reports and uses our sysroot.
-//!   4. Callers set `RUSTC=<wrapper path>` when invoking cargo — cargo
-//!      picks up the wrapper via standard RUSTC env-var handling. No
-//!      rustup-level state is modified; `target/seraph-toolchain/` is a
-//!      pure build artifact under `target/`.
+//!   3. Install the `seraph-wrapper-shim` native binary at
+//!      `target/seraph-toolchain/bin/rustc` (and the same binary again
+//!      as `bin/ws-clippy`). The shim dispatches on argv[0] basename,
+//!      reads its config from `SERAPH_SHIM_*` env vars set by the
+//!      caller, and execs the real rustc / clippy-driver with the
+//!      right flags so every rustc invocation (including `rustc
+//!      --print sysroot` which cargo uses internally) reports and
+//!      uses our sysroot. The shim replaces the previous `#!/bin/sh`
+//!      wrappers — a native binary works on every host without
+//!      shebang interpretation, POSIX shell, or chmod.
+//!   4. Callers route `cargo build` / `cargo clippy` through the
+//!      mirror by calling `SeraphToolchain::apply_env(&mut cmd)`,
+//!      which sets `RUSTC`, `RUSTC_WORKSPACE_WRAPPER`, the three
+//!      `SERAPH_SHIM_*` config vars, and `RUSTC_BOOTSTRAP=1` in one
+//!      go. No rustup-level state is modified;
+//!      `target/seraph-toolchain/` is a pure build artifact under
+//!      `target/`.
 //!
 //! # Invariants
 //!
@@ -53,14 +61,14 @@
 //! the shared inode with the real toolchain is never mutated.
 
 use std::fs;
-use std::os::unix::fs::{PermissionsExt, symlink};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::{Context, Result, bail};
 
 use crate::context::Context as BuildContext;
-use crate::util::step;
+use crate::fs_compat::link_or_copy;
+use crate::util::{run_cmd, step};
 
 /// Substring placed in every patched source file for idempotency
 /// detection. Single marker per file suffices; atomic-per-file edits.
@@ -75,22 +83,46 @@ const VERSION_STAMP: &str = ".seraph-toolchain-stamp";
 
 // ── Public entry point ────────────────────────────────────────────────────────
 
-/// Wrapper paths callers set into cargo's environment for StdUser builds.
+/// Paths and shim config callers route their cargo invocations
+/// through for StdUser builds.
 ///
-/// Both live under `target/seraph-toolchain/bin/`. `rustc` is used by cargo
-/// build and cargo clippy alike (via `RUSTC=`) so `-Z build-std` reads the
-/// overlaid sysroot. `ws_clippy` is used only for cargo clippy (via
-/// `RUSTC_WORKSPACE_WRAPPER=`) to override clippy-driver's baked-in rustup
-/// toolchain — see the wrapper script for detail.
+/// `rustc` and `ws_clippy` point at the installed shim under
+/// `target/seraph-toolchain/bin/` (the same binary, installed under
+/// two names, dispatched by argv[0] basename). `real_rustc`,
+/// `real_clippy`, and `mirror_sysroot` are the absolute paths the
+/// shim needs to do its job — exposed here so `apply_env` can wire
+/// them into cargo's environment.
 pub struct SeraphToolchain
 {
     pub rustc: PathBuf,
     pub ws_clippy: PathBuf,
+    real_rustc: PathBuf,
+    real_clippy: PathBuf,
+    mirror_sysroot: PathBuf,
 }
 
-/// Ensure the seraph sysroot mirror exists under `target/` with overlays
-/// applied, and return the paths to the `bin/rustc` + `bin/ws-clippy`
-/// wrappers cargo should use for StdUser builds.
+impl SeraphToolchain
+{
+    /// Set every env var the shim and cargo need to route a StdUser
+    /// build through the seraph toolchain mirror: `RUSTC` and
+    /// `RUSTC_WORKSPACE_WRAPPER` (mirror entry points), the three
+    /// `SERAPH_SHIM_*` config vars (so the shim knows what to exec),
+    /// and `RUSTC_BOOTSTRAP=1` (so the StdUser builds can use
+    /// `restricted_std` and `rustc_private`).
+    pub fn apply_env(&self, cmd: &mut Command)
+    {
+        cmd.env("RUSTC", &self.rustc);
+        cmd.env("RUSTC_WORKSPACE_WRAPPER", &self.ws_clippy);
+        cmd.env("SERAPH_SHIM_REAL_RUSTC", &self.real_rustc);
+        cmd.env("SERAPH_SHIM_REAL_CLIPPY", &self.real_clippy);
+        cmd.env("SERAPH_SHIM_MIRROR_SYSROOT", &self.mirror_sysroot);
+        cmd.env("RUSTC_BOOTSTRAP", "1");
+    }
+}
+
+/// Ensure the seraph sysroot mirror exists under `target/` with
+/// overlays applied and the wrapper shim installed, and return the
+/// `SeraphToolchain` callers route their cargo invocations through.
 pub fn ensure_seraph_toolchain(ctx: &BuildContext) -> Result<SeraphToolchain>
 {
     let real = probe_real_sysroot().context("locating real rustc sysroot")?;
@@ -118,12 +150,34 @@ pub fn ensure_seraph_toolchain(ctx: &BuildContext) -> Result<SeraphToolchain>
     ensure_mirror(&real, &mirror, &overlay_root, &ctx.root)
         .context("assembling seraph-toolchain mirror")?;
     apply_all_overlays(&mirror, &overlay_root).context("applying seraph overlays")?;
-    install_rustc_wrapper(&real, &mirror).context("installing rustc wrapper")?;
-    install_ws_clippy_wrapper(&real, &mirror).context("installing ws-clippy wrapper")?;
+    let real_clippy = real.join("bin/clippy-driver");
+    if !real_clippy.exists()
+    {
+        bail!(
+            "clippy-driver not found at {}; add \"clippy\" to components \
+             in rust-toolchain.toml or run `rustup component add clippy`",
+            real_clippy.display()
+        );
+    }
+    install_wrappers(ctx, &real, &mirror).context("installing wrapper shim")?;
+
+    let real_rustc = real
+        .join("bin/rustc")
+        .canonicalize()
+        .context("canonicalising real rustc")?;
+    let real_clippy = real_clippy
+        .canonicalize()
+        .context("canonicalising real clippy-driver")?;
+    let mirror_sysroot = mirror
+        .canonicalize()
+        .context("canonicalising seraph mirror")?;
 
     Ok(SeraphToolchain {
         rustc: mirror.join("bin/rustc"),
         ws_clippy: mirror.join("bin/ws-clippy"),
+        real_rustc,
+        real_clippy,
+        mirror_sysroot,
     })
 }
 
@@ -201,8 +255,10 @@ fn ensure_mirror(real: &Path, mirror: &Path, overlay_root: &Path, project_root: 
 }
 
 /// For every direct-child entry in `real` whose name differs from
-/// `skip`, create a symlink in `mirror` pointing at the real entry.
-/// Idempotent: entries already present are left alone.
+/// `skip`, materialise it in `mirror` via the cheapest mechanism the
+/// host supports (symlink on Unix/macOS, falls back to hard-link or
+/// copy on Windows via `fs_compat::link_or_copy`). Idempotent:
+/// entries already present are left alone.
 fn symlink_siblings_except(real: &Path, mirror: &Path, skip: &str) -> Result<()>
 {
     for entry in fs::read_dir(real).with_context(|| format!("reading {}", real.display()))?
@@ -218,8 +274,12 @@ fn symlink_siblings_except(real: &Path, mirror: &Path, skip: &str) -> Result<()>
         {
             continue;
         }
-        symlink(entry.path(), &dst).with_context(|| {
-            format!("symlinking {} -> {}", dst.display(), entry.path().display())
+        link_or_copy(&entry.path(), &dst).with_context(|| {
+            format!(
+                "materialising {} -> {}",
+                dst.display(),
+                entry.path().display()
+            )
         })?;
     }
     Ok(())
@@ -244,36 +304,73 @@ fn hard_link_tree(src: &Path, dst: &Path) -> Result<()>
         }
         else if ft.is_symlink()
         {
+            // Symlinks inside library/ are vanishingly rare in the
+            // shipped rust-src; if one appears, materialise it via
+            // `link_or_copy` (symlink on Unix, copy on Windows). The
+            // important invariant is that the file resolves to the
+            // same bytes — relative-target preservation isn't
+            // necessary for cargo's purposes.
             if dst_path.symlink_metadata().is_err()
             {
-                let target = fs::read_link(&path)
-                    .with_context(|| format!("reading symlink {}", path.display()))?;
-                symlink(target, &dst_path)
-                    .with_context(|| format!("writing symlink {}", dst_path.display()))?;
+                link_or_copy(&path, &dst_path).with_context(|| {
+                    format!(
+                        "materialising library/ symlink {} -> {}",
+                        dst_path.display(),
+                        path.display(),
+                    )
+                })?;
             }
         }
         else
         {
-            // Hard link the file. If a destination already exists and
-            // shares our inode, skip; otherwise replace to refresh.
-            use std::os::unix::fs::MetadataExt;
-            if let Ok(dst_meta) = dst_path.symlink_metadata()
+            // Hard link the file. If a destination already exists,
+            // see whether we can detect (on Unix) that it already
+            // shares our inode; otherwise replace to refresh. Cargo
+            // canonicalises source paths and bypasses overlays
+            // through symlinks, so files inside library/ MUST be
+            // hard-linked or physically copied — never symlinked.
+            if let Ok(_dst_meta) = dst_path.symlink_metadata()
             {
-                if let Ok(src_meta) = path.symlink_metadata()
-                    && dst_meta.ino() == src_meta.ino()
-                    && dst_meta.dev() == src_meta.dev()
+                if same_inode(&path, &dst_path)
                 {
                     continue;
                 }
                 fs::remove_file(&dst_path)
                     .with_context(|| format!("removing stale {}", dst_path.display()))?;
             }
-            fs::hard_link(&path, &dst_path).with_context(|| {
-                format!("hard linking {} -> {}", path.display(), dst_path.display())
-            })?;
+            // Hard link first (cheap, no copy). On Windows we may
+            // fall back to a physical copy via `link_or_copy` if the
+            // file systems don't support hard links across the
+            // mirror tree — semantically equivalent for cargo.
+            if fs::hard_link(&path, &dst_path).is_err()
+            {
+                fs::copy(&path, &dst_path).with_context(|| {
+                    format!("copying {} -> {}", path.display(), dst_path.display())
+                })?;
+            }
         }
     }
     Ok(())
+}
+
+/// Returns true when `a` and `b` are known to share a hard-link inode
+/// (only computable on Unix; conservatively returns false elsewhere
+/// so the caller does a refresh).
+#[cfg(unix)]
+fn same_inode(a: &Path, b: &Path) -> bool
+{
+    use std::os::unix::fs::MetadataExt;
+    match (a.symlink_metadata(), b.symlink_metadata())
+    {
+        (Ok(ma), Ok(mb)) => ma.ino() == mb.ino() && ma.dev() == mb.dev(),
+        _ => false,
+    }
+}
+
+#[cfg(not(unix))]
+fn same_inode(_a: &Path, _b: &Path) -> bool
+{
+    false
 }
 
 /// Identity string for the mirror. Combines the underlying rustc version
@@ -374,154 +471,140 @@ fn fnv_mix(state: &mut u64, byte: u8)
     *state = state.wrapping_mul(FNV_PRIME);
 }
 
-// ── rustc wrapper ─────────────────────────────────────────────────────────────
+// ── Wrapper-shim installation ────────────────────────────────────────────────
 
-/// Write `mirror/bin/rustc` as a shell wrapper that exec's the real
-/// rustc with `--sysroot=<mirror>` prepended. The wrapper only injects
-/// the flag if the caller didn't already pass `--sysroot` — so cargo's
-/// internal invocations (which don't) pick up our override, while any
-/// caller who manually specifies `--sysroot` retains that choice.
-fn install_rustc_wrapper(real: &Path, mirror: &Path) -> Result<()>
+/// Name of the shim crate inside the workspace. Built once per
+/// `ensure_seraph_toolchain` call; cargo will no-op when nothing
+/// changed.
+const SHIM_PACKAGE: &str = "seraph-wrapper-shim";
+
+/// Wrapper-binary names installed in `mirror/bin/`. The shim
+/// dispatches by argv[0] basename, so both names point at the same
+/// physical binary.
+const WRAPPER_NAMES: &[&str] = &["rustc", "ws-clippy"];
+
+/// Build the `seraph-wrapper-shim` crate once for the host triple
+/// (no-op when nothing changed), then install its binary into
+/// `mirror/bin/` under both wrapper names.
+///
+/// The previous implementation wrote `#!/bin/sh` heredoc scripts and
+/// `chmod +x`'d them — both Unix-only mechanisms. The shim binary
+/// works on every host with a native executable format. Wrapper
+/// behavior is parameterised via the `SERAPH_SHIM_*` env vars that
+/// `SeraphToolchain::apply_env` sets before invoking cargo.
+fn install_wrappers(ctx: &BuildContext, real: &Path, mirror: &Path) -> Result<()>
 {
-    let real_rustc = real.join("bin/rustc");
-    let real_rustc_abs = real_rustc
-        .canonicalize()
-        .with_context(|| format!("canonicalising {}", real_rustc.display()))?;
-    let mirror_abs = mirror
-        .canonicalize()
-        .with_context(|| format!("canonicalising {}", mirror.display()))?;
-
-    let script = format!(
-        "#!/bin/sh\n\
-         # Auto-generated by xtask — see xtask/src/rust_src.rs.\n\
-         # Exec the real rustc with --sysroot pointing at the seraph\n\
-         # toolchain mirror, unless the caller already passed --sysroot.\n\
-         for arg in \"$@\"; do\n\
-         \tcase \"$arg\" in\n\
-         \t\t--sysroot=*|--sysroot) exec \"{real}\" \"$@\" ;;\n\
-         \tesac\n\
-         done\n\
-         exec \"{real}\" --sysroot \"{ours}\" \"$@\"\n",
-        real = real_rustc_abs.display(),
-        ours = mirror_abs.display(),
-    );
-
-    // The mirror's bin/ may be a symlink to real/bin/; replace with a
-    // real directory so we can drop in the wrapper.
     let bin_dir = mirror.join("bin");
-    let is_symlink = bin_dir
-        .symlink_metadata()
-        .map(|m| m.file_type().is_symlink())
-        .unwrap_or(false);
-    if is_symlink
-    {
-        let real_bin = bin_dir
-            .canonicalize()
-            .with_context(|| format!("canonicalising {}", bin_dir.display()))?;
-        fs::remove_file(&bin_dir).with_context(|| format!("removing {}", bin_dir.display()))?;
-        fs::create_dir_all(&bin_dir).with_context(|| format!("creating {}", bin_dir.display()))?;
-        for entry in
-            fs::read_dir(&real_bin).with_context(|| format!("reading {}", real_bin.display()))?
-        {
-            let entry = entry?;
-            let dst = bin_dir.join(entry.file_name());
-            if dst.symlink_metadata().is_err()
-            {
-                symlink(entry.path(), &dst).with_context(|| {
-                    format!("symlinking {} -> {}", dst.display(), entry.path().display())
-                })?;
-            }
-        }
-    }
+    materialise_bin_dir(real, &bin_dir).context("materialising mirror bin/")?;
 
-    let wrapper = bin_dir.join("rustc");
-    if let Ok(current) = fs::read_to_string(&wrapper)
-        && current == script
+    let shim_binary = build_shim_binary(ctx)?;
+    for &name in WRAPPER_NAMES
     {
-        return Ok(());
+        let dst = bin_dir.join(install_name_for(name));
+        if dst.symlink_metadata().is_ok()
+        {
+            fs::remove_file(&dst).with_context(|| format!("removing {}", dst.display()))?;
+        }
+        // Copy outright — hard-linking would let the shim binary's
+        // mode bits / atime tracking diverge across the two install
+        // names, and dir-symlinking is not what we want here.
+        fs::copy(&shim_binary, &dst).with_context(|| {
+            format!(
+                "installing wrapper shim {} -> {}",
+                shim_binary.display(),
+                dst.display()
+            )
+        })?;
     }
-    if wrapper.symlink_metadata().is_ok()
-    {
-        fs::remove_file(&wrapper).with_context(|| format!("removing {}", wrapper.display()))?;
-    }
-    fs::write(&wrapper, &script).with_context(|| format!("writing {}", wrapper.display()))?;
-    let mut perms = fs::metadata(&wrapper)?.permissions();
-    perms.set_mode(0o755);
-    fs::set_permissions(&wrapper, perms)
-        .with_context(|| format!("chmod +x {}", wrapper.display()))?;
     step(&format!(
-        "seraph-toolchain: wrote rustc wrapper {}",
-        wrapper.display()
+        "seraph-toolchain: installed wrapper shim into {}",
+        bin_dir.display()
     ));
     Ok(())
 }
 
-/// Write `mirror/bin/ws-clippy` — a shell wrapper used by StdUser clippy
-/// invocations via `RUSTC_WORKSPACE_WRAPPER=<wrapper>`.
-///
-/// Cargo invokes a workspace wrapper as `<wrapper> <rustc_path> <args>`.
-/// The natural thing is to point it at the real `clippy-driver`, but that
-/// binary has its rustup toolchain baked in via `option_env!("RUSTUP_HOME")`
-/// and friends, so it reports the real sysroot regardless of `RUSTC`.
-/// Copying it into the mirror's `bin/` does not help — those env lookups
-/// are compile-time constants.
-///
-/// The wrapper fixes this by dropping the `<rustc_path>` arg cargo prepends
-/// and re-driving clippy-driver with both `SYSROOT=<mirror>` (env) and
-/// `--sysroot=<mirror>` (arg). clippy-driver checks args first, then env,
-/// then its baked-in values — both overrides are needed together.
-fn install_ws_clippy_wrapper(real: &Path, mirror: &Path) -> Result<()>
+/// Cargo builds shims into `target/release/<name><EXE>`. Encode the
+/// per-host exe suffix here so the path lookup is portable.
+fn install_name_for(name: &str) -> String
 {
-    let real_clippy = real.join("bin/clippy-driver");
-    if !real_clippy.exists()
+    if std::env::consts::EXE_SUFFIX.is_empty()
+    {
+        name.to_owned()
+    }
+    else
+    {
+        format!("{name}{}", std::env::consts::EXE_SUFFIX)
+    }
+}
+
+/// `cargo build --release -p seraph-wrapper-shim`. Returns the path
+/// to the produced binary. cargo is a no-op when nothing changed.
+fn build_shim_binary(ctx: &BuildContext) -> Result<PathBuf>
+{
+    let mut cmd = Command::new("cargo");
+    cmd.current_dir(&ctx.root)
+        .arg("build")
+        .arg("--release")
+        .arg("-p")
+        .arg(SHIM_PACKAGE);
+    run_cmd(&mut cmd).context("building seraph-wrapper-shim")?;
+
+    let mut binary = ctx.target_dir.join("release");
+    binary.push(format!(
+        "{SHIM_PACKAGE}{suffix}",
+        suffix = std::env::consts::EXE_SUFFIX,
+    ));
+    if !binary.is_file()
     {
         bail!(
-            "clippy-driver not found at {}; add \"clippy\" to components \
-             in rust-toolchain.toml or run `rustup component add clippy`",
-            real_clippy.display()
+            "expected seraph-wrapper-shim binary at {} after build",
+            binary.display()
         );
     }
-    let real_clippy_abs = real_clippy
-        .canonicalize()
-        .with_context(|| format!("canonicalising {}", real_clippy.display()))?;
-    let mirror_abs = mirror
-        .canonicalize()
-        .with_context(|| format!("canonicalising {}", mirror.display()))?;
-    let mirror_rustc = mirror_abs.join("bin/rustc");
+    Ok(binary)
+}
 
-    let script = format!(
-        "#!/bin/sh\n\
-         # Auto-generated by xtask — see xtask/src/rust_src.rs.\n\
-         # cargo invokes RUSTC_WORKSPACE_WRAPPER as <wrapper> <rustc_path> <args...>.\n\
-         # clippy-driver bakes in rustup env vars at compile time, so it ignores RUSTC\n\
-         # and reports the real sysroot unless we force both --sysroot= (arg) and\n\
-         # SYSROOT (env). Drop the <rustc_path> arg cargo prepends and re-drive.\n\
-         shift\n\
-         SYSROOT=\"{mirror}\" exec \"{clippy}\" \"{rustc}\" --sysroot=\"{mirror}\" \"$@\"\n",
-        mirror = mirror_abs.display(),
-        clippy = real_clippy_abs.display(),
-        rustc = mirror_rustc.display(),
-    );
-
-    let wrapper = mirror.join("bin/ws-clippy");
-    if let Ok(current) = fs::read_to_string(&wrapper)
-        && current == script
+/// If `bin_dir` is currently a symlink to `real/bin/`, replace it
+/// with a real directory and populate it with mirror entries for
+/// every binary in `real/bin/` (so cargo's `rustc --print sysroot`
+/// path-resolution still finds the rest of the toolchain). If
+/// already a real directory, leave it alone.
+fn materialise_bin_dir(real: &Path, bin_dir: &Path) -> Result<()>
+{
+    let is_symlink = bin_dir
+        .symlink_metadata()
+        .map(|m| m.file_type().is_symlink())
+        .unwrap_or(false);
+    if !is_symlink
     {
         return Ok(());
     }
-    if wrapper.symlink_metadata().is_ok()
+
+    let real_bin = bin_dir
+        .canonicalize()
+        .with_context(|| format!("canonicalising {}", bin_dir.display()))?;
+    fs::remove_file(bin_dir).with_context(|| format!("removing {}", bin_dir.display()))?;
+    fs::create_dir_all(bin_dir).with_context(|| format!("creating {}", bin_dir.display()))?;
+    for entry in
+        fs::read_dir(&real_bin).with_context(|| format!("reading {}", real_bin.display()))?
     {
-        fs::remove_file(&wrapper).with_context(|| format!("removing {}", wrapper.display()))?;
+        let entry = entry?;
+        let dst = bin_dir.join(entry.file_name());
+        if dst.symlink_metadata().is_ok()
+        {
+            continue;
+        }
+        link_or_copy(&entry.path(), &dst).with_context(|| {
+            format!(
+                "materialising {} -> {}",
+                dst.display(),
+                entry.path().display()
+            )
+        })?;
     }
-    fs::write(&wrapper, &script).with_context(|| format!("writing {}", wrapper.display()))?;
-    let mut perms = fs::metadata(&wrapper)?.permissions();
-    perms.set_mode(0o755);
-    fs::set_permissions(&wrapper, perms)
-        .with_context(|| format!("chmod +x {}", wrapper.display()))?;
-    step(&format!(
-        "seraph-toolchain: wrote ws-clippy wrapper {}",
-        wrapper.display()
-    ));
+    // The real_bin path is needed only for the canonicalise+read_dir
+    // walk; nothing else references it after this function returns.
+    let _ = real;
     Ok(())
 }
 

--- a/xtask/src/rust_src.rs
+++ b/xtask/src/rust_src.rs
@@ -347,9 +347,11 @@ fn hard_link_tree(src: &Path, dst: &Path) -> Result<()>
                     .with_context(|| format!("removing stale {}", dst_path.display()))?;
             }
             // Hard link first (cheap, no copy). On Windows we may
-            // fall back to a physical copy via `link_or_copy` if the
-            // file systems don't support hard links across the
-            // mirror tree — semantically equivalent for cargo.
+            // fall back to a physical `fs::copy` if the file systems
+            // don't support hard links across the mirror tree —
+            // semantically equivalent for cargo. Symlinks are
+            // forbidden here per the module's "Why hard-link-mirror
+            // the library/ tree" section.
             if fs::hard_link(&path, &dst_path).is_err()
             {
                 fs::copy(&path, &dst_path).with_context(|| {
@@ -1378,7 +1380,8 @@ fn write_if_changed(src: &Path, dst: &Path, short: &str) -> Result<()>
 
 fn probe_real_sysroot() -> Result<PathBuf>
 {
-    let out = Command::new("rustc")
+    let rustc = require_tool("rustc")?;
+    let out = Command::new(&rustc)
         .args(["--print", "sysroot"])
         .output()
         .context("invoking rustc --print sysroot")?;

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -54,6 +54,44 @@ pub fn run_cmd_capture(cmd: &mut Command) -> Result<String>
 
 // ── Tool discovery ────────────────────────────────────────────────────────────
 
+/// Resolve `name` on PATH, returning a clear error with per-tool
+/// install hints if missing. Use this before `Command::new(name)` for
+/// tools that aren't part of xtask's own dependency chain (qemu,
+/// llvm-objcopy from rustup, etc.) so a missing tool produces an
+/// actionable message instead of the OS's opaque "No such file or
+/// directory" from Command::spawn.
+pub fn require_tool(name: &str) -> Result<PathBuf>
+{
+    which::which(name).map_err(|err| {
+        anyhow::anyhow!(
+            "{name} not found on PATH ({err})\n{hint}",
+            hint = install_hint_for(name),
+        )
+    })
+}
+
+fn install_hint_for(name: &str) -> String
+{
+    match name
+    {
+        "qemu-system-x86_64" => "Install with:\n  \
+            Fedora:           dnf install qemu-system-x86\n  \
+            Debian / Ubuntu:  apt install qemu-system-x86\n  \
+            Arch:             pacman -S qemu-system-x86\n  \
+            macOS (Homebrew): brew install qemu\n  \
+            FreeBSD:          pkg install qemu"
+            .into(),
+        "qemu-system-riscv64" => "Install with:\n  \
+            Fedora:           dnf install qemu-system-riscv\n  \
+            Debian / Ubuntu:  apt install qemu-system-misc\n  \
+            Arch:             pacman -S qemu-system-riscv\n  \
+            macOS (Homebrew): brew install qemu\n  \
+            FreeBSD:          pkg install qemu"
+            .into(),
+        _ => format!("Install {name} via your distribution's package manager."),
+    }
+}
+
 /// Locate `llvm-objcopy` from the active Rust toolchain's `llvm-tools` component.
 ///
 /// Resolves to: `$(rustc --print sysroot)/lib/rustlib/<host-triple>/bin/llvm-objcopy`

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -88,6 +88,10 @@ fn install_hint_for(name: &str) -> String
             macOS (Homebrew): brew install qemu\n  \
             FreeBSD:          pkg install qemu"
             .into(),
+        "cargo" => "Install rustup (https://rustup.rs/); xtask requires the toolchain pinned in \
+             rust-toolchain.toml. This usually means xtask itself was invoked outside a \
+             rustup-managed environment."
+            .into(),
         _ => format!("Install {name} via your distribution's package manager."),
     }
 }

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -88,9 +88,9 @@ fn install_hint_for(name: &str) -> String
             macOS (Homebrew): brew install qemu\n  \
             FreeBSD:          pkg install qemu"
             .into(),
-        "cargo" => "Install rustup (https://rustup.rs/); xtask requires the toolchain pinned in \
-             rust-toolchain.toml. This usually means xtask itself was invoked outside a \
-             rustup-managed environment."
+        "cargo" | "rustc" => "Install rustup (https://rustup.rs/); xtask requires the toolchain \
+             pinned in rust-toolchain.toml. This usually means xtask itself was invoked \
+             outside a rustup-managed environment."
             .into(),
         _ => format!("Install {name} via your distribution's package manager."),
     }
@@ -103,10 +103,11 @@ fn install_hint_for(name: &str) -> String
 /// Returns an error with install instructions if not found.
 pub fn find_llvm_objcopy() -> Result<PathBuf>
 {
-    let sysroot_out = run_cmd_capture(Command::new("rustc").args(["--print", "sysroot"]))?;
+    let rustc = require_tool("rustc")?;
+    let sysroot_out = run_cmd_capture(Command::new(&rustc).args(["--print", "sysroot"]))?;
     let sysroot = sysroot_out.trim();
 
-    let version_out = run_cmd_capture(Command::new("rustc").args(["-vV"]))?;
+    let version_out = run_cmd_capture(Command::new(&rustc).args(["-vV"]))?;
     let host_triple = version_out
         .lines()
         .find_map(|line| line.strip_prefix("host: "))

--- a/xtask/wrapper-shim/Cargo.toml
+++ b/xtask/wrapper-shim/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "seraph-wrapper-shim"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+# Host-target binary. Built once per toolchain mirror by xtask, then
+# installed into target/seraph-toolchain/bin/ as both `rustc` and
+# `ws-clippy`; dispatches on argv[0] basename.
+[[bin]]
+name = "seraph-wrapper-shim"
+path = "src/main.rs"
+test = false
+
+# Zero-dependency by design — the shim is on the hot path of every
+# rustc invocation during StdUser builds. Keep the working set tiny.
+[dependencies]
+
+[lints]
+workspace = true

--- a/xtask/wrapper-shim/Cargo.toml
+++ b/xtask/wrapper-shim/Cargo.toml
@@ -12,9 +12,9 @@ name = "seraph-wrapper-shim"
 path = "src/main.rs"
 test = false
 
-# Zero-dependency by design — the shim is on the hot path of every
-# rustc invocation during StdUser builds. Keep the working set tiny.
-[dependencies]
+# Intentionally no [dependencies] — the shim is on the hot path of
+# every rustc invocation during StdUser builds. Keep the working set
+# tiny (std plus the few syscall sites the dispatch needs).
 
 [lints]
 workspace = true

--- a/xtask/wrapper-shim/README.md
+++ b/xtask/wrapper-shim/README.md
@@ -1,0 +1,83 @@
+# seraph-wrapper-shim
+
+Tiny native binary installed into the seraph toolchain mirror at
+`target/seraph-toolchain/bin/` as both `rustc` and `ws-clippy`.
+Dispatches on argv[0] basename and execs the real rustc or
+clippy-driver with the flags `-Z build-std` needs to read the
+overlaid `std::sys::seraph`.
+
+Replaces the previous `#!/bin/sh` heredoc wrappers that xtask wrote
+in earlier versions of `rust_src.rs`. A native binary works on every
+host with a normal executable format — no shebang interpretation, no
+POSIX shell, no Unix execute-bit semantics. The shim is the last
+piece of the toolchain-mirror assembly that ran into Windows
+portability issues; this crate eliminates them.
+
+## Scope
+
+This crate exists exclusively to back the toolchain mirror. It is
+not a user-facing tool. The user never invokes it directly; xtask
+builds it, copies it, and arranges for cargo to spawn it as part of
+StdUser builds. See
+[`xtask/src/rust_src.rs`](../src/rust_src.rs) for the install
+mechanism and [`xtask/README.md`](../README.md) for how the
+toolchain mirror fits into the wider build flow.
+
+## Behavior
+
+Dispatch is by argv[0] basename:
+
+| Install name | Behavior |
+|---|---|
+| `rustc` | Exec the real rustc with `--sysroot=<mirror>` prepended, unless the caller already supplied `--sysroot`. Lets cargo's internal invocations pick up the overlay while letting an explicit `rustc --sysroot=…` caller bypass. |
+| `ws-clippy` | Cargo invokes `RUSTC_WORKSPACE_WRAPPER` as `<wrapper> <rustc_path> <args...>`. Drop the cargo-prepended `<rustc_path>`, set `SYSROOT=<mirror>` in the env, and re-drive clippy-driver with `<mirror>/bin/rustc` and an explicit `--sysroot=<mirror>` arg. clippy-driver bakes its rustup env vars at compile time, so both the env and the flag are required to override its baked-in sysroot view. |
+
+Unknown install names produce a clear error and exit 2.
+
+On Unix the shim uses `exec(3)` (`std::os::unix::process::CommandExt::exec`)
+to replace the current process — no extra hop, no second wait. On
+Windows it spawns and mirrors the child's exit code.
+
+## Configuration
+
+Three env vars set by xtask before invoking cargo:
+
+| Env var | Purpose |
+|---|---|
+| `SERAPH_SHIM_REAL_RUSTC` | Absolute path to the real rustup rustc binary. |
+| `SERAPH_SHIM_REAL_CLIPPY` | Absolute path to the real rustup clippy-driver binary. |
+| `SERAPH_SHIM_MIRROR_SYSROOT` | Absolute path to the seraph toolchain mirror root. |
+
+xtask is always the root of the process tree for StdUser builds, so
+these env vars propagate naturally to every cargo and rustc spawn
+that descends from it. Any of the three being unset (or empty)
+causes the shim to die with a clear message naming the missing var.
+
+The values are wired into a single cargo `Command` by
+[`SeraphToolchain::apply_env`](../src/rust_src.rs); callers route
+through that helper rather than setting any of these vars directly.
+
+## Dependencies
+
+Intentionally zero. The shim is on the hot path of every rustc
+invocation during StdUser builds; keeping the working set tiny
+(roughly std + the few syscall sites the dispatch needs) means a
+release build is around 400 KiB with no transitive crates.
+
+## Build and install
+
+Built by xtask, not invoked directly:
+
+```sh
+# Triggered automatically as part of any StdUser build:
+cargo xtask build
+
+# Direct build (for inspection or debugging):
+cargo build --release -p seraph-wrapper-shim
+```
+
+The release binary lands at
+`target/release/seraph-wrapper-shim` (with `.exe` on Windows).
+xtask copies it into `target/seraph-toolchain/bin/rustc` and
+`target/seraph-toolchain/bin/ws-clippy` (same physical file, two
+install names, dispatch by argv[0] basename).

--- a/xtask/wrapper-shim/README.md
+++ b/xtask/wrapper-shim/README.md
@@ -1,27 +1,39 @@
 # seraph-wrapper-shim
 
 Tiny native binary installed into the seraph toolchain mirror at
-`target/seraph-toolchain/bin/` as both `rustc` and `ws-clippy`.
-Dispatches on argv[0] basename and execs the real rustc or
-clippy-driver with the flags `-Z build-std` needs to read the
-overlaid `std::sys::seraph`.
+`target/seraph-toolchain/bin/` as both `rustc` and `ws-clippy`, dispatching on
+argv[0] basename to exec the real rustc or clippy-driver with the flags
+`-Z build-std` needs to read the overlaid `std::sys::seraph`.
 
-Replaces the previous `#!/bin/sh` heredoc wrappers that xtask wrote
-in earlier versions of `rust_src.rs`. A native binary works on every
-host with a normal executable format — no shebang interpretation, no
-POSIX shell, no Unix execute-bit semantics. The shim is the last
-piece of the toolchain-mirror assembly that ran into Windows
-portability issues; this crate eliminates them.
+---
+
+## Why
+
+Replaces the previous `#!/bin/sh` heredoc wrappers that xtask wrote in
+earlier versions of `rust_src.rs`. A native binary works on every host
+with a normal executable format — no shebang interpretation, no POSIX
+shell, no Unix execute-bit semantics. The shim is the last piece of the
+toolchain-mirror assembly that ran into Windows portability issues; this
+crate eliminates them.
 
 ## Scope
 
-This crate exists exclusively to back the toolchain mirror. It is
-not a user-facing tool. The user never invokes it directly; xtask
-builds it, copies it, and arranges for cargo to spawn it as part of
-StdUser builds. See
-[`xtask/src/rust_src.rs`](../src/rust_src.rs) for the install
-mechanism and [`xtask/README.md`](../README.md) for how the
-toolchain mirror fits into the wider build flow.
+This crate exists exclusively to back the toolchain mirror. It is not a
+user-facing tool. The user never invokes it directly; xtask builds it,
+copies it, and arranges for cargo to spawn it as part of StdUser builds.
+See [xtask/src/rust_src.rs](../src/rust_src.rs) for the install
+mechanism and [xtask/README.md](../README.md) for how the toolchain
+mirror fits into the wider build flow.
+
+## Source Layout
+
+```
+wrapper-shim/
+├── Cargo.toml      Dep-less host-target binary package.
+├── README.md       This file.
+└── src/
+    └── main.rs     argv[0]-dispatched shim: rustc or ws-clippy mode.
+```
 
 ## Behavior
 
@@ -29,14 +41,15 @@ Dispatch is by argv[0] basename:
 
 | Install name | Behavior |
 |---|---|
-| `rustc` | Exec the real rustc with `--sysroot=<mirror>` prepended, unless the caller already supplied `--sysroot`. Lets cargo's internal invocations pick up the overlay while letting an explicit `rustc --sysroot=…` caller bypass. |
+| `rustc`     | Exec the real rustc with `--sysroot=<mirror>` prepended, unless the caller already supplied `--sysroot`. Lets cargo's internal invocations pick up the overlay while letting an explicit `rustc --sysroot=…` caller bypass. |
 | `ws-clippy` | Cargo invokes `RUSTC_WORKSPACE_WRAPPER` as `<wrapper> <rustc_path> <args...>`. Drop the cargo-prepended `<rustc_path>`, set `SYSROOT=<mirror>` in the env, and re-drive clippy-driver with `<mirror>/bin/rustc` and an explicit `--sysroot=<mirror>` arg. clippy-driver bakes its rustup env vars at compile time, so both the env and the flag are required to override its baked-in sysroot view. |
 
 Unknown install names produce a clear error and exit 2.
 
-On Unix the shim uses `exec(3)` (`std::os::unix::process::CommandExt::exec`)
-to replace the current process — no extra hop, no second wait. On
-Windows it spawns and mirrors the child's exit code.
+On Unix the shim uses `exec(3)`
+(`std::os::unix::process::CommandExt::exec`) to replace the current
+process — no extra hop, no second wait. On Windows it spawns and
+mirrors the child's exit code.
 
 ## Configuration
 
@@ -44,14 +57,14 @@ Three env vars set by xtask before invoking cargo:
 
 | Env var | Purpose |
 |---|---|
-| `SERAPH_SHIM_REAL_RUSTC` | Absolute path to the real rustup rustc binary. |
-| `SERAPH_SHIM_REAL_CLIPPY` | Absolute path to the real rustup clippy-driver binary. |
+| `SERAPH_SHIM_REAL_RUSTC`     | Absolute path to the real rustup rustc binary. |
+| `SERAPH_SHIM_REAL_CLIPPY`    | Absolute path to the real rustup clippy-driver binary. |
 | `SERAPH_SHIM_MIRROR_SYSROOT` | Absolute path to the seraph toolchain mirror root. |
 
 xtask is always the root of the process tree for StdUser builds, so
-these env vars propagate naturally to every cargo and rustc spawn
-that descends from it. Any of the three being unset (or empty)
-causes the shim to die with a clear message naming the missing var.
+these env vars propagate naturally to every cargo and rustc spawn that
+descends from it. Any of the three being unset (or empty) causes the
+shim to die with a clear message naming the missing var.
 
 The values are wired into a single cargo `Command` by
 [`SeraphToolchain::apply_env`](../src/rust_src.rs); callers route
@@ -60,11 +73,11 @@ through that helper rather than setting any of these vars directly.
 ## Dependencies
 
 Intentionally zero. The shim is on the hot path of every rustc
-invocation during StdUser builds; keeping the working set tiny
-(roughly std + the few syscall sites the dispatch needs) means a
-release build is around 400 KiB with no transitive crates.
+invocation during StdUser builds; keeping the working set tiny (roughly
+std plus the few syscall sites the dispatch needs) means a release
+build is around 400 KiB with no transitive crates.
 
-## Build and install
+## Build and Install
 
 Built by xtask, not invoked directly:
 
@@ -76,8 +89,22 @@ cargo xtask build
 cargo build --release -p seraph-wrapper-shim
 ```
 
-The release binary lands at
-`target/release/seraph-wrapper-shim` (with `.exe` on Windows).
-xtask copies it into `target/seraph-toolchain/bin/rustc` and
+The release binary lands at `target/release/seraph-wrapper-shim` (with
+`.exe` on Windows). xtask copies it into
+`target/seraph-toolchain/bin/rustc` and
 `target/seraph-toolchain/bin/ws-clippy` (same physical file, two
 install names, dispatch by argv[0] basename).
+
+## Relevant Design Documents
+
+| Document | Why |
+|---|---|
+| [docs/build-system.md](../../docs/build-system.md) | System-wide build flow and toolchain conventions. |
+| [docs/coding-standards.md](../../docs/coding-standards.md) | Style and safety rules this crate follows. |
+| [xtask/README.md](../README.md) | Build task runner; owns the install mechanism for this crate's binary. |
+
+---
+
+## Summarized By
+
+[xtask/README.md](../README.md)

--- a/xtask/wrapper-shim/src/main.rs
+++ b/xtask/wrapper-shim/src/main.rs
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+//! seraph-wrapper-shim
+//!
+//! Tiny native binary installed into the seraph toolchain mirror as
+//! both `rustc` and `ws-clippy`. Replaces the previous `#!/bin/sh`
+//! wrapper scripts so the toolchain mirror works on every host with a
+//! native executable format — no shebang interpretation, no POSIX
+//! shell, no Unix permission bits beyond what the file system already
+//! gives a compiled binary.
+//!
+//! Dispatches on argv[0] basename:
+//!
+//! - **`rustc`**: exec the real rustc with `--sysroot=<mirror>`
+//!   prepended, unless the caller already supplied `--sysroot`. This
+//!   makes cargo's internal invocations (which never supply
+//!   `--sysroot`) pick up the overlaid mirror, while letting an
+//!   explicit `rustc --sysroot=…` caller bypass.
+//!
+//! - **`ws-clippy`**: cargo invokes `RUSTC_WORKSPACE_WRAPPER` as
+//!   `<wrapper> <rustc_path> <args...>`. Drop the cargo-prepended
+//!   rustc_path, set `SYSROOT=<mirror>` in the env, and re-drive
+//!   `clippy-driver` with both `<mirror>/bin/rustc` and an explicit
+//!   `--sysroot=<mirror>` arg. clippy-driver bakes its rustup env
+//!   vars at compile time, so both the env var and the flag are
+//!   required to override its baked-in sysroot view.
+//!
+//! Configuration is read from three env vars set by xtask before it
+//! invokes cargo. xtask is always the root of the process tree, so
+//! the vars propagate naturally to every child cargo and rustc
+//! spawn:
+//!
+//! - `SERAPH_SHIM_REAL_RUSTC` — absolute path to the real rustup
+//!   rustc binary.
+//! - `SERAPH_SHIM_REAL_CLIPPY` — absolute path to the real rustup
+//!   clippy-driver binary.
+//! - `SERAPH_SHIM_MIRROR_SYSROOT` — absolute path to the seraph
+//!   toolchain mirror's root.
+
+use std::env;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::{Command, exit};
+
+/// Env var: absolute path to the real rustup rustc binary.
+const ENV_REAL_RUSTC: &str = "SERAPH_SHIM_REAL_RUSTC";
+
+/// Env var: absolute path to the real rustup clippy-driver binary.
+const ENV_REAL_CLIPPY: &str = "SERAPH_SHIM_REAL_CLIPPY";
+
+/// Env var: absolute path to the seraph toolchain mirror root.
+const ENV_MIRROR_SYSROOT: &str = "SERAPH_SHIM_MIRROR_SYSROOT";
+
+fn main() -> !
+{
+    let mut argv = env::args_os();
+    let argv0 = match argv.next()
+    {
+        Some(a) => a,
+        None => die("argv[0] missing (impossible per POSIX/Windows)"),
+    };
+    let argv_rest: Vec<OsString> = argv.collect();
+
+    let basename = Path::new(&argv0)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or_default();
+
+    match basename
+    {
+        "rustc" => exec_rustc(argv_rest),
+        "ws-clippy" => exec_ws_clippy(argv_rest),
+        other => die(&format!(
+            "seraph-wrapper-shim: unknown install name {other:?} \
+             (expected 'rustc' or 'ws-clippy')"
+        )),
+    }
+}
+
+/// Exec the real rustc with `--sysroot=<mirror>` prepended unless the
+/// caller already supplied `--sysroot`. Never returns on success.
+fn exec_rustc(args: Vec<OsString>) -> !
+{
+    let real = required_env_path(ENV_REAL_RUSTC);
+    let mirror = required_env_path(ENV_MIRROR_SYSROOT);
+
+    let has_sysroot = args.iter().any(|a| {
+        let bytes = a.as_encoded_bytes();
+        bytes == b"--sysroot" || bytes.starts_with(b"--sysroot=")
+    });
+
+    let mut cmd = Command::new(&real);
+    if !has_sysroot
+    {
+        cmd.arg("--sysroot").arg(&mirror);
+    }
+    cmd.args(args);
+    run_or_exec(cmd, "rustc")
+}
+
+/// Drop cargo's prepended rustc_path arg and re-drive clippy-driver
+/// with both `SYSROOT` env and `--sysroot=` flag pointing at the
+/// seraph mirror. Never returns on success.
+fn exec_ws_clippy(mut args: Vec<OsString>) -> !
+{
+    let real_clippy = required_env_path(ENV_REAL_CLIPPY);
+    let mirror = required_env_path(ENV_MIRROR_SYSROOT);
+
+    if args.is_empty()
+    {
+        die(
+            "ws-clippy: expected at least one arg (rustc_path injected by cargo's \
+             RUSTC_WORKSPACE_WRAPPER)",
+        );
+    }
+    args.remove(0);
+
+    let mirror_rustc = mirror.join("bin").join("rustc");
+    let sysroot_arg = format!("--sysroot={}", mirror.display());
+
+    let mut cmd = Command::new(&real_clippy);
+    cmd.env("SYSROOT", &mirror);
+    cmd.arg(&mirror_rustc);
+    cmd.arg(&sysroot_arg);
+    cmd.args(args);
+    run_or_exec(cmd, "clippy-driver")
+}
+
+/// Read a required env var and return it as a `PathBuf`. Dies with
+/// a clear message naming the missing var if unset.
+fn required_env_path(name: &str) -> PathBuf
+{
+    match env::var_os(name)
+    {
+        Some(v) if !v.is_empty() => PathBuf::from(v),
+        _ => die(&format!(
+            "seraph-wrapper-shim: required env var {name} is not set \
+             (xtask should set this before invoking cargo)"
+        )),
+    }
+}
+
+/// Replace the current process with `cmd` on Unix (`exec(3)`) or
+/// spawn-and-mirror-exit-code on Windows.
+#[cfg(unix)]
+fn run_or_exec(mut cmd: Command, label: &str) -> !
+{
+    use std::os::unix::process::CommandExt;
+    let err = cmd.exec();
+    die(&format!("seraph-wrapper-shim: exec {label} failed: {err}"));
+}
+
+#[cfg(not(unix))]
+fn run_or_exec(mut cmd: Command, label: &str) -> !
+{
+    match cmd.status()
+    {
+        Ok(s) => exit(s.code().unwrap_or(2)),
+        Err(e) => die(&format!("seraph-wrapper-shim: spawn {label} failed: {e}")),
+    }
+}
+
+fn die(msg: &str) -> !
+{
+    eprintln!("{msg}");
+    exit(2);
+}


### PR DESCRIPTION
## Summary

Replaces the last Unix-only mechanisms in xtask's toolchain-mirror
assembly with portable Rust-native equivalents. After this PR every
piece of xtask compiles cleanly on Unix, macOS, BSD, and Windows
without shell scripts, `chmod`, or `std::os::unix::*` outside narrow
\`cfg(unix)\`-gated implementation modules.

| Layer | Was | Now |
|---|---|---|
| Mirror assembly symlinks | \`std::os::unix::fs::symlink\` at 4 call sites in \`rust_src.rs\` | \`fs_compat::link_or_copy\` — symlink → hard link → copy fallback chain, returns the kind that succeeded |
| Wrapper scripts | \`#!/bin/sh\` heredocs written + \`chmod +x\` | \`seraph-wrapper-shim\` native binary (new workspace member, zero deps), installed as both \`rustc\` and \`ws-clippy\`, dispatches by argv[0] basename |
| Env wiring | piecewise \`cmd.env(\"RUSTC\", ...)\` at 2 call sites | \`SeraphToolchain::apply_env(&mut Command)\` — sets RUSTC, RUSTC_WORKSPACE_WRAPPER, SERAPH_SHIM_*, RUSTC_BOOTSTRAP in one call |
| Missing-tool errors | \`Command::spawn\` opaque \"No such file or directory\" | \`util::require_tool\` (via \`which\` crate) — names the tool and lists install commands per platform |

## Why

This was the third and final PR of the xtask portability refactor.
The previous two PRs (#80 terminal I/O, #81 firmware/accel) made
everything except the toolchain mirror portable. The mirror still
relied on:

- Unix-specific \`std::os::unix::fs::symlink\` for the directory tree
  that mirrors the real rustup toolchain.
- \`#!/bin/sh\` shebang-interpreted wrapper scripts at \`bin/rustc\` and
  \`bin/ws-clippy\` — no equivalent on Windows.
- Unix-only \`set_mode(0o755)\` to make the scripts executable —
  Windows doesn't have a separate execute bit.

After this PR, mirror assembly works on every host. On Windows
without developer mode, dir-symlink falls back to recursive copy
(slower but functionally identical). The shim binary is a normal
native executable that needs no special privileges to run.

## The shim binary

Lives in \`xtask/wrapper-shim/\`. Zero external dependencies. Reads
configuration from three env vars at startup:

- \`SERAPH_SHIM_REAL_RUSTC\` — absolute path to rustup's rustc
- \`SERAPH_SHIM_REAL_CLIPPY\` — absolute path to rustup's clippy-driver
- \`SERAPH_SHIM_MIRROR_SYSROOT\` — absolute path to the seraph mirror

Dispatches on argv[0] basename:

- **rustc**: exec real rustc with \`--sysroot=<mirror>\` prepended,
  unless caller already supplied \`--sysroot\`.
- **ws-clippy**: cargo invokes \`<wrapper> <rustc_path> <args...>\`;
  drop the rustc_path, set \`SYSROOT\` env, re-drive clippy-driver
  with \`<mirror>/bin/rustc\` and \`--sysroot=<mirror>\`.

On Unix uses \`exec(3)\` to replace the current process; on Windows
spawns and mirrors the exit code. xtask is always the root of the
process tree, so env vars set on xtask's cargo invocation propagate
to the shim child.

## Dependency changes

Added: \`which = \"8\"\`. Wraps the cross-platform PATH lookup so missing
host tools surface clear errors.

The shim crate is dep-less: a normal release build of
\`seraph-wrapper-shim\` produces a ~400 KiB binary with no transitive
crates beyond \`std\`.

## Test plan

- [x] \`cargo xtask test\` — 61 xtask tests pass (4 new \`fs_compat\`).
      Coverage: file copy, recursive directory copy, missing-source
      error, deep nested copy.
- [x] \`cargo xtask clean --all && cargo xtask build && cargo xtask
      run --headless\` on x86_64 — full from-scratch build exercises
      shim crate build, mirror assembly via link_or_copy, shim
      install, SERAPH_SHIM_* env wiring, end-to-end \`ALL TESTS
      PASSED\`.
- [x] Same flow on riscv64.
- [x] \`cargo xtask run-parallel --parallel 2 --runs 2\` — 2/2 PASS
      with the require_tool resolution at startup.
- [x] \`PATH=/tmp /path/to/xtask run\` — confirms the
      \`require_tool\` clean error path: \"qemu-system-x86_64 not
      found on PATH ... Install with: dnf install qemu-system-x86
      ...\".

## By-design unverified

- macOS / Windows / BSD link_or_copy fallback chain (works in
  principle; CI is Linux only).
- The shim's Windows code path (CommandExt::spawn-and-mirror vs the
  Unix exec(3) replacement).
- Windows-without-developer-mode dir-symlink → recursive copy fallback.

The cfg-gated code paths compile cleanly on a Linux host; runtime
behavior on the other hosts is on the next person who runs xtask
there to confirm.