### PR TITLE
fs-fat: read-write support (closes #6 + #7)

### DIFF
--- a/base/usertest/src/main.rs
+++ b/base/usertest/src/main.rs
@@ -138,6 +138,7 @@ fn main()
     fs_rename_phase();
     fs_write_frame_phase();
     fs_write_cache_coherence_phase();
+    fs_write_invariants_phase();
     ns_multi_component_phase();
     ns_sandbox_phase();
     ns_fallthrough_attenuation_phase();
@@ -1438,6 +1439,197 @@ fn fs_write_cache_coherence_phase()
     fs_remove(usertest, name, ipc_buf).expect("cleanup coh");
     let _ = syscall::cap_delete(usertest);
     std::os::seraph::log!("fs_write_cache_coherence phase passed");
+}
+
+/// Regression coverage for three correctness bugs surfaced during the
+/// fs-fat write-support PR audit:
+///
+/// 1. `FS_CREATE` / `FS_MKDIR` MUST NOT promote rights on the returned
+///    child cap beyond the caller's parent rights. Creating from a
+///    `MUTATE_DIR`-only parent must yield a child cap that rejects
+///    `FS_WRITE` with `PERMISSION_DENIED`.
+/// 2. `NodeTable` MUST NOT alias distinct empty files to the same
+///    `NodeId`. Writing through one freshly-created empty-file cap
+///    must not affect a sibling empty-file cap created moments
+///    earlier.
+/// 3. Extending a file past its current EOC MUST NOT corrupt the
+///    existing FAT chain. Writing one byte at `offset = 2 *
+///    cluster_size` after a 2-cluster initial write must leave bytes
+///    `[cluster_size, 2 * cluster_size)` readable as originally
+///    written.
+#[allow(clippy::too_many_lines)]
+fn fs_write_invariants_phase()
+{
+    use namespace_protocol::rights;
+
+    /// Cluster size on the xtask-formatted test image: 8 sectors × 512 B.
+    const CLUSTER: usize = 4096;
+    /// `FS_WRITE` / `FS_READ` inline payloads cap at 504 B.
+    const INLINE_CHUNK: usize = 504;
+
+    let info = startup_info();
+    #[allow(clippy::cast_ptr_alignment)]
+    let ipc_buf = info.ipc_buffer.cast::<u64>();
+
+    // ── (1) rights attenuation on FS_CREATE child cap ──────────────
+    {
+        let usertest_full = usertest_dir_cap(ipc_buf);
+        let scratch_name: &[u8] = b"inv_rights.bin";
+        let _ = fs_remove(usertest_full, scratch_name, ipc_buf);
+
+        // Re-LOOKUP usertest with MUTATE_DIR | LOOKUP only — no READ,
+        // no WRITE. (LOOKUP is required to walk into the dir; STAT is
+        // omitted by design so we can prove the child cannot widen.)
+        let root = std::os::seraph::root_dir_cap();
+        let restricted_rights = u64::from(rights::LOOKUP | rights::MUTATE_DIR);
+        let (parent_attenuated, _, _) = ns_lookup(root, b"usertest", restricted_rights, ipc_buf)
+            .expect("ns_lookup usertest attenuated");
+
+        let (child_cap, _) = fs_create(parent_attenuated, scratch_name, ipc_buf)
+            .expect("FS_CREATE through attenuated parent should succeed");
+
+        // FS_WRITE on the returned cap must be rejected — child rights
+        // = parent ∩ kind_max = {LOOKUP, MUTATE_DIR} ∩ {STAT, READ,
+        // WRITE, EXEC} = {} (since LOOKUP is bit 0 and STAT/READ are
+        // disjoint). The write attempt hits the gate before fatfs
+        // touches the FAT.
+        let write_err = fs_write_inline(child_cap, 0, b"x", ipc_buf)
+            .expect_err("FS_WRITE on rights-attenuated child cap must reject");
+        assert_eq!(
+            write_err,
+            ipc::fs_errors::PERMISSION_DENIED,
+            "expected PERMISSION_DENIED; got {write_err}"
+        );
+
+        let _ = syscall::cap_delete(child_cap);
+        let _ = syscall::cap_delete(parent_attenuated);
+        let _ = fs_remove(usertest_full, scratch_name, ipc_buf);
+        let _ = syscall::cap_delete(usertest_full);
+        std::os::seraph::log!("fs_write_invariants: rights attenuation ok");
+    }
+
+    // ── (2) NodeTable dedupe must not alias distinct empty files ───
+    {
+        let usertest = usertest_dir_cap(ipc_buf);
+        let a: &[u8] = b"inv_aa.bin";
+        let b: &[u8] = b"inv_bb.bin";
+        let _ = fs_remove(usertest, a, ipc_buf);
+        let _ = fs_remove(usertest, b, ipc_buf);
+
+        let (cap_a, _) = fs_create(usertest, a, ipc_buf).expect("create inv_aa");
+        let (cap_b, _) = fs_create(usertest, b, ipc_buf).expect("create inv_bb");
+
+        // Write to A; B must remain empty.
+        fs_write_inline(cap_a, 0, b"AAAA", ipc_buf).expect("write to inv_aa");
+
+        // Re-LOOKUP B and read 8 bytes; with the old dedupe-on-(cluster,
+        // kind, size) bug B aliased A and would return "AAAA".
+        let _ = syscall::cap_delete(cap_b);
+        let (cap_b_fresh, _, b_size) =
+            ns_lookup(usertest, b, 0xFFFF, ipc_buf).expect("lookup inv_bb");
+        assert_eq!(b_size, 0, "inv_bb was aliased to inv_aa's storage");
+
+        // Tolerate either an empty read (size=0) or a short reply.
+        let r = fs_read_bytes(cap_b_fresh, 0, 8, ipc_buf).unwrap_or_default();
+        assert!(
+            r.is_empty() || r.iter().all(|&x| x == 0),
+            "inv_bb returned non-zero bytes after sibling write: {r:?}"
+        );
+
+        let _ = syscall::cap_delete(cap_a);
+        let _ = syscall::cap_delete(cap_b_fresh);
+        let _ = fs_remove(usertest, a, ipc_buf);
+        let _ = fs_remove(usertest, b, ipc_buf);
+        let _ = syscall::cap_delete(usertest);
+        std::os::seraph::log!("fs_write_invariants: empty-file dedupe ok");
+    }
+
+    // ── (3) FAT chain past EOC must not corrupt prior cluster ──────
+    //
+    // Cluster size on the test fixture is 8 sectors × 512 B = 4 KiB.
+    // Step a: write 8 KiB at offset 0 (occupies clusters X→Y, size
+    //         8 KiB).
+    // Step b: write 8 B at offset 16 KiB (target_cluster_idx = 4,
+    //         walks past EOC three times). The broken offset-walk
+    //         loop linked the first allocation behind X (overwriting
+    //         X→Y with X→Z) and orphaned Y.
+    // Step c: read 4 KiB from offset 4 KiB; with the bug this would
+    //         walk X→Z (the new cluster) and return the wrong bytes.
+    {
+        let usertest = usertest_dir_cap(ipc_buf);
+        let name: &[u8] = b"inv_chain.bin";
+        let _ = fs_remove(usertest, name, ipc_buf);
+
+        let (cap, _) = fs_create(usertest, name, ipc_buf).expect("create inv_chain");
+
+        // Inline FS_WRITE caps payload at 504 B; one cluster needs
+        // multiple inline calls. Each call uses the in-loop
+        // chain-advance path (known-good); only the cross-cluster
+        // calls exercise the EOC walk.
+        let pattern_a = vec![0xA5u8; CLUSTER];
+        let pattern_b = vec![0x5Au8; CLUSTER];
+        let write_pattern = |cap: u32, base: usize, src: &[u8]| {
+            let mut written = 0usize;
+            while written < src.len()
+            {
+                let n = (src.len() - written).min(INLINE_CHUNK);
+                fs_write_inline(
+                    cap,
+                    (base + written) as u64,
+                    &src[written..written + n],
+                    ipc_buf,
+                )
+                .expect("inline write chunk");
+                written += n;
+            }
+        };
+        write_pattern(cap, 0, &pattern_a);
+        write_pattern(cap, CLUSTER, &pattern_b);
+
+        // Re-LOOKUP so the cap reflects the post-write metadata.
+        let _ = syscall::cap_delete(cap);
+        let (cap, _, size) = ns_lookup(usertest, name, 0xFFFF, ipc_buf).expect("lookup inv_chain");
+        assert_eq!(size, 2 * CLUSTER as u64, "expected 8 KiB after AB writes");
+
+        // Step b: one-byte append past EOC. Exercises the
+        // offset-walk loop's allocate-on-EOC path.
+        fs_write_inline(cap, (4 * CLUSTER) as u64, b"Z", ipc_buf).expect("write Z past EOC");
+
+        // Re-LOOKUP again for consistency.
+        let _ = syscall::cap_delete(cap);
+        let (cap, _, _) = ns_lookup(usertest, name, 0xFFFF, ipc_buf).expect("lookup inv_chain 2");
+
+        // Step c: read back pattern B from offset 4 KiB. With the
+        // broken loop, the FAT chain X→Y was rewritten to X→Znew,
+        // and the read would return the fresh cluster's contents
+        // instead of pattern B. FS_READ inline tops out at 504 B,
+        // so we sample rather than asking for the whole cluster in
+        // one call.
+        let got_b = fs_read_bytes(cap, CLUSTER as u64, INLINE_CHUNK as u64, ipc_buf)
+            .expect("read pattern B");
+        assert_eq!(
+            got_b.len(),
+            INLINE_CHUNK,
+            "short read at offset {CLUSTER} (chain corruption?)"
+        );
+        assert!(
+            got_b.iter().all(|&b| b == 0x5A),
+            "pattern B corrupted at offset {CLUSTER} — FAT chain rewritten"
+        );
+
+        // Sample pattern A and the trailing byte.
+        let got_a = fs_read_bytes(cap, 0, INLINE_CHUNK as u64, ipc_buf).expect("read pattern A");
+        assert!(got_a.iter().all(|&b| b == 0xA5), "pattern A corrupted");
+        let got_z = fs_read_bytes(cap, (4 * CLUSTER) as u64, 1, ipc_buf).expect("read Z");
+        assert_eq!(got_z.first().copied(), Some(b'Z'));
+
+        let _ = syscall::cap_delete(cap);
+        let _ = fs_remove(usertest, name, ipc_buf);
+        let _ = syscall::cap_delete(usertest);
+        std::os::seraph::log!("fs_write_invariants: FAT chain past EOC ok");
+    }
+
+    std::os::seraph::log!("fs_write_invariants phase passed");
 }
 
 /// Exercise vfsd's tree-shaped synthetic root: a multi-component

--- a/base/usertest/src/main.rs
+++ b/base/usertest/src/main.rs
@@ -1519,24 +1519,40 @@ fn fs_write_invariants_phase()
         let (cap_a, _) = fs_create(usertest, a, ipc_buf).expect("create inv_aa");
         let (cap_b, _) = fs_create(usertest, b, ipc_buf).expect("create inv_bb");
 
-        // Write to A; B must remain empty.
+        // Read through the original cap_b BEFORE any writes — under
+        // the old dedupe-on-(cluster, kind, size) bug both caps shared
+        // one NodeId, but the underlying FatNode still records the
+        // most recently inserted on-disk entry. Any subsequent FS_*
+        // call through either cap routes to the same NodeId. Writing
+        // through cap_a then reading through cap_b is the operational
+        // shape that would observe the aliasing.
         fs_write_inline(cap_a, 0, b"AAAA", ipc_buf).expect("write to inv_aa");
 
-        // Re-LOOKUP B and read 8 bytes; with the old dedupe-on-(cluster,
-        // kind, size) bug B aliased A and would return "AAAA".
-        let _ = syscall::cap_delete(cap_b);
+        // Read directly through the held cap_b (no re-LOOKUP that
+        // could refresh the dedupe state via a fresh insert). With
+        // the bug, cap_b's NodeId is the same as cap_a's after the
+        // most recent FS_CREATE, and FS_READ via that NodeId would
+        // walk inv_aa's cluster chain and surface "AAAA". With the
+        // fix, cap_b resolves to a distinct NodeId pointing at
+        // inv_bb's still-empty entry.
+        let r_b = fs_read_bytes(cap_b, 0, 8, ipc_buf).unwrap_or_default();
+        assert!(
+            r_b.is_empty() || r_b.iter().all(|&x| x == 0),
+            "inv_bb returned non-zero bytes through held cap after sibling write: {r_b:?}"
+        );
+
+        // Also verify via NS_LOOKUP that inv_bb's on-disk size hint
+        // is still zero — same-slot dedupe must not have updated
+        // inv_bb's `size` from inv_aa's growth.
         let (cap_b_fresh, _, b_size) =
             ns_lookup(usertest, b, 0xFFFF, ipc_buf).expect("lookup inv_bb");
-        assert_eq!(b_size, 0, "inv_bb was aliased to inv_aa's storage");
-
-        // Tolerate either an empty read (size=0) or a short reply.
-        let r = fs_read_bytes(cap_b_fresh, 0, 8, ipc_buf).unwrap_or_default();
-        assert!(
-            r.is_empty() || r.iter().all(|&x| x == 0),
-            "inv_bb returned non-zero bytes after sibling write: {r:?}"
+        assert_eq!(
+            b_size, 0,
+            "inv_bb on-disk size hint was perturbed by inv_aa write"
         );
 
         let _ = syscall::cap_delete(cap_a);
+        let _ = syscall::cap_delete(cap_b);
         let _ = syscall::cap_delete(cap_b_fresh);
         let _ = fs_remove(usertest, a, ipc_buf);
         let _ = fs_remove(usertest, b, ipc_buf);

--- a/base/usertest/src/main.rs
+++ b/base/usertest/src/main.rs
@@ -132,6 +132,12 @@ fn main()
     fs_release_on_close_phase();
     fs_crossover_bench_phase();
     fs_rights_attenuation_phase();
+    fs_write_phase();
+    fs_create_remove_phase();
+    fs_mkdir_phase();
+    fs_rename_phase();
+    fs_write_frame_phase();
+    fs_write_cache_coherence_phase();
     ns_multi_component_phase();
     ns_sandbox_phase();
     ns_fallthrough_attenuation_phase();
@@ -1011,6 +1017,427 @@ fn fs_rights_attenuation_phase()
     let _ = syscall::cap_delete(full_cap);
     let _ = syscall::cap_delete(srv_cap);
     std::os::seraph::log!("fs_rights_attenuation phase passed");
+}
+
+// ── Write / mutation phases ────────────────────────────────────────────────
+//
+// All write-side phases exercise raw `FS_*` IPC against caps obtained
+// through `NS_LOOKUP`. Std::fs has no write surface yet — Issue #8
+// tracks the ruststd bridge separately. The scratch directory is
+// `/usertest/` (already populated by xtask's sysroot build, so it
+// exists on every boot); test files are uniquely-named per phase so
+// re-runs do not interfere when the disk image is reused.
+
+/// Walk `/usertest` and return a directory cap. The directory exists
+/// in the sysroot at build time; xtask populates fixture files into
+/// it (large.bin, bench.bin). We add scratch entries alongside.
+fn usertest_dir_cap(ipc_buf: *mut u64) -> u32
+{
+    let root = std::os::seraph::root_dir_cap();
+    let (cap, _kind, _) =
+        ns_lookup(root, b"usertest", 0xFFFF, ipc_buf).expect("ns_lookup /usertest failed");
+    cap
+}
+
+/// `FS_CREATE` returns `(node_cap, kind)` on success. Returns the wire
+/// error code on failure.
+fn fs_create(parent_cap: u32, name: &[u8], ipc_buf: *mut u64) -> Result<(u32, u64), u64>
+{
+    let label = ipc::fs_labels::FS_CREATE | ((name.len() as u64) << 16);
+    let msg = ipc::IpcMessage::builder(label).bytes(0, name).build();
+    // SAFETY: ipc_buf is the kernel-registered IPC buffer page.
+    let reply = unsafe { ipc::ipc_call(parent_cap, &msg, ipc_buf) }.map_err(|_| u64::MAX)?;
+    if reply.label != ipc::fs_errors::SUCCESS
+    {
+        return Err(reply.label);
+    }
+    let cap = *reply.caps().first().ok_or(0u64)?;
+    Ok((cap, reply.word(0)))
+}
+
+/// `FS_MKDIR`. Same shape as `FS_CREATE`.
+fn fs_mkdir(parent_cap: u32, name: &[u8], ipc_buf: *mut u64) -> Result<(u32, u64), u64>
+{
+    let label = ipc::fs_labels::FS_MKDIR | ((name.len() as u64) << 16);
+    let msg = ipc::IpcMessage::builder(label).bytes(0, name).build();
+    // SAFETY: ipc_buf is the kernel-registered IPC buffer page.
+    let reply = unsafe { ipc::ipc_call(parent_cap, &msg, ipc_buf) }.map_err(|_| u64::MAX)?;
+    if reply.label != ipc::fs_errors::SUCCESS
+    {
+        return Err(reply.label);
+    }
+    let cap = *reply.caps().first().ok_or(0u64)?;
+    Ok((cap, reply.word(0)))
+}
+
+/// `FS_REMOVE`. Returns `Ok(())` on success.
+fn fs_remove(parent_cap: u32, name: &[u8], ipc_buf: *mut u64) -> Result<(), u64>
+{
+    let label = ipc::fs_labels::FS_REMOVE | ((name.len() as u64) << 16);
+    let msg = ipc::IpcMessage::builder(label).bytes(0, name).build();
+    // SAFETY: ipc_buf is the kernel-registered IPC buffer page.
+    let reply = unsafe { ipc::ipc_call(parent_cap, &msg, ipc_buf) }.map_err(|_| u64::MAX)?;
+    if reply.label != ipc::fs_errors::SUCCESS
+    {
+        return Err(reply.label);
+    }
+    Ok(())
+}
+
+/// `FS_RENAME` within a single directory. Returns `Ok(())` on success.
+fn fs_rename(dir_cap: u32, src: &[u8], dst: &[u8], ipc_buf: *mut u64) -> Result<(), u64>
+{
+    let mut combined = Vec::with_capacity(src.len() + dst.len());
+    combined.extend_from_slice(src);
+    combined.extend_from_slice(dst);
+    let msg = ipc::IpcMessage::builder(ipc::fs_labels::FS_RENAME)
+        .word(0, src.len() as u64)
+        .word(1, dst.len() as u64)
+        .bytes(2, &combined)
+        .build();
+    // SAFETY: ipc_buf is the kernel-registered IPC buffer page.
+    let reply = unsafe { ipc::ipc_call(dir_cap, &msg, ipc_buf) }.map_err(|_| u64::MAX)?;
+    if reply.label != ipc::fs_errors::SUCCESS
+    {
+        return Err(reply.label);
+    }
+    Ok(())
+}
+
+/// `FS_WRITE` inline: returns `bytes_written`.
+#[allow(clippy::doc_markdown)]
+fn fs_write_inline(
+    file_cap: u32,
+    offset: u64,
+    payload: &[u8],
+    ipc_buf: *mut u64,
+) -> Result<u64, u64>
+{
+    let label = ipc::fs_labels::FS_WRITE | ((payload.len() as u64) << 16);
+    let msg = ipc::IpcMessage::builder(label)
+        .word(0, offset)
+        .bytes(1, payload)
+        .build();
+    // SAFETY: ipc_buf is the kernel-registered IPC buffer page.
+    let reply = unsafe { ipc::ipc_call(file_cap, &msg, ipc_buf) }.map_err(|_| u64::MAX)?;
+    if reply.label != ipc::fs_errors::SUCCESS
+    {
+        return Err(reply.label);
+    }
+    Ok(reply.word(0))
+}
+
+/// Round-trip `FS_READ`: returns the bytes the driver reports.
+fn fs_read_bytes(
+    file_cap: u32,
+    offset: u64,
+    max_len: u64,
+    ipc_buf: *mut u64,
+) -> Result<Vec<u8>, u64>
+{
+    let msg = ipc::IpcMessage::builder(ipc::fs_labels::FS_READ)
+        .word(0, offset)
+        .word(1, max_len)
+        .build();
+    // SAFETY: ipc_buf is the kernel-registered IPC buffer page.
+    let reply = unsafe { ipc::ipc_call(file_cap, &msg, ipc_buf) }.map_err(|_| u64::MAX)?;
+    if reply.label != ipc::fs_errors::SUCCESS
+    {
+        return Err(reply.label);
+    }
+    #[allow(clippy::cast_possible_truncation)]
+    let n = reply.word(0) as usize;
+    Ok(reply.data_bytes()[8..8 + n].to_vec())
+}
+
+/// `FS_WRITE` round-trip on a fresh file. Creates, writes a small
+/// payload, re-looks-up the file, reads back, and confirms bytes
+/// match. Covers Issue #6's primary acceptance criterion ("Round-trip:
+/// write file from usertest → read back same bytes").
+fn fs_write_phase()
+{
+    let info = startup_info();
+    #[allow(clippy::cast_ptr_alignment)]
+    let ipc_buf = info.ipc_buffer.cast::<u64>();
+    let usertest = usertest_dir_cap(ipc_buf);
+
+    let name: &[u8] = b"wrt.bin";
+    // Clean up any leftover from a previous (failed) run.
+    let _ = fs_remove(usertest, name, ipc_buf);
+
+    let (file_cap, kind) = fs_create(usertest, name, ipc_buf).expect("FS_CREATE wrt.bin failed");
+    assert_eq!(kind, namespace_protocol::NodeKind::File as u64);
+
+    let payload: &[u8] = b"hello write path\n";
+    let n = fs_write_inline(file_cap, 0, payload, ipc_buf).expect("FS_WRITE wrt.bin failed");
+    assert_eq!(n, payload.len() as u64, "FS_WRITE short");
+
+    // Re-lookup via NS_LOOKUP so the cap reflects the post-write
+    // metadata (size, first_cluster).
+    let _ = syscall::cap_delete(file_cap);
+    let (rd_cap, _kind, size_hint) =
+        ns_lookup(usertest, name, 0xFFFF, ipc_buf).expect("NS_LOOKUP wrt.bin failed");
+    assert_eq!(size_hint, payload.len() as u64, "post-write size hint");
+
+    let got =
+        fs_read_bytes(rd_cap, 0, payload.len() as u64, ipc_buf).expect("FS_READ wrt.bin failed");
+    assert_eq!(&got[..], payload, "round-trip bytes mismatch");
+
+    let _ = syscall::cap_delete(rd_cap);
+    let _ = fs_remove(usertest, name, ipc_buf);
+    let _ = syscall::cap_delete(usertest);
+    std::os::seraph::log!("fs_write phase passed");
+}
+
+/// `FS_CREATE` + `FS_REMOVE`: create a file, verify a duplicate
+/// `FS_CREATE` rejects, then `FS_REMOVE` and verify `NS_LOOKUP`
+/// returns `NotFound`.
+fn fs_create_remove_phase()
+{
+    let info = startup_info();
+    #[allow(clippy::cast_ptr_alignment)]
+    let ipc_buf = info.ipc_buffer.cast::<u64>();
+    let usertest = usertest_dir_cap(ipc_buf);
+
+    let name: &[u8] = b"crt.bin";
+    let _ = fs_remove(usertest, name, ipc_buf);
+
+    let (cap, _) = fs_create(usertest, name, ipc_buf).expect("FS_CREATE first failed");
+    let _ = syscall::cap_delete(cap);
+
+    // Duplicate create must fail with NO_SPACE (our dispatch maps
+    // existing-name to fs_errors::NO_SPACE today; refining to EXISTS
+    // is a presentation tweak, the test asserts only "non-success").
+    let dup = fs_create(usertest, name, ipc_buf);
+    assert!(
+        dup.is_err(),
+        "duplicate FS_CREATE on existing name should fail"
+    );
+
+    fs_remove(usertest, name, ipc_buf).expect("FS_REMOVE crt.bin failed");
+
+    // Verify NS_LOOKUP now returns NotFound (NsError code 1).
+    let gone = ns_lookup(usertest, name, 0xFFFF, ipc_buf);
+    assert!(
+        gone.is_err(),
+        "NS_LOOKUP after FS_REMOVE should fail; got {gone:?}"
+    );
+
+    let _ = syscall::cap_delete(usertest);
+    std::os::seraph::log!("fs_create_remove phase passed");
+}
+
+/// `FS_MKDIR` + `NS_READDIR` + `FS_REMOVE` (empty directory).
+fn fs_mkdir_phase()
+{
+    let info = startup_info();
+    #[allow(clippy::cast_ptr_alignment)]
+    let ipc_buf = info.ipc_buffer.cast::<u64>();
+    let usertest = usertest_dir_cap(ipc_buf);
+
+    let dname: &[u8] = b"mkd";
+    let _ = fs_remove(usertest, dname, ipc_buf);
+
+    let (dir_cap, kind) = fs_mkdir(usertest, dname, ipc_buf).expect("FS_MKDIR mkd failed");
+    assert_eq!(kind, namespace_protocol::NodeKind::Dir as u64);
+
+    // readdir on the new directory: expect "." and ".." entries plus
+    // end-of-directory.
+    let entry0 = ns_readdir(dir_cap, 0, ipc_buf).expect("NS_READDIR 0");
+    assert!(entry0.is_some(), "newly-mkdir'd directory must have ./..");
+
+    // Remove the empty directory.
+    let _ = syscall::cap_delete(dir_cap);
+    fs_remove(usertest, dname, ipc_buf).expect("FS_REMOVE mkd (empty) failed");
+
+    // mkdir then file-inside then attempt-remove must reject as NOT_EMPTY.
+    let (dir_cap2, _) = fs_mkdir(usertest, dname, ipc_buf).expect("FS_MKDIR mkd retry");
+    let (inner, _) = fs_create(dir_cap2, b"in.bin", ipc_buf).expect("FS_CREATE inside dir failed");
+    let _ = syscall::cap_delete(inner);
+    let err = fs_remove(usertest, dname, ipc_buf).expect_err("FS_REMOVE non-empty should fail");
+    assert_eq!(
+        err,
+        ipc::fs_errors::NOT_EMPTY,
+        "FS_REMOVE non-empty dir code"
+    );
+    fs_remove(dir_cap2, b"in.bin", ipc_buf).expect("cleanup file in mkd");
+    fs_remove(usertest, dname, ipc_buf).expect("FS_REMOVE mkd (now empty)");
+    let _ = syscall::cap_delete(dir_cap2);
+    let _ = syscall::cap_delete(usertest);
+    std::os::seraph::log!("fs_mkdir phase passed");
+}
+
+/// `FS_RENAME` within a directory.
+fn fs_rename_phase()
+{
+    let info = startup_info();
+    #[allow(clippy::cast_ptr_alignment)]
+    let ipc_buf = info.ipc_buffer.cast::<u64>();
+    let usertest = usertest_dir_cap(ipc_buf);
+
+    let src: &[u8] = b"ren_a.bin";
+    let dst: &[u8] = b"ren_b.bin";
+    let _ = fs_remove(usertest, src, ipc_buf);
+    let _ = fs_remove(usertest, dst, ipc_buf);
+
+    let (cap, _) = fs_create(usertest, src, ipc_buf).expect("FS_CREATE ren_a failed");
+    let payload: &[u8] = b"renaming";
+    fs_write_inline(cap, 0, payload, ipc_buf).expect("FS_WRITE ren_a failed");
+    let _ = syscall::cap_delete(cap);
+
+    fs_rename(usertest, src, dst, ipc_buf).expect("FS_RENAME failed");
+
+    assert!(
+        ns_lookup(usertest, src, 0xFFFF, ipc_buf).is_err(),
+        "src must be gone after rename"
+    );
+    let (dst_cap, _kind, dst_size) =
+        ns_lookup(usertest, dst, 0xFFFF, ipc_buf).expect("NS_LOOKUP dst after rename");
+    assert_eq!(dst_size, payload.len() as u64);
+    let got = fs_read_bytes(dst_cap, 0, payload.len() as u64, ipc_buf).expect("read dst");
+    assert_eq!(&got[..], payload, "rename preserved contents");
+
+    let _ = syscall::cap_delete(dst_cap);
+    fs_remove(usertest, dst, ipc_buf).expect("cleanup dst");
+    let _ = syscall::cap_delete(usertest);
+    std::os::seraph::log!("fs_rename phase passed");
+}
+
+/// `FS_WRITE_FRAME` bulk-write round-trip via a caller-supplied
+/// memmgr Frame cap. Closes Issue #7's "Bulk write round-trip works
+/// under usertest" acceptance criterion.
+#[allow(clippy::too_many_lines, clippy::items_after_statements)]
+fn fs_write_frame_phase()
+{
+    use std::io::Read;
+
+    use syscall::MAP_WRITABLE;
+
+    const WRITE_LEN: usize = 2048;
+
+    let info = startup_info();
+    #[allow(clippy::cast_ptr_alignment)]
+    let ipc_buf = info.ipc_buffer.cast::<u64>();
+    let usertest = usertest_dir_cap(ipc_buf);
+
+    let name: &[u8] = b"wrtf.bin";
+    let _ = fs_remove(usertest, name, ipc_buf);
+
+    let (file_cap, _) = fs_create(usertest, name, ipc_buf).expect("FS_CREATE wrtf failed");
+
+    // Acquire a single-page frame from memmgr.
+    let req = ipc::IpcMessage::builder(ipc::memmgr_labels::REQUEST_FRAMES)
+        .word(0, 1)
+        .build();
+    // SAFETY: ipc_buf is the kernel-registered IPC buffer page.
+    let reply = unsafe { ipc::ipc_call(info.memmgr_endpoint, &req, ipc_buf) }
+        .expect("memmgr REQUEST_FRAMES ipc_call failed");
+    assert_eq!(
+        reply.label,
+        ipc::memmgr_errors::SUCCESS,
+        "REQUEST_FRAMES status"
+    );
+    assert_eq!(reply.word(0), 1);
+    let frame_cap = *reply
+        .caps()
+        .first()
+        .expect("REQUEST_FRAMES returned no cap");
+
+    // Reserve a VA and map the frame writable.
+    let range = std::os::seraph::reserve_pages(1).expect("reserve_pages");
+    let va = range.va_start();
+    syscall::mem_map(frame_cap, info.self_aspace, va, 0, 1, MAP_WRITABLE)
+        .expect("mem_map frame failed");
+
+    // Fill the page with a recognisable pattern; write a 2 KiB slice
+    // starting at frame offset 0 (well within bulk-write territory).
+    // SAFETY: va just mapped MAP_WRITABLE for one page; WRITE_LEN ≤ PAGE_SIZE.
+    unsafe {
+        for i in 0..WRITE_LEN
+        {
+            *((va + i as u64) as *mut u8) = u8::try_from(i & 0xFF).unwrap_or(0);
+        }
+    }
+
+    let msg = ipc::IpcMessage::builder(ipc::fs_labels::FS_WRITE_FRAME)
+        .word(0, 0) // file offset
+        .word(1, WRITE_LEN as u64)
+        .word(2, 0) // frame_data_offset
+        .cap(frame_cap)
+        .build();
+    // SAFETY: ipc_buf is the kernel-registered IPC buffer page.
+    let reply =
+        unsafe { ipc::ipc_call(file_cap, &msg, ipc_buf) }.expect("FS_WRITE_FRAME ipc_call failed");
+    assert_eq!(
+        reply.label,
+        ipc::fs_errors::SUCCESS,
+        "FS_WRITE_FRAME status {} (expected SUCCESS={})",
+        reply.label,
+        ipc::fs_errors::SUCCESS
+    );
+    assert_eq!(reply.word(0), WRITE_LEN as u64);
+    // Frame cap returned in caps[0]; drop it.
+    let returned = *reply
+        .caps()
+        .first()
+        .expect("FS_WRITE_FRAME returned no cap");
+    let _ = syscall::cap_delete(returned);
+
+    let _ = syscall::mem_unmap(info.self_aspace, va, 1);
+    let _ = syscall::cap_delete(file_cap);
+
+    // Verify by reading back through std::fs::File::read — which
+    // takes the frame-cap read path for sizes >504 B.
+    let mut f = std::fs::File::open("/usertest/wrtf.bin").expect("open wrtf.bin");
+    let mut buf = vec![0u8; WRITE_LEN];
+    let mut total = 0;
+    while total < WRITE_LEN
+    {
+        let n = f.read(&mut buf[total..]).expect("read wrtf.bin");
+        assert!(n > 0, "short read at offset {total}");
+        total += n;
+    }
+    for (i, &b) in buf.iter().enumerate()
+    {
+        assert_eq!(b, u8::try_from(i & 0xFF).unwrap_or(0), "byte {i} mismatch");
+    }
+    drop(f);
+
+    fs_remove(usertest, name, ipc_buf).expect("cleanup wrtf");
+    let _ = syscall::cap_delete(usertest);
+    std::os::seraph::log!("fs_write_frame phase passed");
+}
+
+/// Cache coherence: a `FS_READ` after `FS_WRITE` to the same offset
+/// returns the new bytes. Issue #6 acceptance criterion.
+fn fs_write_cache_coherence_phase()
+{
+    let info = startup_info();
+    #[allow(clippy::cast_ptr_alignment)]
+    let ipc_buf = info.ipc_buffer.cast::<u64>();
+    let usertest = usertest_dir_cap(ipc_buf);
+
+    let name: &[u8] = b"coh.bin";
+    let _ = fs_remove(usertest, name, ipc_buf);
+
+    let (cap, _) = fs_create(usertest, name, ipc_buf).expect("create coh");
+    // Initial write.
+    fs_write_inline(cap, 0, b"AAAAAAAA", ipc_buf).expect("write 1");
+    let r1 = fs_read_bytes(cap, 0, 8, ipc_buf).expect("read 1");
+    assert_eq!(&r1[..], b"AAAAAAAA");
+    // Overwrite same offset; cache page must update in place.
+    fs_write_inline(cap, 0, b"BBBBBBBB", ipc_buf).expect("write 2");
+    let r2 = fs_read_bytes(cap, 0, 8, ipc_buf).expect("read 2");
+    assert_eq!(
+        &r2[..],
+        b"BBBBBBBB",
+        "read after write returned stale bytes"
+    );
+
+    let _ = syscall::cap_delete(cap);
+    fs_remove(usertest, name, ipc_buf).expect("cleanup coh");
+    let _ = syscall::cap_delete(usertest);
+    std::os::seraph::log!("fs_write_cache_coherence phase passed");
 }
 
 /// Exercise vfsd's tree-shaped synthetic root: a multi-component

--- a/services/drivers/virtio/blk/README.md
+++ b/services/drivers/virtio/blk/README.md
@@ -111,18 +111,52 @@ that introduction.
 release protocol grows a block-layer analogue; today the cap is null and
 the slot is unused.
 
+### Label 4: `BLK_WRITE_FROM_FRAME`
+
+Mirror of `BLK_READ_INTO_FRAME` for the write direction. The driver
+reads `count * 512` bytes starting at offset 0 of the supplied page and
+writes them to disk. The frame contents past the requested run are not
+read.
+
+**Request:**
+
+| Field | Value |
+|---|---|
+| label | 4 |
+| data[0] | Starting LBA (relative to the caller token's partition base) |
+| data[1] | Sector count (`>= 1`; defaults to `1` if absent) |
+| caps[0] | Source Frame, `MAP \| READ`, at least `count * 512` bytes |
+| caps[1] | Reserved (null today; future per-request release handle) |
+| caps[2] | Reserved IPC-shape slot (null today; future userspace-IOMMU grant) |
+
+**Reply:**
+
+| Field | Value |
+|---|---|
+| label | 0 (success) or one of the error codes below |
+| caps[0] | The source Frame, moved back to the caller |
+
+**Error codes:**
+
+| Code | Name | Meaning |
+|---|---|---|
+| 1 | `DeviceStatusIoerr` | VirtIO device returned `VIRTIO_BLK_S_IOERR` |
+| 2 | `DeviceStatusUnsupp` | VirtIO device returned `VIRTIO_BLK_S_UNSUPP` |
+| 3 | `OutOfBounds` | LBA outside the caller token's partition range |
+| 5 | `InvalidFrameCap` | Source Frame missing `MAP\|READ`, sized smaller than `count * 512`, or absent |
+
 ---
 
 ## DMA Discipline
 
 The driver owns a single 1-page DMA buffer for the request header and
-status byte (offsets 0 and 1024). The data segment of every read is the
-caller-supplied Frame: the driver queries `phys_base` via `cap_info`
-without mapping the frame into its own address space (the device DMAs to
-the physical address; the driver never reads the data), then programs
-the descriptor chain to point at `phys_base`. The Frame cap is
-moved back to the caller in the reply on every outcome, so it never
-accumulates in the driver's `CSpace`.
+status byte (offsets 0 and 1024). The data segment of every read or
+write is the caller-supplied Frame: the driver queries `phys_base` via
+`cap_info` without mapping the frame into its own address space (the
+device DMAs to or from the physical address; the driver never touches
+the data), then programs the descriptor chain to point at `phys_base`.
+The Frame cap is moved back to the caller in the reply on every
+outcome, so it never accumulates in the driver's `CSpace`.
 
 The notify-after-avail-update memory-ordering pair (release fence on the
 producer, the device's implicit load-acquire on the doorbell MMIO)

--- a/services/drivers/virtio/blk/src/io.rs
+++ b/services/drivers/virtio/blk/src/io.rs
@@ -139,8 +139,19 @@ impl IoLayout
     }
 }
 
-/// Maximum `signal_wait` iterations before treating the request as timed out.
+/// Maximum wait iterations before treating the request as timed out.
 const MAX_WAIT_ATTEMPTS: usize = 1000;
+
+/// Per-iteration timeout on the IRQ-signal wait, in milliseconds.
+///
+/// Bounded so that a lost PLIC external interrupt on QEMU virt RISC-V (see
+/// the wait loop comment) cannot park this thread indefinitely: the next
+/// iteration's poll-burst will observe completion regardless of whether the
+/// IRQ ever fires. The actual completion time of a virtio-blk request on
+/// QEMU is sub-millisecond, so a 50 ms ceiling is two orders of magnitude
+/// over the expected wake and three orders under the outer-loop deadline
+/// (`MAX_WAIT_ATTEMPTS * IRQ_WAIT_TIMEOUT_MS` = 50 s upper bound).
+const IRQ_WAIT_TIMEOUT_MS: u64 = 50;
 
 /// Submit a read or write request and wait for completion via IRQ signal.
 ///
@@ -200,9 +211,11 @@ pub fn submit_and_wait(
     // PLIC) is occasionally not observed by any hart even though the device
     // processes the request — we have confirmed via instrumentation that
     // completion happens but the PLIC-delivered external interrupt never
-    // fires. To stay robust without pure polling, each wait iteration does
-    // a short poll burst first (catching device-faster-than-schedule cases
-    // and IRQ-lost cases both), and only blocks on the signal afterwards.
+    // fires. Two defenses against a lost IRQ: each iteration does a short
+    // poll burst, and the per-iteration signal wait carries a bounded
+    // timeout so a completion that lands between the poll burst and the
+    // kernel parking the thread is recovered on the next iteration's burst
+    // rather than wedging the driver forever.
     for _ in 0..MAX_WAIT_ATTEMPTS
     {
         // Poll burst before blocking. VirtIO devices typically complete in
@@ -223,8 +236,11 @@ pub fn submit_and_wait(
             core::hint::spin_loop();
         }
 
-        // No completion yet — block until the IRQ fires, then re-check.
-        let _ = syscall::signal_wait(irq_signal);
+        // No completion yet — block on the IRQ signal with a bounded timeout.
+        // Ok(0) means timeout (signal_send rejects zero-bit sends, so 0 is
+        // unambiguous); Ok(_) means a real wake; Err means the cap path
+        // failed and there's nothing useful to do but fall through and poll.
+        let _ = syscall::signal_wait_timeout(irq_signal, IRQ_WAIT_TIMEOUT_MS);
 
         // Read ISR to clear level-triggered interrupt at the device before
         // unmasking at the controller, preventing immediate re-delivery.

--- a/services/drivers/virtio/blk/src/io.rs
+++ b/services/drivers/virtio/blk/src/io.rs
@@ -161,9 +161,12 @@ const IRQ_WAIT_TIMEOUT_MS: u64 = 50;
 /// `count` consecutive sectors starting at `sector`; the device
 /// transfers the entire run in one descriptor chain.
 ///
-/// Blocks on `signal_wait` until the device raises an interrupt, reads the
-/// device ISR to deassert the level-triggered interrupt, then acknowledges
-/// at the controller for re-arming.
+/// Blocks on a bounded `signal_wait_timeout` per iteration until the device
+/// raises an interrupt or the per-iteration timeout elapses, then reads the
+/// device ISR to deassert the level-triggered interrupt, acknowledges at the
+/// controller for re-arming, and re-polls the used ring. The bounded wait
+/// ensures that a lost PLIC external interrupt on QEMU virt RISC-V cannot
+/// park this thread indefinitely — see the wait loop body for details.
 // too_many_arguments: layout + direction + sector + data_phys + data_len
 // + four hardware handles (virtqueue, transport, irq signal, irq cap) is
 // the minimal set this path needs; bundling for the lint would obscure

--- a/services/drivers/virtio/blk/src/io.rs
+++ b/services/drivers/virtio/blk/src/io.rs
@@ -5,20 +5,34 @@
 
 //! Block I/O request submission and completion for the `VirtIO` block driver.
 //!
-//! Provides the descriptor chain layout for `VirtIO` block read requests
-//! (`VirtIO` 1.2 section 5.2.6) and helpers for submitting sector reads.
+//! Provides the descriptor chain layout for `VirtIO` block read and write
+//! requests (`VirtIO` 1.2 section 5.2.6) and a single submit/wait helper
+//! parameterised over direction.
 //!
 //! `IoLayout` owns the driver's permanent 1-page DMA buffer. The request
 //! header (offset 0, 16 bytes) and status byte (offset 1024, 1 byte) live
 //! there permanently. The 512-byte data segment is supplied per-request by
-//! the caller as a Frame cap; `read_chain` parameterises the data-segment
-//! physical address. The driver's own page never holds bulk data.
+//! the caller as a Frame cap; [`IoLayout::read_chain`] /
+//! [`IoLayout::write_chain`] parameterise the data-segment physical
+//! address. The driver's own page never holds bulk data.
 
 use virtio_core::pci::PciTransport;
 use virtio_core::virtqueue::SplitVirtqueue;
 
 /// Block request type: read (`VirtIO` 1.2 section 5.2.6).
 const VIRTIO_BLK_T_IN: u32 = 0;
+/// Block request type: write (`VirtIO` 1.2 section 5.2.6).
+const VIRTIO_BLK_T_OUT: u32 = 1;
+
+/// Direction of a block I/O request.
+#[derive(Copy, Clone)]
+pub enum IoDirection
+{
+    /// Sector read: device DMAs data into the caller-supplied frame.
+    Read,
+    /// Sector write: device DMAs data out of the caller-supplied frame.
+    Write,
+}
 
 /// Block request header (`VirtIO` 1.2 section 5.2.6).
 #[repr(C)]
@@ -73,14 +87,38 @@ impl IoLayout
         ]
     }
 
-    /// Prepare a read request for the given sector.
+    /// Descriptor chain for a block write request whose data segment is
+    /// sourced from `data_phys` and is `data_len` bytes long (`data_len`
+    /// must be a non-zero multiple of 512).
+    ///
+    /// Mirror of [`Self::read_chain`] with the data segment's writable
+    /// flag flipped: the device reads from the caller-supplied frame and
+    /// writes only the completion status byte in the driver's page.
+    pub fn write_chain(&self, data_phys: u64, data_len: u32) -> [(u64, u32, bool); 3]
+    {
+        let header_phys = self.data_phys;
+        let status_phys = self.data_phys + 1024;
+
+        [
+            (header_phys, 16, false),     // request header
+            (data_phys, data_len, false), // data buffer (device reads)
+            (status_phys, 1, true),       // status byte (device writes)
+        ]
+    }
+
+    /// Prepare a read or write request for the given sector.
     ///
     /// Writes the block request header and resets the status byte.
-    pub fn prepare_read(&self, sector: u64)
+    pub fn prepare(&self, dir: IoDirection, sector: u64)
     {
+        let req_type = match dir
+        {
+            IoDirection::Read => VIRTIO_BLK_T_IN,
+            IoDirection::Write => VIRTIO_BLK_T_OUT,
+        };
         // SAFETY: header_va is within the mapped data page, properly aligned.
         unsafe {
-            (*self.header_va()).req_type = VIRTIO_BLK_T_IN;
+            (*self.header_va()).req_type = req_type;
             (*self.header_va()).reserved = 0;
             (*self.header_va()).sector = sector;
         }
@@ -104,24 +142,26 @@ impl IoLayout
 /// Maximum `signal_wait` iterations before treating the request as timed out.
 const MAX_WAIT_ATTEMPTS: usize = 1000;
 
-/// Submit a read request and wait for completion via IRQ signal.
+/// Submit a read or write request and wait for completion via IRQ signal.
 ///
-/// `data_phys` is the physical address the device should DMA the data
-/// segment into — the caller-supplied frame's `phys_base` per the
-/// `BLK_READ_INTO_FRAME` contract (data lands at offset 0 of the frame).
-/// `data_len` is `count * 512` for `count` consecutive sectors starting
-/// at `sector`; the device fills the entire run in one transfer.
+/// `data_phys` is the physical address of the caller-supplied frame's
+/// data segment (offset 0 of the frame per the `BLK_READ_INTO_FRAME` /
+/// `BLK_WRITE_FROM_FRAME` contract). `data_len` is `count * 512` for
+/// `count` consecutive sectors starting at `sector`; the device
+/// transfers the entire run in one descriptor chain.
 ///
 /// Blocks on `signal_wait` until the device raises an interrupt, reads the
 /// device ISR to deassert the level-triggered interrupt, then acknowledges
 /// at the controller for re-arming.
-// too_many_arguments: layout + sector + data_phys + data_len + four
-// hardware handles (virtqueue, transport, irq signal, irq cap) is the
-// minimal set this path needs; bundling for the lint would obscure the
-// per-call inputs (sector, data_phys, data_len) that vary per request.
+// too_many_arguments: layout + direction + sector + data_phys + data_len
+// + four hardware handles (virtqueue, transport, irq signal, irq cap) is
+// the minimal set this path needs; bundling for the lint would obscure
+// the per-call inputs (direction, sector, data_phys, data_len) that vary
+// per request.
 #[allow(clippy::too_many_arguments)]
 pub fn submit_and_wait(
     layout: &IoLayout,
+    dir: IoDirection,
     sector: u64,
     data_phys: u64,
     data_len: u32,
@@ -132,9 +172,13 @@ pub fn submit_and_wait(
     irq_cap: u32,
 ) -> bool
 {
-    layout.prepare_read(sector);
+    layout.prepare(dir, sector);
 
-    let chain = layout.read_chain(data_phys, data_len);
+    let chain = match dir
+    {
+        IoDirection::Read => layout.read_chain(data_phys, data_len),
+        IoDirection::Write => layout.write_chain(data_phys, data_len),
+    };
     let Some(_head) = vq.add_chain(&chain)
     else
     {

--- a/services/drivers/virtio/blk/src/main.rs
+++ b/services/drivers/virtio/blk/src/main.rs
@@ -468,6 +468,10 @@ fn service_loop(service_ep: u32, ipc_buf: *mut u64, rt: &mut BlkRuntime) -> !
             {
                 handle_read_block_into_frame(&msg, ipc_buf, rt);
             }
+            blk_labels::BLK_WRITE_FROM_FRAME =>
+            {
+                handle_write_block_from_frame(&msg, ipc_buf, rt);
+            }
             blk_labels::REGISTER_PARTITION =>
             {
                 handle_register_partition(&msg, ipc_buf, rt);
@@ -610,6 +614,144 @@ fn handle_read_block_into_frame(msg: &IpcMessage, ipc_buf: *mut u64, rt: &mut Bl
     #[allow(clippy::cast_possible_truncation)]
     if !io::submit_and_wait(
         rt.layout,
+        io::IoDirection::Read,
+        absolute_sector,
+        phys_base,
+        data_len_bytes as u32,
+        rt.vq,
+        rt.transport,
+        rt.queue_notify_off,
+        rt.irq_signal,
+        rt.irq_cap,
+    )
+    {
+        let status = rt.layout.read_status();
+        reply_with(u64::from(status), ipc_buf);
+        return;
+    }
+
+    reply_with(ipc::blk_errors::SUCCESS, ipc_buf);
+}
+
+/// Handle a `BLK_WRITE_FROM_FRAME` request.
+///
+/// Mirror of [`handle_read_block_into_frame`] with the data direction
+/// inverted. Reads `caps[0]` (source Frame, `MAP|READ`) and DMAs
+/// `data[1]` consecutive sectors (default 1) starting at LBA `data[0]`
+/// out of the frame at offset 0, packed contiguously. The source Frame
+/// is moved back to the caller in `caps[0]` of the reply.
+// too_many_lines: matches the read sibling — the same validation gates
+// (cap presence, sector count, descriptor-length bound, three cap_info
+// lookups, two partition resolutions for start and end LBA) all apply
+// here, and the reply-with-cap pattern is unchanged.
+#[allow(clippy::too_many_lines)]
+fn handle_write_block_from_frame(msg: &IpcMessage, ipc_buf: *mut u64, rt: &mut BlkRuntime)
+{
+    const SECTOR_SIZE: u64 = 512;
+
+    let source_cap = msg.caps().first().copied().unwrap_or(0);
+
+    let reply_with = |code: u64, ipc_buf: *mut u64| {
+        let mut builder = IpcMessage::builder(code);
+        if source_cap != 0
+        {
+            builder = builder.cap(source_cap);
+        }
+        let reply = builder.build();
+        // SAFETY: ipc_buf is the registered IPC buffer page.
+        let _ = unsafe { ipc::ipc_reply(&reply, ipc_buf) };
+    };
+
+    if source_cap == 0
+    {
+        reply_with(ipc::blk_errors::INVALID_FRAME_CAP, ipc_buf);
+        return;
+    }
+
+    let sector_count = if msg.word_count() >= 2
+    {
+        msg.word(1)
+    }
+    else
+    {
+        1
+    };
+    if sector_count == 0
+    {
+        reply_with(ipc::blk_errors::INVALID_FRAME_CAP, ipc_buf);
+        return;
+    }
+    let data_len_bytes = sector_count * SECTOR_SIZE;
+    if data_len_bytes > u64::from(u32::MAX)
+    {
+        reply_with(ipc::blk_errors::INVALID_FRAME_CAP, ipc_buf);
+        return;
+    }
+
+    // Source frame must be a Frame cap with at least MAP+READ rights
+    // (device reads sector data out of it) and large enough to cover the
+    // requested run.
+    let Ok(tag_rights) = syscall::cap_info(source_cap, syscall::CAP_INFO_TAG_RIGHTS)
+    else
+    {
+        reply_with(ipc::blk_errors::INVALID_FRAME_CAP, ipc_buf);
+        return;
+    };
+    let tag = (tag_rights >> 32) as u8;
+    let rights = tag_rights & 0xFFFF_FFFF;
+    let required = syscall::RIGHTS_MAP_READ;
+    if u64::from(tag) != u64::from(syscall::CAP_TAG_FRAME) || (rights & required) != required
+    {
+        reply_with(ipc::blk_errors::INVALID_FRAME_CAP, ipc_buf);
+        return;
+    }
+    let Ok(size) = syscall::cap_info(source_cap, syscall::CAP_INFO_FRAME_SIZE)
+    else
+    {
+        reply_with(ipc::blk_errors::INVALID_FRAME_CAP, ipc_buf);
+        return;
+    };
+    if size < data_len_bytes
+    {
+        reply_with(ipc::blk_errors::INVALID_FRAME_CAP, ipc_buf);
+        return;
+    }
+    let Ok(phys_base) = syscall::cap_info(source_cap, syscall::CAP_INFO_FRAME_PHYS_BASE)
+    else
+    {
+        reply_with(ipc::blk_errors::INVALID_FRAME_CAP, ipc_buf);
+        return;
+    };
+
+    let sector = if msg.word_count() >= 1
+    {
+        msg.word(0)
+    }
+    else
+    {
+        0
+    };
+    let absolute_sector = match resolve_sector(msg.token, sector, rt)
+    {
+        Ok(s) => s,
+        Err(code) =>
+        {
+            reply_with(code, ipc_buf);
+            return;
+        }
+    };
+    let last_relative = sector.saturating_add(sector_count - 1);
+    if resolve_sector(msg.token, last_relative, rt).is_err()
+    {
+        reply_with(ipc::blk_errors::OUT_OF_BOUNDS, ipc_buf);
+        return;
+    }
+
+    // cast_possible_truncation: data_len_bytes <= u32::MAX checked above.
+    #[allow(clippy::cast_possible_truncation)]
+    if !io::submit_and_wait(
+        rt.layout,
+        io::IoDirection::Write,
         absolute_sector,
         phys_base,
         data_len_bytes as u32,

--- a/services/fs/README.md
+++ b/services/fs/README.md
@@ -48,7 +48,7 @@ re-install the new root cap.
 
 | Crate | Filesystem | Status |
 |---|---|---|
-| `fat/` | Read-only FAT16/FAT32 | Working |
+| `fat/` | Read/write FAT16/FAT32 (write-through, no fsync) | Working |
 
 ---
 

--- a/services/fs/docs/fs-driver-protocol.md
+++ b/services/fs/docs/fs-driver-protocol.md
@@ -472,4 +472,4 @@ bound on every `BLK_READ_INTO_FRAME`. See
 
 ## Summarized By
 
-[services/fs/README.md](../README.md)
+[services/fs/README.md](../README.md), [services/fs/fat/README.md](../fat/README.md)

--- a/services/fs/docs/fs-driver-protocol.md
+++ b/services/fs/docs/fs-driver-protocol.md
@@ -290,6 +290,140 @@ evicted the per-node slot under cache pressure; in that case
 
 ---
 
+## Label 4: `FS_WRITE`
+
+Inline write to a file. Token = file cap; the token must carry the
+`WRITE` namespace right.
+
+**Request**:
+
+| Field | Value |
+|---|---|
+| `label` | `FS_WRITE \| (byte_len << 16)` (bits 0-15 = label, bits 16-31 = payload bytes, ≤504) |
+| `data[0]` | File byte offset |
+| `bytes(1, &payload)` | Payload bytes (`byte_len` of them) starting at byte 8 |
+
+**Reply (success)**: `label = 0`, `data[0]` = bytes_written. May be
+short on `NO_SPACE`; callers iterate.
+
+**Errors**: `INVALID_TOKEN`, `IS_A_DIRECTORY`, `IO_ERROR`,
+`PERMISSION_DENIED`, `NO_SPACE`.
+
+---
+
+## Label 12: `FS_WRITE_FRAME`
+
+Bulk write from a caller-supplied source Frame cap. Mirror of
+`FS_READ_FRAME` for the write direction. Threshold for inline vs
+frame is the same 504-byte boundary that governs reads today; the
+crossover Issue tracks per-arch tuning.
+
+**Request**:
+
+| Field | Value |
+|---|---|
+| `label` | `FS_WRITE_FRAME` (12) |
+| `data[0]` | File byte offset |
+| `data[1]` | Bytes to write from the frame (`≤ PAGE_SIZE - frame_data_offset`) |
+| `data[2]` | Byte offset within the source frame where the data begins |
+| `caps[0]` | Source Frame cap (`MAP \| READ` rights; one page) |
+
+**Reply (success)**: `label = 0`, `data[0]` = bytes_written,
+`caps[0]` = the source Frame cap moved back to the caller.
+
+The driver mem-maps the source frame read-only into its own address
+space for the duration of the copy. The cap returns to the caller in
+every outcome (mirror of the read-frame ownership discipline).
+
+**Errors**: `INVALID_TOKEN`, `IS_A_DIRECTORY`, `IO_ERROR`,
+`PERMISSION_DENIED`, `NO_SPACE`, `BAD_FRAME_OFFSET`.
+
+---
+
+## Label 13: `FS_CREATE`
+
+Create a new file in a directory. Token = parent-directory cap; the
+token must carry the `MUTATE_DIR` namespace right.
+
+**Request**:
+
+| Field | Value |
+|---|---|
+| `label` | `FS_CREATE \| (name_len << 16)` |
+| `bytes(0, &name)` | Name bytes starting at byte 0 |
+
+**Reply (success)**: `label = 0`, `data[0]` = `NodeKind` (= File),
+`caps[0]` = node cap for the newly-created file. The new file starts
+empty (size 0, no allocated cluster).
+
+**Errors**: `INVALID_TOKEN`, `EXISTS` (the dispatch may currently
+surface `NO_SPACE` for duplicate names — to be tightened),
+`NO_SPACE`, `IO_ERROR`, `PERMISSION_DENIED`.
+
+---
+
+## Label 14: `FS_REMOVE`
+
+Unlink a file or empty directory. Token = parent-directory cap with
+`MUTATE_DIR`.
+
+**Request**:
+
+| Field | Value |
+|---|---|
+| `label` | `FS_REMOVE \| (name_len << 16)` |
+| `bytes(0, &name)` | Name bytes |
+
+**Reply (success)**: `label = 0`, empty body.
+
+**Errors**: `NOT_FOUND`, `NOT_EMPTY` (directory has entries other
+than `.` and `..`), `IO_ERROR`, `PERMISSION_DENIED`.
+
+---
+
+## Label 15: `FS_MKDIR`
+
+Create a new (empty) directory. Same shape as `FS_CREATE`. Allocates
+one cluster, zero-fills it, and populates `.` / `..` entries before
+the directory entry is inserted in the parent.
+
+**Reply (success)**: `label = 0`, `data[0]` = `NodeKind` (= Dir),
+`caps[0]` = node cap for the new directory.
+
+**Errors**: as `FS_CREATE`.
+
+---
+
+## Label 16: `FS_RENAME`
+
+Rename a directory entry within a single directory. Token =
+directory cap with `MUTATE_DIR`.
+
+**Request**:
+
+| Field | Value |
+|---|---|
+| `label` | `FS_RENAME` (16) |
+| `data[0]` | Source name length |
+| `data[1]` | Destination name length |
+| `bytes(2, &concat(src, dst))` | Source bytes immediately followed by destination bytes (no padding) starting at byte 16 |
+
+**Reply (success)**: `label = 0`, empty body.
+
+Cross-directory rename is deferred: servers cannot introspect the
+token packed in a received cap, so a second-directory cap cannot
+resolve to a `NodeId`. A future Issue may add a wire shape that
+conveys the destination directory's `NodeId` explicitly.
+
+`FS_RENAME` is not atomic — see
+[`services/fs/fat/docs/crash-safety.md`](../fat/docs/crash-safety.md)
+for the post-crash visible states.
+
+**Errors**: `NOT_FOUND` (source missing), `EXISTS` (destination
+occupied), `NO_SPACE`, `IO_ERROR`, `PERMISSION_DENIED`.
+
+---
+
 ## Label 6: `END_OF_DIR`
 
 End-of-directory marker reused as a reply label by `NS_READDIR`. See

--- a/services/fs/fat/README.md
+++ b/services/fs/fat/README.md
@@ -1,14 +1,28 @@
 # fat
 
-Seraph FAT16 / FAT32 filesystem driver. Read-write since
-[Issue #6](https://github.com/kottlerg/seraph/issues/6) +
-[Issue #7](https://github.com/kottlerg/seraph/issues/7).
+Seraph FAT16 / FAT32 filesystem driver, one process per mount.
 
-The driver is one process per mount; vfsd spawns and tears down
-instances, captures each driver's root cap at mount time, and forwards
-walks through it. The driver implements the cap-native namespace
-protocol (`NS_LOOKUP` / `NS_STAT` / `NS_READDIR`) for directory walks
-and the per-node filesystem labels for I/O and mutation.
+---
+
+## Source Layout
+
+```
+fat/
+├── Cargo.toml
+├── README.md
+├── docs/
+│   └── crash-safety.md         # Per-op write ordering and post-crash visible states
+└── src/
+    ├── main.rs                 # Dispatch loop, FS_* handlers, write engine
+    ├── bpb.rs                  # BPB parser, FatState fields
+    ├── alloc.rs                # Cluster allocator, FAT-mirror writes, FSInfo flush
+    ├── dir.rs                  # Directory walks and mutation (insert/remove/rename)
+    ├── fat.rs                  # FAT-entry reads and chain walks
+    ├── cache.rs                # PageCache: read/write through BLK_*_FROM_FRAME
+    ├── eviction.rs             # Cooperative-release eviction worker
+    ├── file.rs                 # OpenFile / OutstandingPage bookkeeping
+    └── backend.rs              # NamespaceBackend impl + NodeTable
+```
 
 ---
 
@@ -32,14 +46,21 @@ and the per-node filesystem labels for I/O and mutation.
 `FS_RENAME` is single-directory only at v0.1.0 because servers cannot
 introspect the token packed in a received cap; cross-directory rename
 needs either a kernel-level `cap_info` selector for tokens or a wire
-shape that conveys the destination `NodeId` out-of-band.
+shape that conveys the destination `NodeId` out-of-band. Tracked as
+[Issue #89](https://github.com/kottlerg/seraph/issues/89).
 
 Per-label rights gating (`WRITE` for the write labels, `MUTATE_DIR`
 for the mutation labels) goes through
-[`namespace-protocol::gate`](../../shared/namespace-protocol/src/gate.rs).
+[`namespace-protocol::gate`](../../../shared/namespace-protocol/src/gate.rs).
 The exact wire shapes are defined in
-[`shared/ipc/src/lib.rs`](../../shared/ipc/src/lib.rs) and documented
+[`shared/ipc/src/lib.rs`](../../../shared/ipc/src/lib.rs) and documented
 in [`../docs/fs-driver-protocol.md`](../docs/fs-driver-protocol.md).
+
+Cap-monotonic attenuation: `FS_CREATE` / `FS_MKDIR` mint a child cap
+with rights `caller_parent ∩ kind_max` where `kind_max` is
+`{STAT, READ, WRITE, EXEC}` for files and `NamespaceRights::ALL` for
+directories. A caller with `MUTATE_DIR`-only on a parent cannot widen
+into `READ` or `WRITE` on the created entry.
 
 ---
 
@@ -49,7 +70,8 @@ in [`../docs/fs-driver-protocol.md`](../docs/fs-driver-protocol.md).
   the FAT32 FSInfo `FSI_Nxt_Free` advisory hint. Mirror writes across
   all FAT copies. Invalidates the per-`FatState` private
   `cached_fat_sector` after every FAT-sector write to keep chain walks
-  consistent.
+  consistent. Best-effort FSInfo write-back after every allocation /
+  free.
 * **Directory mutation** (`src/dir.rs`): `insert_entry` / `remove_entry`
   / `update_entry_metadata`. Strict-8.3 short names round-trip
   exactly; non-strict names take a `NUMERIC_TAIL` (`~1..~6`) basis
@@ -62,6 +84,11 @@ in [`../docs/fs-driver-protocol.md`](../docs/fs-driver-protocol.md).
   the cached page is updated in place before the on-disk write so any
   outstanding `FS_READ_FRAME` cap aliasing the page observes new bytes
   immediately.
+* **NodeTable** (`src/backend.rs`): dedupes by on-disk slot
+  `(sector_lba, offset_in_sector)`; two distinct on-disk entries
+  always allocate distinct `NodeId`s, even when both are empty files
+  at cluster 0. `FS_REMOVE` and `FS_RENAME` invalidate the entry for
+  the unlinked slot.
 * **Eviction worker** (`src/eviction.rs`): unchanged from the read-side
   cooperative-release design; outstanding write paths return their
   caps before reply so they do not create new eviction pressure.
@@ -73,4 +100,21 @@ in [`../docs/fs-driver-protocol.md`](../docs/fs-driver-protocol.md).
 FAT has no commit ordering. Per-op write ordering is documented in
 [`docs/crash-safety.md`](docs/crash-safety.md), including the
 post-crash visible states for each mutation. v0.1.0 accepts these
-windows — no journal, no boot-time fsck.
+windows.
+
+---
+
+## Relevant Design Documents
+
+| Document | Content |
+|---|---|
+| [docs/crash-safety.md](docs/crash-safety.md) | Per-op write ordering and post-crash visible states |
+| [services/fs/docs/fs-driver-protocol.md](../docs/fs-driver-protocol.md) | Wire shapes for every FS_* label |
+| [docs/namespace-model.md](../../../docs/namespace-model.md) | Cap-as-namespace, rights attenuation |
+| [shared/namespace-protocol/README.md](../../../shared/namespace-protocol/README.md) | `NS_*` wire surface and `NamespaceBackend` trait |
+
+---
+
+## Summarized By
+
+[services/fs/README.md](../README.md)

--- a/services/fs/fat/README.md
+++ b/services/fs/fat/README.md
@@ -1,0 +1,76 @@
+# fat
+
+Seraph FAT16 / FAT32 filesystem driver. Read-write since
+[Issue #6](https://github.com/kottlerg/seraph/issues/6) +
+[Issue #7](https://github.com/kottlerg/seraph/issues/7).
+
+The driver is one process per mount; vfsd spawns and tears down
+instances, captures each driver's root cap at mount time, and forwards
+walks through it. The driver implements the cap-native namespace
+protocol (`NS_LOOKUP` / `NS_STAT` / `NS_READDIR`) for directory walks
+and the per-node filesystem labels for I/O and mutation.
+
+---
+
+## IPC surface
+
+| Label | Untokened? | Description |
+|---|---|---|
+| `FS_MOUNT` | yes | vfsd's BPB-validation probe at mount time |
+| `NS_LOOKUP` / `NS_STAT` / `NS_READDIR` | no | namespace dispatch |
+| `FS_READ` | no | inline read on a file cap |
+| `FS_READ_FRAME` | no | zero-copy read via a returned `Frame` cap |
+| `FS_RELEASE_FRAME` | no | client-side cooperative release |
+| `FS_CLOSE` | no | release per-file driver-side bookkeeping |
+| `FS_WRITE` | no | inline write on a file cap |
+| `FS_WRITE_FRAME` | no | caller-supplied source `Frame` cap |
+| `FS_CREATE` | no | new file in a directory |
+| `FS_REMOVE` | no | unlink a file or empty directory |
+| `FS_MKDIR` | no | new empty directory |
+| `FS_RENAME` | no | rename within a single directory |
+
+`FS_RENAME` is single-directory only at v0.1.0 because servers cannot
+introspect the token packed in a received cap; cross-directory rename
+needs either a kernel-level `cap_info` selector for tokens or a wire
+shape that conveys the destination `NodeId` out-of-band.
+
+Per-label rights gating (`WRITE` for the write labels, `MUTATE_DIR`
+for the mutation labels) goes through
+[`namespace-protocol::gate`](../../shared/namespace-protocol/src/gate.rs).
+The exact wire shapes are defined in
+[`shared/ipc/src/lib.rs`](../../shared/ipc/src/lib.rs) and documented
+in [`../docs/fs-driver-protocol.md`](../docs/fs-driver-protocol.md).
+
+---
+
+## Storage layout
+
+* **Cluster allocator** (`src/alloc.rs`): linear FAT scan seeded from
+  the FAT32 FSInfo `FSI_Nxt_Free` advisory hint. Mirror writes across
+  all FAT copies. Invalidates the per-`FatState` private
+  `cached_fat_sector` after every FAT-sector write to keep chain walks
+  consistent.
+* **Directory mutation** (`src/dir.rs`): `insert_entry` / `remove_entry`
+  / `update_entry_metadata`. Strict-8.3 short names round-trip
+  exactly; non-strict names take a `NUMERIC_TAIL` (`~1..~6`) basis
+  with an LFN run packed in reverse-sequence order. The trailing
+  `0x40` LFN sequence flag and `LDIR_Chksum` computation match the
+  Microsoft FAT specification.
+* **Page cache** (`src/cache.rs`): 128 single-page slots backed by
+  `BLK_READ_INTO_FRAME` for fills and a process-static scratch frame
+  for single-sector `BLK_WRITE_FROM_FRAME` writebacks. Write-through:
+  the cached page is updated in place before the on-disk write so any
+  outstanding `FS_READ_FRAME` cap aliasing the page observes new bytes
+  immediately.
+* **Eviction worker** (`src/eviction.rs`): unchanged from the read-side
+  cooperative-release design; outstanding write paths return their
+  caps before reply so they do not create new eviction pressure.
+
+---
+
+## Crash window
+
+FAT has no commit ordering. Per-op write ordering is documented in
+[`docs/crash-safety.md`](docs/crash-safety.md), including the
+post-crash visible states for each mutation. v0.1.0 accepts these
+windows — no journal, no boot-time fsck.

--- a/services/fs/fat/docs/crash-safety.md
+++ b/services/fs/fat/docs/crash-safety.md
@@ -1,0 +1,84 @@
+# fs-fat crash safety
+
+FAT has no commit ordering. Every mutation in `services/fs/fat` is a
+sequence of independent block writes, and the on-disk state between
+any two of them is a legitimate FAT layout the driver will accept on
+the next mount. v0.1.0 accepts these windows — there is no journal
+and no boot-time fsck.
+
+This document enumerates the windows so callers can reason about what
+they may observe after an interrupted operation.
+
+---
+
+## Write ordering
+
+| Operation | Per-block order | Post-crash visible states |
+|---|---|---|
+| `FS_WRITE` (extending) | data cluster(s) → FAT chain link(s) → directory `size` | (a) old size, no data; (b) old size, new data orphaned in unreferenced clusters; (c) old size, data + FAT link, dir entry unchanged → orphaned chain past EOF; (d) new size, new data |
+| `FS_WRITE` (in-place) | data cluster sector | (a) old bytes; (b) new bytes. Single-sector RMW; partial sector writes never observed because the cache page is updated in place before the on-disk write. |
+| `FS_CREATE` | (none yet — first cluster allocated lazily by the first `FS_WRITE`) → directory entry | (a) no entry; (b) entry present with `first_cluster = 0`, `size = 0` |
+| `FS_MKDIR` | allocate cluster → zero-fill cluster → write "."/".." → directory entry | (a) no entry; (b) orphaned zeroed cluster; (c) orphaned cluster with "."/".." (looks like a stray empty directory by inode); (d) entry present pointing at the new cluster |
+| `FS_REMOVE` | dir entry → `0xE5`; LFN slots → `0xE5`; FAT chain → free | (a) entry present; (b) entry deleted, chain still linked → orphan cluster chain; (c) entry deleted, chain freed |
+| `FS_RENAME` | insert dest entry → mark src entry `0xE5` | (a) only src present; (b) **both** src and dst present (two names referring to the same cluster chain — readers see the file twice); (c) only dst present |
+
+The FAT mirror copies (`num_fats == 2` on the default xtask-formatted
+image) are written in `0..num_fats` order. A crash between them
+leaves an inconsistent FAT pair; `fsck.vfat` reports a discrepancy
+but reconciles to FAT 0.
+
+---
+
+## Orphan classes
+
+* **Orphan cluster chain**: clusters marked allocated in the FAT but
+  with no directory entry pointing at them. Walking the FAT finds them;
+  walking the directory tree does not. Result: lost space. Recoverable
+  by `fsck.vfat` (Linux) or `chkdsk /F` (Windows). v0.1.0 does not
+  schedule a boot-time fsck; orphans persist until manual repair.
+
+* **Orphan directory entry**: an entry whose `first_cluster` points at a
+  cluster the FAT has freed (or marked bad). Reading via the entry
+  returns garbage from whatever was last on those sectors. Writing
+  through it could corrupt unrelated data once those clusters are
+  reused.
+
+* **Duplicate entry (rename window c)**: two directory entries with the
+  same `first_cluster`. Reads via either entry behave correctly until
+  the chain is mutated through one of them; subsequent reads via the
+  other entry see the mutation. Removing one entry frees the chain
+  the other entry still references — silent data loss on the survivor.
+
+---
+
+## What v0.1.0 does *not* do
+
+* No fsync wire label. Every `FS_WRITE` is write-through to the block
+  device by the time the reply lands; there is no "data acknowledged
+  but unflushed" window in fatfs itself. The block device may itself
+  buffer (virtio-blk on QEMU does not, but the design space includes
+  drivers that do). A separate `FS_FSYNC` label is a follow-up.
+
+* No journal. The write-back-cache work tracked as a follow-up Issue
+  would need its own crash-safety story before it lands; write-through
+  is intentionally chosen first so v0.1.0 has a simpler crash window.
+
+* No boot-time fsck. A consistency check at mount would catch
+  orphan-chain and duplicate-entry cases; the design space is
+  reasonable but not in v0.1.0 scope.
+
+---
+
+## Tested ordering invariants
+
+`usertest`'s `fs_write_cache_coherence_phase` confirms that
+write-through means `FS_READ` after `FS_WRITE` observes the new bytes
+without any explicit flush — no scenario in v0.1.0 requires a flush
+between write and read for correctness within the lifetime of a
+process.
+
+The other write-side phases (`fs_write_phase`, `fs_create_remove_phase`,
+`fs_mkdir_phase`, `fs_rename_phase`, `fs_write_frame_phase`) are
+golden-path round-trip tests; the windows above are not exercised
+by deliberate crash injection at v0.1.0. A two-boot QEMU harness for
+remount-survive testing is tracked as a follow-up.

--- a/services/fs/fat/docs/crash-safety.md
+++ b/services/fs/fat/docs/crash-safety.md
@@ -82,3 +82,9 @@ The other write-side phases (`fs_write_phase`, `fs_create_remove_phase`,
 golden-path round-trip tests; the windows above are not exercised
 by deliberate crash injection at v0.1.0. A two-boot QEMU harness for
 remount-survive testing is tracked as a follow-up.
+
+---
+
+## Summarized By
+
+[services/fs/fat/README.md](../README.md)

--- a/services/fs/fat/src/alloc.rs
+++ b/services/fs/fat/src/alloc.rs
@@ -156,7 +156,7 @@ pub fn update_fat_entry(
     }
     let (first_fat_sector, ent_off) = fat_entry_location(state, cluster);
 
-    let mut sector_buf = [0u8; SECTOR_SIZE];
+    let mut sector_buf = Box::new([0u8; SECTOR_SIZE]);
 
     for fat_idx in 0..u32::from(state.num_fats)
     {
@@ -389,7 +389,7 @@ pub fn load_fsinfo(state: &mut FatState, cache: &PageCache, block_dev: u32, ipc_
     {
         return;
     }
-    let mut buf = [0u8; SECTOR_SIZE];
+    let mut buf = Box::new([0u8; SECTOR_SIZE]);
     if !cache.read_sector(u64::from(state.fsinfo_sector), block_dev, &mut buf, ipc_buf)
     {
         std::os::seraph::log!("`FSInfo` sector read failed; allocator falls back to FAT scan");
@@ -426,7 +426,7 @@ pub fn flush_fsinfo(state: &mut FatState, cache: &PageCache, block_dev: u32, ipc
     {
         return;
     }
-    let mut buf = [0u8; SECTOR_SIZE];
+    let mut buf = Box::new([0u8; SECTOR_SIZE]);
     if !cache.read_sector(u64::from(state.fsinfo_sector), block_dev, &mut buf, ipc_buf)
     {
         std::os::seraph::log!("`FSInfo` flush: sector read failed");

--- a/services/fs/fat/src/alloc.rs
+++ b/services/fs/fat/src/alloc.rs
@@ -1,0 +1,441 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// fs/fat/src/alloc.rs
+
+//! FAT cluster allocation, freeing, and FAT-entry mutation.
+//!
+//! Hand-rolled allocator backed by a linear scan over the on-disk FAT
+//! array. FAT32 mounts seed the scan from the `FSInfo` `FSI_Nxt_Free`
+//! advisory hint (validated against the FAT entry before use); FAT16
+//! and FAT32 on hint miss fall back to scanning from cluster 2.
+//!
+//! All mutations go through [`update_fat_entry`], which performs a
+//! single-sector read-modify-write through [`PageCache::write_sector`]
+//! against every FAT copy in `0..num_fats`. The driver's
+//! `cached_fat_sector` private cache (outside `PageCache`) is
+//! invalidated when it covers the modified sector — failure to do this
+//! is the highest-risk silent-corruption bug in the allocator.
+//!
+//! End-of-chain (`EOC`) and free (`0`) sentinels are FAT-type specific.
+//! Bad-cluster entries (`0xFFF7` / `0x0FFF_FFF7`) are *never* allocated
+//! and never freed by this module.
+
+// Allocator helpers other than load_fsinfo are wired into dispatch
+// handlers in a later commit.
+#![allow(dead_code)]
+
+use crate::bpb::{FatState, FatType, SECTOR_SIZE};
+use crate::cache::PageCache;
+use crate::fat::next_cluster;
+
+/// Per-module error surface. Mapped to `fs_errors` wire codes at the
+/// dispatch boundary.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum FatError
+{
+    /// Block-device read or write failure, or cache-acquire failure.
+    Io,
+    /// No free cluster remains on the volume.
+    NoSpace,
+    /// FAT chain or directory entry violates an invariant we cannot
+    /// recover from (e.g. cluster index past `total_clusters`).
+    Corrupt,
+}
+
+/// End-of-chain sentinel for the given FAT type, written into the
+/// terminal cluster of a newly-allocated chain.
+const fn eoc_value(fat_type: FatType) -> u32
+{
+    match fat_type
+    {
+        FatType::Fat16 => 0xFFFF,
+        FatType::Fat32 => 0x0FFF_FFFF,
+    }
+}
+
+/// Free-cluster sentinel.
+const FREE: u32 = 0;
+
+/// Bad-cluster sentinel for the given FAT type. Entries with this
+/// value must be skipped by the allocator and never written.
+const fn bad_value(fat_type: FatType) -> u32
+{
+    match fat_type
+    {
+        FatType::Fat16 => 0xFFF7,
+        FatType::Fat32 => 0x0FFF_FFF7,
+    }
+}
+
+/// `FSInfo` sector signatures per Microsoft FAT32 specification §6.
+const FSI_LEAD_SIG: u32 = 0x4161_5252;
+const FSI_STRUCT_SIG: u32 = 0x6141_7272;
+const FSI_TRAIL_SIG: u32 = 0xAA55_0000;
+
+/// Compute the FAT-sector LBA and byte offset within that sector for
+/// the given cluster index. Mirrors the arithmetic in [`next_cluster`]
+/// without duplicating its cache-lookup path.
+fn fat_entry_location(state: &FatState, cluster: u32) -> (u32, usize)
+{
+    let entry_bytes = match state.fat_type
+    {
+        FatType::Fat16 => 2,
+        FatType::Fat32 => 4,
+    };
+    let offset = cluster * entry_bytes;
+    let sector = u32::from(state.reserved_sectors) + offset / u32::from(state.bytes_per_sector);
+    let ent_off = (offset % u32::from(state.bytes_per_sector)) as usize;
+    (sector, ent_off)
+}
+
+/// Read a single FAT entry value (resolved to a 32-bit cluster number
+/// for FAT16, masked to 28 bits for FAT32).
+fn read_fat_entry(
+    state: &mut FatState,
+    cluster: u32,
+    cache: &PageCache,
+    block_dev: u32,
+    ipc_buf: *mut u64,
+) -> Result<u32, FatError>
+{
+    let (fat_sector, ent_off) = fat_entry_location(state, cluster);
+    if state.cached_fat_sector != fat_sector
+    {
+        if !cache.read_sector(
+            u64::from(fat_sector),
+            block_dev,
+            &mut state.cached_fat_data,
+            ipc_buf,
+        )
+        {
+            return Err(FatError::Io);
+        }
+        state.cached_fat_sector = fat_sector;
+    }
+    Ok(match state.fat_type
+    {
+        FatType::Fat16 => u32::from(u16::from_le_bytes([
+            state.cached_fat_data[ent_off],
+            state.cached_fat_data[ent_off + 1],
+        ])),
+        FatType::Fat32 =>
+        {
+            u32::from_le_bytes([
+                state.cached_fat_data[ent_off],
+                state.cached_fat_data[ent_off + 1],
+                state.cached_fat_data[ent_off + 2],
+                state.cached_fat_data[ent_off + 3],
+            ]) & 0x0FFF_FFFF
+        }
+    })
+}
+
+/// Write a single FAT entry value to every FAT mirror copy.
+///
+/// FAT32 preserves the top four reserved bits of each entry per
+/// Microsoft spec §4; FAT16 entries are fully overwritten. The
+/// modified sector is read once into a scratch buffer, the entry
+/// patched, and written through [`PageCache::write_sector`] for every
+/// copy in `0..num_fats`. The driver's private `cached_fat_sector` is
+/// invalidated when it covers the modified sector — the cluster
+/// allocator and chain walker rely on this so a stale read does not
+/// resurrect freed clusters or skip newly-allocated ones.
+pub fn update_fat_entry(
+    state: &mut FatState,
+    cluster: u32,
+    value: u32,
+    cache: &PageCache,
+    block_dev: u32,
+    ipc_buf: *mut u64,
+) -> Result<(), FatError>
+{
+    if cluster < 2 || cluster >= 2 + state.total_clusters
+    {
+        return Err(FatError::Corrupt);
+    }
+    let (first_fat_sector, ent_off) = fat_entry_location(state, cluster);
+
+    let mut sector_buf = [0u8; SECTOR_SIZE];
+
+    for fat_idx in 0..u32::from(state.num_fats)
+    {
+        let fat_sector = first_fat_sector + fat_idx * state.fat_size;
+
+        // RMW: read the current sector contents, patch the entry,
+        // write it back. Reading via the page cache amortises with
+        // adjacent allocations / frees in the same FAT sector.
+        if !cache.read_sector(u64::from(fat_sector), block_dev, &mut sector_buf, ipc_buf)
+        {
+            return Err(FatError::Io);
+        }
+
+        match state.fat_type
+        {
+            FatType::Fat16 =>
+            {
+                let bytes = (value as u16).to_le_bytes();
+                sector_buf[ent_off] = bytes[0];
+                sector_buf[ent_off + 1] = bytes[1];
+            }
+            FatType::Fat32 =>
+            {
+                let existing = u32::from_le_bytes([
+                    sector_buf[ent_off],
+                    sector_buf[ent_off + 1],
+                    sector_buf[ent_off + 2],
+                    sector_buf[ent_off + 3],
+                ]);
+                // Preserve top four reserved bits (Microsoft FAT32
+                // spec §4: "Note that the high 4 bits of a FAT32 FAT
+                // entry are reserved").
+                let merged = (existing & 0xF000_0000) | (value & 0x0FFF_FFFF);
+                let bytes = merged.to_le_bytes();
+                sector_buf[ent_off] = bytes[0];
+                sector_buf[ent_off + 1] = bytes[1];
+                sector_buf[ent_off + 2] = bytes[2];
+                sector_buf[ent_off + 3] = bytes[3];
+            }
+        }
+
+        if !cache.write_sector(u64::from(fat_sector), block_dev, &sector_buf, ipc_buf)
+        {
+            return Err(FatError::Io);
+        }
+
+        // Invalidate the per-FatState private cache if it currently
+        // holds the sector we just modified. Skipping this is the
+        // single largest silent-corruption hazard in the allocator:
+        // next_cluster() would return the pre-write FAT bytes.
+        if state.cached_fat_sector == fat_sector
+        {
+            state.cached_fat_sector = u32::MAX;
+        }
+    }
+    Ok(())
+}
+
+/// Allocate one free cluster, mark it end-of-chain, and optionally
+/// link it as the successor of `prev`.
+///
+/// Scan strategy: start at `next_free_hint` (or cluster 2 on FAT16 /
+/// hint miss), walk forward, wrap to cluster 2 once, terminate on
+/// finding a free entry or completing the wrap. Bad clusters are
+/// skipped. On success, the returned cluster's FAT entry is written
+/// `eoc_value(fat_type)` and `next_free_hint` is bumped to the slot
+/// after the allocation.
+pub fn allocate_cluster(
+    state: &mut FatState,
+    prev: Option<u32>,
+    cache: &PageCache,
+    block_dev: u32,
+    ipc_buf: *mut u64,
+) -> Result<u32, FatError>
+{
+    if state.total_clusters == 0
+    {
+        return Err(FatError::Corrupt);
+    }
+    let max_cluster = state.total_clusters + 1; // inclusive upper index
+    let start = if state.next_free_hint >= 2 && state.next_free_hint <= max_cluster
+    {
+        state.next_free_hint
+    }
+    else
+    {
+        2
+    };
+
+    let bad = bad_value(state.fat_type);
+
+    let mut cluster = start;
+    let mut wrapped = false;
+    let found = loop
+    {
+        let entry = read_fat_entry(state, cluster, cache, block_dev, ipc_buf)?;
+        if entry == FREE
+        {
+            break cluster;
+        }
+        let _ = bad; // touched below; lint quiet without binding here
+        cluster += 1;
+        if cluster > max_cluster
+        {
+            if wrapped
+            {
+                return Err(FatError::NoSpace);
+            }
+            cluster = 2;
+            wrapped = true;
+        }
+        if wrapped && cluster >= start
+        {
+            return Err(FatError::NoSpace);
+        }
+    };
+
+    // Skip the bad-cluster sentinel just in case (read_fat_entry returns
+    // the raw value).
+    if found_is_bad(state, found, cache, block_dev, ipc_buf, bad)?
+    {
+        return Err(FatError::Corrupt);
+    }
+
+    // Mark the new cluster end-of-chain.
+    update_fat_entry(
+        state,
+        found,
+        eoc_value(state.fat_type),
+        cache,
+        block_dev,
+        ipc_buf,
+    )?;
+
+    // Link prev → found if requested.
+    if let Some(p) = prev
+    {
+        update_fat_entry(state, p, found, cache, block_dev, ipc_buf)?;
+    }
+
+    // Bump the advisory hint past the allocation (wrap to 2 at end).
+    state.next_free_hint = if found + 1 > max_cluster
+    {
+        2
+    }
+    else
+    {
+        found + 1
+    };
+    if state.free_count_hint != u32::MAX && state.free_count_hint > 0
+    {
+        state.free_count_hint -= 1;
+    }
+
+    Ok(found)
+}
+
+/// Defensive double-check that `cluster` is not the bad-cluster
+/// sentinel. Used by `allocate_cluster` after the scan; the scan loop
+/// itself never breaks on a non-free entry so this should always be
+/// false but guards against a corrupt FAT.
+fn found_is_bad(
+    state: &mut FatState,
+    cluster: u32,
+    cache: &PageCache,
+    block_dev: u32,
+    ipc_buf: *mut u64,
+    bad: u32,
+) -> Result<bool, FatError>
+{
+    Ok(read_fat_entry(state, cluster, cache, block_dev, ipc_buf)? == bad)
+}
+
+/// Free every cluster in the chain starting at `start`, writing
+/// `FREE = 0` into each FAT entry. Returns the count of clusters
+/// freed.
+///
+/// Stops on end-of-chain, bad-cluster sentinel, or
+/// [`next_cluster`] returning `None`. The `next_free_hint` is biased
+/// toward the freed range so subsequent allocations reuse the slots.
+pub fn free_cluster_chain(
+    state: &mut FatState,
+    start: u32,
+    cache: &PageCache,
+    block_dev: u32,
+    ipc_buf: *mut u64,
+) -> Result<u32, FatError>
+{
+    if start < 2 || start >= 2 + state.total_clusters
+    {
+        return Err(FatError::Corrupt);
+    }
+    let mut cluster = start;
+    let mut freed = 0u32;
+    loop
+    {
+        let next = next_cluster(state, cluster, cache, block_dev, ipc_buf);
+        update_fat_entry(state, cluster, FREE, cache, block_dev, ipc_buf)?;
+        freed += 1;
+        if state.free_count_hint != u32::MAX
+        {
+            state.free_count_hint = state.free_count_hint.saturating_add(1);
+        }
+        // Bias the next-free hint toward the lower of (current hint,
+        // freed cluster) so we reuse the space promptly.
+        if cluster < state.next_free_hint
+        {
+            state.next_free_hint = cluster;
+        }
+        match next
+        {
+            Some(n) if n >= 2 && n < 2 + state.total_clusters => cluster = n,
+            _ => break,
+        }
+    }
+    Ok(freed)
+}
+
+/// Read the `FSInfo` sector at mount and populate
+/// `state.next_free_hint` / `state.free_count_hint`. FAT16 mounts and
+/// FAT32 mounts without an `FSInfo` sector leave the hints at the
+/// `u32::MAX` sentinel; the allocator falls back to scanning from
+/// cluster 2.
+///
+/// Signature mismatches are logged and treated as "no usable hints";
+/// the allocator still operates from the FAT itself.
+pub fn load_fsinfo(state: &mut FatState, cache: &PageCache, block_dev: u32, ipc_buf: *mut u64)
+{
+    if !matches!(state.fat_type, FatType::Fat32) || state.fsinfo_sector == u32::MAX
+    {
+        return;
+    }
+    let mut buf = [0u8; SECTOR_SIZE];
+    if !cache.read_sector(u64::from(state.fsinfo_sector), block_dev, &mut buf, ipc_buf)
+    {
+        std::os::seraph::log!("`FSInfo` sector read failed; allocator falls back to FAT scan");
+        return;
+    }
+    let lead = u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]);
+    let structsig = u32::from_le_bytes([buf[484], buf[485], buf[486], buf[487]]);
+    let trail = u32::from_le_bytes([buf[508], buf[509], buf[510], buf[511]]);
+    if lead != FSI_LEAD_SIG || structsig != FSI_STRUCT_SIG || trail != FSI_TRAIL_SIG
+    {
+        std::os::seraph::log!(
+            "`FSInfo` signature mismatch (lead={lead:#x} struct={structsig:#x} trail={trail:#x}); ignoring hints"
+        );
+        return;
+    }
+    let free = u32::from_le_bytes([buf[488], buf[489], buf[490], buf[491]]);
+    let nxt = u32::from_le_bytes([buf[492], buf[493], buf[494], buf[495]]);
+    if free != u32::MAX
+    {
+        state.free_count_hint = free;
+    }
+    if nxt != u32::MAX && nxt >= 2 && nxt < 2 + state.total_clusters
+    {
+        state.next_free_hint = nxt;
+    }
+}
+
+/// Write the current `next_free_hint` and `free_count_hint` back to
+/// the `FSInfo` sector. Best-effort: failures are logged but not
+/// propagated, since the `FSInfo` sector is advisory per Microsoft spec.
+pub fn flush_fsinfo(state: &mut FatState, cache: &PageCache, block_dev: u32, ipc_buf: *mut u64)
+{
+    if !matches!(state.fat_type, FatType::Fat32) || state.fsinfo_sector == u32::MAX
+    {
+        return;
+    }
+    let mut buf = [0u8; SECTOR_SIZE];
+    if !cache.read_sector(u64::from(state.fsinfo_sector), block_dev, &mut buf, ipc_buf)
+    {
+        std::os::seraph::log!("`FSInfo` flush: sector read failed");
+        return;
+    }
+    buf[488..492].copy_from_slice(&state.free_count_hint.to_le_bytes());
+    buf[492..496].copy_from_slice(&state.next_free_hint.to_le_bytes());
+    if !cache.write_sector(u64::from(state.fsinfo_sector), block_dev, &buf, ipc_buf)
+    {
+        std::os::seraph::log!("`FSInfo` flush: sector write failed");
+    }
+}

--- a/services/fs/fat/src/alloc.rs
+++ b/services/fs/fat/src/alloc.rs
@@ -21,10 +21,6 @@
 //! Bad-cluster entries (`0xFFF7` / `0x0FFF_FFF7`) are *never* allocated
 //! and never freed by this module.
 
-// Allocator helpers other than load_fsinfo are wired into dispatch
-// handlers in a later commit.
-#![allow(dead_code)]
-
 use crate::bpb::{FatState, FatType, SECTOR_SIZE};
 use crate::cache::PageCache;
 use crate::fat::next_cluster;
@@ -311,6 +307,12 @@ pub fn allocate_cluster(
         state.free_count_hint -= 1;
     }
 
+    // Best-effort FSInfo write-back: keeps the on-disk hints aligned
+    // with in-memory state so a subsequent mount does not have to
+    // rescan the FAT to compute `free_count`. No-op on FAT16 / when
+    // the FAT32 image has no FSInfo sector.
+    flush_fsinfo(state, cache, block_dev, ipc_buf);
+
     Ok(found)
 }
 
@@ -372,6 +374,9 @@ pub fn free_cluster_chain(
             _ => break,
         }
     }
+    // Mirror allocate_cluster: persist the updated free-count and
+    // next-free hints so a remount sees the correct state.
+    flush_fsinfo(state, cache, block_dev, ipc_buf);
     Ok(freed)
 }
 

--- a/services/fs/fat/src/backend.rs
+++ b/services/fs/fat/src/backend.rs
@@ -142,6 +142,28 @@ impl NodeTable
             node.open_slot = slot;
         }
     }
+
+    /// Invalidate any entries that match `(cluster, kind, size)`.
+    /// Called from `FS_REMOVE` so a follow-on `FS_CREATE` that lands at
+    /// the same disk location does not dedupe to a stale `NodeId`.
+    ///
+    /// The append-only table cannot recycle slots (filed as Issue #27),
+    /// so the slot is left present but cleared to `None`; the dedupe
+    /// scan in `alloc()` only matches `Some` entries.
+    #[allow(dead_code)] // wired in by the FS_REMOVE handler in a later commit
+    pub fn invalidate_for_entry(&mut self, cluster: u32, kind: NodeKind, size: u32)
+    {
+        for slot in &mut self.entries[..self.len]
+        {
+            if let Some(existing) = slot
+                && existing.cluster == cluster
+                && existing.kind == kind
+                && existing.size == size
+            {
+                *slot = None;
+            }
+        }
+    }
 }
 
 /// `NamespaceBackend` over a FAT volume.
@@ -247,16 +269,28 @@ impl NamespaceBackend for FatfsBackend<'_>
             })
             .ok_or(NsError::OutOfResources)?;
 
+        // Rights composition (`parent ∩ entry.max ∩ requested`) means a
+        // dir's `max_rights` ceiling must include every bit a child
+        // file or subdir might legitimately inherit — otherwise the
+        // walk drops `READ` (or `WRITE`) on a leaf because an
+        // intermediate dir cleared it. Dirs therefore carry the full
+        // mask (the per-operation rights enforcement at the leaf still
+        // gates each request via `gate()`); files narrow to the
+        // file-only set.
+        let max = match kind
+        {
+            NodeKind::Dir => NamespaceRights::ALL,
+            NodeKind::File => NamespaceRights::from_raw(
+                rights::STAT | rights::READ | rights::WRITE | rights::EXEC,
+            ),
+        };
         Ok(EntryView {
             target: EntryTarget::Local(node_id),
             kind,
             size_hint: u64::from(entry.size),
-            // Read-only volume: hand out everything the namespace
-            // model defines as observable. Future write support
-            // narrows this on a per-entry basis.
-            max_rights: NamespaceRights::from_raw(
-                rights::LOOKUP | rights::READDIR | rights::STAT | rights::READ | rights::EXEC,
-            ),
+            // FAT directory `DIR_ATTR_READ_ONLY` is not honoured here;
+            // tracked as a follow-up Issue.
+            max_rights: max,
             visible_requires: NamespaceRights::NONE,
         })
     }

--- a/services/fs/fat/src/backend.rs
+++ b/services/fs/fat/src/backend.rs
@@ -60,7 +60,6 @@ pub struct FatNode
     /// chain. `sector_lba == 0` is the sentinel "no location known"
     /// (LBA 0 is the BPB, never a directory sector); the dispatch
     /// rejects mutation requests against such nodes.
-    #[allow(dead_code)] // consumed by dispatch handlers in a later commit
     pub loc: DirEntryLocation,
 }
 
@@ -115,19 +114,18 @@ impl NodeTable
 
     fn alloc(&mut self, node: FatNode) -> Option<NodeId>
     {
-        // Dedupe by (cluster, kind, size). Different on-disk entries
-        // never collide on starting cluster (FAT invariant for non-empty
-        // files; empty files at cluster 0 are content-indistinguishable
-        // and may safely share a NodeId). Saves the table from monotonic
-        // growth on repeated lookups of the same path — without this,
-        // 64 unique walks exhausts MAX_NODES, even for paths a caller
-        // re-walks every iteration.
+        // Dedupe by on-disk slot location. `(sector_lba,
+        // offset_in_sector)` uniquely identifies a 32-byte directory
+        // entry — two distinct files can never share one, and repeated
+        // walks of the same file always rediscover the same slot.
+        // Previous keys based on `(cluster, kind, size)` collapsed
+        // every empty file (cluster=0, size=0) to a single NodeId,
+        // silently aliasing FS_CREATEs of distinct empty files.
         for (i, slot) in self.entries[..self.len].iter().enumerate()
         {
             if let Some(existing) = slot
-                && existing.cluster == node.cluster
-                && existing.kind == node.kind
-                && existing.size == node.size
+                && existing.loc.sector_lba == node.loc.sector_lba
+                && existing.loc.offset_in_sector == node.loc.offset_in_sector
             {
                 return NodeId::new((i + 1) as u64);
             }
@@ -163,22 +161,21 @@ impl NodeTable
         }
     }
 
-    /// Invalidate any entries that match `(cluster, kind, size)`.
-    /// Called from `FS_REMOVE` so a follow-on `FS_CREATE` that lands at
-    /// the same disk location does not dedupe to a stale `NodeId`.
+    /// Invalidate any entry whose on-disk slot matches `loc`. Called
+    /// from `FS_REMOVE` / `FS_RENAME` so a follow-on `FS_CREATE` that
+    /// lands at the same disk slot does not dedupe to a stale
+    /// `NodeId`.
     ///
-    /// The append-only table cannot recycle slots (filed as Issue #27),
-    /// so the slot is left present but cleared to `None`; the dedupe
-    /// scan in `alloc()` only matches `Some` entries.
-    #[allow(dead_code)] // wired in by the FS_REMOVE handler in a later commit
-    pub fn invalidate_for_entry(&mut self, cluster: u32, kind: NodeKind, size: u32)
+    /// The append-only table cannot recycle slots (filed as Issue
+    /// #27), so the slot is left present but cleared to `None`; the
+    /// dedupe scan in `alloc()` only matches `Some` entries.
+    pub fn invalidate_for_loc(&mut self, loc: DirEntryLocation)
     {
         for slot in &mut self.entries[..self.len]
         {
             if let Some(existing) = slot
-                && existing.cluster == cluster
-                && existing.kind == kind
-                && existing.size == size
+                && existing.loc.sector_lba == loc.sector_lba
+                && existing.loc.offset_in_sector == loc.offset_in_sector
             {
                 *slot = None;
             }
@@ -187,7 +184,6 @@ impl NodeTable
 
     /// Update the cluster and size fields of a non-root node entry.
     /// Used by `FS_WRITE` after extending the file's cluster chain.
-    #[allow(dead_code)] // wired in by the FS_WRITE handler in this PR's next commit
     pub fn update_size_and_cluster(&mut self, id: NodeId, new_cluster: u32, new_size: u32)
     {
         let raw = id.raw();

--- a/services/fs/fat/src/backend.rs
+++ b/services/fs/fat/src/backend.rs
@@ -21,7 +21,10 @@
 
 use crate::bpb::{FatState, FatType};
 use crate::cache::PageCache;
-use crate::dir::{DirEntry, MAX_LFN_UTF8, read_dir_entry_at_index};
+use crate::dir::{
+    DirEntry, DirEntryLocation, MAX_LFN_UTF8, find_in_directory_with_location,
+    read_dir_entry_at_index,
+};
 use namespace_protocol::{
     EntryName, EntryTarget, EntryView, FrameReply, NamespaceBackend, NamespaceRights, NodeId,
     NodeKind, NodeStat, NsError, rights,
@@ -51,6 +54,14 @@ pub struct FatNode
     pub size: u32,
     pub kind: NodeKind,
     pub open_slot: u32,
+    /// On-disk position of this entry's 8.3 record. Populated by
+    /// `lookup()` so write / metadata-update handlers can patch
+    /// `first_cluster` and `size` in place after extending the cluster
+    /// chain. `sector_lba == 0` is the sentinel "no location known"
+    /// (LBA 0 is the BPB, never a directory sector); the dispatch
+    /// rejects mutation requests against such nodes.
+    #[allow(dead_code)] // consumed by dispatch handlers in a later commit
+    pub loc: DirEntryLocation,
 }
 
 /// Sentinel for [`FatNode::open_slot`] meaning "no `OpenFile` slot
@@ -91,6 +102,15 @@ impl NodeTable
         }
         let idx = (raw - 1) as usize;
         self.entries.get(idx).copied().flatten()
+    }
+
+    /// Public-to-the-crate wrapper around `alloc` so dispatch handlers
+    /// in `main.rs` can mint a new node entry directly for
+    /// freshly-created files / directories.
+    #[must_use]
+    pub fn alloc_for_dispatch(&mut self, node: FatNode) -> Option<NodeId>
+    {
+        self.alloc(node)
     }
 
     fn alloc(&mut self, node: FatNode) -> Option<NodeId>
@@ -162,6 +182,24 @@ impl NodeTable
             {
                 *slot = None;
             }
+        }
+    }
+
+    /// Update the cluster and size fields of a non-root node entry.
+    /// Used by `FS_WRITE` after extending the file's cluster chain.
+    #[allow(dead_code)] // wired in by the FS_WRITE handler in this PR's next commit
+    pub fn update_size_and_cluster(&mut self, id: NodeId, new_cluster: u32, new_size: u32)
+    {
+        let raw = id.raw();
+        if raw == 0
+        {
+            return;
+        }
+        let idx = (raw - 1) as usize;
+        if let Some(Some(node)) = self.entries.get_mut(idx)
+        {
+            node.cluster = new_cluster;
+            node.size = new_size;
         }
     }
 }
@@ -243,13 +281,21 @@ impl NamespaceBackend for FatfsBackend<'_>
     {
         let dir_cluster = self.cluster_for(dir).ok_or(NsError::NotADirectory)?;
 
-        // Single-component scan against `dir_cluster`. Mirrors the
-        // logic in `dir.rs::find_in_directory`, inlined here because
-        // that helper is module-private to dir.rs and structured for
-        // the multi-component path walker rather than the per-call
-        // single-name dispatch the namespace protocol expects.
-        let entry = scan_dir_for_name(
-            dir_cluster,
+        // Resolves a single component against `dir_cluster` and also
+        // surfaces the on-disk `DirEntryLocation` so the write-side
+        // dispatch can patch metadata in place without re-scanning the
+        // parent directory.
+        let dir_cluster_resolved = if dir_cluster == 0
+            && matches!(self.state.fat_type, FatType::Fat32)
+        {
+            self.state.root_cluster
+        }
+        else
+        {
+            dir_cluster
+        };
+        let (entry, loc) = find_in_directory_with_location(
+            dir_cluster_resolved,
             name,
             self.state,
             self.cache,
@@ -266,6 +312,7 @@ impl NamespaceBackend for FatfsBackend<'_>
                 size: entry.size,
                 kind,
                 open_slot: NO_OPEN_SLOT,
+                loc,
             })
             .ok_or(NsError::OutOfResources)?;
 
@@ -358,43 +405,4 @@ impl NamespaceBackend for FatfsBackend<'_>
     fn release_frame(&mut self, _file: NodeId, _cookie: u64) {}
 
     fn close(&mut self, _node: NodeId) {}
-}
-
-/// Single-component lookup against `dir_cluster`.
-///
-/// Bridges the gap left by `dir::find_in_directory` being private:
-/// Resolve a single name against `dir_cluster`, returning the matching
-/// directory entry (or `None` for absence).
-///
-/// Delegates to [`crate::dir::find_in_directory`] for both the FAT32
-/// cluster-chain walk and the FAT16 fixed-root case. That helper
-/// performs LFN-aware matching via `scan_sector_for_name`, so names
-/// whose 8.3 short form is generated (e.g. `boot.conf` → `BOOT~1.CON`)
-/// resolve correctly through their long-name entry. The
-/// FAT32-root-cluster path also lands on `find_in_directory` (no
-/// special-case dispatch) — `resolve_path` is only needed when the
-/// caller doesn't yet know the start cluster.
-fn scan_dir_for_name(
-    dir_cluster: u32,
-    name: &[u8],
-    state: &mut FatState,
-    cache: &PageCache,
-    block_dev: u32,
-    ipc_buf: *mut u64,
-) -> Option<DirEntry>
-{
-    if dir_cluster == 0 && matches!(state.fat_type, FatType::Fat32)
-    {
-        // FAT32 with cluster 0 means "uninitialised" — fall back to
-        // resolving from the configured root cluster.
-        return crate::dir::find_in_directory(
-            state.root_cluster,
-            name,
-            state,
-            cache,
-            block_dev,
-            ipc_buf,
-        );
-    }
-    crate::dir::find_in_directory(dir_cluster, name, state, cache, block_dev, ipc_buf)
 }

--- a/services/fs/fat/src/bpb.rs
+++ b/services/fs/fat/src/bpb.rs
@@ -40,6 +40,25 @@ pub struct FatState
     pub cached_fat_sector: u32,
     /// Cached FAT sector data.
     pub cached_fat_data: [u8; SECTOR_SIZE],
+    /// Total cluster count (data-region size / cluster size). Used by
+    /// the cluster allocator to bound its FAT scan and by mount-time
+    /// validation. `cached_fat_sector` and the FAT array index range
+    /// `[2..2 + total_clusters)`.
+    pub total_clusters: u32,
+    /// `FSInfo` sector LBA (FAT32 only; `u32::MAX` sentinel otherwise).
+    /// Loaded from BPB offset 48 by `parse_bpb` when the detected type
+    /// is FAT32. The `FSInfo` content (free count, next-free hint) is
+    /// loaded separately by the allocator at mount, since `parse_bpb`
+    /// does not have block-device access.
+    pub fsinfo_sector: u32,
+    /// FAT32 advisory hint: next cluster the allocator should consider
+    /// for a free-cluster search. Microsoft spec §6 marks this field
+    /// advisory; the allocator revalidates by reading the FAT entry. A
+    /// `u32::MAX` sentinel forces a scan from cluster 2.
+    pub next_free_hint: u32,
+    /// FAT32 advisory free-cluster count. `u32::MAX` sentinel means
+    /// unknown. Maintained best-effort by the allocator.
+    pub free_count_hint: u32,
 }
 
 impl FatState
@@ -59,6 +78,10 @@ impl FatState
             data_start_sector: 0,
             cached_fat_sector: u32::MAX,
             cached_fat_data: [0; SECTOR_SIZE],
+            total_clusters: 0,
+            fsinfo_sector: u32::MAX,
+            next_free_hint: u32::MAX,
+            free_count_hint: u32::MAX,
         }
     }
 
@@ -171,6 +194,7 @@ pub fn parse_bpb(sector_data: &[u8; SECTOR_SIZE], state: &mut FatState) -> bool
 
     let data_sectors = total_sectors.saturating_sub(state.data_start_sector);
     let total_clusters = data_sectors / u32::from(state.sectors_per_cluster);
+    state.total_clusters = total_clusters;
 
     // FAT type determination per Microsoft specification.
     if total_clusters < 65525
@@ -182,6 +206,15 @@ pub fn parse_bpb(sector_data: &[u8; SECTOR_SIZE], state: &mut FatState) -> bool
     {
         state.fat_type = FatType::Fat32;
         std::os::seraph::log!("detected FAT32");
+        // FAT32 extended BPB: `FSInfo` sector LBA at offset 48 (2 bytes).
+        // A value of 0 or 0xFFFF means "no `FSInfo` sector"; we hold the
+        // u32::MAX sentinel in those cases so the allocator skips load
+        // and falls back to a full FAT scan.
+        let fsinfo = u16::from_le_bytes([sector_data[48], sector_data[49]]);
+        if fsinfo != 0 && fsinfo != 0xFFFF
+        {
+            state.fsinfo_sector = u32::from(fsinfo);
+        }
     }
 
     std::os::seraph::log!(

--- a/services/fs/fat/src/cache.rs
+++ b/services/fs/fat/src/cache.rs
@@ -198,7 +198,6 @@ impl PageCache
     ///
     /// Returns `false` on cache acquire failure, missing scratch frame
     /// (cache init never ran), or block-driver error.
-    #[allow(dead_code)] // wired in by alloc.rs / dispatch in subsequent commits
     pub fn write_sector(
         &self,
         lba: u64,

--- a/services/fs/fat/src/cache.rs
+++ b/services/fs/fat/src/cache.rs
@@ -34,9 +34,36 @@ use core::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 
 use ipc::{IpcMessage, blk_errors, blk_labels, memmgr_errors, memmgr_labels};
 use std::os::seraph::reserve_pages;
+use std::sync::OnceLock;
 use syscall_abi::{MAP_WRITABLE, PAGE_SIZE};
 
 use crate::bpb::SECTOR_SIZE;
+
+/// Process-static scratch frame used for single-sector writeback in
+/// [`PageCache::write_sector`].
+///
+/// virtio-blk DMAs sector data starting at offset 0 of the supplied
+/// frame, so we cannot pass a cache page directly when only one of its
+/// eight sectors has been dirtied (the device would over-write the
+/// other seven on the disk side using whatever happened to be in the
+/// page). The scratch frame holds a single 512-byte sector copy per
+/// write and is reused across calls; allocated lazily on first write
+/// and held for the process lifetime.
+static SCRATCH_FRAME: OnceLock<ScratchFrame> = OnceLock::new();
+
+struct ScratchFrame
+{
+    cap: AtomicU32,
+    va: u64,
+}
+
+// SAFETY: ScratchFrame holds an AtomicU32 cap (Sync by construction) and
+// a raw VA value (u64) that is process-static. Concurrent callers
+// serialise their use of the frame via the cap_swap dance in
+// write_sector, not via Rust borrow checking.
+unsafe impl Send for ScratchFrame {}
+// SAFETY: see Send above — same justification.
+unsafe impl Sync for ScratchFrame {}
 
 /// Number of cache slots.
 pub const SLOT_COUNT: usize = 128;
@@ -138,7 +165,79 @@ impl PageCache
             slot.frame_cap.store(cap, Ordering::Release);
         }
 
+        // Allocate and map the single-page scratch frame used for
+        // single-sector writeback in `write_sector`. Lazy fallback would
+        // need to re-do the request/reserve/map dance under an Ordering
+        // discipline; doing it once at startup keeps `write_sector`
+        // synchronous and free of init-time error paths.
+        let scratch_va = reserve_pages(1).map_err(|_| InitError::Reserve)?.va_start();
+        let scratch_cap = request_one_page(memmgr_ep, ipc_buf).ok_or(InitError::Memmgr)?;
+        syscall::mem_map(scratch_cap, self_aspace, scratch_va, 0, 1, MAP_WRITABLE)
+            .map_err(|_| InitError::Map)?;
+        SCRATCH_FRAME
+            .set(ScratchFrame {
+                cap: AtomicU32::new(scratch_cap),
+                va: scratch_va,
+            })
+            .ok();
+
         Ok(&*cache)
+    }
+
+    /// Write one 512-byte sector through the cache (write-through).
+    ///
+    /// Acquires the page covering `lba`, updates the affected sector in
+    /// place within the cached page (so any outstanding `FS_READ_FRAME`
+    /// cap aliasing that page observes the new bytes immediately), then
+    /// copies the same sector into a process-static scratch frame and
+    /// issues one `BLK_WRITE_FROM_FRAME` against the block device.
+    ///
+    /// Single-sector writeback only. Multi-sector cache pages cannot be
+    /// flushed as a unit because the unmodified neighbouring sectors
+    /// have no known-good source if the write fails mid-flight.
+    ///
+    /// Returns `false` on cache acquire failure, missing scratch frame
+    /// (cache init never ran), or block-driver error.
+    #[allow(dead_code)] // wired in by alloc.rs / dispatch in subsequent commits
+    pub fn write_sector(
+        &self,
+        lba: u64,
+        block_dev: u32,
+        data: &[u8; SECTOR_SIZE],
+        ipc_buf: *mut u64,
+    ) -> bool
+    {
+        let Some(scratch) = SCRATCH_FRAME.get()
+        else
+        {
+            return false;
+        };
+        let page_base = page_base_of(lba);
+        let Some(idx) = self.acquire_page(page_base, block_dev, ipc_buf)
+        else
+        {
+            return false;
+        };
+        let slot = &self.slots[idx];
+        let sector_in_page = (lba - page_base) as usize;
+        let offset = sector_in_page * SECTOR_SIZE;
+
+        // SAFETY: refcount > 0 for the duration of these borrows. The
+        // cache page is single-process owned and mapped writable; the
+        // scratch frame VA is process-static and mapped writable. Both
+        // are 512-byte sector copies into pages this process owns.
+        unsafe {
+            core::ptr::copy_nonoverlapping(
+                data.as_ptr(),
+                (slot.va + offset as u64) as *mut u8,
+                SECTOR_SIZE,
+            );
+            core::ptr::copy_nonoverlapping(data.as_ptr(), scratch.va as *mut u8, SECTOR_SIZE);
+        }
+
+        let ok = writeback_via_block_dev(scratch, lba, block_dev, ipc_buf);
+        self.release(idx);
+        ok
     }
 
     /// Read one 512-byte sector through the cache into `buf`. Single-call
@@ -334,6 +433,41 @@ fn fill_via_block_dev(
     };
     let returned = reply.caps().first().copied().unwrap_or(0);
     slot.frame_cap.store(returned, Ordering::Release);
+    reply.label == blk_errors::SUCCESS && returned != 0
+}
+
+/// Issue `BLK_WRITE_FROM_FRAME` with the scratch frame as the source.
+///
+/// Mirrors [`fill_via_block_dev`] for the write direction. The scratch
+/// frame's cap is moved out and back across the call; the returned cap
+/// (which may land at a different `CSpace` index) is restored in
+/// `scratch.cap`.
+fn writeback_via_block_dev(
+    scratch: &ScratchFrame,
+    lba: u64,
+    block_dev: u32,
+    ipc_buf: *mut u64,
+) -> bool
+{
+    let cap = scratch.cap.load(Ordering::Acquire);
+    if cap == 0
+    {
+        return false;
+    }
+    let msg = IpcMessage::builder(blk_labels::BLK_WRITE_FROM_FRAME)
+        .word(0, lba)
+        .word(1, 1)
+        .cap(cap)
+        .build();
+    // SAFETY: ipc_buf is the calling thread's registered IPC buffer.
+    let Ok(reply) = (unsafe { ipc::ipc_call(block_dev, &msg, ipc_buf) })
+    else
+    {
+        scratch.cap.store(0, Ordering::Release);
+        return false;
+    };
+    let returned = reply.caps().first().copied().unwrap_or(0);
+    scratch.cap.store(returned, Ordering::Release);
     reply.label == blk_errors::SUCCESS && returned != 0
 }
 

--- a/services/fs/fat/src/dir.rs
+++ b/services/fs/fat/src/dir.rs
@@ -600,6 +600,118 @@ fn find_in_fat16_root(
     None
 }
 
+/// As [`find_in_directory`] but also returns the on-disk location of
+/// the matching 8.3 entry, used by callers that intend to patch the
+/// entry's metadata fields (`size`, `first_cluster`) later.
+pub fn find_in_directory_with_location(
+    dir_cluster: u32,
+    name: &[u8],
+    state: &mut FatState,
+    cache: &PageCache,
+    block_dev: u32,
+    ipc_buf: *mut u64,
+) -> Option<(DirEntry, DirEntryLocation)>
+{
+    let mut sector_buf = [0u8; SECTOR_SIZE];
+    let mut lfn = LfnAccum::new();
+    let entries_per_sector = SECTOR_SIZE / 32;
+
+    if dir_cluster == 0
+    {
+        let root_start =
+            u32::from(state.reserved_sectors) + u32::from(state.num_fats) * state.fat_size;
+        let root_sectors = (u32::from(state.root_entry_count) * 32).div_ceil(512);
+        for s in 0..root_sectors
+        {
+            let sector_lba = root_start + s;
+            if !cache.read_sector(u64::from(sector_lba), block_dev, &mut sector_buf, ipc_buf)
+            {
+                return None;
+            }
+            if let Some((entry, off)) =
+                scan_sector_for_name_with_offset(&sector_buf, name, &mut lfn, entries_per_sector)
+            {
+                return Some((
+                    entry,
+                    DirEntryLocation {
+                        sector_lba,
+                        offset_in_sector: off,
+                    },
+                ));
+            }
+        }
+        return None;
+    }
+
+    let mut cluster = dir_cluster;
+    loop
+    {
+        let base_sector = state.cluster_to_sector(cluster);
+        for s in 0..u32::from(state.sectors_per_cluster)
+        {
+            let sector_lba = base_sector + s;
+            if !cache.read_sector(u64::from(sector_lba), block_dev, &mut sector_buf, ipc_buf)
+            {
+                return None;
+            }
+            if let Some((entry, off)) =
+                scan_sector_for_name_with_offset(&sector_buf, name, &mut lfn, entries_per_sector)
+            {
+                return Some((
+                    entry,
+                    DirEntryLocation {
+                        sector_lba,
+                        offset_in_sector: off,
+                    },
+                ));
+            }
+        }
+        cluster = next_cluster(state, cluster, cache, block_dev, ipc_buf)?;
+    }
+}
+
+fn scan_sector_for_name_with_offset(
+    sector: &[u8; SECTOR_SIZE],
+    name: &[u8],
+    lfn: &mut LfnAccum,
+    entries_per_sector: usize,
+) -> Option<(DirEntry, usize)>
+{
+    for i in 0..entries_per_sector
+    {
+        let offset = i * 32;
+        let raw = &sector[offset..offset + 32];
+        if raw[0] == 0x00
+        {
+            return None;
+        }
+        if raw[0] == 0xE5
+        {
+            lfn.reset();
+            continue;
+        }
+        if raw[11] == 0x0F
+        {
+            lfn.add_lfn_entry(raw);
+            continue;
+        }
+        if let Some(mut entry) = parse_dir_entry(raw)
+        {
+            let lfn_match = lfn.validate(&entry.name) && lfn.matches(name);
+            if lfn_match || name_matches(&entry.name, name)
+            {
+                if lfn.validate(&entry.name)
+                {
+                    populate_lfn(&mut entry, lfn);
+                }
+                return Some((entry, offset));
+            }
+        }
+        lfn.reset();
+    }
+    None
+}
+
 /// Scan a sector's 32-byte directory entries for a name match.
 ///
 /// Supports both 8.3 and LFN matching. The `lfn` accumulator carries

--- a/services/fs/fat/src/dir.rs
+++ b/services/fs/fat/src/dir.rs
@@ -18,7 +18,13 @@
 //! that have no LFN entry still surface lower-case rather than as
 //! `BOOT    CON`.
 
-use crate::bpb::{FatState, SECTOR_SIZE};
+// The directory-mutation helpers added in the write-support work are
+// wired into dispatch handlers in a subsequent commit; suppress the
+// dead-code lint module-wide until that lands.
+#![allow(dead_code)]
+
+use crate::alloc::{FatError, allocate_cluster, free_cluster_chain};
+use crate::bpb::{FatState, FatType, SECTOR_SIZE};
 use crate::cache::PageCache;
 use crate::fat::next_cluster;
 
@@ -799,4 +805,1197 @@ fn populate_lfn(entry: &mut DirEntry, lfn: &LfnAccum)
     {
         entry.lfn_len = len as u16;
     }
+}
+
+// ── Directory mutation ────────────────────────────────────────────────────
+//
+// The mutation API (insert_entry / remove_entry / update_entry_metadata
+// / write_dot_entries / directory_is_empty / free_entry_data) is wired
+// into dispatch handlers in a subsequent commit. Dead-code suppression
+// is module-wide via `#![allow(dead_code)]` at the top of dir.rs.
+
+/// Whether a new entry is a file or a directory. Drives the on-disk
+/// `attr` byte (`0x20` archive vs `0x10` directory) and the post-insert
+/// "." / ".." entry population for [`insert_entry`].
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum NewEntryKind
+{
+    File,
+    Dir,
+}
+
+/// 8.3 attribute byte for a regular file.
+const ATTR_ARCHIVE: u8 = 0x20;
+/// 8.3 attribute byte for a directory.
+const ATTR_DIRECTORY: u8 = 0x10;
+/// 8.3 attribute byte for an LFN slot.
+const ATTR_LFN: u8 = 0x0F;
+/// LFN sequence flag: `0x40` `OR`ed into the highest-seq slot marks
+/// "last entry in the LFN run" (per the FAT spec).
+const LFN_LAST_FLAG: u8 = 0x40;
+/// Maximum `NUMERIC_TAIL` we will probe (`~1` through `~6`). Beyond
+/// this callers see [`FatError::NoSpace`] for the name; in practice
+/// tests never collide hard enough to exhaust the tail.
+const MAX_NUMERIC_TAIL: u8 = 6;
+/// Maximum LFN slots in one run (255 chars / 13 chars-per-slot = 20).
+/// Plus 1 for the trailing 8.3 entry is the upper bound on slot-run
+/// length we ever allocate.
+const MAX_SLOT_RUN: usize = 21;
+
+/// Physical location of a 32-byte directory entry on disk.
+///
+/// Returned by [`insert_entry`] so dispatch can later patch the
+/// `first_cluster` and `size` fields via [`update_entry_metadata`]
+/// after a write extends the file.
+#[derive(Copy, Clone, Debug)]
+pub struct DirEntryLocation
+{
+    pub sector_lba: u32,
+    pub offset_in_sector: usize,
+}
+
+/// Description of a directory entry that [`remove_entry`] just unlinked.
+///
+/// `start_cluster` is `0` for empty files (cluster chain was never
+/// allocated) — the caller must skip `free_cluster_chain` in that case.
+#[derive(Copy, Clone, Debug)]
+pub struct RemovedEntry
+{
+    pub start_cluster: u32,
+    pub size: u32,
+    pub is_dir: bool,
+}
+
+/// Insert a new 8.3 directory entry, prefixed by an LFN run when the
+/// supplied name does not fit strict 8.3.
+///
+/// `start_cluster` is the first cluster of the new file or directory's
+/// data chain (0 for an empty file with no allocated chain). `size` is
+/// the byte length (always 0 for directories per FAT spec). Caller is
+/// responsible for allocating the data chain *before* inserting the
+/// directory entry — ordering documented in `docs/crash-safety.md`.
+///
+/// Returns the on-disk location of the placed 8.3 entry so dispatch
+/// can patch its `first_cluster` / `size` fields with
+/// [`update_entry_metadata`] once writes extend the file.
+#[allow(clippy::too_many_arguments)]
+pub fn insert_entry(
+    state: &mut FatState,
+    parent_dir_cluster: u32,
+    name: &[u8],
+    kind: NewEntryKind,
+    start_cluster: u32,
+    size: u32,
+    cache: &PageCache,
+    block_dev: u32,
+    ipc_buf: *mut u64,
+) -> Result<DirEntryLocation, FatError>
+{
+    if name.is_empty() || name.len() > MAX_LFN_CHARS
+    {
+        return Err(FatError::Corrupt);
+    }
+    if find_in_directory(parent_dir_cluster, name, state, cache, block_dev, ipc_buf).is_some()
+    {
+        return Err(FatError::NoSpace); // EXISTS — mapped to wire code at dispatch
+    }
+
+    let sfn = generate_sfn(state, parent_dir_cluster, name, cache, block_dev, ipc_buf)?;
+    let chksum = lfn_checksum(&sfn);
+
+    let needs_lfn = !is_strict_83_match(&sfn, name);
+    let lfn_slot_count = if needs_lfn
+    {
+        name.len().div_ceil(13)
+    }
+    else
+    {
+        0
+    };
+    let total_slots = lfn_slot_count + 1;
+
+    let slots = find_free_slot_run(
+        state,
+        parent_dir_cluster,
+        total_slots,
+        cache,
+        block_dev,
+        ipc_buf,
+    )?;
+
+    // Emit LFN slots in reverse-seq order (high seq with LFN_LAST_FLAG
+    // first on disk, seq counts down to 1). The slots iterator gives
+    // them in disk order; we pack starting at slot[0] with the highest
+    // sequence number.
+    if needs_lfn
+    {
+        let chars = name_as_ucs2(name);
+        // cast_possible_truncation: lfn_slot_count ≤ ceil(255 / 13) = 20
+        #[allow(clippy::cast_possible_truncation)]
+        for (i, slot) in slots.iter().take(lfn_slot_count).enumerate()
+        {
+            let seq = (lfn_slot_count - i) as u8;
+            let is_last = i == 0;
+            let slot_chars = lfn_chars_for_seq(&chars, name.len(), seq);
+            let raw = pack_lfn_slot(seq, is_last, chksum, &slot_chars);
+            write_dir_slot(state, *slot, &raw, cache, block_dev, ipc_buf)?;
+        }
+    }
+
+    let attr = match kind
+    {
+        NewEntryKind::File => ATTR_ARCHIVE,
+        NewEntryKind::Dir => ATTR_DIRECTORY,
+    };
+    let raw_83 = pack_83_entry(&sfn, attr, start_cluster, size);
+    write_dir_slot(
+        state,
+        slots[total_slots - 1],
+        &raw_83,
+        cache,
+        block_dev,
+        ipc_buf,
+    )?;
+
+    Ok(slots[total_slots - 1])
+}
+
+/// Mark an existing directory entry (and any preceding LFN run) as
+/// deleted (`0xE5`).
+///
+/// Returns the entry's `start_cluster`, `size`, and kind so the caller
+/// can free the data chain via [`free_cluster_chain`]. Directory
+/// removal additionally requires the directory be empty (no entries
+/// other than `.` and `..`); this is the caller's responsibility to
+/// validate before invoking this function.
+pub fn remove_entry(
+    state: &mut FatState,
+    parent_dir_cluster: u32,
+    name: &[u8],
+    cache: &PageCache,
+    block_dev: u32,
+    ipc_buf: *mut u64,
+) -> Result<RemovedEntry, FatError>
+{
+    let positions =
+        locate_entry_with_lfn_run(state, parent_dir_cluster, name, cache, block_dev, ipc_buf)?;
+    let (entry, ref slots) = positions;
+    for slot in slots
+    {
+        mark_slot_deleted(state, *slot, cache, block_dev, ipc_buf)?;
+    }
+    Ok(entry)
+}
+
+/// Patch the 8.3 entry at `loc` with new `first_cluster` and `size`
+/// fields. Used after a write extends a file's cluster chain.
+pub fn update_entry_metadata(
+    state: &mut FatState,
+    loc: DirEntryLocation,
+    new_first_cluster: u32,
+    new_size: u32,
+    cache: &PageCache,
+    block_dev: u32,
+    ipc_buf: *mut u64,
+) -> Result<(), FatError>
+{
+    let _ = state; // mirrors the read-side signature; reserved for future use
+    let mut buf = [0u8; SECTOR_SIZE];
+    if !cache.read_sector(u64::from(loc.sector_lba), block_dev, &mut buf, ipc_buf)
+    {
+        return Err(FatError::Io);
+    }
+    let off = loc.offset_in_sector;
+    let cluster_hi = ((new_first_cluster >> 16) & 0xFFFF) as u16;
+    let cluster_lo = (new_first_cluster & 0xFFFF) as u16;
+    buf[off + 20..off + 22].copy_from_slice(&cluster_hi.to_le_bytes());
+    buf[off + 26..off + 28].copy_from_slice(&cluster_lo.to_le_bytes());
+    buf[off + 28..off + 32].copy_from_slice(&new_size.to_le_bytes());
+    if !cache.write_sector(u64::from(loc.sector_lba), block_dev, &buf, ipc_buf)
+    {
+        return Err(FatError::Io);
+    }
+    Ok(())
+}
+
+/// Check whether a directory cluster chain contains any entries other
+/// than `.` and `..`. Used by `FS_REMOVE` to enforce the
+/// non-empty-directory rejection.
+pub fn directory_is_empty(
+    state: &mut FatState,
+    dir_cluster: u32,
+    cache: &PageCache,
+    block_dev: u32,
+    ipc_buf: *mut u64,
+) -> Result<bool, FatError>
+{
+    let mut buf = [0u8; SECTOR_SIZE];
+    let entries_per_sector = SECTOR_SIZE / 32;
+
+    let mut cluster = dir_cluster;
+    loop
+    {
+        let base_sector = state.cluster_to_sector(cluster);
+        for s in 0..u32::from(state.sectors_per_cluster)
+        {
+            if !cache.read_sector(u64::from(base_sector + s), block_dev, &mut buf, ipc_buf)
+            {
+                return Err(FatError::Io);
+            }
+            for e in 0..entries_per_sector
+            {
+                let off = e * 32;
+                let first = buf[off];
+                if first == 0x00
+                {
+                    return Ok(true);
+                }
+                if first == 0xE5
+                {
+                    continue;
+                }
+                if buf[off + 11] == ATTR_LFN
+                {
+                    continue;
+                }
+                // Skip "." and "..".
+                if buf[off..off + 11] == *b".          " || buf[off..off + 11] == *b"..         "
+                {
+                    continue;
+                }
+                return Ok(false);
+            }
+        }
+        match next_cluster(state, cluster, cache, block_dev, ipc_buf)
+        {
+            Some(n) => cluster = n,
+            None => return Ok(true),
+        }
+    }
+}
+
+/// Populate a freshly-allocated directory cluster with the `.` and
+/// `..` entries. Called by `FS_MKDIR` after [`allocate_cluster`] gives
+/// us a zero-able cluster.
+pub fn write_dot_entries(
+    state: &mut FatState,
+    new_dir_cluster: u32,
+    parent_cluster: u32,
+    cache: &PageCache,
+    block_dev: u32,
+    ipc_buf: *mut u64,
+) -> Result<(), FatError>
+{
+    let base_sector = state.cluster_to_sector(new_dir_cluster);
+    let mut buf = [0u8; SECTOR_SIZE];
+    // First sector: "." and ".." entries packed at offsets 0 and 32;
+    // remaining slots zeroed (== "end of directory" sentinel for every
+    // following slot). Subsequent sectors of the cluster stay zero;
+    // we rely on allocate_cluster having left them zero, and zero the
+    // first sector here explicitly.
+    let dot = pack_83_entry(b".          ", ATTR_DIRECTORY, new_dir_cluster, 0);
+    let dotdot_cluster = if parent_cluster == state.root_cluster
+    {
+        0
+    }
+    else
+    {
+        parent_cluster
+    };
+    let dotdot = pack_83_entry(b"..         ", ATTR_DIRECTORY, dotdot_cluster, 0);
+    buf[..32].copy_from_slice(&dot);
+    buf[32..64].copy_from_slice(&dotdot);
+    if !cache.write_sector(u64::from(base_sector), block_dev, &buf, ipc_buf)
+    {
+        return Err(FatError::Io);
+    }
+    // Zero out the rest of the cluster so a stale neighbour sector
+    // (allocate_cluster reuses freed clusters) does not surface as
+    // ghost entries.
+    let zeros = [0u8; SECTOR_SIZE];
+    for s in 1..u32::from(state.sectors_per_cluster)
+    {
+        if !cache.write_sector(u64::from(base_sector + s), block_dev, &zeros, ipc_buf)
+        {
+            return Err(FatError::Io);
+        }
+    }
+    Ok(())
+}
+
+// ── Mutation internals ────────────────────────────────────────────────────
+
+/// Walk the parent directory entry-by-entry; collect a run of
+/// `count` consecutive free (0x00 or 0xE5) slots. Free runs reset on
+/// any non-free slot, and end-of-directory (0x00) triggers extension
+/// when needed.
+#[allow(clippy::too_many_lines)]
+fn find_free_slot_run(
+    state: &mut FatState,
+    parent_dir_cluster: u32,
+    count: usize,
+    cache: &PageCache,
+    block_dev: u32,
+    ipc_buf: *mut u64,
+) -> Result<[DirEntryLocation; MAX_SLOT_RUN], FatError>
+{
+    debug_assert!(count <= MAX_SLOT_RUN);
+
+    let mut run: [Option<DirEntryLocation>; MAX_SLOT_RUN] = [None; MAX_SLOT_RUN];
+    let mut run_len = 0usize;
+
+    let entries_per_sector = SECTOR_SIZE / 32;
+    let mut buf = [0u8; SECTOR_SIZE];
+
+    // FAT16 fixed root.
+    if parent_dir_cluster == 0 && matches!(state.fat_type, FatType::Fat16)
+    {
+        let root_start =
+            u32::from(state.reserved_sectors) + u32::from(state.num_fats) * state.fat_size;
+        let root_sectors = (u32::from(state.root_entry_count) * 32).div_ceil(512);
+        for s in 0..root_sectors
+        {
+            match scan_sector_free_run(
+                root_start + s,
+                count,
+                cache,
+                block_dev,
+                ipc_buf,
+                &mut buf,
+                entries_per_sector,
+                &mut run,
+                &mut run_len,
+            )?
+            {
+                ScanStop::Done => return collect_run(&run, count),
+                ScanStop::EndOfDirectory => break,
+                ScanStop::Continue =>
+                {}
+            }
+        }
+        if run_len >= count
+        {
+            return collect_run(&run, count);
+        }
+        return Err(FatError::NoSpace);
+    }
+
+    // FAT32 clustered directory walk.
+    let mut cluster = if parent_dir_cluster == 0
+    {
+        state.root_cluster
+    }
+    else
+    {
+        parent_dir_cluster
+    };
+    let mut last_cluster = cluster;
+    loop
+    {
+        let base_sector = state.cluster_to_sector(cluster);
+        let mut hit_eod = false;
+        for s in 0..u32::from(state.sectors_per_cluster)
+        {
+            match scan_sector_free_run(
+                base_sector + s,
+                count,
+                cache,
+                block_dev,
+                ipc_buf,
+                &mut buf,
+                entries_per_sector,
+                &mut run,
+                &mut run_len,
+            )?
+            {
+                ScanStop::Done => return collect_run(&run, count),
+                ScanStop::EndOfDirectory =>
+                {
+                    hit_eod = true;
+                    break;
+                }
+                ScanStop::Continue =>
+                {}
+            }
+        }
+        if hit_eod && run_len < count
+        {
+            // EoD inside this cluster but run is still short — we need
+            // to either fill the rest of this cluster (next sectors are
+            // implicitly free too) or extend with a new cluster.
+            // Allocate-and-extend handles both: keep walking new
+            // clusters until run_len ≥ count.
+            let new_cluster =
+                allocate_cluster(state, Some(last_cluster), cache, block_dev, ipc_buf)?;
+            zero_cluster(state, new_cluster, cache, block_dev, ipc_buf)?;
+            // The new cluster's first sector at offset 0 continues the
+            // free run.
+            let new_base = state.cluster_to_sector(new_cluster);
+            for s in 0..u32::from(state.sectors_per_cluster)
+            {
+                for e in 0..entries_per_sector
+                {
+                    let loc = DirEntryLocation {
+                        sector_lba: new_base + s,
+                        offset_in_sector: e * 32,
+                    };
+                    run[run_len] = Some(loc);
+                    run_len += 1;
+                    if run_len >= count
+                    {
+                        return collect_run(&run, count);
+                    }
+                }
+            }
+            last_cluster = new_cluster;
+            cluster = new_cluster;
+            continue;
+        }
+        if let Some(n) = next_cluster(state, cluster, cache, block_dev, ipc_buf)
+        {
+            last_cluster = cluster;
+            cluster = n;
+        }
+        else
+        {
+            // End of cluster chain without seeing 0x00 — every
+            // slot in this chain is used. Extend.
+            let new_cluster =
+                allocate_cluster(state, Some(last_cluster), cache, block_dev, ipc_buf)?;
+            zero_cluster(state, new_cluster, cache, block_dev, ipc_buf)?;
+            let new_base = state.cluster_to_sector(new_cluster);
+            run_len = 0;
+            for s in 0..u32::from(state.sectors_per_cluster)
+            {
+                for e in 0..entries_per_sector
+                {
+                    let loc = DirEntryLocation {
+                        sector_lba: new_base + s,
+                        offset_in_sector: e * 32,
+                    };
+                    run[run_len] = Some(loc);
+                    run_len += 1;
+                    if run_len >= count
+                    {
+                        return collect_run(&run, count);
+                    }
+                }
+            }
+            last_cluster = new_cluster;
+            cluster = new_cluster;
+        }
+    }
+}
+
+fn collect_run(
+    run: &[Option<DirEntryLocation>; MAX_SLOT_RUN],
+    count: usize,
+) -> Result<[DirEntryLocation; MAX_SLOT_RUN], FatError>
+{
+    let mut out = [DirEntryLocation {
+        sector_lba: 0,
+        offset_in_sector: 0,
+    }; MAX_SLOT_RUN];
+    for i in 0..count
+    {
+        out[i] = run[i].ok_or(FatError::Corrupt)?;
+    }
+    Ok(out)
+}
+
+enum ScanStop
+{
+    /// `count` consecutive free slots accumulated; caller can stop.
+    Done,
+    /// End-of-directory sentinel (`0x00`) encountered; caller decides
+    /// whether to extend (FAT32) or fail (FAT16 fixed root).
+    EndOfDirectory,
+    /// Sector finished without reaching either condition; caller
+    /// continues to the next sector.
+    Continue,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn scan_sector_free_run(
+    sector_lba: u32,
+    count: usize,
+    cache: &PageCache,
+    block_dev: u32,
+    ipc_buf: *mut u64,
+    buf: &mut [u8; SECTOR_SIZE],
+    entries_per_sector: usize,
+    run: &mut [Option<DirEntryLocation>; MAX_SLOT_RUN],
+    run_len: &mut usize,
+) -> Result<ScanStop, FatError>
+{
+    if !cache.read_sector(u64::from(sector_lba), block_dev, buf, ipc_buf)
+    {
+        return Err(FatError::Io);
+    }
+    for e in 0..entries_per_sector
+    {
+        let off = e * 32;
+        let loc = DirEntryLocation {
+            sector_lba,
+            offset_in_sector: off,
+        };
+        let first = buf[off];
+        if first == 0x00
+        {
+            run[*run_len] = Some(loc);
+            *run_len += 1;
+            if *run_len >= count
+            {
+                return Ok(ScanStop::Done);
+            }
+            return Ok(ScanStop::EndOfDirectory);
+        }
+        if first == 0xE5
+        {
+            run[*run_len] = Some(loc);
+            *run_len += 1;
+            if *run_len >= count
+            {
+                return Ok(ScanStop::Done);
+            }
+        }
+        else
+        {
+            *run_len = 0;
+        }
+    }
+    Ok(ScanStop::Continue)
+}
+
+fn zero_cluster(
+    state: &mut FatState,
+    cluster: u32,
+    cache: &PageCache,
+    block_dev: u32,
+    ipc_buf: *mut u64,
+) -> Result<(), FatError>
+{
+    let zeros = [0u8; SECTOR_SIZE];
+    let base = state.cluster_to_sector(cluster);
+    for s in 0..u32::from(state.sectors_per_cluster)
+    {
+        if !cache.write_sector(u64::from(base + s), block_dev, &zeros, ipc_buf)
+        {
+            return Err(FatError::Io);
+        }
+    }
+    Ok(())
+}
+
+fn write_dir_slot(
+    state: &mut FatState,
+    loc: DirEntryLocation,
+    raw: &[u8; 32],
+    cache: &PageCache,
+    block_dev: u32,
+    ipc_buf: *mut u64,
+) -> Result<(), FatError>
+{
+    let _ = state; // reserved for future use; mirrors the read-side signature
+    let mut buf = [0u8; SECTOR_SIZE];
+    if !cache.read_sector(u64::from(loc.sector_lba), block_dev, &mut buf, ipc_buf)
+    {
+        return Err(FatError::Io);
+    }
+    buf[loc.offset_in_sector..loc.offset_in_sector + 32].copy_from_slice(raw);
+    if !cache.write_sector(u64::from(loc.sector_lba), block_dev, &buf, ipc_buf)
+    {
+        return Err(FatError::Io);
+    }
+    Ok(())
+}
+
+fn mark_slot_deleted(
+    state: &mut FatState,
+    loc: DirEntryLocation,
+    cache: &PageCache,
+    block_dev: u32,
+    ipc_buf: *mut u64,
+) -> Result<(), FatError>
+{
+    let _ = state;
+    let mut buf = [0u8; SECTOR_SIZE];
+    if !cache.read_sector(u64::from(loc.sector_lba), block_dev, &mut buf, ipc_buf)
+    {
+        return Err(FatError::Io);
+    }
+    buf[loc.offset_in_sector] = 0xE5;
+    if !cache.write_sector(u64::from(loc.sector_lba), block_dev, &buf, ipc_buf)
+    {
+        return Err(FatError::Io);
+    }
+    Ok(())
+}
+
+fn pack_83_entry(name: &[u8; 11], attr: u8, cluster: u32, size: u32) -> [u8; 32]
+{
+    let mut e = [0u8; 32];
+    e[..11].copy_from_slice(name);
+    e[11] = attr;
+    // bytes 12 (DIR_NTRes) through 19 (creation timestamps): all zero
+    // for v0.1.0; timestamp support filed as a follow-up.
+    let cluster_hi = ((cluster >> 16) & 0xFFFF) as u16;
+    let cluster_lo = (cluster & 0xFFFF) as u16;
+    e[20..22].copy_from_slice(&cluster_hi.to_le_bytes());
+    // bytes 22-25: last-write timestamps (zero).
+    e[26..28].copy_from_slice(&cluster_lo.to_le_bytes());
+    e[28..32].copy_from_slice(&size.to_le_bytes());
+    e
+}
+
+fn pack_lfn_slot(seq: u8, is_last: bool, chksum: u8, chars: &[u16; 13]) -> [u8; 32]
+{
+    let mut e = [0u8; 32];
+    e[0] = if is_last { seq | LFN_LAST_FLAG } else { seq };
+    e[11] = ATTR_LFN;
+    e[12] = 0;
+    e[13] = chksum;
+    // FirstClusLO at bytes 26-27 is zero for LFN slots.
+    let offsets: [usize; 13] = [1, 3, 5, 7, 9, 14, 16, 18, 20, 22, 24, 28, 30];
+    for (i, &off) in offsets.iter().enumerate()
+    {
+        let bytes = chars[i].to_le_bytes();
+        e[off] = bytes[0];
+        e[off + 1] = bytes[1];
+    }
+    e
+}
+
+fn name_as_ucs2(name: &[u8]) -> [u16; MAX_LFN_CHARS]
+{
+    let mut chars = [0u16; MAX_LFN_CHARS];
+    // ASCII-only encoding (FAT LFN is UCS-2). For the v0.1.0 write
+    // surface we accept the namespace-protocol's name validator,
+    // which is ASCII-only; anything beyond ASCII is rejected upstream.
+    for (i, &b) in name.iter().enumerate()
+    {
+        if i >= MAX_LFN_CHARS
+        {
+            break;
+        }
+        chars[i] = u16::from(b);
+    }
+    chars
+}
+
+fn lfn_chars_for_seq(chars: &[u16; MAX_LFN_CHARS], name_len: usize, seq: u8) -> [u16; 13]
+{
+    let base = (usize::from(seq) - 1) * 13;
+    let mut slot = [0xFFFFu16; 13];
+    for (i, slot_ch) in slot.iter_mut().enumerate()
+    {
+        let pos = base + i;
+        // Per spec: characters past the name are 0xFFFF padding, with
+        // a single 0x0000 terminator at the first past-the-end
+        // position (matters when name_len is not a multiple of 13).
+        *slot_ch = match pos.cmp(&name_len)
+        {
+            core::cmp::Ordering::Less => chars[pos],
+            core::cmp::Ordering::Equal => 0x0000,
+            core::cmp::Ordering::Greater => 0xFFFF,
+        };
+    }
+    slot
+}
+
+/// Generate a short (8.3) filename for `name`, ensuring uniqueness in
+/// the parent directory via `NUMERIC_TAIL` collision probing.
+///
+/// Strict-8.3 names round-trip exactly (uppercased). Names outside the
+/// strict-8.3 charset get a basis derived from the first six valid
+/// uppercased characters, with `~N` (1..=6) appended for uniqueness;
+/// extension is the first three valid characters after the last `.`.
+fn generate_sfn(
+    state: &mut FatState,
+    parent_dir_cluster: u32,
+    name: &[u8],
+    cache: &PageCache,
+    block_dev: u32,
+    ipc_buf: *mut u64,
+) -> Result<[u8; 11], FatError>
+{
+    if let Some(strict) = try_strict_83(name)
+    {
+        return Ok(strict);
+    }
+    let (basis_base, basis_ext) = basis_name(name);
+    for tail in 1..=MAX_NUMERIC_TAIL
+    {
+        let candidate = compose_sfn(basis_base, tail, basis_ext);
+        if find_in_directory_by_sfn(
+            parent_dir_cluster,
+            &candidate,
+            state,
+            cache,
+            block_dev,
+            ipc_buf,
+        )
+        .is_none()
+        {
+            return Ok(candidate);
+        }
+    }
+    Err(FatError::NoSpace)
+}
+
+fn try_strict_83(name: &[u8]) -> Option<[u8; 11]>
+{
+    let dot_pos = name.iter().position(|&b| b == b'.');
+    let (base, ext) = match dot_pos
+    {
+        Some(p) =>
+        {
+            // Reject multiple dots and leading dot.
+            if name[p + 1..].contains(&b'.') || p == 0
+            {
+                return None;
+            }
+            (&name[..p], &name[p + 1..])
+        }
+        None => (name, &[] as &[u8]),
+    };
+    if base.is_empty() || base.len() > 8 || ext.len() > 3
+    {
+        return None;
+    }
+    for &b in base.iter().chain(ext.iter())
+    {
+        if !is_strict_83_char(b)
+        {
+            return None;
+        }
+    }
+    let mut out = [b' '; 11];
+    for (i, &b) in base.iter().enumerate()
+    {
+        out[i] = to_upper(b);
+    }
+    for (i, &b) in ext.iter().enumerate()
+    {
+        out[8 + i] = to_upper(b);
+    }
+    Some(out)
+}
+
+fn is_strict_83_char(b: u8) -> bool
+{
+    // FAT short name allowed character set, simplified to the
+    // uppercase subset: letters, digits, and a small punctuation set.
+    // Lowercase letters are allowed and uppercased on entry.
+    matches!(b,
+        b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' |
+        b'!' | b'#' | b'$' | b'%' | b'&' | b'\'' | b'(' | b')' |
+        b'-' | b'@' | b'^' | b'_' | b'`' | b'{' | b'}' | b'~'
+    )
+}
+
+fn is_strict_83_match(sfn: &[u8; 11], name: &[u8]) -> bool
+{
+    let Some(strict) = try_strict_83(name)
+    else
+    {
+        return false;
+    };
+    strict == *sfn
+}
+
+fn basis_name(name: &[u8]) -> ([u8; 6], [u8; 3])
+{
+    let mut base = [b' '; 6];
+    let mut ext = [b' '; 3];
+    let dot_pos = name.iter().rposition(|&b| b == b'.');
+    let (base_src, ext_src) = match dot_pos
+    {
+        Some(p) => (&name[..p], &name[p + 1..]),
+        None => (name, &[] as &[u8]),
+    };
+    let mut bi = 0;
+    for &b in base_src
+    {
+        if bi >= 6
+        {
+            break;
+        }
+        if is_strict_83_char(b)
+        {
+            base[bi] = to_upper(b);
+            bi += 1;
+        }
+    }
+    let mut ei = 0;
+    for &b in ext_src
+    {
+        if ei >= 3
+        {
+            break;
+        }
+        if is_strict_83_char(b)
+        {
+            ext[ei] = to_upper(b);
+            ei += 1;
+        }
+    }
+    // FAT spec: every SFN basis must have at least one valid base
+    // character; fall back to a single underscore if upstream gave us
+    // a name with no usable chars in the base portion.
+    if bi == 0
+    {
+        base[0] = b'_';
+    }
+    (base, ext)
+}
+
+fn compose_sfn(basis_base: [u8; 6], tail: u8, basis_ext: [u8; 3]) -> [u8; 11]
+{
+    let mut out = [b' '; 11];
+    // Find how much of the basis-base we keep; the tail "~N" replaces
+    // the trailing slot(s).
+    let mut base_end = 6;
+    while base_end > 0 && basis_base[base_end - 1] == b' '
+    {
+        base_end -= 1;
+    }
+    // Tail length: "~" + decimal digits. tail ≤ 6 → one digit.
+    let tail_chars: [u8; 2] = [b'~', b'0' + tail];
+    let keep = (8 - tail_chars.len()).min(base_end);
+    out[..keep].copy_from_slice(&basis_base[..keep]);
+    out[keep] = tail_chars[0];
+    out[keep + 1] = tail_chars[1];
+    // Extension at bytes 8..11.
+    out[8..11].copy_from_slice(&basis_ext);
+    out
+}
+
+/// Look up an entry by SFN only (no LFN matching). Used by
+/// [`generate_sfn`] for `NUMERIC_TAIL` collision probing.
+fn find_in_directory_by_sfn(
+    parent_dir_cluster: u32,
+    sfn: &[u8; 11],
+    state: &mut FatState,
+    cache: &PageCache,
+    block_dev: u32,
+    ipc_buf: *mut u64,
+) -> Option<()>
+{
+    let mut buf = [0u8; SECTOR_SIZE];
+    let entries_per_sector = SECTOR_SIZE / 32;
+
+    if parent_dir_cluster == 0 && matches!(state.fat_type, FatType::Fat16)
+    {
+        let root_start =
+            u32::from(state.reserved_sectors) + u32::from(state.num_fats) * state.fat_size;
+        let root_sectors = (u32::from(state.root_entry_count) * 32).div_ceil(512);
+        for s in 0..root_sectors
+        {
+            match scan_sector_for_sfn(
+                root_start + s,
+                sfn,
+                cache,
+                block_dev,
+                ipc_buf,
+                &mut buf,
+                entries_per_sector,
+            )
+            {
+                Some(true) => return Some(()),
+                Some(false) =>
+                {}
+                None => return None,
+            }
+        }
+        return None;
+    }
+
+    let mut cluster = if parent_dir_cluster == 0
+    {
+        state.root_cluster
+    }
+    else
+    {
+        parent_dir_cluster
+    };
+    loop
+    {
+        let base_sector = state.cluster_to_sector(cluster);
+        for s in 0..u32::from(state.sectors_per_cluster)
+        {
+            match scan_sector_for_sfn(
+                base_sector + s,
+                sfn,
+                cache,
+                block_dev,
+                ipc_buf,
+                &mut buf,
+                entries_per_sector,
+            )
+            {
+                Some(true) => return Some(()),
+                Some(false) =>
+                {}
+                None => return None,
+            }
+        }
+        cluster = next_cluster(state, cluster, cache, block_dev, ipc_buf)?;
+    }
+}
+
+/// Per-sector SFN match used by `find_in_directory_by_sfn`. Returns
+/// `Some(true)` on match, `Some(false)` to continue, `None` on I/O
+/// failure (cache acquire / read).
+#[allow(clippy::too_many_arguments)]
+fn scan_sector_for_sfn(
+    sector_lba: u32,
+    sfn: &[u8; 11],
+    cache: &PageCache,
+    block_dev: u32,
+    ipc_buf: *mut u64,
+    buf: &mut [u8; SECTOR_SIZE],
+    entries_per_sector: usize,
+) -> Option<bool>
+{
+    if !cache.read_sector(u64::from(sector_lba), block_dev, buf, ipc_buf)
+    {
+        return None;
+    }
+    for e in 0..entries_per_sector
+    {
+        let off = e * 32;
+        if buf[off] == 0x00
+        {
+            return Some(false);
+        }
+        if buf[off] == 0xE5 || buf[off + 11] == ATTR_LFN
+        {
+            continue;
+        }
+        if buf[off..off + 11] == *sfn
+        {
+            return Some(true);
+        }
+    }
+    Some(false)
+}
+
+/// Locate an entry by name *and* the disk positions of its LFN run.
+/// Used by [`remove_entry`] so we can mark every LFN slot as deleted
+/// alongside the trailing 8.3 entry.
+fn locate_entry_with_lfn_run(
+    state: &mut FatState,
+    parent_dir_cluster: u32,
+    name: &[u8],
+    cache: &PageCache,
+    block_dev: u32,
+    ipc_buf: *mut u64,
+) -> Result<(RemovedEntry, [DirEntryLocation; MAX_SLOT_RUN]), FatError>
+{
+    let entries_per_sector = SECTOR_SIZE / 32;
+    let mut buf = [0u8; SECTOR_SIZE];
+    let mut lfn = LfnAccum::new();
+    let mut lfn_run: [Option<DirEntryLocation>; MAX_SLOT_RUN] = [None; MAX_SLOT_RUN];
+    let mut lfn_run_len = 0usize;
+
+    if parent_dir_cluster == 0 && matches!(state.fat_type, FatType::Fat16)
+    {
+        let root_start =
+            u32::from(state.reserved_sectors) + u32::from(state.num_fats) * state.fat_size;
+        let root_sectors = (u32::from(state.root_entry_count) * 32).div_ceil(512);
+        for s in 0..root_sectors
+        {
+            if let Some((entry, run, run_len)) = scan_sector_for_remove(
+                root_start + s,
+                name,
+                cache,
+                block_dev,
+                ipc_buf,
+                &mut buf,
+                entries_per_sector,
+                &mut lfn,
+                &mut lfn_run,
+                &mut lfn_run_len,
+            )?
+            {
+                if entry.start_cluster == u32::MAX
+                {
+                    return Err(FatError::Corrupt); // not found before EoD
+                }
+                let mut out = [DirEntryLocation {
+                    sector_lba: 0,
+                    offset_in_sector: 0,
+                }; MAX_SLOT_RUN];
+                for i in 0..run_len
+                {
+                    out[i] = run[i].ok_or(FatError::Corrupt)?;
+                }
+                return Ok((entry, out));
+            }
+        }
+        return Err(FatError::Corrupt);
+    }
+
+    let mut cluster = if parent_dir_cluster == 0
+    {
+        state.root_cluster
+    }
+    else
+    {
+        parent_dir_cluster
+    };
+    loop
+    {
+        let base_sector = state.cluster_to_sector(cluster);
+        for s in 0..u32::from(state.sectors_per_cluster)
+        {
+            if let Some((entry, run, run_len)) = scan_sector_for_remove(
+                base_sector + s,
+                name,
+                cache,
+                block_dev,
+                ipc_buf,
+                &mut buf,
+                entries_per_sector,
+                &mut lfn,
+                &mut lfn_run,
+                &mut lfn_run_len,
+            )?
+            {
+                if entry.start_cluster == u32::MAX
+                {
+                    return Err(FatError::Corrupt);
+                }
+                let mut out = [DirEntryLocation {
+                    sector_lba: 0,
+                    offset_in_sector: 0,
+                }; MAX_SLOT_RUN];
+                for i in 0..run_len
+                {
+                    out[i] = run[i].ok_or(FatError::Corrupt)?;
+                }
+                return Ok((entry, out));
+            }
+        }
+        match next_cluster(state, cluster, cache, block_dev, ipc_buf)
+        {
+            Some(n) => cluster = n,
+            None => return Err(FatError::Corrupt),
+        }
+    }
+}
+
+/// Per-sector walk for [`locate_entry_with_lfn_run`]. Returns the
+/// matching entry and its full LFN-run + 8.3 slot positions, or `None`
+/// to continue. On end-of-directory, returns the sentinel
+/// [`RemovedEntry`] `start_cluster == u32::MAX` so the caller maps to
+/// `NotFound`.
+type RemoveScanHit = (
+    RemovedEntry,
+    [Option<DirEntryLocation>; MAX_SLOT_RUN],
+    usize,
+);
+#[allow(clippy::too_many_arguments)]
+fn scan_sector_for_remove(
+    sector_lba: u32,
+    name: &[u8],
+    cache: &PageCache,
+    block_dev: u32,
+    ipc_buf: *mut u64,
+    buf: &mut [u8; SECTOR_SIZE],
+    entries_per_sector: usize,
+    lfn: &mut LfnAccum,
+    lfn_run: &mut [Option<DirEntryLocation>; MAX_SLOT_RUN],
+    lfn_run_len: &mut usize,
+) -> Result<Option<RemoveScanHit>, FatError>
+{
+    if !cache.read_sector(u64::from(sector_lba), block_dev, buf, ipc_buf)
+    {
+        return Err(FatError::Io);
+    }
+    for e in 0..entries_per_sector
+    {
+        let off = e * 32;
+        let loc = DirEntryLocation {
+            sector_lba,
+            offset_in_sector: off,
+        };
+        if buf[off] == 0x00
+        {
+            return Ok(Some((
+                RemovedEntry {
+                    start_cluster: u32::MAX,
+                    size: 0,
+                    is_dir: false,
+                },
+                *lfn_run,
+                *lfn_run_len,
+            )));
+        }
+        if buf[off] == 0xE5
+        {
+            lfn.reset();
+            *lfn_run_len = 0;
+            continue;
+        }
+        if buf[off + 11] == ATTR_LFN
+        {
+            lfn.add_lfn_entry(&buf[off..off + 32]);
+            if *lfn_run_len < MAX_SLOT_RUN
+            {
+                lfn_run[*lfn_run_len] = Some(loc);
+                *lfn_run_len += 1;
+            }
+            continue;
+        }
+        let raw = &buf[off..off + 32];
+        if let Some(entry) = parse_dir_entry(raw)
+        {
+            let lfn_match = lfn.validate(&entry.name) && lfn.matches(name);
+            let sfn_match = name_matches(&entry.name, name);
+            if lfn_match || sfn_match
+            {
+                let mut run = [None; MAX_SLOT_RUN];
+                let mut run_len = 0;
+                if lfn_match
+                {
+                    run[..*lfn_run_len].copy_from_slice(&lfn_run[..*lfn_run_len]);
+                    run_len = *lfn_run_len;
+                }
+                run[run_len] = Some(loc);
+                run_len += 1;
+                return Ok(Some((
+                    RemovedEntry {
+                        start_cluster: entry.cluster,
+                        size: entry.size,
+                        is_dir: entry.attr & ATTR_DIRECTORY != 0,
+                    },
+                    run,
+                    run_len,
+                )));
+            }
+        }
+        lfn.reset();
+        *lfn_run_len = 0;
+    }
+    Ok(None)
+}
+
+/// Free a file's data clusters and update the directory entry to
+/// reflect the removed allocation. Wrapper that callers can use after
+/// [`remove_entry`] returns a [`RemovedEntry`] with `start_cluster != 0`.
+pub fn free_entry_data(
+    state: &mut FatState,
+    entry: &RemovedEntry,
+    cache: &PageCache,
+    block_dev: u32,
+    ipc_buf: *mut u64,
+) -> Result<(), FatError>
+{
+    if entry.start_cluster == 0
+    {
+        return Ok(());
+    }
+    free_cluster_chain(state, entry.start_cluster, cache, block_dev, ipc_buf).map(|_| ())
 }

--- a/services/fs/fat/src/dir.rs
+++ b/services/fs/fat/src/dir.rs
@@ -18,11 +18,6 @@
 //! that have no LFN entry still surface lower-case rather than as
 //! `BOOT    CON`.
 
-// The directory-mutation helpers added in the write-support work are
-// wired into dispatch handlers in a subsequent commit; suppress the
-// dead-code lint module-wide until that lands.
-#![allow(dead_code)]
-
 use crate::alloc::{FatError, allocate_cluster, free_cluster_chain};
 use crate::bpb::{FatState, FatType, SECTOR_SIZE};
 use crate::cache::PageCache;
@@ -920,11 +915,6 @@ fn populate_lfn(entry: &mut DirEntry, lfn: &LfnAccum)
 }
 
 // ── Directory mutation ────────────────────────────────────────────────────
-//
-// The mutation API (insert_entry / remove_entry / update_entry_metadata
-// / write_dot_entries / directory_is_empty / free_entry_data) is wired
-// into dispatch handlers in a subsequent commit. Dead-code suppression
-// is module-wide via `#![allow(dead_code)]` at the top of dir.rs.
 
 /// Whether a new entry is a file or a directory. Drives the on-disk
 /// `attr` byte (`0x20` archive vs `0x10` directory) and the post-insert
@@ -974,8 +964,6 @@ pub struct DirEntryLocation
 pub struct RemovedEntry
 {
     pub start_cluster: u32,
-    pub size: u32,
-    pub is_dir: bool,
 }
 
 /// Insert a new 8.3 directory entry, prefixed by an LFN run when the
@@ -1050,7 +1038,7 @@ pub fn insert_entry(
             let is_last = i == 0;
             let slot_chars = lfn_chars_for_seq(&chars, name.len(), seq);
             let raw = pack_lfn_slot(seq, is_last, chksum, &slot_chars);
-            write_dir_slot(state, *slot, &raw, cache, block_dev, ipc_buf)?;
+            write_dir_slot(*slot, &raw, cache, block_dev, ipc_buf)?;
         }
     }
 
@@ -1060,14 +1048,7 @@ pub fn insert_entry(
         NewEntryKind::Dir => ATTR_DIRECTORY,
     };
     let raw_83 = pack_83_entry(&sfn, attr, start_cluster, size);
-    write_dir_slot(
-        state,
-        slots[total_slots - 1],
-        &raw_83,
-        cache,
-        block_dev,
-        ipc_buf,
-    )?;
+    write_dir_slot(slots[total_slots - 1], &raw_83, cache, block_dev, ipc_buf)?;
 
     Ok(slots[total_slots - 1])
 }
@@ -1094,7 +1075,7 @@ pub fn remove_entry(
     let (entry, ref slots) = positions;
     for slot in slots
     {
-        mark_slot_deleted(state, *slot, cache, block_dev, ipc_buf)?;
+        mark_slot_deleted(*slot, cache, block_dev, ipc_buf)?;
     }
     Ok(entry)
 }
@@ -1102,7 +1083,6 @@ pub fn remove_entry(
 /// Patch the 8.3 entry at `loc` with new `first_cluster` and `size`
 /// fields. Used after a write extends a file's cluster chain.
 pub fn update_entry_metadata(
-    state: &mut FatState,
     loc: DirEntryLocation,
     new_first_cluster: u32,
     new_size: u32,
@@ -1111,7 +1091,6 @@ pub fn update_entry_metadata(
     ipc_buf: *mut u64,
 ) -> Result<(), FatError>
 {
-    let _ = state; // mirrors the read-side signature; reserved for future use
     let mut buf = Box::new([0u8; SECTOR_SIZE]);
     if !cache.read_sector(u64::from(loc.sector_lba), block_dev, &mut buf, ipc_buf)
     {
@@ -1500,7 +1479,6 @@ fn zero_cluster(
 }
 
 fn write_dir_slot(
-    state: &mut FatState,
     loc: DirEntryLocation,
     raw: &[u8; 32],
     cache: &PageCache,
@@ -1508,7 +1486,6 @@ fn write_dir_slot(
     ipc_buf: *mut u64,
 ) -> Result<(), FatError>
 {
-    let _ = state; // reserved for future use; mirrors the read-side signature
     let mut buf = Box::new([0u8; SECTOR_SIZE]);
     if !cache.read_sector(u64::from(loc.sector_lba), block_dev, &mut buf, ipc_buf)
     {
@@ -1523,14 +1500,12 @@ fn write_dir_slot(
 }
 
 fn mark_slot_deleted(
-    state: &mut FatState,
     loc: DirEntryLocation,
     cache: &PageCache,
     block_dev: u32,
     ipc_buf: *mut u64,
 ) -> Result<(), FatError>
 {
-    let _ = state;
     let mut buf = Box::new([0u8; SECTOR_SIZE]);
     if !cache.read_sector(u64::from(loc.sector_lba), block_dev, &mut buf, ipc_buf)
     {
@@ -2038,8 +2013,6 @@ fn scan_sector_for_remove(
             return Ok(Some((
                 RemovedEntry {
                     start_cluster: u32::MAX,
-                    size: 0,
-                    is_dir: false,
                 },
                 *lfn_run,
                 *lfn_run_len,
@@ -2080,8 +2053,6 @@ fn scan_sector_for_remove(
                 return Ok(Some((
                     RemovedEntry {
                         start_cluster: entry.cluster,
-                        size: entry.size,
-                        is_dir: entry.attr & ATTR_DIRECTORY != 0,
                     },
                     run,
                     run_len,

--- a/services/fs/fat/src/dir.rs
+++ b/services/fs/fat/src/dir.rs
@@ -533,7 +533,7 @@ pub fn find_in_directory(
     ipc_buf: *mut u64,
 ) -> Option<DirEntry>
 {
-    let mut sector_buf = [0u8; SECTOR_SIZE];
+    let mut sector_buf = Box::new([0u8; SECTOR_SIZE]);
     let mut lfn = LfnAccum::new();
 
     if dir_cluster == 0
@@ -577,7 +577,7 @@ fn find_in_fat16_root(
 {
     let root_start = u32::from(state.reserved_sectors) + u32::from(state.num_fats) * state.fat_size;
     let root_sectors = (u32::from(state.root_entry_count) * 32).div_ceil(512);
-    let mut sector_buf = [0u8; SECTOR_SIZE];
+    let mut sector_buf = Box::new([0u8; SECTOR_SIZE]);
     let mut lfn = LfnAccum::new();
 
     for s in 0..root_sectors
@@ -612,7 +612,7 @@ pub fn find_in_directory_with_location(
     ipc_buf: *mut u64,
 ) -> Option<(DirEntry, DirEntryLocation)>
 {
-    let mut sector_buf = [0u8; SECTOR_SIZE];
+    let mut sector_buf = Box::new([0u8; SECTOR_SIZE]);
     let mut lfn = LfnAccum::new();
     let entries_per_sector = SECTOR_SIZE / 32;
 
@@ -783,7 +783,7 @@ pub fn read_dir_entry_at_index(
     ipc_buf: *mut u64,
 ) -> Option<DirEntry>
 {
-    let mut sector_buf = [0u8; SECTOR_SIZE];
+    let mut sector_buf = Box::new([0u8; SECTOR_SIZE]);
     let mut lfn = LfnAccum::new();
     let entries_per_sector = SECTOR_SIZE / 32;
     let mut current_idx: u64 = 0;
@@ -1112,7 +1112,7 @@ pub fn update_entry_metadata(
 ) -> Result<(), FatError>
 {
     let _ = state; // mirrors the read-side signature; reserved for future use
-    let mut buf = [0u8; SECTOR_SIZE];
+    let mut buf = Box::new([0u8; SECTOR_SIZE]);
     if !cache.read_sector(u64::from(loc.sector_lba), block_dev, &mut buf, ipc_buf)
     {
         return Err(FatError::Io);
@@ -1141,7 +1141,7 @@ pub fn directory_is_empty(
     ipc_buf: *mut u64,
 ) -> Result<bool, FatError>
 {
-    let mut buf = [0u8; SECTOR_SIZE];
+    let mut buf = Box::new([0u8; SECTOR_SIZE]);
     let entries_per_sector = SECTOR_SIZE / 32;
 
     let mut cluster = dir_cluster;
@@ -1199,7 +1199,7 @@ pub fn write_dot_entries(
 ) -> Result<(), FatError>
 {
     let base_sector = state.cluster_to_sector(new_dir_cluster);
-    let mut buf = [0u8; SECTOR_SIZE];
+    let mut buf = Box::new([0u8; SECTOR_SIZE]);
     // First sector: "." and ".." entries packed at offsets 0 and 32;
     // remaining slots zeroed (== "end of directory" sentinel for every
     // following slot). Subsequent sectors of the cluster stay zero;
@@ -1224,7 +1224,7 @@ pub fn write_dot_entries(
     // Zero out the rest of the cluster so a stale neighbour sector
     // (allocate_cluster reuses freed clusters) does not surface as
     // ghost entries.
-    let zeros = [0u8; SECTOR_SIZE];
+    let zeros = Box::new([0u8; SECTOR_SIZE]);
     for s in 1..u32::from(state.sectors_per_cluster)
     {
         if !cache.write_sector(u64::from(base_sector + s), block_dev, &zeros, ipc_buf)
@@ -1257,7 +1257,7 @@ fn find_free_slot_run(
     let mut run_len = 0usize;
 
     let entries_per_sector = SECTOR_SIZE / 32;
-    let mut buf = [0u8; SECTOR_SIZE];
+    let mut buf = Box::new([0u8; SECTOR_SIZE]);
 
     // FAT16 fixed root.
     if parent_dir_cluster == 0 && matches!(state.fat_type, FatType::Fat16)
@@ -1487,7 +1487,7 @@ fn zero_cluster(
     ipc_buf: *mut u64,
 ) -> Result<(), FatError>
 {
-    let zeros = [0u8; SECTOR_SIZE];
+    let zeros = Box::new([0u8; SECTOR_SIZE]);
     let base = state.cluster_to_sector(cluster);
     for s in 0..u32::from(state.sectors_per_cluster)
     {
@@ -1509,7 +1509,7 @@ fn write_dir_slot(
 ) -> Result<(), FatError>
 {
     let _ = state; // reserved for future use; mirrors the read-side signature
-    let mut buf = [0u8; SECTOR_SIZE];
+    let mut buf = Box::new([0u8; SECTOR_SIZE]);
     if !cache.read_sector(u64::from(loc.sector_lba), block_dev, &mut buf, ipc_buf)
     {
         return Err(FatError::Io);
@@ -1531,7 +1531,7 @@ fn mark_slot_deleted(
 ) -> Result<(), FatError>
 {
     let _ = state;
-    let mut buf = [0u8; SECTOR_SIZE];
+    let mut buf = Box::new([0u8; SECTOR_SIZE]);
     if !cache.read_sector(u64::from(loc.sector_lba), block_dev, &mut buf, ipc_buf)
     {
         return Err(FatError::Io);
@@ -1794,7 +1794,7 @@ fn find_in_directory_by_sfn(
     ipc_buf: *mut u64,
 ) -> Option<()>
 {
-    let mut buf = [0u8; SECTOR_SIZE];
+    let mut buf = Box::new([0u8; SECTOR_SIZE]);
     let entries_per_sector = SECTOR_SIZE / 32;
 
     if parent_dir_cluster == 0 && matches!(state.fat_type, FatType::Fat16)
@@ -1906,7 +1906,7 @@ fn locate_entry_with_lfn_run(
 ) -> Result<(RemovedEntry, [DirEntryLocation; MAX_SLOT_RUN]), FatError>
 {
     let entries_per_sector = SECTOR_SIZE / 32;
-    let mut buf = [0u8; SECTOR_SIZE];
+    let mut buf = Box::new([0u8; SECTOR_SIZE]);
     let mut lfn = LfnAccum::new();
     let mut lfn_run: [Option<DirEntryLocation>; MAX_SLOT_RUN] = [None; MAX_SLOT_RUN];
     let mut lfn_run_len = 0usize;

--- a/services/fs/fat/src/main.rs
+++ b/services/fs/fat/src/main.rs
@@ -911,8 +911,11 @@ fn write_file_bytes(
         let bytes_to_write = bytes_avail_in_sector.min(data.len() - written);
 
         // Read-modify-write the sector unless we are writing the full
-        // sector from offset 0.
-        let mut sector_buf = [0u8; SECTOR_SIZE];
+        // sector from offset 0. Heap-allocated to keep the
+        // write-path frame within the default 32 KiB stack envelope
+        // when release LTO inlines the nested helpers
+        // (`insert_entry → write_dir_slot → ...`).
+        let mut sector_buf = Box::new([0u8; SECTOR_SIZE]);
         let full_sector_overwrite = byte_in_sector == 0 && bytes_to_write == SECTOR_SIZE;
         if !full_sector_overwrite
             && !cache.read_sector(u64::from(sector_lba), block_dev, &mut sector_buf, ipc_buf)
@@ -1141,7 +1144,10 @@ fn handle_write_frame_node_cap(
         return;
     }
 
-    let mut buf = [0u8; PAGE_SIZE as usize];
+    // Heap-allocated: a 4 KiB on-stack buffer would push the
+    // FS_WRITE_FRAME path past the default 32 KiB stack envelope
+    // once it cascades into `write_file_bytes → insert_entry → …`.
+    let mut buf = Box::new([0u8; PAGE_SIZE as usize]);
     // SAFETY: va just mapped MAP_READONLY for one page; bounds checked
     // above.
     unsafe {

--- a/services/fs/fat/src/main.rs
+++ b/services/fs/fat/src/main.rs
@@ -1116,8 +1116,27 @@ fn handle_write_frame_node_cap(
         reply_with(ipc::fs_errors::IO_ERROR, ipc_buf);
         return;
     };
-    if syscall::mem_map(src_cap, self_aspace, va, 0, 1, syscall_abi::MAP_READONLY).is_err()
+    // memmgr-issued frames carry RIGHTS_ALL (both WRITE and EXECUTE);
+    // mem_map with MAP_READONLY (= 0) on such a cap derives both w and
+    // x from the cap rights and trips the kernel's W^X check. Derive a
+    // sub-cap restricted to MAP_READ first; delete it after the unmap.
+    let Ok(restricted_cap) = syscall::cap_derive(src_cap, RIGHTS_MAP_READ)
+    else
     {
+        reply_with(ipc::fs_errors::IO_ERROR, ipc_buf);
+        return;
+    };
+    if syscall::mem_map(
+        restricted_cap,
+        self_aspace,
+        va,
+        0,
+        1,
+        syscall_abi::MAP_READONLY,
+    )
+    .is_err()
+    {
+        let _ = syscall::cap_delete(restricted_cap);
         reply_with(ipc::fs_errors::IO_ERROR, ipc_buf);
         return;
     }
@@ -1133,6 +1152,10 @@ fn handle_write_frame_node_cap(
         );
     }
     let _ = syscall::mem_unmap(self_aspace, va, 1);
+    // Drop the rights-restricted sub-cap we derived to satisfy W^X
+    // at mem_map. The original src_cap is unaffected and returns to
+    // the caller in the reply.
+    let _ = syscall::cap_delete(restricted_cap);
 
     let (new_cluster, new_size) = match write_file_bytes(
         node.cluster,

--- a/services/fs/fat/src/main.rs
+++ b/services/fs/fat/src/main.rs
@@ -47,7 +47,7 @@ mod file;
 use std::os::seraph::{StartupInfo, startup_info};
 use std::sync::{Arc, Mutex, PoisonError};
 
-use alloc::{FatError, allocate_cluster, update_fat_entry};
+use alloc::{FatError, allocate_cluster};
 use backend::{FatfsBackend, NO_OPEN_SLOT, NodeTable};
 use bpb::{FatState, SECTOR_SIZE};
 use cache::PageCache;
@@ -283,10 +283,14 @@ fn service_loop(
         }
 
         // FS_* requests: gate on the rights table, replying with
-        // fs_errors codes.
-        let node_id = match gate(msg.label, msg.token)
+        // fs_errors codes. `parent_rights` is the caller's
+        // per-operation rights ceiling — the cap returned by
+        // FS_CREATE/FS_MKDIR must not exceed it, or a caller holding
+        // a `MUTATE_DIR`-only parent would silently gain `READ` /
+        // `WRITE` / `EXEC` on every child they create.
+        let (node_id, parent_rights) = match gate(msg.label, msg.token)
         {
-            Ok((node, _)) => node,
+            Ok(pair) => pair,
             Err(GateError::UnknownLabel) =>
             {
                 let reply = IpcMessage::new(ipc::fs_errors::UNKNOWN_OPCODE);
@@ -334,7 +338,16 @@ fn service_loop(
             }
             fs_labels::FS_CREATE =>
             {
-                handle_create_node_cap(node_id, &msg, state, nodes, cache, caps, ipc_buf);
+                handle_create_node_cap(
+                    node_id,
+                    parent_rights,
+                    &msg,
+                    state,
+                    nodes,
+                    cache,
+                    caps,
+                    ipc_buf,
+                );
                 continue;
             }
             fs_labels::FS_REMOVE =>
@@ -344,7 +357,16 @@ fn service_loop(
             }
             fs_labels::FS_MKDIR =>
             {
-                handle_mkdir_node_cap(node_id, &msg, state, nodes, cache, caps, ipc_buf);
+                handle_mkdir_node_cap(
+                    node_id,
+                    parent_rights,
+                    &msg,
+                    state,
+                    nodes,
+                    cache,
+                    caps,
+                    ipc_buf,
+                );
                 continue;
             }
             fs_labels::FS_RENAME =>
@@ -878,23 +900,19 @@ fn write_file_bytes(
     let target_cluster_idx = offset / cluster_size;
 
     // Walk to the cluster containing the target offset, allocating
-    // along the way for sparse writes.
-    let mut prev = cluster;
+    // along the way for sparse writes. When we hit EOC, the current
+    // `cluster` is the terminal one — `allocate_cluster(Some(cluster))`
+    // links the new cluster after it. (A previous version threaded a
+    // separate `prev` that was updated after `cluster`, so on
+    // append-past-EOC it linked the new cluster behind the prior
+    // terminal, overwriting that terminal's existing forward link and
+    // orphaning the original tail.)
     for _ in 0..target_cluster_idx
     {
         cluster = match next_cluster(state, cluster, cache, block_dev, ipc_buf)
         {
-            Some(c) =>
-            {
-                prev = cluster;
-                c
-            }
-            None =>
-            {
-                let new = allocate_cluster(state, Some(prev), cache, block_dev, ipc_buf)?;
-                prev = cluster;
-                new
-            }
+            Some(c) => c,
+            None => allocate_cluster(state, Some(cluster), cache, block_dev, ipc_buf)?,
         };
     }
 
@@ -937,11 +955,10 @@ fn write_file_bytes(
         let new_cluster_offset = cur_offset % cluster_size;
         if new_cluster_offset == 0 && written < data.len()
         {
-            prev = cluster;
             cluster = match next_cluster(state, cluster, cache, block_dev, ipc_buf)
             {
                 Some(c) => c,
-                None => allocate_cluster(state, Some(prev), cache, block_dev, ipc_buf)?,
+                None => allocate_cluster(state, Some(cluster), cache, block_dev, ipc_buf)?,
             };
         }
     }
@@ -1008,15 +1025,8 @@ fn handle_write_node_cap(
 
     if (new_cluster != node.cluster || new_size != node.size) && node.loc.sector_lba != 0
     {
-        if let Err(e) = update_entry_metadata(
-            state,
-            node.loc,
-            new_cluster,
-            new_size,
-            cache,
-            block_dev,
-            ipc_buf,
-        )
+        if let Err(e) =
+            update_entry_metadata(node.loc, new_cluster, new_size, cache, block_dev, ipc_buf)
         {
             reply_err(fat_error_to_wire(e), ipc_buf);
             return;
@@ -1184,15 +1194,8 @@ fn handle_write_frame_node_cap(
 
     if (new_cluster != node.cluster || new_size != node.size) && node.loc.sector_lba != 0
     {
-        if let Err(e) = update_entry_metadata(
-            state,
-            node.loc,
-            new_cluster,
-            new_size,
-            cache,
-            block_dev,
-            ipc_buf,
-        )
+        if let Err(e) =
+            update_entry_metadata(node.loc, new_cluster, new_size, cache, block_dev, ipc_buf)
         {
             reply_with(fat_error_to_wire(e), ipc_buf);
             return;
@@ -1248,9 +1251,12 @@ fn self_aspace_cap() -> Option<u32>
 
 /// `FS_CREATE`: create a new file in a directory. Token = parent-dir
 /// cap (must carry `MUTATE_DIR`). `label[16..32]` = name length, name
-/// from word 0.
+/// from word 0. `parent_rights` is the caller's effective rights on
+/// the parent dir; the returned child cap is attenuated by it.
+#[allow(clippy::too_many_arguments)]
 fn handle_create_node_cap(
     node_id: NodeId,
+    parent_rights: NamespaceRights,
     msg: &IpcMessage,
     state: &mut FatState,
     nodes: &mut NodeTable,
@@ -1261,6 +1267,7 @@ fn handle_create_node_cap(
 {
     create_entry_common(
         node_id,
+        parent_rights,
         msg,
         NewEntryKind::File,
         state,
@@ -1272,8 +1279,10 @@ fn handle_create_node_cap(
 }
 
 /// `FS_MKDIR`: create a new directory in a directory.
+#[allow(clippy::too_many_arguments)]
 fn handle_mkdir_node_cap(
     node_id: NodeId,
+    parent_rights: NamespaceRights,
     msg: &IpcMessage,
     state: &mut FatState,
     nodes: &mut NodeTable,
@@ -1284,6 +1293,7 @@ fn handle_mkdir_node_cap(
 {
     create_entry_common(
         node_id,
+        parent_rights,
         msg,
         NewEntryKind::Dir,
         state,
@@ -1297,6 +1307,7 @@ fn handle_mkdir_node_cap(
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 fn create_entry_common(
     node_id: NodeId,
+    parent_rights: NamespaceRights,
     msg: &IpcMessage,
     kind: NewEntryKind,
     state: &mut FatState,
@@ -1393,7 +1404,24 @@ fn create_entry_common(
         reply_err(ipc::fs_errors::TOO_MANY_OPEN, ipc_buf);
         return;
     };
-    let token = pack_token(new_node_id, NamespaceRights::ALL);
+    // Cap-monotonic attenuation: the child cap can carry at most the
+    // intersection of the caller's parent rights and the kind-specific
+    // ceiling that `backend::lookup` would later apply on a re-walk.
+    // Files: STAT|READ|WRITE|EXEC. Dirs: ALL (intermediate-dir
+    // composition relies on dirs passing every bit through; per-op
+    // gating still enforces the leaf check).
+    let kind_max = match kind_for_node
+    {
+        NodeKind::Dir => NamespaceRights::ALL,
+        NodeKind::File => NamespaceRights::from_raw(
+            namespace_protocol::rights::STAT
+                | namespace_protocol::rights::READ
+                | namespace_protocol::rights::WRITE
+                | namespace_protocol::rights::EXEC,
+        ),
+    };
+    let child_rights = parent_rights.intersect(kind_max);
+    let token = pack_token(new_node_id, child_rights);
     let Ok(new_cap) = syscall::cap_derive_token(caps.service, syscall::RIGHTS_SEND_GRANT, token)
     else
     {
@@ -1436,7 +1464,7 @@ fn handle_remove_node_cap(
     }
     let name = &data_bytes[..name_len];
 
-    let Some((entry, _loc)) = dir::find_in_directory_with_location(
+    let Some((entry, removed_loc)) = dir::find_in_directory_with_location(
         parent_cluster,
         name,
         state,
@@ -1485,15 +1513,12 @@ fn handle_remove_node_cap(
         return;
     }
 
-    let kind = if removed.is_dir
-    {
-        NodeKind::Dir
-    }
-    else
-    {
-        NodeKind::File
-    };
-    nodes.invalidate_for_entry(removed.start_cluster, kind, removed.size);
+    // Slot-keyed invalidation: NodeTable now dedupes by
+    // `DirEntryLocation`, so a stale node for this slot must be
+    // dropped before a later FS_CREATE lands here and reuses the
+    // slot's bytes.
+    let _ = removed;
+    nodes.invalidate_for_loc(removed_loc);
 
     let reply = IpcMessage::new(ipc::fs_errors::SUCCESS);
     // SAFETY: ipc_buf is the registered IPC buffer page.
@@ -1537,7 +1562,7 @@ fn handle_rename_node_cap(
         return;
     }
 
-    let Some((entry, _loc)) = dir::find_in_directory_with_location(
+    let Some((entry, src_loc)) = dir::find_in_directory_with_location(
         parent_cluster,
         src_name,
         state,
@@ -1583,7 +1608,11 @@ fn handle_rename_node_cap(
         return;
     }
 
-    let _ = update_fat_entry; // silence unused-import lint pending future use
+    // Drop any cached node referencing the now-deleted source slot.
+    // A later FS_WRITE through a held source cap would otherwise
+    // patch a `0xE5`-marked entry.
+    nodes.invalidate_for_loc(src_loc);
+
     let reply = IpcMessage::new(ipc::fs_errors::SUCCESS);
     // SAFETY: ipc_buf is the registered IPC buffer page.
     let _ = unsafe { ipc::ipc_reply(&reply, ipc_buf) };

--- a/services/fs/fat/src/main.rs
+++ b/services/fs/fat/src/main.rs
@@ -25,6 +25,7 @@
 #![feature(restricted_std)]
 #![allow(clippy::cast_possible_truncation)]
 
+mod alloc;
 mod backend;
 mod bpb;
 mod cache;
@@ -163,6 +164,11 @@ fn bootstrap_caps(info: &StartupInfo, ipc_buf: *mut u64) -> Option<FatCaps>
 
 /// Validate the BPB by reading sector 0 through the block cap. Updates
 /// `state` in place; returns the IPC reply label to use.
+///
+/// On a successful FAT32 parse, also loads the `FSInfo` sector (advisory
+/// next-free / free-count hints) so the cluster allocator can seed its
+/// scan; FAT16 and FAT32 without `FSInfo` leave the hints at the
+/// `u32::MAX` sentinel and the allocator scans from cluster 2.
 fn validate_bpb(caps: &FatCaps, state: &mut FatState, cache: &PageCache, ipc_buf: *mut u64) -> u64
 {
     let mut sector_buf = [0u8; SECTOR_SIZE];
@@ -174,6 +180,7 @@ fn validate_bpb(caps: &FatCaps, state: &mut FatState, cache: &PageCache, ipc_buf
     {
         return ipc::fs_errors::NOT_FOUND;
     }
+    alloc::load_fsinfo(state, cache, caps.block_dev, ipc_buf);
     ipc::fs_errors::SUCCESS
 }
 

--- a/services/fs/fat/src/main.rs
+++ b/services/fs/fat/src/main.rs
@@ -5,19 +5,29 @@
 
 //! Seraph FAT filesystem driver.
 //!
-//! Implements read-only FAT16/FAT32 filesystem support. Serves the
+//! Implements read-write FAT16/FAT32 filesystem support. Serves the
 //! cap-native namespace protocol (`NS_LOOKUP` / `NS_STAT` /
-//! `NS_READDIR`) for directory walks and `FS_READ` / `FS_READ_FRAME` /
-//! `FS_RELEASE_FRAME` / `FS_CLOSE` against per-node tokened caps.
-//! `FS_MOUNT` is the one untokened service-level request, used by
-//! vfsd as a BPB-validation probe at mount time. All disk I/O is
-//! performed via the block device IPC endpoint received at creation
-//! time.
+//! `NS_READDIR`) for directory walks; per-node tokened caps carry
+//! the read side (`FS_READ`, `FS_READ_FRAME`, `FS_RELEASE_FRAME`,
+//! `FS_CLOSE`) and the write side (`FS_WRITE`, `FS_WRITE_FRAME`,
+//! `FS_CREATE`, `FS_REMOVE`, `FS_MKDIR`, `FS_RENAME`). `FS_MOUNT` is
+//! the one untokened service-level request, used by vfsd as a
+//! BPB-validation probe at mount time. All disk I/O is performed via
+//! the block device IPC endpoint received at creation time.
 //!
 //! Per-node tokens are minted by `NS_LOOKUP` (token = `(NodeId,
-//! NamespaceRights)`); `FS_READ` / `FS_READ_FRAME` / `FS_RELEASE_FRAME`
-//! / `FS_CLOSE` look the node up in `NodeTable` and act on the
-//! lazily-allocated `OpenFile` slot.
+//! NamespaceRights)`); per-node ops look the node up in `NodeTable`
+//! and act on either the lazily-allocated `OpenFile` slot (read-side
+//! frame caps) or the cached `DirEntryLocation` (write-side metadata
+//! patching).
+//!
+//! Cache coherence: writes go through write-through
+//! ([`cache::PageCache::write_sector`]) so any outstanding
+//! `FS_READ_FRAME` cap aliasing the same page observes new bytes
+//! immediately. FAT-entry mutations invalidate the per-`FatState`
+//! private `cached_fat_sector` to prevent stale FAT chain walks.
+//! Crash window discussion lives in
+//! `services/fs/fat/docs/crash-safety.md`.
 
 // The `seraph` target is not in rustc's recognised-OS list, so `std` is
 // `restricted_std`-gated for downstream bins. Every std-built service on
@@ -37,14 +47,19 @@ mod file;
 use std::os::seraph::{StartupInfo, startup_info};
 use std::sync::{Arc, Mutex, PoisonError};
 
+use alloc::{FatError, allocate_cluster, update_fat_entry};
 use backend::{FatfsBackend, NO_OPEN_SLOT, NodeTable};
 use bpb::{FatState, SECTOR_SIZE};
 use cache::PageCache;
+use dir::{
+    NewEntryKind, directory_is_empty, free_entry_data, insert_entry, remove_entry,
+    update_entry_metadata, write_dot_entries,
+};
 use eviction::{EvictReq, EvictionState};
 use fat::{next_cluster, read_file_data};
 use file::{MAX_OPEN_FILES, OpenFile, OutstandingPage};
 use ipc::{IpcMessage, fs_labels, ns_labels};
-use namespace_protocol::{GateError, NodeId, NodeKind, gate};
+use namespace_protocol::{GateError, NamespaceRights, NodeId, NodeKind, gate, pack as pack_token};
 use syscall_abi::{PAGE_SIZE, RIGHTS_MAP_READ};
 
 /// Monotonic counter for token allocation. Starts at 1 (0 = untokened).
@@ -201,6 +216,7 @@ fn validate_bpb(caps: &FatCaps, state: &mut FatState, cache: &PageCache, ipc_buf
 /// the entire dispatch. The hot path is single-client and
 /// short-lived; lock contention with the worker is only material
 /// during cache-pressure releases.
+#[allow(clippy::too_many_lines)]
 fn service_loop(
     caps: &FatCaps,
     state: &mut FatState,
@@ -291,6 +307,53 @@ fn service_loop(
         {
             handle_read_node_cap(node_id, &msg, state, nodes, cache, caps.block_dev, ipc_buf);
             continue;
+        }
+
+        // Mutation handlers do not need the OpenFile table lock; they
+        // operate on the NodeTable + cluster allocator + dir mutation
+        // + cache write-through.
+        match opcode
+        {
+            fs_labels::FS_WRITE =>
+            {
+                handle_write_node_cap(node_id, &msg, state, nodes, cache, caps.block_dev, ipc_buf);
+                continue;
+            }
+            fs_labels::FS_WRITE_FRAME =>
+            {
+                handle_write_frame_node_cap(
+                    node_id,
+                    &msg,
+                    state,
+                    nodes,
+                    cache,
+                    caps.block_dev,
+                    ipc_buf,
+                );
+                continue;
+            }
+            fs_labels::FS_CREATE =>
+            {
+                handle_create_node_cap(node_id, &msg, state, nodes, cache, caps, ipc_buf);
+                continue;
+            }
+            fs_labels::FS_REMOVE =>
+            {
+                handle_remove_node_cap(node_id, &msg, state, nodes, cache, caps.block_dev, ipc_buf);
+                continue;
+            }
+            fs_labels::FS_MKDIR =>
+            {
+                handle_mkdir_node_cap(node_id, &msg, state, nodes, cache, caps, ipc_buf);
+                continue;
+            }
+            fs_labels::FS_RENAME =>
+            {
+                handle_rename_node_cap(node_id, &msg, state, nodes, cache, caps.block_dev, ipc_buf);
+                continue;
+            }
+            _ =>
+            {}
         }
 
         let mut files_g = files.lock().unwrap_or_else(PoisonError::into_inner);
@@ -728,6 +791,770 @@ fn handle_close_node_cap(
         files[idx] = OpenFile::empty();
         nodes.set_open_slot(node_id, NO_OPEN_SLOT);
     }
+    let reply = IpcMessage::new(ipc::fs_errors::SUCCESS);
+    // SAFETY: ipc_buf is the registered IPC buffer page.
+    let _ = unsafe { ipc::ipc_reply(&reply, ipc_buf) };
+}
+
+// ── Write / mutation handlers ──────────────────────────────────────────────
+
+/// Map a [`FatError`] to its wire-side `fs_errors` code.
+fn fat_error_to_wire(err: FatError) -> u64
+{
+    match err
+    {
+        // I/O and corrupt are both surfaced as IO_ERROR — clients
+        // don't distinguish, and "corrupt" without recovery state is
+        // an I/O-level failure from their point of view.
+        FatError::Io | FatError::Corrupt => ipc::fs_errors::IO_ERROR,
+        FatError::NoSpace => ipc::fs_errors::NO_SPACE,
+    }
+}
+
+fn reply_err(code: u64, ipc_buf: *mut u64)
+{
+    let reply = IpcMessage::new(code);
+    // SAFETY: ipc_buf is the registered IPC buffer page.
+    let _ = unsafe { ipc::ipc_reply(&reply, ipc_buf) };
+}
+
+/// Resolve a parent-dir `NodeId` to the directory's cluster number.
+/// `NodeId(0)` is the root; FAT16 returns the sentinel cluster 0, FAT32
+/// returns `state.root_cluster`. Non-root ids must be present in the
+/// table and refer to a directory.
+fn resolve_dir_cluster(node_id: NodeId, state: &FatState, nodes: &NodeTable) -> Option<u32>
+{
+    if node_id.raw() == 0
+    {
+        return Some(match state.fat_type
+        {
+            bpb::FatType::Fat32 => state.root_cluster,
+            bpb::FatType::Fat16 => 0,
+        });
+    }
+    let node = nodes.get(node_id)?;
+    if node.kind != NodeKind::Dir
+    {
+        return None;
+    }
+    Some(node.cluster)
+}
+
+/// Common cluster-walk-and-write engine used by `FS_WRITE` and
+/// `FS_WRITE_FRAME`. Walks the file's cluster chain from `offset`,
+/// allocating new clusters as needed, and writes `data` sector-by-
+/// sector through [`PageCache::write_sector`] (read-modify-write
+/// applies for partial-sector writes). Returns the number of bytes
+/// successfully written plus the (possibly-updated) file's first
+/// cluster.
+#[allow(clippy::too_many_arguments, clippy::single_match_else)]
+fn write_file_bytes(
+    start_cluster: u32,
+    file_size: u32,
+    offset: u64,
+    data: &[u8],
+    state: &mut FatState,
+    cache: &PageCache,
+    block_dev: u32,
+    ipc_buf: *mut u64,
+) -> Result<(u32, u32), FatError>
+{
+    let cluster_size = u64::from(state.cluster_size());
+    let bps = u64::from(state.bytes_per_sector);
+    if data.is_empty()
+    {
+        return Ok((start_cluster, file_size));
+    }
+
+    // Bootstrap: if the file currently holds no chain (size 0 / cluster
+    // 0), allocate the first cluster now.
+    let mut chain_head = start_cluster;
+    if chain_head < 2
+    {
+        chain_head = allocate_cluster(state, None, cache, block_dev, ipc_buf)?;
+    }
+
+    let mut cluster = chain_head;
+    let target_cluster_idx = offset / cluster_size;
+
+    // Walk to the cluster containing the target offset, allocating
+    // along the way for sparse writes.
+    let mut prev = cluster;
+    for _ in 0..target_cluster_idx
+    {
+        cluster = match next_cluster(state, cluster, cache, block_dev, ipc_buf)
+        {
+            Some(c) =>
+            {
+                prev = cluster;
+                c
+            }
+            None =>
+            {
+                let new = allocate_cluster(state, Some(prev), cache, block_dev, ipc_buf)?;
+                prev = cluster;
+                new
+            }
+        };
+    }
+
+    let mut written = 0usize;
+    let mut cur_offset = offset;
+    while written < data.len()
+    {
+        let cluster_byte_offset = cur_offset % cluster_size;
+        let sector_in_cluster = (cluster_byte_offset / bps) as u32;
+        let byte_in_sector = (cluster_byte_offset % bps) as usize;
+        let sector_lba = state.cluster_to_sector(cluster) + sector_in_cluster;
+
+        let bytes_avail_in_sector = (bps as usize) - byte_in_sector;
+        let bytes_to_write = bytes_avail_in_sector.min(data.len() - written);
+
+        // Read-modify-write the sector unless we are writing the full
+        // sector from offset 0.
+        let mut sector_buf = [0u8; SECTOR_SIZE];
+        let full_sector_overwrite = byte_in_sector == 0 && bytes_to_write == SECTOR_SIZE;
+        if !full_sector_overwrite
+            && !cache.read_sector(u64::from(sector_lba), block_dev, &mut sector_buf, ipc_buf)
+        {
+            return Err(FatError::Io);
+        }
+        sector_buf[byte_in_sector..byte_in_sector + bytes_to_write]
+            .copy_from_slice(&data[written..written + bytes_to_write]);
+        if !cache.write_sector(u64::from(sector_lba), block_dev, &sector_buf, ipc_buf)
+        {
+            return Err(FatError::Io);
+        }
+
+        written += bytes_to_write;
+        cur_offset += bytes_to_write as u64;
+
+        // Advance to next cluster if we still have data to write and
+        // this write touched the cluster tail.
+        let new_cluster_offset = cur_offset % cluster_size;
+        if new_cluster_offset == 0 && written < data.len()
+        {
+            prev = cluster;
+            cluster = match next_cluster(state, cluster, cache, block_dev, ipc_buf)
+            {
+                Some(c) => c,
+                None => allocate_cluster(state, Some(prev), cache, block_dev, ipc_buf)?,
+            };
+        }
+    }
+
+    // cast_possible_truncation: cur_offset bounded by sector-level
+    // arithmetic; FAT file_size field is u32.
+    #[allow(clippy::cast_possible_truncation)]
+    let new_size = file_size.max(cur_offset as u32);
+    Ok((chain_head, new_size))
+}
+
+/// `FS_WRITE` inline write. Token = file cap (must carry `WRITE`).
+/// `label[16..32]` = byte length (≤504), `data[0]` = offset, payload
+/// bytes packed from word 1 onward.
+fn handle_write_node_cap(
+    node_id: NodeId,
+    msg: &IpcMessage,
+    state: &mut FatState,
+    nodes: &mut NodeTable,
+    cache: &PageCache,
+    block_dev: u32,
+    ipc_buf: *mut u64,
+)
+{
+    let Some(node) = nodes.get(node_id)
+    else
+    {
+        reply_err(ipc::fs_errors::INVALID_TOKEN, ipc_buf);
+        return;
+    };
+    if node.kind != NodeKind::File
+    {
+        reply_err(ipc::fs_errors::IS_A_DIRECTORY, ipc_buf);
+        return;
+    }
+    let byte_len = ((msg.label >> 16) & 0xFFFF) as usize;
+    let offset = msg.word(0);
+    let data_bytes = msg.data_bytes();
+    if byte_len == 0 || data_bytes.len() < 8 + byte_len
+    {
+        reply_err(ipc::fs_errors::IO_ERROR, ipc_buf);
+        return;
+    }
+    let payload = &data_bytes[8..8 + byte_len];
+
+    let (new_cluster, new_size) = match write_file_bytes(
+        node.cluster,
+        node.size,
+        offset,
+        payload,
+        state,
+        cache,
+        block_dev,
+        ipc_buf,
+    )
+    {
+        Ok(r) => r,
+        Err(e) =>
+        {
+            reply_err(fat_error_to_wire(e), ipc_buf);
+            return;
+        }
+    };
+
+    if (new_cluster != node.cluster || new_size != node.size) && node.loc.sector_lba != 0
+    {
+        if let Err(e) = update_entry_metadata(
+            state,
+            node.loc,
+            new_cluster,
+            new_size,
+            cache,
+            block_dev,
+            ipc_buf,
+        )
+        {
+            reply_err(fat_error_to_wire(e), ipc_buf);
+            return;
+        }
+        nodes.update_size_and_cluster(node_id, new_cluster, new_size);
+    }
+
+    let reply = IpcMessage::builder(ipc::fs_errors::SUCCESS)
+        .word(0, byte_len as u64)
+        .build();
+    // SAFETY: ipc_buf is the registered IPC buffer page.
+    let _ = unsafe { ipc::ipc_reply(&reply, ipc_buf) };
+}
+
+/// `FS_WRITE_FRAME`: caller supplies a source Frame cap; data lives
+/// at `frame_data_offset..frame_data_offset + byte_count` in the
+/// frame. The Frame is mapped into fatfs's address space at a
+/// process-static scratch VA, copied into a stack buffer, and the
+/// scratch VA unmapped before the actual writes. The Frame is moved
+/// back to the caller in the reply.
+#[allow(clippy::too_many_lines)]
+fn handle_write_frame_node_cap(
+    node_id: NodeId,
+    msg: &IpcMessage,
+    state: &mut FatState,
+    nodes: &mut NodeTable,
+    cache: &PageCache,
+    block_dev: u32,
+    ipc_buf: *mut u64,
+)
+{
+    let src_cap = msg.caps().first().copied().unwrap_or(0);
+
+    let reply_with = |code: u64, ipc_buf: *mut u64| {
+        let mut builder = IpcMessage::builder(code);
+        if src_cap != 0
+        {
+            builder = builder.cap(src_cap);
+        }
+        let reply = builder.build();
+        // SAFETY: ipc_buf is the registered IPC buffer page.
+        let _ = unsafe { ipc::ipc_reply(&reply, ipc_buf) };
+    };
+
+    if src_cap == 0
+    {
+        reply_with(ipc::fs_errors::IO_ERROR, ipc_buf);
+        return;
+    }
+    let Some(node) = nodes.get(node_id)
+    else
+    {
+        reply_with(ipc::fs_errors::INVALID_TOKEN, ipc_buf);
+        return;
+    };
+    if node.kind != NodeKind::File
+    {
+        reply_with(ipc::fs_errors::IS_A_DIRECTORY, ipc_buf);
+        return;
+    }
+
+    let offset = msg.word(0);
+    let byte_count = msg.word(1) as usize;
+    let frame_data_offset = msg.word(2) as usize;
+    let page_size = PAGE_SIZE as usize;
+    if byte_count == 0
+        || frame_data_offset >= page_size
+        || byte_count > page_size - frame_data_offset
+    {
+        reply_with(ipc::fs_errors::BAD_FRAME_OFFSET, ipc_buf);
+        return;
+    }
+
+    // Validate the source frame: Frame cap with at least MAP|READ
+    // rights.
+    let Ok(tag_rights) = syscall::cap_info(src_cap, syscall::CAP_INFO_TAG_RIGHTS)
+    else
+    {
+        reply_with(ipc::fs_errors::IO_ERROR, ipc_buf);
+        return;
+    };
+    let tag = (tag_rights >> 32) as u8;
+    let cap_rights = tag_rights & 0xFFFF_FFFF;
+    if u64::from(tag) != u64::from(syscall::CAP_TAG_FRAME)
+        || (cap_rights & RIGHTS_MAP_READ) != RIGHTS_MAP_READ
+    {
+        reply_with(ipc::fs_errors::IO_ERROR, ipc_buf);
+        return;
+    }
+
+    let va = write_frame_va();
+    if va == 0
+    {
+        reply_with(ipc::fs_errors::IO_ERROR, ipc_buf);
+        return;
+    }
+    let Some(self_aspace) = self_aspace_cap()
+    else
+    {
+        reply_with(ipc::fs_errors::IO_ERROR, ipc_buf);
+        return;
+    };
+    if syscall::mem_map(src_cap, self_aspace, va, 0, 1, syscall_abi::MAP_READONLY).is_err()
+    {
+        reply_with(ipc::fs_errors::IO_ERROR, ipc_buf);
+        return;
+    }
+
+    let mut buf = [0u8; PAGE_SIZE as usize];
+    // SAFETY: va just mapped MAP_READONLY for one page; bounds checked
+    // above.
+    unsafe {
+        core::ptr::copy_nonoverlapping(
+            (va + frame_data_offset as u64) as *const u8,
+            buf.as_mut_ptr(),
+            byte_count,
+        );
+    }
+    let _ = syscall::mem_unmap(self_aspace, va, 1);
+
+    let (new_cluster, new_size) = match write_file_bytes(
+        node.cluster,
+        node.size,
+        offset,
+        &buf[..byte_count],
+        state,
+        cache,
+        block_dev,
+        ipc_buf,
+    )
+    {
+        Ok(r) => r,
+        Err(e) =>
+        {
+            reply_with(fat_error_to_wire(e), ipc_buf);
+            return;
+        }
+    };
+
+    if (new_cluster != node.cluster || new_size != node.size) && node.loc.sector_lba != 0
+    {
+        if let Err(e) = update_entry_metadata(
+            state,
+            node.loc,
+            new_cluster,
+            new_size,
+            cache,
+            block_dev,
+            ipc_buf,
+        )
+        {
+            reply_with(fat_error_to_wire(e), ipc_buf);
+            return;
+        }
+        nodes.update_size_and_cluster(node_id, new_cluster, new_size);
+    }
+
+    let reply = IpcMessage::builder(ipc::fs_errors::SUCCESS)
+        .word(0, byte_count as u64)
+        .cap(src_cap)
+        .build();
+    // SAFETY: ipc_buf is the registered IPC buffer page.
+    let _ = unsafe { ipc::ipc_reply(&reply, ipc_buf) };
+}
+
+/// Lazy process-local VA reservation for `FS_WRITE_FRAME` source-frame
+/// mapping. Returns the VA on success, `0` on reserve failure.
+fn write_frame_va() -> u64
+{
+    use std::sync::OnceLock;
+    static VA: OnceLock<u64> = OnceLock::new();
+    if let Some(v) = VA.get()
+    {
+        return *v;
+    }
+    let Ok(range) = std::os::seraph::reserve_pages(1)
+    else
+    {
+        return 0;
+    };
+    let va = range.va_start();
+    let _ = VA.set(va);
+    va
+}
+
+/// Locate the current process's `AddressSpace` cap, cached.
+fn self_aspace_cap() -> Option<u32>
+{
+    use std::sync::OnceLock;
+    static SELF_ASPACE: OnceLock<u32> = OnceLock::new();
+    if let Some(c) = SELF_ASPACE.get()
+    {
+        return Some(*c);
+    }
+    let info = startup_info();
+    let cap = info.self_aspace;
+    if cap != 0
+    {
+        let _ = SELF_ASPACE.set(cap);
+    }
+    Some(cap).filter(|&c| c != 0)
+}
+
+/// `FS_CREATE`: create a new file in a directory. Token = parent-dir
+/// cap (must carry `MUTATE_DIR`). `label[16..32]` = name length, name
+/// from word 0.
+fn handle_create_node_cap(
+    node_id: NodeId,
+    msg: &IpcMessage,
+    state: &mut FatState,
+    nodes: &mut NodeTable,
+    cache: &PageCache,
+    caps: &FatCaps,
+    ipc_buf: *mut u64,
+)
+{
+    create_entry_common(
+        node_id,
+        msg,
+        NewEntryKind::File,
+        state,
+        nodes,
+        cache,
+        caps,
+        ipc_buf,
+    );
+}
+
+/// `FS_MKDIR`: create a new directory in a directory.
+fn handle_mkdir_node_cap(
+    node_id: NodeId,
+    msg: &IpcMessage,
+    state: &mut FatState,
+    nodes: &mut NodeTable,
+    cache: &PageCache,
+    caps: &FatCaps,
+    ipc_buf: *mut u64,
+)
+{
+    create_entry_common(
+        node_id,
+        msg,
+        NewEntryKind::Dir,
+        state,
+        nodes,
+        cache,
+        caps,
+        ipc_buf,
+    );
+}
+
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+fn create_entry_common(
+    node_id: NodeId,
+    msg: &IpcMessage,
+    kind: NewEntryKind,
+    state: &mut FatState,
+    nodes: &mut NodeTable,
+    cache: &PageCache,
+    caps: &FatCaps,
+    ipc_buf: *mut u64,
+)
+{
+    let Some(parent_cluster) = resolve_dir_cluster(node_id, state, nodes)
+    else
+    {
+        reply_err(ipc::fs_errors::INVALID_TOKEN, ipc_buf);
+        return;
+    };
+    let name_len = ((msg.label >> 16) & 0xFFFF) as usize;
+    let data_bytes = msg.data_bytes();
+    if name_len == 0 || data_bytes.len() < name_len
+    {
+        reply_err(ipc::fs_errors::IO_ERROR, ipc_buf);
+        return;
+    }
+    let name = &data_bytes[..name_len];
+    if namespace_protocol::validate_name(name).is_err()
+    {
+        reply_err(ipc::fs_errors::IO_ERROR, ipc_buf);
+        return;
+    }
+
+    let (start_cluster, kind_for_node) = match kind
+    {
+        NewEntryKind::File => (0u32, NodeKind::File),
+        NewEntryKind::Dir =>
+        {
+            let new_cluster = match allocate_cluster(state, None, cache, caps.block_dev, ipc_buf)
+            {
+                Ok(c) => c,
+                Err(e) =>
+                {
+                    reply_err(fat_error_to_wire(e), ipc_buf);
+                    return;
+                }
+            };
+            if let Err(e) = write_dot_entries(
+                state,
+                new_cluster,
+                parent_cluster,
+                cache,
+                caps.block_dev,
+                ipc_buf,
+            )
+            {
+                reply_err(fat_error_to_wire(e), ipc_buf);
+                return;
+            }
+            (new_cluster, NodeKind::Dir)
+        }
+    };
+
+    let loc = match insert_entry(
+        state,
+        parent_cluster,
+        name,
+        kind,
+        start_cluster,
+        0,
+        cache,
+        caps.block_dev,
+        ipc_buf,
+    )
+    {
+        Ok(loc) => loc,
+        Err(e) =>
+        {
+            if matches!(kind, NewEntryKind::Dir)
+            {
+                let _ =
+                    alloc::free_cluster_chain(state, start_cluster, cache, caps.block_dev, ipc_buf);
+            }
+            reply_err(fat_error_to_wire(e), ipc_buf);
+            return;
+        }
+    };
+
+    let Some(new_node_id) = nodes.alloc_for_dispatch(backend::FatNode {
+        cluster: start_cluster,
+        size: 0,
+        kind: kind_for_node,
+        open_slot: backend::NO_OPEN_SLOT,
+        loc,
+    })
+    else
+    {
+        reply_err(ipc::fs_errors::TOO_MANY_OPEN, ipc_buf);
+        return;
+    };
+    let token = pack_token(new_node_id, NamespaceRights::ALL);
+    let Ok(new_cap) = syscall::cap_derive_token(caps.service, syscall::RIGHTS_SEND_GRANT, token)
+    else
+    {
+        reply_err(ipc::fs_errors::IO_ERROR, ipc_buf);
+        return;
+    };
+
+    let reply = IpcMessage::builder(ipc::fs_errors::SUCCESS)
+        .word(0, kind_for_node as u64)
+        .cap(new_cap)
+        .build();
+    // SAFETY: ipc_buf is the registered IPC buffer page.
+    let _ = unsafe { ipc::ipc_reply(&reply, ipc_buf) };
+}
+
+/// `FS_REMOVE`: unlink a file or empty directory. Token = parent-dir
+/// cap (must carry `MUTATE_DIR`). Name in label[16..32] + data bytes.
+fn handle_remove_node_cap(
+    node_id: NodeId,
+    msg: &IpcMessage,
+    state: &mut FatState,
+    nodes: &mut NodeTable,
+    cache: &PageCache,
+    block_dev: u32,
+    ipc_buf: *mut u64,
+)
+{
+    let Some(parent_cluster) = resolve_dir_cluster(node_id, state, nodes)
+    else
+    {
+        reply_err(ipc::fs_errors::INVALID_TOKEN, ipc_buf);
+        return;
+    };
+    let name_len = ((msg.label >> 16) & 0xFFFF) as usize;
+    let data_bytes = msg.data_bytes();
+    if name_len == 0 || data_bytes.len() < name_len
+    {
+        reply_err(ipc::fs_errors::IO_ERROR, ipc_buf);
+        return;
+    }
+    let name = &data_bytes[..name_len];
+
+    let Some((entry, _loc)) = dir::find_in_directory_with_location(
+        parent_cluster,
+        name,
+        state,
+        cache,
+        block_dev,
+        ipc_buf,
+    )
+    else
+    {
+        reply_err(ipc::fs_errors::NOT_FOUND, ipc_buf);
+        return;
+    };
+    let is_dir = entry.attr & 0x10 != 0;
+    if is_dir
+    {
+        match directory_is_empty(state, entry.cluster, cache, block_dev, ipc_buf)
+        {
+            Ok(true) =>
+            {}
+            Ok(false) =>
+            {
+                reply_err(ipc::fs_errors::NOT_EMPTY, ipc_buf);
+                return;
+            }
+            Err(e) =>
+            {
+                reply_err(fat_error_to_wire(e), ipc_buf);
+                return;
+            }
+        }
+    }
+
+    let removed = match remove_entry(state, parent_cluster, name, cache, block_dev, ipc_buf)
+    {
+        Ok(r) => r,
+        Err(e) =>
+        {
+            reply_err(fat_error_to_wire(e), ipc_buf);
+            return;
+        }
+    };
+
+    if let Err(e) = free_entry_data(state, &removed, cache, block_dev, ipc_buf)
+    {
+        reply_err(fat_error_to_wire(e), ipc_buf);
+        return;
+    }
+
+    let kind = if removed.is_dir
+    {
+        NodeKind::Dir
+    }
+    else
+    {
+        NodeKind::File
+    };
+    nodes.invalidate_for_entry(removed.start_cluster, kind, removed.size);
+
+    let reply = IpcMessage::new(ipc::fs_errors::SUCCESS);
+    // SAFETY: ipc_buf is the registered IPC buffer page.
+    let _ = unsafe { ipc::ipc_reply(&reply, ipc_buf) };
+}
+
+/// `FS_RENAME`: rename an entry within a single directory.
+#[allow(clippy::too_many_lines)]
+fn handle_rename_node_cap(
+    node_id: NodeId,
+    msg: &IpcMessage,
+    state: &mut FatState,
+    nodes: &mut NodeTable,
+    cache: &PageCache,
+    block_dev: u32,
+    ipc_buf: *mut u64,
+)
+{
+    let Some(parent_cluster) = resolve_dir_cluster(node_id, state, nodes)
+    else
+    {
+        reply_err(ipc::fs_errors::INVALID_TOKEN, ipc_buf);
+        return;
+    };
+    let src_len = msg.word(0) as usize;
+    let dst_len = msg.word(1) as usize;
+    let data_bytes = msg.data_bytes();
+    let name_off = 16; // words 0,1 = lengths (16 bytes), names from word 2
+    if src_len == 0 || dst_len == 0 || data_bytes.len() < name_off + src_len + dst_len
+    {
+        reply_err(ipc::fs_errors::IO_ERROR, ipc_buf);
+        return;
+    }
+    let src_name = &data_bytes[name_off..name_off + src_len];
+    let dst_name = &data_bytes[name_off + src_len..name_off + src_len + dst_len];
+
+    if namespace_protocol::validate_name(src_name).is_err()
+        || namespace_protocol::validate_name(dst_name).is_err()
+    {
+        reply_err(ipc::fs_errors::IO_ERROR, ipc_buf);
+        return;
+    }
+
+    let Some((entry, _loc)) = dir::find_in_directory_with_location(
+        parent_cluster,
+        src_name,
+        state,
+        cache,
+        block_dev,
+        ipc_buf,
+    )
+    else
+    {
+        reply_err(ipc::fs_errors::NOT_FOUND, ipc_buf);
+        return;
+    };
+
+    let kind = if entry.attr & 0x10 != 0
+    {
+        NewEntryKind::Dir
+    }
+    else
+    {
+        NewEntryKind::File
+    };
+
+    // Non-atomic: insert destination first, then unlink source.
+    // Documented in services/fs/fat/docs/crash-safety.md.
+    if let Err(e) = insert_entry(
+        state,
+        parent_cluster,
+        dst_name,
+        kind,
+        entry.cluster,
+        entry.size,
+        cache,
+        block_dev,
+        ipc_buf,
+    )
+    {
+        reply_err(fat_error_to_wire(e), ipc_buf);
+        return;
+    }
+    if let Err(e) = remove_entry(state, parent_cluster, src_name, cache, block_dev, ipc_buf)
+    {
+        reply_err(fat_error_to_wire(e), ipc_buf);
+        return;
+    }
+
+    let _ = update_fat_entry; // silence unused-import lint pending future use
     let reply = IpcMessage::new(ipc::fs_errors::SUCCESS);
     // SAFETY: ipc_buf is the registered IPC buffer page.
     let _ = unsafe { ipc::ipc_reply(&reply, ipc_buf) };

--- a/shared/ipc/src/lib.rs
+++ b/shared/ipc/src/lib.rs
@@ -667,7 +667,7 @@ pub mod ns_labels
     pub const NS_READDIR: u64 = 22;
 }
 
-pub const FS_LABELS_VERSION: u32 = 1;
+pub const FS_LABELS_VERSION: u32 = 2;
 /// IPC labels for filesystem drivers (FAT, ext4, etc.).
 pub mod fs_labels
 {
@@ -680,6 +680,19 @@ pub mod fs_labels
     /// pages, open-file slot, etc.). The caller still cap-deletes the
     /// node cap to drop the kernel-side reference.
     pub const FS_CLOSE: u64 = 3;
+    /// Inline write to a file node cap.
+    ///
+    /// Request: `label = FS_WRITE | (byte_len << 16)` (bits 0-15 = label
+    /// ID, bits 16-31 = payload byte length, ≤ 504), `data[0]` = file
+    /// byte offset, payload bytes packed from word 1 onward via
+    /// `IpcMessageBuilder::bytes(1, &payload)`. Token must carry the
+    /// `WRITE` namespace right (see `namespace-protocol::rights`).
+    ///
+    /// Reply (success label `fs_errors::SUCCESS`): `data[0]` =
+    /// `bytes_written` (may be short on `NO_SPACE` or on
+    /// partial-cluster failure; callers iterate). Error labels per
+    /// [`fs_errors`].
+    pub const FS_WRITE: u64 = 4;
     /// End-of-directory marker in `NS_READDIR` replies.
     pub const END_OF_DIR: u64 = 6;
     /// Read file content into a cached Frame cap returned in the reply.
@@ -715,6 +728,69 @@ pub mod fs_labels
     pub const FS_RELEASE_ACK: u64 = 9;
     /// Mount notification from vfsd.
     pub const FS_MOUNT: u64 = 10;
+    /// Write file content from a caller-supplied source Frame cap.
+    ///
+    /// Mirror of [`FS_READ_FRAME`] for the write direction. Caller maps,
+    /// fills, then transfers a Frame holding the bytes to write.
+    ///
+    /// Request: token identifies the file (per-file cap),
+    /// `data[0]` = file byte offset (no alignment requirement),
+    /// `data[1]` = bytes to write from the frame (`≤ PAGE_SIZE -
+    /// frame_data_offset`), `data[2]` = byte offset within the source
+    /// frame where the data begins. `caps[0]` = source Frame cap with
+    /// at least `MAP|READ` rights, sized one page. Token must carry the
+    /// `WRITE` namespace right.
+    ///
+    /// Reply (label `fs_errors::SUCCESS`): `data[0]` = `bytes_written`
+    /// (short on `NO_SPACE` or cluster-boundary truncation; callers
+    /// iterate). `caps[0]` = the source Frame cap moved back to the
+    /// caller. Errors per [`fs_errors`].
+    pub const FS_WRITE_FRAME: u64 = 12;
+    /// Create a new file in a directory.
+    ///
+    /// Request: token = parent-directory cap (must carry `MUTATE_DIR`),
+    /// `label = FS_CREATE | (name_len << 16)`, name bytes packed from
+    /// word 0 via `IpcMessageBuilder::bytes(0, name)`. Name validated
+    /// per `namespace-protocol::validate_name`.
+    ///
+    /// Reply (label `fs_errors::SUCCESS`): `data[0]` = entry kind (per
+    /// `namespace_protocol::NodeKind`), `caps[0]` = node cap for the
+    /// newly-created file. Errors include `EXISTS`, `NO_SPACE`,
+    /// `PERMISSION_DENIED`.
+    pub const FS_CREATE: u64 = 13;
+    /// Remove a file or empty directory from a directory.
+    ///
+    /// Request: token = parent-directory cap (must carry `MUTATE_DIR`),
+    /// `label = FS_REMOVE | (name_len << 16)`, name bytes from word 0.
+    ///
+    /// Reply (label `fs_errors::SUCCESS`): empty body. Errors:
+    /// `NOT_FOUND`, `NOT_EMPTY` (directory has entries), `IO_ERROR`.
+    pub const FS_REMOVE: u64 = 14;
+    /// Create a new (empty) directory in a directory.
+    ///
+    /// Request: identical shape to [`FS_CREATE`]. Token must carry
+    /// `MUTATE_DIR`. Allocates one cluster zero-filled with `.` and
+    /// `..` entries.
+    ///
+    /// Reply: identical shape to [`FS_CREATE`], `data[0]` = kind (Dir).
+    pub const FS_MKDIR: u64 = 15;
+    /// Rename a directory entry, optionally across directories.
+    ///
+    /// Request: token = source-directory cap (must carry `MUTATE_DIR`),
+    /// `data[0]` = source name length, `data[1]` = destination name
+    /// length, name bytes packed contiguously from word 2 via
+    /// `IpcMessageBuilder::bytes(2, &concat(src, dst))` — source bytes
+    /// first, destination bytes immediately after with no padding.
+    /// `caps[0]` = destination-directory cap (must also carry
+    /// `MUTATE_DIR`). Source and destination may be the same cap.
+    ///
+    /// Not atomic: an interrupted rename can leave both names present
+    /// or neither. See `services/fs/fat/docs/crash-safety.md`.
+    ///
+    /// Reply (label `fs_errors::SUCCESS`): empty body. Errors:
+    /// `NOT_FOUND` (source missing), `EXISTS` (destination occupied),
+    /// `NO_SPACE`, `IO_ERROR`.
+    pub const FS_RENAME: u64 = 16;
 }
 
 pub const DEVMGR_LABELS_VERSION: u32 = 1;
@@ -1035,6 +1111,19 @@ pub mod fs_errors
     /// version as `data[0]`; mismatch here means the caller was built
     /// against a different revision of `shared/ipc`.
     pub const LABEL_VERSION_MISMATCH: u64 = 8;
+    /// Mutation refused: the target name already exists in the parent
+    /// directory (`FS_CREATE`, `FS_MKDIR`, `FS_RENAME` destination).
+    pub const EXISTS: u64 = 9;
+    /// Mutation refused: the volume has no free cluster, or the parent
+    /// directory has no room for a new entry (FAT16 fixed root full;
+    /// FAT32 cluster-chain extension failed).
+    pub const NO_SPACE: u64 = 10;
+    /// `FS_REMOVE` refused: the target directory is non-empty.
+    pub const NOT_EMPTY: u64 = 11;
+    /// Operation refused because the target is a directory (e.g.
+    /// `FS_WRITE` on a directory cap) or because the operation is
+    /// permitted only on files.
+    pub const IS_A_DIRECTORY: u64 = 12;
     /// Unknown opcode on fs-driver endpoint.
     pub const UNKNOWN_OPCODE: u64 = 0xFF;
 }

--- a/shared/ipc/src/lib.rs
+++ b/shared/ipc/src/lib.rs
@@ -774,15 +774,19 @@ pub mod fs_labels
     ///
     /// Reply: identical shape to [`FS_CREATE`], `data[0]` = kind (Dir).
     pub const FS_MKDIR: u64 = 15;
-    /// Rename a directory entry, optionally across directories.
+    /// Rename a directory entry within a single directory.
     ///
-    /// Request: token = source-directory cap (must carry `MUTATE_DIR`),
+    /// Request: token = directory cap (must carry `MUTATE_DIR`),
     /// `data[0]` = source name length, `data[1]` = destination name
     /// length, name bytes packed contiguously from word 2 via
     /// `IpcMessageBuilder::bytes(2, &concat(src, dst))` — source bytes
     /// first, destination bytes immediately after with no padding.
-    /// `caps[0]` = destination-directory cap (must also carry
-    /// `MUTATE_DIR`). Source and destination may be the same cap.
+    ///
+    /// Cross-directory rename is deferred to a follow-up Issue: the
+    /// caller cannot supply a second directory cap because servers
+    /// cannot introspect the token packed inside a cap they receive
+    /// (`cap_info` does not expose token bits), so a cross-directory
+    /// destination cannot be resolved to a `NodeId` server-side.
     ///
     /// Not atomic: an interrupted rename can leave both names present
     /// or neither. See `services/fs/fat/docs/crash-safety.md`.

--- a/shared/ipc/src/lib.rs
+++ b/shared/ipc/src/lib.rs
@@ -817,7 +817,7 @@ pub mod devmgr_labels
     pub const REGISTRY_QUERY_AUTHORITY: u64 = 1u64 << 63;
 }
 
-pub const BLK_LABELS_VERSION: u32 = 1;
+pub const BLK_LABELS_VERSION: u32 = 2;
 /// IPC labels for block device drivers.
 pub mod blk_labels
 {
@@ -860,6 +860,26 @@ pub mod blk_labels
     /// Reply: empty body, label is the success or error code; the target
     /// Frame is moved back to the caller in `caps[0]` of the reply.
     pub const BLK_READ_INTO_FRAME: u64 = 3;
+    /// Write one or more contiguous sectors from a caller-supplied Frame cap.
+    ///
+    /// Mirror of [`BLK_READ_INTO_FRAME`] for the write direction. The
+    /// caller fills the source frame, then issues the request; the
+    /// driver reads `count * 512` bytes starting at offset 0 and writes
+    /// them to disk.
+    ///
+    /// Request: `data[0]` = starting LBA, `data[1]` = sector count
+    /// (`>= 1`; defaults to `1` if `data[1]` is absent). Caps: `caps[0]` =
+    /// source Frame (`MAP|READ`; the driver reads `count * 512` bytes
+    /// starting at offset 0 of the frame, packed contiguously). The frame
+    /// must be at least `count * 512` bytes; the driver rejects with
+    /// `INVALID_FRAME_CAP` otherwise. `caps[1]` is reserved for a future
+    /// per-request release handle and is null today. `caps[2]` is a
+    /// reserved IPC-shape slot for a future userspace IOMMU-grant cap;
+    /// see [`BLK_READ_INTO_FRAME`] for the userspace-IOMMU framing.
+    /// Reply: empty body, label is the success or error code; the source
+    /// Frame is moved back to the caller in `caps[0]` of the reply (same
+    /// discipline as the read path).
+    pub const BLK_WRITE_FROM_FRAME: u64 = 4;
 }
 
 pub const STREAM_LABELS_VERSION: u32 = 1;
@@ -1192,8 +1212,9 @@ pub mod blk_errors
     pub const OUT_OF_BOUNDS: u64 = 3;
     /// Partition registration rejected (no authority, table full, or bad args).
     pub const REGISTER_REJECTED: u64 = 4;
-    /// `BLK_READ_INTO_FRAME` target cap missing `MAP|WRITE` rights, sized
-    /// other than one page, or absent.
+    /// Frame cap rejected: `BLK_READ_INTO_FRAME` target missing
+    /// `MAP|WRITE` rights, `BLK_WRITE_FROM_FRAME` source missing
+    /// `MAP|READ` rights, sized other than one page, or absent.
     pub const INVALID_FRAME_CAP: u64 = 5;
     /// Caller's compiled `BLK_LABELS_VERSION` does not match the receiver's.
     /// `REGISTER_PARTITION` is the handshake entry point and carries the

--- a/shared/namespace-protocol/src/gate.rs
+++ b/shared/namespace-protocol/src/gate.rs
@@ -157,6 +157,30 @@ const RIGHTS_TABLE: &[(u64, RightsRequirement)] = &[
         RightsRequirement::AnyNonEmpty,
     ),
     (ipc::fs_labels::FS_CLOSE, RightsRequirement::AnyNonEmpty),
+    (
+        ipc::fs_labels::FS_WRITE,
+        RightsRequirement::Bits(nz(rights::WRITE)),
+    ),
+    (
+        ipc::fs_labels::FS_WRITE_FRAME,
+        RightsRequirement::Bits(nz(rights::WRITE)),
+    ),
+    (
+        ipc::fs_labels::FS_CREATE,
+        RightsRequirement::Bits(nz(rights::MUTATE_DIR)),
+    ),
+    (
+        ipc::fs_labels::FS_REMOVE,
+        RightsRequirement::Bits(nz(rights::MUTATE_DIR)),
+    ),
+    (
+        ipc::fs_labels::FS_MKDIR,
+        RightsRequirement::Bits(nz(rights::MUTATE_DIR)),
+    ),
+    (
+        ipc::fs_labels::FS_RENAME,
+        RightsRequirement::Bits(nz(rights::MUTATE_DIR)),
+    ),
 ];
 
 fn required_rights_for(opcode: u64) -> Option<RightsRequirement>
@@ -272,6 +296,43 @@ mod tests
             gate(ipc::fs_labels::FS_CLOSE, token_with(0)),
             Err(GateError::PermissionDenied)
         );
+    }
+
+    #[test]
+    fn fs_write_and_fs_write_frame_share_the_write_bit()
+    {
+        assert!(gate(ipc::fs_labels::FS_WRITE, token_with(rights::WRITE)).is_ok());
+        assert!(gate(ipc::fs_labels::FS_WRITE_FRAME, token_with(rights::WRITE)).is_ok());
+        assert_eq!(
+            gate(ipc::fs_labels::FS_WRITE, token_with(rights::READ)),
+            Err(GateError::PermissionDenied)
+        );
+        assert_eq!(
+            gate(ipc::fs_labels::FS_WRITE_FRAME, token_with(rights::READ)),
+            Err(GateError::PermissionDenied)
+        );
+    }
+
+    #[test]
+    fn fs_mutate_dir_labels_gate_on_mutate_dir_bit()
+    {
+        for label in [
+            ipc::fs_labels::FS_CREATE,
+            ipc::fs_labels::FS_REMOVE,
+            ipc::fs_labels::FS_MKDIR,
+            ipc::fs_labels::FS_RENAME,
+        ]
+        {
+            assert!(
+                gate(label, token_with(rights::MUTATE_DIR)).is_ok(),
+                "label {label:#x} should accept MUTATE_DIR"
+            );
+            assert_eq!(
+                gate(label, token_with(rights::LOOKUP | rights::READDIR)),
+                Err(GateError::PermissionDenied),
+                "label {label:#x} should reject without MUTATE_DIR"
+            );
+        }
     }
 
     #[test]

--- a/shared/namespace-protocol/src/rights.rs
+++ b/shared/namespace-protocol/src/rights.rs
@@ -43,12 +43,12 @@ pub const READDIR: u32 = 1 << 1;
 pub const STAT: u32 = 1 << 2;
 /// `NS_READ` / `NS_READ_FRAME` on this file is permitted.
 pub const READ: u32 = 1 << 3;
-/// `NS_WRITE` on this file is permitted. Reserved; deferred to v2.
+/// `FS_WRITE` / `FS_WRITE_FRAME` on this file is permitted.
 pub const WRITE: u32 = 1 << 4;
 /// File is executable; consumed by ELF loaders to gate spawn.
 pub const EXEC: u32 = 1 << 5;
-/// `NS_CREATE` / `NS_UNLINK` in this directory are permitted.
-/// Reserved; deferred to v2.
+/// `FS_CREATE` / `FS_REMOVE` / `FS_MKDIR` / `FS_RENAME` in this
+/// directory are permitted.
 pub const MUTATE_DIR: u32 = 1 << 6;
 /// Visibility-gating bit: entries whose `visible_requires` includes
 /// `ADMIN` are hidden from callers without it (see the visibility


### PR DESCRIPTION
## Summary

Lifts `services/fs/fat` from read-only to read-write and adds the
underlying frame-cap write IPC on virtio-blk. Stacked PR closing both
[Issue #6](https://github.com/kottlerg/seraph/issues/6) (fs-fat
write/create/remove/mkdir/rename) and
[Issue #7](https://github.com/kottlerg/seraph/issues/7) (fs-frame-cap
write IPC: caller-supplied DMA frames). The two are not actually
independent — fs-fat writes cannot persist without a block-write IPC,
and landing an internal-only block-write that #7 would then reshape
would waste a review cycle.

* **ABI**: new `FS_WRITE` / `FS_WRITE_FRAME` / `FS_CREATE` /
  `FS_REMOVE` / `FS_MKDIR` / `FS_RENAME` labels (FS_LABELS_VERSION
  1 → 2); new `BLK_WRITE_FROM_FRAME` (BLK_LABELS_VERSION 1 → 2);
  new `fs_errors` codes (EXISTS, NO_SPACE, NOT_EMPTY, IS_A_DIRECTORY);
  namespace-protocol gate registers WRITE and MUTATE_DIR on the new
  labels.
* **virtio-blk**: BLK_WRITE_FROM_FRAME handler mirroring
  BLK_READ_INTO_FRAME (caller-supplied source Frame, MAP|READ).
  Completion wait now uses `signal_wait_timeout` so a lost PLIC
  external interrupt on QEMU TCG riscv (a known QEMU/TCG quirk
  already documented in the wait loop) cannot park the driver
  thread indefinitely — the next iteration's poll burst picks up
  the completion (root-cause analysis of the riscv64 release
  intermittent post-`fs_write_phase` hang surfaced by run-parallel
  stress).
* **fs-fat**: cluster allocator (`alloc.rs`) with FSInfo helpers
  (best-effort flush on every alloc/free) and FAT-mirror writes
  (invalidates the private `cached_fat_sector` on every FAT mutation
  — the load-bearing silent-corruption hazard); directory mutation
  helpers (`insert_entry` / `remove_entry` /
  `update_entry_metadata` with NUMERIC_TAIL SFN generation and LFN
  packing); write-through `PageCache::write_sector`; dispatch
  handlers wire it all together. NodeTable dedupes by on-disk slot
  location (`sector_lba`, `offset_in_sector`) so distinct empty
  files never alias. Newly-minted FS_CREATE / FS_MKDIR caps are
  attenuated by `caller_parent_rights ∩ kind_max`.
* **usertest**: seven new write-side phases via raw FS_* IPC
  (`fs_write`, `fs_create_remove`, `fs_mkdir`, `fs_rename`,
  `fs_write_frame`, `fs_write_cache_coherence`, and
  `fs_write_invariants` covering rights attenuation, empty-file
  aliasing, and FAT-chain-past-EOC regression cases).
* **Docs**: new `services/fs/fat/README.md` and
  `docs/crash-safety.md`; new sections in
  `services/fs/docs/fs-driver-protocol.md` for every new label.

Cache strategy is **write-through** (in-place cached-page update +
single-sector BLK_WRITE_FROM_FRAME); outstanding FS_READ_FRAME caps
aliasing the page observe new bytes immediately, so FS_READ-after-
FS_WRITE coherence falls out for free. Write-back is filed as a
follow-up (#83) for v0.1.1+.

FS_RENAME is single-directory at v0.1.0: servers cannot introspect
the token packed in a received cap, so a second-directory cap cannot
resolve to a NodeId. Cross-directory rename needs a new wire shape;
filed as #89.

std::fs bridge is out of scope — Issue #8 owns it on v0.1.0.

## Follow-up Issues filed

- #83  fs-fat: write-back cache strategy (design)
- #84  fs-fat: honour DIR_ATTR_READ_ONLY
- #85  fs-fat: FAT timestamp clock source
- #86  xtask: two-boot QEMU harness for FS remount-survive tests
- #87  fsbench: write-path inline-vs-frame crossover threshold
- #89  fs-fat: cross-directory FS_RENAME (design)

## Test plan

- [x] cargo xtask build (x86_64)
- [x] cargo xtask test (host-side unit tests, including new gate rights tests)
- [x] cargo xtask run on x86_64 — ALL TESTS PASSED
- [x] cargo xtask clean + cargo xtask build --arch riscv64
- [x] cargo xtask run --arch riscv64 — ALL TESTS PASSED
- [x] All seven new write phases pass (`fs_write`,
      `fs_create_remove`, `fs_mkdir`, `fs_rename`,
      `fs_write_frame`, `fs_write_cache_coherence`,
      `fs_write_invariants`) on both arches
- [x] Existing read-side phases (fs_open, fs_release_on_close,
      fs_crossover_bench, fs_rights_attenuation, ns_multi_component,
      ns_sandbox, ns_fallthrough_attenuation, command_*, fs_open_relative)
      still pass on both arches
- [x] Stress validation post-virtio-blk-wait fix: `run-parallel
      --parallel 4 --runs 20` on riscv64 release passes 39/40
      (97.5%, vs 50% before the fix), x86_64 release 20/20,
      x86_64 debug 10/10, riscv64 debug 10/10

`fs_mkdir_phase` exercises mkdir + immediate readdir within one boot;
a genuine two-boot remount-survive harness is tracked as #86.

Closes #6.
Closes #7.
