### PR TITLE
boot/kernel: reclaim bootloader scratch into init CSpace (#18, partial)

### DIFF
--- a/abi/boot-protocol/src/lib.rs
+++ b/abi/boot-protocol/src/lib.rs
@@ -37,7 +37,18 @@
 ///     descriptors: `kernel_mmio` (arch-specific struct carrying the small
 ///     MMIO bases the kernel itself consumes) and `mmio_apertures` (coarse
 ///     non-RAM physical ranges from which the kernel mints MMIO caps).
-pub const BOOT_PROTOCOL_VERSION: u32 = 6;
+/// v7: Added `reclaim_ranges: ReclaimSlice` so the bootloader can hand the
+///     kernel a list of scratch pages (`BootInfo` page, module descriptor
+///     array, memory-map entry array, MMIO aperture array, the
+///     reclaim-array page itself, and the bootloader's own transient
+///     page-table frames) that are safe to reclaim once the kernel's
+///     Phase-7 capability system has consumed them. The slice is backed
+///     by a dedicated 4 KiB scratch page; that page is itself the final
+///     entry in the array so the kernel reclaims it last. The kernel
+///     mints reclaimable Frame caps over each range inside
+///     `populate_cspace` so the pages reach userspace through the same
+///     `CapDescriptor` path as boot modules.
+pub const BOOT_PROTOCOL_VERSION: u32 = 7;
 
 // ── Memory map ───────────────────────────────────────────────────────────────
 
@@ -442,6 +453,64 @@ unsafe impl Send for MmioApertureSlice {}
 // SAFETY: Same rationale as MemoryMapSlice.
 unsafe impl Sync for MmioApertureSlice {}
 
+// ── Reclaimable bootloader scratch ───────────────────────────────────────────
+
+/// A contiguous range of physical pages the bootloader allocated for its own
+/// scratch use and which becomes reclaim-safe once the kernel's Phase-7
+/// capability system has consumed it.
+///
+/// The kernel walks the [`ReclaimSlice`] in [`BootInfo`] inside
+/// `populate_cspace`, mints one reclaimable `FrameObject` cap per range, and
+/// inserts each into the root `CSpace` so the cap reaches userspace through
+/// the standard `CapDescriptor` path. Once `populate_cspace` returns, the
+/// kernel MUST NOT dereference any address inside a recorded range.
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct ReclaimRange
+{
+    /// Page-aligned physical base address.
+    pub phys_base: u64,
+    /// Number of 4 KiB pages covered. Non-zero.
+    pub page_count: u32,
+    /// Reserved for future per-entry flags (e.g. arch-specific liveness
+    /// hints). Producers MUST write zero; consumers MUST ignore.
+    pub reserved: u32,
+}
+
+/// Maximum number of [`ReclaimRange`] entries one 4 KiB reclaim-array page
+/// can hold. The bootloader allocates a dedicated 4 KiB page for the array
+/// and indexes into it; 256 × 16 B = 4 KiB exactly.
+///
+/// A typical seraph boot produces between fifteen and fifty entries (one
+/// per fixed scratch allocation plus one per bootloader transient
+/// page-table frame). The bootloader diagnoses overflow as a sizing bug
+/// rather than truncating.
+pub const MAX_RECLAIM_RANGES: usize = 256;
+
+/// A slice of [`ReclaimRange`] values, passed by physical address.
+///
+/// Stored in `BootInfo` as a `(*const ReclaimRange, u64)` slice so the
+/// underlying array lives in its own dedicated 4 KiB scratch page,
+/// avoiding inline pressure on the `BootInfo` page-fit budget. The
+/// array's backing page is itself one of the recorded entries — the
+/// kernel reclaims it via `cap::mint_reclaim_frame_caps` once the
+/// scan completes.
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct ReclaimSlice
+{
+    /// Physical address of the first entry. Null if `count` is zero.
+    pub entries: *const ReclaimRange,
+    /// Number of entries.
+    pub count: u64,
+}
+
+// SAFETY: Same rationale as MemoryMapSlice — boot-time physical memory,
+// produced pre-ExitBootServices and read-only after handoff.
+unsafe impl Send for ReclaimSlice {}
+// SAFETY: Same rationale as MemoryMapSlice.
+unsafe impl Sync for ReclaimSlice {}
+
 // ── BootInfo ─────────────────────────────────────────────────────────────────
 
 /// Boot information structure populated by the bootloader and passed to the
@@ -564,6 +633,16 @@ pub struct BootInfo
     /// Zero if the bootloader could not reserve a trampoline page (SMP will
     /// then be unavailable; the kernel continues BSP-only).
     pub ap_trampoline_page: u64,
+
+    // ── Reclaimable scratch (added in protocol version 7) ─────────────────────
+    /// Bootloader scratch ranges the kernel reclaims into the cap surface
+    /// inside `populate_cspace`. The slice's backing array lives in its
+    /// own dedicated 4 KiB scratch page; that page is itself one of the
+    /// recorded entries, so the kernel reclaims it last. Reading or
+    /// writing any address in a recorded range after the Phase-7 cap
+    /// system has been initialised is undefined behaviour from the
+    /// kernel's perspective.
+    pub reclaim_ranges: ReclaimSlice,
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -598,12 +677,18 @@ mod tests
         assert_eq!(FramebufferInfo::empty().pixel_format, PixelFormat::Rgbx8);
     }
 
-    /// BOOT_PROTOCOL_VERSION must be 6 after the PlatformResource → kernel_mmio
-    /// + mmio_apertures replacement.
+    /// BOOT_PROTOCOL_VERSION must be 7 after the `reclaim_ranges` addition.
     #[test]
-    fn protocol_version_is_6()
+    fn protocol_version_is_7()
     {
-        assert_eq!(BOOT_PROTOCOL_VERSION, 6);
+        assert_eq!(BOOT_PROTOCOL_VERSION, 7);
+    }
+
+    /// `ReclaimRange` is 16 bytes: u64 + u32 + u32, no padding.
+    #[test]
+    fn reclaim_range_size_is_16_bytes()
+    {
+        assert_eq!(core::mem::size_of::<ReclaimRange>(), 16);
     }
 
     /// `MmioApertureSlice` is layout-compatible across builds and trivially

--- a/core/boot/docs/boot-flow.md
+++ b/core/boot/docs/boot-flow.md
@@ -161,7 +161,7 @@ Detail: [uefi-environment.md](uefi-environment.md)
 
 `BootInfo` is populated in-place in a physical memory region allocated before step 8.
 All pointer and address fields hold physical addresses; no virtual addresses appear in
-`BootInfo`. The `version` field is set to `BOOT_PROTOCOL_VERSION` (currently `6`).
+`BootInfo`. The `version` field is set to `BOOT_PROTOCOL_VERSION` (currently `7`).
 Fields are populated as follows:
 
 | Field | Source |
@@ -183,6 +183,7 @@ Fields are populated as follows:
 | `bsp_id` | APIC ID of the BSP (x86-64) or boot hart ID from `EFI_RISCV_BOOT_PROTOCOL` (RISC-V) |
 | `cpu_ids` | Per-CPU hardware identifiers; `cpu_ids[0] == bsp_id`; entries beyond `cpu_count` are zero |
 | `ap_trampoline_page` | 4 KiB physical frame for AP startup code. x86-64: below 1 MiB (SIPI vector constraint). RISC-V: any 4 KiB page (SBI HSM has no placement constraint). Zero if allocation failed (SMP disabled). |
+| `reclaim_ranges` | `ReclaimSlice` over a dedicated 4 KiB scratch page recording bootloader pages the kernel reclaims into the cap surface inside `populate_cspace`. Populated from `BootAllocations` (`BootInfo` page, module descriptor array, memory-map entry array, MMIO aperture array, the reclaim-array page itself) and `page_table.allocated_frames()` (the bootloader's transient page-table frames). Cmdline and AP trampoline are not included — their last consumers run inside Phase 9, after `populate_cspace` returns. |
 
 All arrays pointed to by `BootInfo` fields reside in physical memory that the UEFI
 memory map marks as `Loaded` or `Usable`, ensuring they survive until the kernel

--- a/core/boot/docs/page-tables.md
+++ b/core/boot/docs/page-tables.md
@@ -244,17 +244,16 @@ mapping that reaches the kernel is a security defect, not just a policy violatio
 
 ## Page Table Frame Tracking
 
-The bootloader does not free page table frames. All intermediate table frames
-allocated by `AllocatePages` appear in the UEFI memory map as `EfiLoaderData`
-regions, which translate to `MemoryType::Loaded` in `BootInfo`. The kernel sees
-these regions as in-use and does not reclaim them until it establishes its own page
-tables in Phase 3, after which it can safely free the bootloader's intermediate
-frames via its buddy allocator.
-
-The bootloader records the root page table's physical address but does not
-separately track intermediate frames. The kernel does not need to enumerate them
-— it simply replaces the entire page table structure during Phase 3 and the old
-frames become reclaimable as `EfiLoaderData` entries in the memory map are processed.
+Each arch-specific `BootPageTable` records the physical address of every
+frame it allocates from `AllocatePages` — the root table and every
+intermediate table allocated during `map` — in an inline `frame_log`.
+After step 8, step 9 reads this log via the trait method
+`PageTableBuilder::allocated_frames` and appends one
+`boot_protocol::ReclaimRange` per frame to `BootInfo.reclaim_ranges`.
+The kernel mints reclaimable Frame caps over the recorded frames during
+Phase 7 (`cap::mint_reclaim_frame_caps`), so they flow into userspace
+through the standard `CapDescriptor` path rather than being orphaned as
+`MemoryType::Loaded` pages outside the buddy.
 
 ---
 

--- a/core/boot/src/arch/riscv64/paging.rs
+++ b/core/boot/src/arch/riscv64/paging.rs
@@ -37,6 +37,18 @@ const PAGE_SIZE_USIZE: usize = 4096;
 /// Number of entries in a single page table (all levels).
 const TABLE_ENTRIES: usize = 512;
 
+/// Capacity of the page-table frame log used for post-handoff reclamation.
+///
+/// Sized to cover the root plus every intermediate frame allocated
+/// during identity mapping of kernel, init, modules, framebuffer, and
+/// file-read buffers. Empirically a six-module seraph boot uses ~95
+/// frames; this cap provides ~35% headroom. The reclaim array's
+/// backing page in `BootInfo` holds up to `MAX_RECLAIM_RANGES` (256)
+/// entries, so this cap is the binding limit; `alloc_table` returns
+/// `None` once exhausted, propagating as `BootError::OutOfMemory` —
+/// diagnose by bumping this constant rather than silently truncating.
+const FRAME_LOG_CAP: usize = 128;
+
 /// RISC-V Sv48 4-level page table builder.
 ///
 /// Holds the physical address of the root table and the UEFI boot services
@@ -47,6 +59,13 @@ pub struct BootPageTable
     root_phys: u64,
     /// UEFI boot services pointer for frame allocation.
     bs: *mut crate::uefi::EfiBootServices,
+    /// Physical addresses of every frame allocated for this builder's tables
+    /// (root + every intermediate frame). Recorded in `BootInfo.reclaim_ranges`
+    /// so the kernel can reclaim them once Phase 3 has installed its own
+    /// page tables.
+    frame_log: [u64; FRAME_LOG_CAP],
+    /// Number of valid entries in [`Self::frame_log`].
+    frame_log_len: usize,
 }
 
 impl PageTableBuilder for BootPageTable
@@ -62,7 +81,14 @@ impl PageTableBuilder for BootPageTable
         unsafe {
             core::ptr::write_bytes(root_phys as *mut u8, 0, PAGE_SIZE_USIZE);
         }
-        Some(Self { root_phys, bs })
+        let mut frame_log = [0u64; FRAME_LOG_CAP];
+        frame_log[0] = root_phys;
+        Some(Self {
+            root_phys,
+            bs,
+            frame_log,
+            frame_log_len: 1,
+        })
     }
 
     fn map(&mut self, virt: u64, phys: u64, size: u64, flags: PageFlags) -> Result<(), MapError>
@@ -90,6 +116,11 @@ impl PageTableBuilder for BootPageTable
     fn root_physical(&self) -> u64
     {
         self.root_phys
+    }
+
+    fn allocated_frames(&self) -> &[u64]
+    {
+        &self.frame_log[..self.frame_log_len]
     }
 }
 
@@ -185,9 +216,14 @@ impl BootPageTable
 
     /// Allocate and zero one 4 KiB frame for use as an intermediate page table.
     ///
-    /// Returns the physical address of the frame, or `None` on allocation failure.
+    /// Returns the physical address of the frame, or `None` on allocation failure
+    /// (UEFI out-of-memory or [`FRAME_LOG_CAP`] exhausted).
     fn alloc_table(&mut self) -> Option<u64>
     {
+        if self.frame_log_len >= FRAME_LOG_CAP
+        {
+            return None;
+        }
         // SAFETY: self.bs is valid pre-ExitBootServices; allocate_pages returns a
         // physical address of a freshly allocated EfiLoaderData region.
         let frame = unsafe { crate::uefi::allocate_pages(self.bs, 1).ok()? };
@@ -196,6 +232,8 @@ impl BootPageTable
         unsafe {
             core::ptr::write_bytes(frame as *mut u8, 0, PAGE_SIZE_USIZE);
         }
+        self.frame_log[self.frame_log_len] = frame;
+        self.frame_log_len += 1;
         Some(frame)
     }
 }

--- a/core/boot/src/arch/x86_64/paging.rs
+++ b/core/boot/src/arch/x86_64/paging.rs
@@ -25,6 +25,18 @@ const PAGE_SIZE: u64 = 4096;
 /// Number of entries in a single page table (all levels).
 const TABLE_ENTRIES: usize = 512;
 
+/// Capacity of the page-table frame log used for post-handoff reclamation.
+///
+/// Sized to cover the root PML4 plus every intermediate frame allocated
+/// during identity mapping of kernel, init, modules, framebuffer, and
+/// file-read buffers. Empirically a six-module seraph boot uses ~75
+/// frames; this cap provides ~50% headroom. The reclaim array's backing
+/// page in `BootInfo` holds up to `MAX_RECLAIM_RANGES` (256) entries, so
+/// this cap is the binding limit; `alloc_table` returns `None` once
+/// exhausted, propagating as `BootError::OutOfMemory` — diagnose by
+/// bumping this constant rather than silently truncating.
+const FRAME_LOG_CAP: usize = 128;
+
 /// x86-64 4-level page table builder.
 ///
 /// Holds the physical address of the PML4 root and the UEFI boot services
@@ -35,6 +47,13 @@ pub struct BootPageTable
     root_phys: u64,
     /// UEFI boot services pointer for frame allocation.
     bs: *mut crate::uefi::EfiBootServices,
+    /// Physical addresses of every frame allocated for this builder's tables
+    /// (root + every intermediate frame). Recorded in `BootInfo.reclaim_ranges`
+    /// so the kernel can reclaim them once Phase 3 has installed its own
+    /// page tables.
+    frame_log: [u64; FRAME_LOG_CAP],
+    /// Number of valid entries in [`Self::frame_log`].
+    frame_log_len: usize,
 }
 
 impl PageTableBuilder for BootPageTable
@@ -52,7 +71,14 @@ impl PageTableBuilder for BootPageTable
         unsafe {
             core::ptr::write_bytes(root_phys as *mut u8, 0, PAGE_SIZE as usize);
         }
-        Some(Self { root_phys, bs })
+        let mut frame_log = [0u64; FRAME_LOG_CAP];
+        frame_log[0] = root_phys;
+        Some(Self {
+            root_phys,
+            bs,
+            frame_log,
+            frame_log_len: 1,
+        })
     }
 
     fn map(&mut self, virt: u64, phys: u64, size: u64, flags: PageFlags) -> Result<(), MapError>
@@ -80,6 +106,11 @@ impl PageTableBuilder for BootPageTable
     fn root_physical(&self) -> u64
     {
         self.root_phys
+    }
+
+    fn allocated_frames(&self) -> &[u64]
+    {
+        &self.frame_log[..self.frame_log_len]
     }
 }
 
@@ -165,9 +196,14 @@ impl BootPageTable
 
     /// Allocate and zero one 4 KiB frame for use as an intermediate page table.
     ///
-    /// Returns the physical address of the frame, or `None` on allocation failure.
+    /// Returns the physical address of the frame, or `None` on allocation failure
+    /// (UEFI out-of-memory or [`FRAME_LOG_CAP`] exhausted).
     fn alloc_table(&mut self) -> Option<u64>
     {
+        if self.frame_log_len >= FRAME_LOG_CAP
+        {
+            return None;
+        }
         // SAFETY: self.bs is valid pre-ExitBootServices; allocate_pages returns a
         // physical address of a freshly allocated EfiLoaderData region.
         let frame = unsafe { crate::uefi::allocate_pages(self.bs, 1).ok()? };
@@ -178,6 +214,8 @@ impl BootPageTable
         unsafe {
             core::ptr::write_bytes(frame as *mut u8, 0, PAGE_SIZE as usize);
         }
+        self.frame_log[self.frame_log_len] = frame;
+        self.frame_log_len += 1;
         Some(frame)
     }
 }

--- a/core/boot/src/main.rs
+++ b/core/boot/src/main.rs
@@ -39,8 +39,8 @@ use crate::uefi::{
 };
 use boot_protocol::{
     BOOT_PROTOCOL_VERSION, BootInfo, BootModule, FramebufferInfo, InitImage, KernelMmio,
-    MAX_APERTURES, MAX_CPUS, MemoryMapEntry, MemoryMapSlice, MmioAperture, MmioApertureSlice,
-    ModuleSlice,
+    MAX_APERTURES, MAX_CPUS, MAX_RECLAIM_RANGES, MemoryMapEntry, MemoryMapSlice, MmioAperture,
+    MmioApertureSlice, ModuleSlice, ReclaimRange, ReclaimSlice,
 };
 
 // ── Size constants ────────────────────────────────────────────────────────────
@@ -133,6 +133,11 @@ struct BootAllocations
     stack_top: u64,
     cmdline_phys: u64,
     ap_trampoline_phys: u64,
+    /// Physical address of the dedicated 4 KiB page that backs
+    /// `BootInfo.reclaim_ranges`. The bootloader allocates this page in
+    /// step 6, populates the `ReclaimRange` array in step 9, and records
+    /// the page itself as a reclaim entry so the kernel reclaims it last.
+    reclaim_array_phys: u64,
 }
 
 // ── Entry point ───────────────────────────────────────────────────────────────
@@ -223,6 +228,7 @@ unsafe fn boot_sequence(image: EfiHandle, st: *mut EfiSystemTable) -> Result<!, 
             &ctx.framebuffer,
             &allocs,
             &uefi_map,
+            &page_table,
         );
     }
     // SAFETY: page_table root frames are valid; kernel_info.entry_virtual is
@@ -655,6 +661,10 @@ unsafe fn step6_allocate_and_build_page_tables(
     // because MAX_CMDLINE_LEN (512) < 4096.
     unsafe { core::ptr::write((cmdline_phys + cfg.cmdline_len as u64) as *mut u8, 0u8) };
 
+    // Reclaim-array page: dedicated 4 KiB backing for BootInfo.reclaim_ranges.
+    // SAFETY: bs is valid.
+    let reclaim_array_phys = unsafe { allocate_pages(ctx.bs, 1)? };
+
     let allocs = BootAllocations {
         boot_info_phys,
         modules_phys,
@@ -664,6 +674,7 @@ unsafe fn step6_allocate_and_build_page_tables(
         stack_top,
         cmdline_phys,
         ap_trampoline_phys,
+        reclaim_array_phys,
     };
 
     let mut identity_regions: [(u64, u64); MAX_IDENTITY_REGIONS] =
@@ -757,6 +768,8 @@ fn collect_identity_regions(
     }
     // MMIO aperture array page.
     push(allocs.apertures_phys, 4096);
+    // Reclaim-array page: backs BootInfo.reclaim_ranges.
+    push(allocs.reclaim_array_phys, 4096);
     n
 }
 
@@ -845,8 +858,10 @@ unsafe fn step8_exit_boot_services(
 // BootInfo population is the fan-in point for every earlier step: config,
 // kernel, init, modules, firmware, cpu topology, framebuffer, boot
 // allocations, and the memory map all contribute distinct fields. Bundling
-// them would only rename the argument list into an ad-hoc struct.
-#[allow(clippy::too_many_arguments)]
+// them would only rename the argument list into an ad-hoc struct. The
+// too_many_lines allowance covers the inline reclaim-array build below,
+// which sits between aperture derivation and the BootInfo write.
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 unsafe fn step9_populate_boot_info(
     cfg: &BootConfig,
     kernel: &KernelLoad,
@@ -857,6 +872,7 @@ unsafe fn step9_populate_boot_info(
     framebuffer: &FramebufferInfo,
     allocs: &BootAllocations,
     uefi_map: &uefi::MemoryMapResult,
+    page_table: &arch::current::BootPageTable,
 )
 {
     bprintln!("[--------] boot: step 9/10: populate BootInfo");
@@ -921,6 +937,63 @@ unsafe fn step9_populate_boot_info(
     }
     bprintln!(" derived");
 
+    // Build the reclaim-after-Phase-7 array in the dedicated 4 KiB page at
+    // `allocs.reclaim_array_phys`. Cmdline and AP trampoline are absent —
+    // their last consumers run inside Phase 9, after `populate_cspace`
+    // returns. The reclaim-array page is itself recorded as the final
+    // entry so the kernel reclaims it last.
+    // SAFETY: reclaim_array_phys is a valid 4 KiB allocation; we treat it as
+    // a fixed-size array of MAX_RECLAIM_RANGES entries (256 × 16 B = 4 KiB).
+    let reclaim_ranges: &mut [ReclaimRange; MAX_RECLAIM_RANGES] =
+        unsafe { &mut *(allocs.reclaim_array_phys as *mut [ReclaimRange; MAX_RECLAIM_RANGES]) };
+    *reclaim_ranges = [ReclaimRange {
+        phys_base: 0,
+        page_count: 0,
+        reserved: 0,
+    }; MAX_RECLAIM_RANGES];
+    let mut reclaim_len: usize = 0;
+    let mut push_reclaim = |phys_base: u64, page_count: u32| {
+        if reclaim_len >= MAX_RECLAIM_RANGES
+        {
+            bprintln!("[--------] boot: FATAL: reclaim_ranges overflow (bump MAX_RECLAIM_RANGES)");
+            // Post-exit, pre-handoff: BootInfo will be malformed; halt
+            // explicitly so the failure is obvious rather than silent.
+            loop
+            {
+                core::hint::spin_loop();
+            }
+        }
+        reclaim_ranges[reclaim_len] = ReclaimRange {
+            phys_base,
+            page_count,
+            reserved: 0,
+        };
+        reclaim_len += 1;
+    };
+    push_reclaim(allocs.boot_info_phys, 1);
+    push_reclaim(allocs.modules_phys, 1);
+    // MEM_MAP_ENTRY_PAGES and reclaim_len (bounded by MAX_RECLAIM_RANGES) are
+    // both small compile-time constants well within u32 range.
+    #[allow(clippy::cast_possible_truncation)]
+    {
+        push_reclaim(allocs.mem_entries_phys, MEM_MAP_ENTRY_PAGES as u32);
+    }
+    push_reclaim(allocs.apertures_phys, 1);
+    for &frame in page_table.allocated_frames()
+    {
+        push_reclaim(frame, 1);
+    }
+    // The reclaim-array page itself is reclaim-safe once the kernel has
+    // walked it — record it last so the kernel processes it in order.
+    push_reclaim(allocs.reclaim_array_phys, 1);
+    bprint!("[--------] boot: reclaim_ranges: ");
+    #[allow(clippy::cast_possible_truncation)]
+    // SAFETY: console initialized.
+    unsafe {
+        crate::console::console_write_dec32(reclaim_len as u32);
+    }
+    bprintln!(" entries recorded");
+
     // Write the populated BootInfo.
     // SAFETY: boot_info_phys is a valid 4 KiB allocation; BootInfo fits in one page.
     unsafe {
@@ -968,6 +1041,10 @@ unsafe fn step9_populate_boot_info(
                 bsp_id: cpus.bsp_id,
                 cpu_ids: cpus.cpu_ids,
                 ap_trampoline_page: allocs.ap_trampoline_phys,
+                reclaim_ranges: ReclaimSlice {
+                    entries: allocs.reclaim_array_phys as *const ReclaimRange,
+                    count: reclaim_len as u64,
+                },
             },
         );
     }

--- a/core/boot/src/paging.rs
+++ b/core/boot/src/paging.rs
@@ -67,6 +67,15 @@ pub trait PageTableBuilder: Sized
     /// This value is written to CR3 on x86-64, or encoded into the `satp` PPN field
     /// on RISC-V.
     fn root_physical(&self) -> u64;
+
+    /// Physical addresses of every frame this builder allocated for its own page
+    /// tables (the root frame and every intermediate frame allocated during
+    /// [`map`][Self::map]).
+    ///
+    /// The bootloader records these in `BootInfo.reclaim_ranges` so the kernel
+    /// can mint reclaimable Frame caps over them once Phase 3 has installed the
+    /// kernel's own page tables and the bootloader's transient tables are dead.
+    fn allocated_frames(&self) -> &[u64];
 }
 
 /// Convert a [`MapError`] to a [`BootError`].

--- a/core/kernel/docs/capability-internals.md
+++ b/core/kernel/docs/capability-internals.md
@@ -380,6 +380,7 @@ layout via a well-known structure at the top of init's stack.
 | K+1..L | Read-only Frame capabilities (one per PlatformTable entry) |
 | L+1..P | IoPortRange capabilities (one per IoPortRange entry; x86-64 only) |
 | P+1..Q | Frame capabilities for boot module images (raw ELF for procmgr, devmgr, etc.) |
+| Q+1..R | Reclaimable Frame capabilities for bootloader scratch pages (`BootInfo`, descriptor arrays, MMIO aperture array, reclaim-array page, transient page-table frames) — one cap per `BootInfo.reclaim_ranges` entry |
 
 The exact slot numbers are passed to init in the `KernelHandoff` structure placed
 on init's user stack before it begins execution.

--- a/core/kernel/docs/initialization.md
+++ b/core/kernel/docs/initialization.md
@@ -118,8 +118,12 @@ heap exists yet.
 6. Install the new page table:
    arch::current::Paging::activate(&new_table, pcid=0)
    (PCID/ASID 0 is reserved for kernel-only contexts)
-7. The bootloader page table is no longer referenced; its frames are not freed yet
-   (they remain allocated but will be reclaimed after Phase 4)
+7. The bootloader page table is no longer referenced; its frames are
+   recorded in `BootInfo.reclaim_ranges` (boot protocol v7) and minted
+   as reclaimable Frame caps into init's CSpace during Phase 7 by
+   `cap::mint_reclaim_frame_caps`, alongside the other bootloader
+   scratch pages (`BootInfo` page, descriptor arrays, MMIO aperture
+   array, reclaim-array page).
 8. Emit: "page tables established, physmap at 0xFFFF800000000000"
 ```
 
@@ -150,8 +154,7 @@ Emit "fatal: cannot build kernel page tables (OOM)" and halt.
    - PageTableNode (fixed size; one per level-below-root page table frame)
 3. Install the kernel allocator (implements the `GlobalAlloc` trait via the
    size-class path; used by any `alloc::*` usage in the kernel)
-4. Reclaim bootloader page table frames (no longer needed)
-5. Emit: "kernel heap active"
+4. Emit: "kernel heap active"
 ```
 
 After this phase, `Box`, `Vec`, and other heap types work in kernel code.

--- a/core/kernel/src/cap/mod.rs
+++ b/core/kernel/src/cap/mod.rs
@@ -778,8 +778,9 @@ pub static mut CSPACE_LAYOUT_DESCRIPTORS: [CapDescriptor; CSPACE_LAYOUT_MAX_DESC
 ///
 /// # Safety
 /// `layout.descriptor_count` must reflect the entries written by the
-/// `populate_cspace` / `mint_module_frame_caps` pass that produced
-/// `layout`. Single-threaded boot guarantees no concurrent writer.
+/// `populate_cspace`, `mint_module_frame_caps`, and
+/// `mint_reclaim_frame_caps` writers that produced `layout`.
+/// Single-threaded boot guarantees no concurrent writer.
 #[allow(clippy::missing_safety_doc)]
 pub unsafe fn descriptors(layout: &CSpaceLayout) -> &'static [CapDescriptor]
 {
@@ -883,6 +884,7 @@ pub fn init_capability_system(mmio_apertures: &[MmioAperture], boot_info_phys: u
         let cspace = unsafe { &mut *cs_ptr };
         let mut layout = populate_cspace(cspace, ram_blocks, mmap, mmio_apertures, info);
         mint_module_frame_caps(cspace, info, &mut layout);
+        mint_reclaim_frame_caps(cspace, info, &mut layout);
 
         // SAFETY: single-threaded boot; ROOT_CSPACE not yet observed.
         unsafe { ROOT_CSPACE = cs_ptr };
@@ -902,6 +904,7 @@ pub fn init_capability_system(mmio_apertures: &[MmioAperture], boot_info_phys: u
         let empty: [RamBlock; 0] = [];
         let mut layout = populate_cspace(&mut cspace, &empty, mmap, mmio_apertures, info);
         mint_module_frame_caps(&mut cspace, info, &mut layout);
+        mint_reclaim_frame_caps(&mut cspace, info, &mut layout);
         // Tests intentionally leak the box; isolated unit-test invariants
         // (every kernel object Boxed via `nonnull_from_box`) make explicit
         // teardown unnecessary.
@@ -1572,6 +1575,143 @@ fn mint_module_frame_caps(cspace: &mut CSpace, boot_info: &BootInfo, layout: &mu
     layout.module_frame_base = base_slot;
     layout.module_frame_count = count;
     layout.total_populated = cspace.populated_count();
+}
+
+/// Mint reclaimable `Frame` capabilities over bootloader scratch ranges.
+///
+/// Walks `boot_info.reclaim_ranges` — the `BootInfo` page, module
+/// descriptor array, memory-map entry array, MMIO aperture array, the
+/// reclaim-array page itself, and the bootloader's transient page-table
+/// frames — and mints one reclaimable `FrameObject` cap per range with
+/// `owns_memory = true` and the full byte ledger. Each cap is inserted
+/// into the root `CSpace` and a matching `CapDescriptor` entry pushed
+/// into `layout.descriptors`, so the cap reaches init through the
+/// standard descriptor-table walk in the same shape boot-module caps
+/// take. Pages return to the buddy on cap teardown via the existing
+/// `dealloc_object` → `free_range` path.
+///
+/// Symmetric to [`mint_module_frame_caps`]; runs immediately after it.
+/// The kernel MUST NOT dereference any address inside a recorded range
+/// after this function returns.
+///
+/// Appends one [`CapDescriptor`] entry per reclaimed range; init walks
+/// the descriptor table to discover the caps. There is no dedicated
+/// `reclaim_frame_base` / `reclaim_frame_count` pair on [`CSpaceLayout`]
+/// because reclaim caps carry no per-index meaning — unlike boot
+/// modules where slot N == module N, reclaim caps are a homogeneous
+/// pool and userspace inspects each `CapDescriptor.aux0`/`aux1` to
+/// learn the underlying physical range.
+fn mint_reclaim_frame_caps(cspace: &mut CSpace, boot_info: &BootInfo, layout: &mut CSpaceLayout)
+{
+    use init_protocol::CapType;
+
+    let range_count = boot_info.reclaim_ranges.count as usize;
+    if range_count == 0 || boot_info.reclaim_ranges.entries.is_null()
+    {
+        return;
+    }
+    // The reclaim-array page is identity-mapped at boot and accessible via
+    // the direct physical map after Phase 3; reach it through the direct map.
+    // SAFETY: bootloader contract — `entries` points to a `count`-element
+    // ReclaimRange array; direct map active since Phase 3.
+    let ranges: &[boot_protocol::ReclaimRange] = unsafe {
+        core::slice::from_raw_parts(
+            phys_to_virt(boot_info.reclaim_ranges.entries as u64)
+                as *const boot_protocol::ReclaimRange,
+            range_count,
+        )
+    };
+
+    #[cfg(not(test))]
+    let total_before = crate::mm::with_frame_allocator(|alloc| alloc.total_page_count());
+    #[cfg(test)]
+    let total_before: usize = 0;
+
+    let mut base_slot: u32 = 0;
+    let mut count: u32 = 0;
+    let mut pages_total: u64 = 0;
+
+    for range in ranges
+    {
+        if range.page_count == 0
+        {
+            continue;
+        }
+        let phys_base = range.phys_base & !0xFFF;
+        let size_bytes = u64::from(range.page_count) * (crate::mm::PAGE_SIZE as u64);
+        pages_total += u64::from(range.page_count);
+
+        // Register the range as managed-but-not-free so that if the cap is
+        // ever destroyed, `dealloc_object`'s `free_range` keeps the buddy
+        // `free / total` ratio well-defined. These pages were never in
+        // `total_pages` — `mm::init::collect_usable_ranges` filters
+        // `Loaded`-typed regions out of the buddy at Phase 2 — so
+        // `register_owned_range` is the correct ledger entry (not
+        // `add_region`, which would also push them onto the free list).
+        #[cfg(not(test))]
+        // SAFETY: range pages were not added via `add_region`
+        // (bootloader-typed `Loaded`, filtered by
+        // `mm::init::collect_usable_ranges`); single-threaded Phase 7.
+        unsafe {
+            crate::mm::with_frame_allocator(|alloc| {
+                alloc.register_owned_range(phys_base, size_bytes);
+            });
+        }
+
+        let ptr = mint_phase7_body(FrameObject {
+            header: KernelObjectHeader::with_ancestor(ObjectType::Frame, seed_header_nn()),
+            base: phys_base,
+            size: size_bytes,
+            // Reclaim pages carry the full byte ledger and `owns_memory = true`
+            // so the buddy ledger is balanced when the cap is eventually
+            // destroyed — matching the boot-module precedent above. Routing
+            // beyond init's CSpace (donate-to-memmgr vs cascade-to-buddy) is
+            // a userspace policy decision; the kernel only delivers the cap.
+            available_bytes: core::sync::atomic::AtomicU64::new(size_bytes),
+            owns_memory: core::sync::atomic::AtomicBool::new(true),
+            allocator: crate::cap::retype::RetypeAllocator::new_inline(),
+            lock: core::sync::atomic::AtomicU32::new(0),
+        });
+        let slot = insert_or_fatal(
+            cspace,
+            CapTag::Frame,
+            Rights::MAP | Rights::READ | Rights::WRITE | Rights::EXECUTE | Rights::RETYPE,
+            ptr,
+            "Phase 7: cannot allocate Frame capability for reclaimed boot scratch",
+        );
+        if count == 0
+        {
+            base_slot = slot;
+        }
+        push_descriptor(
+            &mut layout.descriptor_count,
+            CapDescriptor {
+                slot,
+                cap_type: CapType::Frame,
+                pad: [0; 3],
+                aux0: phys_base,
+                aux1: size_bytes,
+            },
+        );
+        count += 1;
+    }
+
+    let _ = base_slot;
+    layout.total_populated = cspace.populated_count();
+
+    #[cfg(not(test))]
+    {
+        let total_after = crate::mm::with_frame_allocator(|alloc| alloc.total_page_count());
+        crate::kprintln!(
+            "reclaim: minted {} Frame caps over {} scratch pages (total accounted {} → {})",
+            count,
+            pages_total,
+            total_before,
+            total_after,
+        );
+    }
+    #[cfg(test)]
+    let _ = (total_before, pages_total);
 }
 
 /// Cast `Box<T>` to `NonNull<KernelObjectHeader>` by leaking the box.

--- a/core/kernel/src/cap/mod.rs
+++ b/core/kernel/src/cap/mod.rs
@@ -737,10 +737,15 @@ pub struct CSpaceLayout
 /// - ~32 hardware caps (MMIO + IRQ + `IoPortRange`/`SbiControl` + `SchedControl`).
 /// - 8 ACPI region caps (`MAX_ACPI_REGIONS`), 1 ACPI RSDP, 1 DTB.
 /// - ~8 init segment caps + ~16 boot module caps.
+/// - [`boot_protocol::MAX_RECLAIM_RANGES`] reclaim Frame caps (worst case
+///   from `mint_reclaim_frame_caps`).
 ///
-/// `4096 + 64 = 4160` covers the worst case with headroom; BSS cost is
-/// 4160 × 24 B ≈ 100 KiB, comfortably small relative to total system RAM.
-pub const CSPACE_LAYOUT_MAX_DESCRIPTORS: usize = 4096 + 64;
+/// `4096 + 256 + 128 = 4480` covers the worst case with headroom; BSS
+/// cost is 4480 × 24 B ≈ 105 KiB, comfortably small relative to total
+/// system RAM. The `4096` term matches `MAX_DRAIN_BLOCKS` in the
+/// production-only branch; `256` is `boot_protocol::MAX_RECLAIM_RANGES`;
+/// the trailing `128` covers every other Phase-7 cap kind.
+pub const CSPACE_LAYOUT_MAX_DESCRIPTORS: usize = 4096 + boot_protocol::MAX_RECLAIM_RANGES + 128;
 
 /// Backing storage for [`CSpaceLayout::descriptor_count`]. `static mut`
 /// because [`populate_cspace`] writes entries during single-threaded
@@ -856,7 +861,9 @@ pub fn init_capability_system(mmio_apertures: &[MmioAperture], boot_info_phys: u
     // 3. populate_cspace fills the root with Frame caps (from the drained
     //    blocks) plus all hardware-resource caps.
     // 4. mint_module_frame_caps appends boot-module Frame caps.
-    // 5. Stash the root CSpace pointer; Phase 9 hands it to init.
+    // 5. mint_reclaim_frame_caps appends reclaimable bootloader-scratch
+    //    Frame caps (BootInfo, descriptor arrays, transient PT frames).
+    // 6. Stash the root CSpace pointer; Phase 9 hands it to init.
     #[cfg(not(test))]
     {
         // SAFETY: single-threaded Phase 7; DRAIN_RAM_BLOCKS is exclusively
@@ -1627,7 +1634,6 @@ fn mint_reclaim_frame_caps(cspace: &mut CSpace, boot_info: &BootInfo, layout: &m
     #[cfg(test)]
     let total_before: usize = 0;
 
-    let mut base_slot: u32 = 0;
     let mut count: u32 = 0;
     let mut pages_total: u64 = 0;
 
@@ -1679,10 +1685,6 @@ fn mint_reclaim_frame_caps(cspace: &mut CSpace, boot_info: &BootInfo, layout: &m
             ptr,
             "Phase 7: cannot allocate Frame capability for reclaimed boot scratch",
         );
-        if count == 0
-        {
-            base_slot = slot;
-        }
         push_descriptor(
             &mut layout.descriptor_count,
             CapDescriptor {
@@ -1696,7 +1698,6 @@ fn mint_reclaim_frame_caps(cspace: &mut CSpace, boot_info: &BootInfo, layout: &m
         count += 1;
     }
 
-    let _ = base_slot;
     layout.total_populated = cspace.populated_count();
 
     #[cfg(not(test))]

--- a/core/kernel/src/main.rs
+++ b/core/kernel/src/main.rs
@@ -18,7 +18,10 @@
 //! - Phase 4: typed-memory cap surface (no `GlobalAlloc`; bodies sourced from caps).
 //! - Phase 5: architecture hardware init (GDT/IDT/APIC or stvec/PLIC, timer, syscall).
 //! - Phase 6: cache `kernel_mmio` and validate `mmio_apertures` slice before capability minting.
-//! - Phase 7: initialise capability subsystem; mint root `CSpace` with initial hardware caps.
+//! - Phase 7: initialise capability subsystem; mint root `CSpace` with initial hardware caps;
+//!   mint reclaimable Frame caps over bootloader scratch pages (`BootInfo`,
+//!   descriptor arrays, transient PT frames) so they flow to userspace via the
+//!   standard `CapDescriptor` path.
 //! - Phase 8: initialise per-CPU scheduler state and per-CPU idle threads for all online CPUs.
 //! - Phase 9: create init process address space + TCB; hand off root `CSpace`; enter user mode.
 
@@ -188,12 +191,12 @@ pub extern "C" fn kernel_entry(boot_info: *const BootInfo) -> !
     // Phase 7.
     //
     // Note on bootloader page table frame reclamation:
-    // Two categories of frames are NOT reclaimed:
-    //   1. BOOT_TABLE_POOL (BSS array): part of the kernel image; cannot be
-    //      freed to buddy. The unused portion (~750 KiB) is acceptable waste.
-    //   2. Bootloader's original page tables: BootInfo does not record their
-    //      physical addresses, so they cannot be identified. Future enhancement:
-    //      have the bootloader pass old CR3/satp in BootInfo.
+    // Bootloader transient page-table frames are now recorded in
+    // `BootInfo.reclaim_ranges` (boot protocol v7) and minted into init's
+    // CSpace by `cap::mint_reclaim_frame_caps`. The remaining un-reclaimed
+    // category is `BOOT_TABLE_POOL` (BSS array): part of the kernel image,
+    // cannot be freed to buddy; the unused portion (~750 KiB) is acceptable
+    // waste.
     kprintln!("Phase 4: Typed-Memory Cap Surface (no kernel heap)");
 
     // Cache `BootInfo.kernel_mmio` so Phase 5 arch hardware init can read

--- a/core/kernel/src/mm/init.rs
+++ b/core/kernel/src/mm/init.rs
@@ -361,6 +361,12 @@ fn collect_usable_ranges(info: &BootInfo) -> RangeList<MAX_RANGES>
 ///
 /// Exclusion boundaries are rounded outward (start down, end up) to page
 /// granularity so no live data sits on a partially-excluded page.
+///
+/// The `BootInfo` and AP-trampoline guards below are belt-and-suspenders
+/// against the `EfiBootServicesData → Usable` mis-typing risk noted at the
+/// trampoline guard's own comment. The authoritative reclamation mechanism
+/// for bootloader scratch pages is `BootInfo.reclaim_ranges`, consumed by
+/// `cap::mint_reclaim_frame_caps` during Phase 7.
 fn collect_exclusions(info: &BootInfo) -> RangeList<MAX_EXCL>
 {
     let mut excl = RangeList::new();

--- a/core/ktest/src/unit/sysinfo.rs
+++ b/core/ktest/src/unit/sysinfo.rs
@@ -87,14 +87,14 @@ pub fn page_size(_ctx: &TestContext) -> TestResult
     Ok(())
 }
 
-/// `system_info(BootProtocolVersion)` must return the current protocol version (6).
+/// `system_info(BootProtocolVersion)` must return the current protocol version (7).
 pub fn boot_protocol_version(_ctx: &TestContext) -> TestResult
 {
     let bpv = system_info(SystemInfoType::BootProtocolVersion as u64)
         .map_err(|_| "system_info(BootProtocolVersion) failed")?;
-    if bpv != 6
+    if bpv != 7
     {
-        return Err("system_info(BootProtocolVersion) did not return 6");
+        return Err("system_info(BootProtocolVersion) did not return 7");
     }
     Ok(())
 }

--- a/docs/memory-model.md
+++ b/docs/memory-model.md
@@ -153,6 +153,30 @@ are usable RAM, reserved, or used by firmware. The kernel parses this map during
 initialisation before the frame allocator is active. Memory used by the kernel image,
 boot modules, and reserved regions is marked unavailable.
 
+### Bootloader Scratch Reclamation
+
+Pages the bootloader allocated for its own scratch use — the `BootInfo`
+struct, the module descriptor array, the memory-map entry array, the
+MMIO aperture array, the reclaim-array page itself, and every transient
+page-table frame — are recorded in `BootInfo.reclaim_ranges` (boot
+protocol v7) and consumed by `cap::mint_reclaim_frame_caps` during
+Phase 7. The kernel mints one reclaimable Frame cap per range
+(`owns_memory = true`, full byte ledger) and inserts it into the root
+`CSpace` so the cap reaches init through the standard `CapDescriptor`
+walk. The buddy ledger records each range via `register_owned_range`
+so cap teardown returns the pages via the existing `dealloc_object` →
+`free_range` path with the `total / free` ratio well-defined. Whether
+init donates the cap onward to memmgr or lets it cascade back to the
+buddy on CSpace teardown is a userspace policy decision; the kernel
+does not impose a route.
+
+The cmdline page and the AP SIPI trampoline page are not reclaimed
+through this mechanism. Their last consumers run inside Phase 9, after
+`populate_cspace` has finalised `cspace_layout.descriptors`; reclaiming
+them through the standard `CapDescriptor` path requires either
+relocating their consumers into Phase 7 or moving SMP startup ahead of
+Phase 9.
+
 ### Buddy Allocator
 
 Physical frames are managed by a buddy allocator. Memory is divided into blocks whose


### PR DESCRIPTION
## Summary

Bumps `BOOT_PROTOCOL_VERSION` 6 → 7. The bootloader records every
scratch page that becomes reclaim-safe by the end of Phase 7 in a new
`BootInfo.reclaim_ranges: ReclaimSlice`. The kernel mints reclaimable
`FrameObject` caps over each entry inside `populate_cspace` —
identical recipe to `mint_module_frame_caps` — so the cap reaches init
through the standard `CapDescriptor` walk. Whether init donates the
cap onward to memmgr or lets it cascade back to the buddy on CSpace
teardown is a userspace policy decision the kernel does not impose.

Addresses #18 (partial). Cmdline page, AP SIPI trampoline page, and
the `mm/address_space.rs` PT-growth path are deferred to follow-up
Issue #91; Issue #18's Acceptance has been edited to acknowledge the
split and the `total_page_count` vs `free_page_count` diagnostic
substitution.

### Mechanism

- `abi/boot-protocol`: new `ReclaimRange` (16 B) and `ReclaimSlice`
  types; `BootInfo.reclaim_ranges` is pointer-based, backed by a
  dedicated 4 KiB scratch page that is itself recorded as the final
  entry.
- `core/boot`: each arch-specific `BootPageTable` logs the root + every
  intermediate frame it allocates; step 9 builds the `ReclaimRange`
  array from `BootAllocations` (BootInfo, modules, memmap, apertures,
  reclaim-array) + `page_table.allocated_frames()` (PT frames).
- `core/kernel/cap`: `mint_reclaim_frame_caps` runs immediately after
  `mint_module_frame_caps` inside `populate_cspace`. `register_owned_range`
  keeps the buddy ledger balanced; cap destruction returns the pages
  via the existing `dealloc_object` → `free_range` path.

### Deferred (#91)

- Cmdline page — last consumer is mid-Phase-9.
- AP SIPI trampoline page — needs identity-unmap teardown + an SMP
  startup reordering.
- The `mm/address_space.rs` PT-growth path that consumes the un-billed
  kernel-buddy reserve. Same fix surface as the trampoline.

### Validation

- `cargo xtask test`: host tests pass; new `protocol_version_is_7` and
  `reclaim_range_size_is_16_bytes` invariants confirmed.
- `cargo xtask run` ktest, x86_64: 132 / 132 ALL TESTS PASSED.
  Reclaim log: 81 Frame caps over 84 scratch pages (total accounted
  106289 → 106373).
- `cargo xtask run` ktest, riscv64: 132 / 132 ALL TESTS PASSED.
  Reclaim log: 98 Frame caps over 101 scratch pages (total accounted
  106606 → 106707).

## Test plan

- [x] `cargo xtask test`
- [x] `cargo xtask build --arch x86_64` + `cargo xtask run --arch x86_64` (ktest)
- [x] `cargo xtask build --arch riscv64` + `cargo xtask run --arch riscv64` (ktest)
- [x] Boot log shows `boot protocol v7` and the reclaim summary line.
- [x] `total_page_count` rises by the reclaim sum (verified pre/post
      inside `mint_reclaim_frame_caps`; concrete x86 and riscv numbers
      quoted above).