### PR TITLE
init/svcmgr: first per-service system_root_cap attenuators (#11)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,6 +467,7 @@ dependencies = [
  "elf",
  "init-protocol",
  "ipc",
+ "namespace-protocol",
  "process-abi",
  "syscall",
  "syscall-abi",

--- a/base/usertest/src/main.rs
+++ b/base/usertest/src/main.rs
@@ -61,6 +61,7 @@ fn main()
     {
         Some("sandbox-child") => sandbox_child_main(),
         Some("cwd-child") => cwd_child_main(),
+        Some("bin-child") => bin_child_main(),
         _ =>
         {}
     }
@@ -141,6 +142,8 @@ fn main()
     fs_write_invariants_phase();
     ns_multi_component_phase();
     ns_sandbox_phase();
+    ns_bin_subtree_phase();
+    ns_startup_cwd_phase();
     ns_fallthrough_attenuation_phase();
     command_cwd_inherit_phase();
     command_cwd_missing_phase();
@@ -420,6 +423,51 @@ fn cwd_child_main() -> !
     {
         Ok(_) => std::process::exit(0),
         Err(_) => std::process::exit(5),
+    }
+}
+
+/// Re-entry path used by [`ns_bin_subtree_phase`] (parent). The
+/// parent walks `root → /bin` requesting `LOOKUP|STAT|READ` (the
+/// exact shape init installs on svcmgr) and spawns this binary with
+/// the attenuated cap as `system_root_cap`. From the child's
+/// perspective, that cap addresses `/bin`, so a path-component walk
+/// of `"/usertest"` resolves to `/bin/usertest` (the binary it was
+/// just spawned from) and `/srv/test.txt` fails before the first
+/// hop because the `/bin` directory has no `srv` entry.
+///
+/// Exit-reason convention (recovered by the parent via the death
+/// queue):
+/// * `0` — `/usertest` opened and `/srv/test.txt` rejected as
+///   expected.
+/// * `1` — `/usertest` open failed (subtree attenuation walked
+///   somewhere unexpected).
+/// * `2` — `/srv/test.txt` unexpectedly succeeded (the cap is not
+///   actually rooted at `/bin`).
+/// * `3` — `/srv/test.txt` failed with an unexpected error kind.
+/// * `4` — child has no `system_root_cap` at all.
+fn bin_child_main() -> !
+{
+    let root = std::os::seraph::root_dir_cap();
+    if root == 0
+    {
+        std::process::exit(4);
+    }
+    if std::fs::File::open("/usertest").is_err()
+    {
+        std::process::exit(1);
+    }
+    match std::fs::File::open("/srv/test.txt")
+    {
+        Ok(_) => std::process::exit(2),
+        Err(e)
+            if matches!(
+                e.kind(),
+                std::io::ErrorKind::NotFound | std::io::ErrorKind::PermissionDenied,
+            ) =>
+        {
+            std::process::exit(0)
+        }
+        Err(_) => std::process::exit(3),
     }
 }
 
@@ -1795,6 +1843,92 @@ fn ns_sandbox_phase()
     std::os::seraph::log!("ns_sandbox phase passed");
 }
 
+/// Exercise the production `NsPolicy::Subtree` shape that init
+/// installs on svcmgr: walk `root → /bin` requesting
+/// `LOOKUP|STAT|READ`, then spawn `/bin/usertest bin-child` with the
+/// attenuated cap delivered via `CommandExt::namespace_cap`. The
+/// child runs [`bin_child_main`], which verifies that (a) its
+/// `system_root_cap` reaches `/bin/usertest` and (b) any path
+/// outside `/bin` is unreachable from the cap.
+///
+/// Parent skips silently if no `root_dir_cap` is configured (no
+/// vfsd, no namespace authority) — same shape as `ns_sandbox_phase`.
+fn ns_bin_subtree_phase()
+{
+    use namespace_protocol::{NamespaceRights, rights};
+    use std::os::seraph::process::CommandExt;
+
+    let root = std::os::seraph::root_dir_cap();
+    if root == 0
+    {
+        std::os::seraph::log!("ns_bin_subtree phase skipped: no root_dir_cap");
+        return;
+    }
+
+    let bin_rights = NamespaceRights::from_raw(rights::LOOKUP | rights::STAT | rights::READ).raw();
+    let bin_cap = match std::os::seraph::namespace_lookup_dir(root, "/bin", u64::from(bin_rights))
+    {
+        Ok(c) => c,
+        Err(e) => panic!("ns_bin_subtree: walk-attenuate /bin failed: {e}"),
+    };
+
+    let mut cmd = std::process::Command::new("/bin/usertest");
+    cmd.arg("bin-child");
+    cmd.namespace_cap(bin_cap);
+    let status = cmd
+        .status()
+        .expect("ns_bin_subtree: spawn /bin/usertest bin-child failed");
+
+    assert!(
+        status.success(),
+        "ns_bin_subtree: child exit status {status:?}; expected 0. \
+         1 = /usertest open failed (cap not rooted at /bin), \
+         2 = /srv/test.txt unexpectedly opened (cap not attenuated), \
+         3 = /srv/test.txt failed with unexpected error kind, \
+         4 = no system_root_cap delivered to child"
+    );
+    std::os::seraph::log!("ns_bin_subtree phase passed");
+}
+
+/// Verify init's `configure_child_namespace` actually delivered a
+/// startup cwd cap addressing `/srv`. usertest is spawned by init
+/// with `cwd = Some((b"/srv", LOOKUP|READDIR|STAT|READ))`; the cap
+/// must arrive in `ProcessInfo.current_dir_cap` and the std startup
+/// path must install it as `current_dir_cap()`.
+///
+/// Asserts the cap is non-zero and that an `NS_LOOKUP` for
+/// `test.txt` succeeds (confirming the cap addresses `/srv` rather
+/// than some other directory). The looked-up cap is released
+/// immediately — this phase only proves wire delivery.
+///
+/// MUST run before `fs_open_relative_phase`, which installs the
+/// path string permanently via `set_current_dir("/srv")` and would
+/// otherwise mask any cap-delivery regression.
+fn ns_startup_cwd_phase()
+{
+    let cwd = std::os::seraph::current_dir_cap();
+    assert_ne!(
+        cwd, 0,
+        "ns_startup_cwd: init did not install a startup cwd cap via CONFIGURE_NAMESPACE",
+    );
+
+    let info = startup_info();
+    // cast_ptr_alignment: IPC buffer is page-aligned (4 KiB).
+    #[allow(clippy::cast_ptr_alignment)]
+    let ipc_buf = info.ipc_buffer.cast::<u64>();
+
+    let (file_cap, kind, _size) = ns_lookup(cwd, b"test.txt", 0xFFFF, ipc_buf).expect(
+        "ns_startup_cwd: NS_LOOKUP test.txt from startup cwd cap failed — cwd cap \
+         does not address /srv",
+    );
+    assert_eq!(
+        kind, 0,
+        "ns_startup_cwd: test.txt should be a file (kind=0), got {kind}",
+    );
+    let _ = syscall::cap_delete(file_cap);
+    std::os::seraph::log!("ns_startup_cwd phase passed");
+}
+
 /// Verify F1: vfsd's fall-through forwarder repacks the request body
 /// to honour the caller's parent rights.
 ///
@@ -3044,27 +3178,34 @@ fn command_invalid_elf_loop_phase()
 
 /// Cap-native cwd surface: `set_current_dir` walks `root_dir_cap()` to
 /// a path and installs the resulting directory cap as
-/// `current_dir_cap()`. Subsequent `File::open` of a relative path
-/// anchors at that cap rather than the root. Asserts both the install
-/// and the relative open succeed.
+/// `current_dir_cap()`, replacing whatever cap (if any) the spawner
+/// installed via `procmgr_labels::CONFIGURE_NAMESPACE`. Subsequent
+/// `File::open` of a relative path anchors at that cap rather than
+/// the root. Asserts the install and the relative open succeed, and
+/// that `std::env::current_dir()` becomes `/srv` once a path string
+/// is recorded.
 fn fs_open_relative_phase()
 {
     use std::fs::File;
     use std::io::Read;
 
-    // Pre-condition: no cwd cap installed (children inherit zero by
-    // default unless the spawner set one). Relative open should fail
-    // with Unsupported.
-    assert_eq!(
+    // Pre-condition: init's `configure_child_namespace` installed a
+    // startup cwd cap addressing `/srv`, but the path-string surface
+    // was never populated (see `env_cwd_unset_phase`), so
+    // `std::env::current_dir()` still returns `Unsupported` and a
+    // relative open with no PathBuf in-hand is rejected before the
+    // walk by the std overlay's "no path recorded" check.
+    assert_ne!(
         std::os::seraph::current_dir_cap(),
         0,
-        "fs_open_relative_phase pre-condition: cwd cap should start zero",
+        "fs_open_relative_phase pre-condition: startup cwd cap should still be present",
     );
-    let pre_err = File::open("test.txt").expect_err("relative open without cwd must fail");
+    let pre_err =
+        std::env::current_dir().expect_err("std::env::current_dir() pre-set should still fail");
     assert_eq!(pre_err.kind(), std::io::ErrorKind::Unsupported);
 
     // Install /srv as cwd via the cap-native primitive. The walk goes
-    // through vfsd's synthetic root.
+    // through vfsd's synthetic root and replaces the startup cap.
     std::os::seraph::set_current_dir("/srv").expect("set_current_dir(/srv) failed");
     assert_ne!(std::os::seraph::current_dir_cap(), 0);
 
@@ -3121,14 +3262,20 @@ fn fs_open_relative_phase()
 /// because the cwd directory *exists*; only its string label is
 /// absent.
 ///
+/// init installs a startup cwd cap (`/srv`) for usertest via
+/// `configure_child_namespace`'s `cwd` argument, so
+/// `current_dir_cap()` is non-zero on entry — the cap surface and the
+/// path-string surface are deliberately independent.
+///
 /// MUST run before `fs_open_relative_phase`: that phase installs the
 /// path string permanently via `set_current_dir("/srv")`.
 fn env_cwd_unset_phase()
 {
-    assert_eq!(
+    assert_ne!(
         std::os::seraph::current_dir_cap(),
         0,
-        "env_cwd_unset_phase pre-condition: cwd cap should still be zero",
+        "env_cwd_unset_phase pre-condition: init's CONFIGURE_NAMESPACE \
+         must have installed a startup cwd cap",
     );
     let err = std::env::current_dir()
         .expect_err("std::env::current_dir() with no recorded path must fail");

--- a/runtime/ruststd/src/os/seraph.rs
+++ b/runtime/ruststd/src/os/seraph.rs
@@ -640,6 +640,32 @@ pub fn namespace_lookup_file(root_cap: u32, path: &str) -> crate::io::Result<(u3
     Ok((walked.file_cap, walked.size))
 }
 
+/// Walk `path` from the supplied namespace cap via `NS_LOOKUP`,
+/// requesting `requested_rights` per hop, and return the resolved
+/// directory's tokened SEND cap.
+///
+/// Every hop (including the final) must resolve to a directory. The
+/// returned cap carries at most `requested_rights` intersected with
+/// each parent's rights and each entry's `max_rights` — see
+/// `shared/namespace-protocol`. Used by spawners that walk-and-
+/// attenuate a subtree cap before installing it on a child via
+/// `CONFIGURE_NAMESPACE`. Callers wanting the full rights chain pass
+/// `0xFFFF`.
+#[stable(feature = "seraph_ext", since = "1.0.0")]
+pub fn namespace_lookup_dir(
+    root_cap: u32,
+    path: &str,
+    requested_rights: u64,
+) -> crate::io::Result<u32> {
+    let ipc_buf = current_ipc_buf();
+    if ipc_buf.is_null() {
+        return Err(crate::io::Error::other("seraph: IPC buffer not registered"));
+    }
+    let walked =
+        crate::sys::fs::walk_path_to_dir_with_rights(root_cap, path, requested_rights, ipc_buf)?;
+    Ok(walked.dir_cap)
+}
+
 /// Return a Frame-cap slot suitable as the source for a `cap_create_*`
 /// retype, with at least `min_bytes` of `available_bytes`.
 ///

--- a/runtime/ruststd/src/sys/fs/seraph.rs
+++ b/runtime/ruststd/src/sys/fs/seraph.rs
@@ -278,7 +278,27 @@ pub(crate) fn walk_path_to_dir(
     ipc_buf: *mut u64,
 ) -> io::Result<WalkedDir>
 {
-    let walked = walk_components(root_cap, path_str, ipc_buf, ExpectKind::Dir)?;
+    walk_path_to_dir_with_rights(root_cap, path_str, 0xFFFF, ipc_buf)
+}
+
+/// Variant of [`walk_path_to_dir`] that requests `requested_rights`
+/// per hop instead of the `0xFFFF` "everything I'm allowed"
+/// sentinel. Used by spawners that walk-and-attenuate a subtree cap
+/// before installing it on a child via `CONFIGURE_NAMESPACE`.
+pub(crate) fn walk_path_to_dir_with_rights(
+    root_cap: u32,
+    path_str: &str,
+    requested_rights: u64,
+    ipc_buf: *mut u64,
+) -> io::Result<WalkedDir>
+{
+    let walked = walk_components(
+        root_cap,
+        path_str,
+        requested_rights,
+        ipc_buf,
+        ExpectKind::Dir,
+    )?;
     Ok(WalkedDir { dir_cap: walked.cap })
 }
 
@@ -298,7 +318,7 @@ pub(crate) fn walk_path_to_file(
     ipc_buf: *mut u64,
 ) -> io::Result<WalkedFile>
 {
-    let walked = walk_components(root_cap, path_str, ipc_buf, ExpectKind::File)?;
+    let walked = walk_components(root_cap, path_str, 0xFFFF, ipc_buf, ExpectKind::File)?;
     Ok(WalkedFile {
         file_cap: walked.cap,
         size: walked.size,
@@ -320,10 +340,15 @@ struct WalkedNode
 }
 
 /// Internal kind-parameterised walk shared by [`walk_path_to_file`] and
-/// [`walk_path_to_dir`].
+/// [`walk_path_to_dir`]. `requested_rights` is the mask sent on every
+/// hop; the namespace server intersects it against parent rights and
+/// per-entry `max_rights`. Callers wanting "everything I'm allowed"
+/// pass `0xFFFF`; callers walking-and-attenuating a subtree pass the
+/// target rights mask directly.
 fn walk_components(
     root_cap: u32,
     path_str: &str,
+    requested_rights: u64,
     ipc_buf: *mut u64,
     expect_kind: ExpectKind,
 ) -> io::Result<WalkedNode>
@@ -365,10 +390,10 @@ fn walk_components(
         let is_last = i == last_idx;
         // Cap-native rights model: server intersects
         // `parent_rights & entry.max_rights & caller_requested`.
-        // Asking for `0xFFFF` (everything I'm allowed) on every hop
-        // is the only shape that lets the final cap come back with
-        // READ when the chain's parents had READ available.
-        let requested_rights: u64 = 0xFFFF;
+        // `requested_rights` is the mask the caller wants on every
+        // hop; `0xFFFF` is the "everything I'm allowed" sentinel
+        // used by `File::open` and friends, and an explicit narrow
+        // mask is used by walk-and-attenuate spawners.
         let label = ns_labels::NS_LOOKUP | ((name.len() as u64) << 16);
         let msg = IpcMessage::builder(label)
             .word(0, requested_rights)

--- a/services/init/Cargo.toml
+++ b/services/init/Cargo.toml
@@ -14,6 +14,7 @@ init-protocol = { path = "../../abi/init-protocol" }
 process-abi = { path = "../../abi/process-abi" }
 elf = { path = "../../shared/elf" }
 ipc = { path = "../../shared/ipc" }
+namespace-protocol = { path = "../../shared/namespace-protocol" }
 syscall = { path = "../../shared/syscall" }
 syscall-abi = { path = "../../abi/syscall" }
 

--- a/services/init/README.md
+++ b/services/init/README.md
@@ -76,13 +76,33 @@ Init's responsibilities are strictly bounded:
    [`services/logd/docs/handover-protocol.md`](../logd/docs/handover-protocol.md).
 
 7. **Spawn Phase 3 services from VFS** — svcmgr, crasher, pwrmgr,
-   usertest, hello, stdiotest are loaded by walking init's seed
-   system-root cap to `/bin/<name>`, then issuing
-   `procmgr_labels::CREATE_FROM_FILE` with the resolved file cap.
-   Each child receives a `cap_copy` of init's root via
-   `CONFIGURE_NAMESPACE` before start. See
-   [`docs/namespace-model.md`](../../docs/namespace-model.md) for the
-   namespace-cap distribution invariants.
+   logd, the per-arch RTC driver, timed, and usertest are loaded by
+   walking init's seed system-root cap to `/bin/<name>` and issuing
+   `procmgr_labels::CREATE_FROM_FILE`. Each spawn site picks a
+   namespace policy that init installs via
+   `procmgr_labels::CONFIGURE_NAMESPACE` before `START_PROCESS`:
+
+   | Service | Policy | Notes |
+   |---|---|---|
+   | `svcmgr` | `Subtree { /bin, LOOKUP\|STAT\|READ }` | Needs to re-walk for crashed-service binaries. |
+   | `usertest` | `Universal` + `cwd = /srv` | Exercises the namespace tests; demonstrates cwd delivery. |
+   | `crasher` | `None` | Intentional fault test; touches no FS. |
+   | `pwrmgr` | `None` | Owns `IoPortRange` / `SbiControl` / ACPI frames; no FS. |
+   | `logd` | `None` | Owns the master log endpoint and arch serial authority; no FS. |
+   | `timed` | `None` | Queries the svcmgr registry for `rtc.primary`; no FS. |
+   | `cmos-rtc` / `goldfish-rtc` | `None` | Hardware-only driver; serves a single RTC read. |
+
+   The `NsPolicy` enum and the `configure_child_namespace` helper
+   live in [`src/service.rs`](src/service.rs); the per-service
+   policies are also re-applied by svcmgr on every restart via the
+   descriptor carried in `REGISTER_SERVICE` (see
+   [`services/svcmgr/docs/restart-protocol.md`](../svcmgr/docs/restart-protocol.md)).
+   `hello` and `stdiotest` exist in `/bin/` as reserved binaries but
+   are not currently spawned by init; whoever wires them up should
+   start from `NsPolicy::None` and widen only as the binary's actual
+   needs require. See
+   [`docs/namespace-model.md`](../../docs/namespace-model.md) for
+   the underlying namespace-cap distribution invariants.
 
    pwrmgr is spawned before usertest so init can derive two SEND
    caps on pwrmgr's service endpoint — one with the

--- a/services/init/src/service.rs
+++ b/services/init/src/service.rs
@@ -18,6 +18,32 @@ use crate::walk;
 use init_protocol::{CapType, InitInfo};
 use ipc::{IpcMessage, procmgr_labels, svcmgr_labels};
 
+/// Per-spawn namespace-cap policy for [`configure_child_namespace`].
+///
+/// The variants encode the three shapes a child's `system_root_cap`
+/// can take: a `cap_copy` of the spawner's seed root, a walked-and-
+/// attenuated subtree, or nothing at all. The descriptor is also
+/// carried in `ServiceRegistration` so svcmgr can re-apply the same
+/// policy on restart (see `services/svcmgr/src/restart.rs`).
+#[derive(Clone, Copy)]
+pub enum NsPolicy<'a>
+{
+    /// Hand the child a `cap_copy` of `system_root_cap` at full
+    /// rights. Equivalent to the pre-attenuation default.
+    Universal,
+    /// Walk `path` from `system_root_cap` requesting `rights` per
+    /// hop, then hand the resulting directory cap to the child. The
+    /// path is bytes; `b"/bin"` etc.
+    Subtree
+    {
+        path: &'a [u8], rights: u64
+    },
+    /// Do not call `CONFIGURE_NAMESPACE` at all. The child's
+    /// `system_root_cap` stays zero; std-side absolute-path fs ops
+    /// return `Unsupported`.
+    None,
+}
+
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 fn derive_tokened_creator(bootstrap_ep: u32) -> Option<(u32, u64)>
@@ -28,33 +54,106 @@ fn derive_tokened_creator(bootstrap_ep: u32) -> Option<(u32, u64)>
 }
 
 /// Issue `procmgr_labels::CONFIGURE_NAMESPACE` on a freshly-created
-/// (suspended) child, handing it a `cap_copy` of init's seed
-/// system-root cap. On any failure the partial child is destroyed
-/// (`DESTROY_PROCESS` on `process_handle`, then `cap_delete`) so a
-/// false return tells callers the handle is no longer usable. Callers
-/// holding additional caps from the same CREATE reply (e.g. a separate
-/// thread cap) remain responsible for releasing those.
+/// (suspended) child according to `policy` and the optional `cwd`.
+///
+/// * `policy` selects the shape of the child's `system_root_cap`:
+///   universal copy of `system_root_cap`, an attenuated subtree
+///   walked from it, or no cap at all.
+/// * `cwd`, when `Some`, walks `(path, rights)` from `system_root_cap`
+///   and delivers the resulting directory cap as `caps[1]` so the
+///   child's `current_dir_cap` is non-zero from the first instruction.
+///
+/// `NsPolicy::None` with `cwd = None` skips the IPC entirely
+/// (procmgr's default leaves both `ProcessInfo` slots at zero).
+/// `NsPolicy::None` with `cwd = Some(_)` is rejected by procmgr
+/// (`root_cap == 0` is `INVALID_ARGUMENT`); callers MUST pair a cwd
+/// with at least `Universal` or `Subtree`.
+///
+/// On any failure the partial child is destroyed (`DESTROY_PROCESS`
+/// on `process_handle`, then `cap_delete`) so a false return tells
+/// callers the handle is no longer usable. Callers holding additional
+/// caps from the same CREATE reply (e.g. a separate thread cap)
+/// remain responsible for releasing those.
 fn configure_child_namespace(
     process_handle: u32,
     system_root_cap: u32,
     init_self_cspace: u32,
+    policy: NsPolicy<'_>,
+    cwd: Option<(&[u8], u64)>,
     ipc_buf: *mut u64,
 ) -> bool
 {
-    let Ok(ns_cap) = syscall::cap_copy(system_root_cap, init_self_cspace, syscall::RIGHTS_SEND)
+    let ns_cap = match policy
+    {
+        NsPolicy::None =>
+        {
+            if cwd.is_some()
+            {
+                // cwd without root is unrepresentable on the wire
+                // (procmgr enforces root_cap != 0). Treat as a
+                // caller bug.
+                log("phase 3: NsPolicy::None with cwd is invalid");
+                destroy_partial_child(process_handle, ipc_buf);
+                return false;
+            }
+            return true;
+        }
+        NsPolicy::Universal =>
+        {
+            let Ok(c) = syscall::cap_copy(system_root_cap, init_self_cspace, syscall::RIGHTS_SEND)
+            else
+            {
+                log("phase 3: cap_copy of system root for child failed");
+                destroy_partial_child(process_handle, ipc_buf);
+                return false;
+            };
+            c
+        }
+        NsPolicy::Subtree { path, rights } =>
+        {
+            let Some(c) = walk::walk_to_dir(system_root_cap, path, rights, ipc_buf)
+            else
+            {
+                log("phase 3: subtree walk for child namespace failed");
+                destroy_partial_child(process_handle, ipc_buf);
+                return false;
+            };
+            c
+        }
+    };
+
+    let cwd_cap = if let Some((path, rights)) = cwd
+    {
+        let Some(c) = walk::walk_to_dir(system_root_cap, path, rights, ipc_buf)
+        else
+        {
+            log("phase 3: cwd walk for child failed");
+            let _ = syscall::cap_delete(ns_cap);
+            destroy_partial_child(process_handle, ipc_buf);
+            return false;
+        };
+        c
+    }
     else
     {
-        log("phase 3: cap_copy of system root for child failed");
-        destroy_partial_child(process_handle, ipc_buf);
-        return false;
+        0
     };
-    let ns_msg = IpcMessage::builder(procmgr_labels::CONFIGURE_NAMESPACE)
-        .cap(ns_cap)
-        .build();
+
+    let mut builder = IpcMessage::builder(procmgr_labels::CONFIGURE_NAMESPACE).cap(ns_cap);
+    if cwd_cap != 0
+    {
+        builder = builder.cap(cwd_cap);
+    }
+    let ns_msg = builder.build();
     // SAFETY: ipc_buf is the registered IPC buffer.
     let reply = unsafe { ipc::ipc_call(process_handle, &ns_msg, ipc_buf) };
-    // The kernel transferred the cap on the IPC; release init's source slot.
+    // The kernel transferred the caps on the IPC; release init's
+    // source slots unconditionally.
     let _ = syscall::cap_delete(ns_cap);
+    if cwd_cap != 0
+    {
+        let _ = syscall::cap_delete(cwd_cap);
+    }
     match reply
     {
         Ok(r) if r.label == 0 => true,
@@ -615,7 +714,7 @@ pub fn create_and_start_pwrmgr(
     ipc_buf: *mut u64,
 ) -> Option<u32>
 {
-    let walked = walk::walk_to_file(system_root_cap, b"/bin/pwrmgr", ipc_buf)?;
+    let walked = walk::walk_to_file(system_root_cap, b"/bin/pwrmgr", 0xFFFF, ipc_buf)?;
 
     let (tokened_creator, child_token) = derive_tokened_creator(bootstrap_ep)?;
 
@@ -654,7 +753,17 @@ pub fn create_and_start_pwrmgr(
         let _ = syscall::cap_delete(reply_caps[1]);
     }
 
-    if !configure_child_namespace(process_handle, system_root_cap, init_self_cspace, ipc_buf)
+    // pwrmgr's only surface is the gated SHUTDOWN/REBOOT IPC; it
+    // owns IoPortRange/SbiControl/ACPI frames directly and never
+    // touches the filesystem. Spawn with no namespace cap.
+    if !configure_child_namespace(
+        process_handle,
+        system_root_cap,
+        init_self_cspace,
+        NsPolicy::None,
+        None,
+        ipc_buf,
+    )
     {
         return None;
     }
@@ -936,7 +1045,7 @@ pub fn create_svcmgr_from_file(
     ipc_buf: *mut u64,
 ) -> Option<(u32, u64)>
 {
-    let walked = walk::walk_to_file(system_root_cap, b"/bin/svcmgr", ipc_buf)?;
+    let walked = walk::walk_to_file(system_root_cap, b"/bin/svcmgr", 0xFFFF, ipc_buf)?;
 
     let (tokened_creator, child_token) = derive_tokened_creator(bootstrap_ep)?;
 
@@ -974,7 +1083,31 @@ pub fn create_svcmgr_from_file(
         let _ = syscall::cap_delete(reply_caps[1]);
     }
 
-    if !configure_child_namespace(process_handle, system_root_cap, init_self_cspace, ipc_buf)
+    // svcmgr only needs the filesystem to (re-)load registered child
+    // binaries from `/bin/<name>`. Attenuate to a `/bin`-rooted cap
+    // with the minimum rights needed: LOOKUP (to walk to the
+    // binary), STAT (the std fs surface stats before opening), READ
+    // (procmgr issues `FS_READ` / `FS_READ_FRAME` against the file
+    // cap during ELF load — see `services/procmgr/src/process.rs::
+    // create_process_from_file` and the gate enforcement at
+    // `shared/namespace-protocol/src/gate.rs:239`). READDIR/WRITE/
+    // EXEC/MUTATE_DIR/ADMIN are deliberately omitted.
+    let bin_rights = u64::from(
+        namespace_protocol::rights::LOOKUP
+            | namespace_protocol::rights::STAT
+            | namespace_protocol::rights::READ,
+    );
+    if !configure_child_namespace(
+        process_handle,
+        system_root_cap,
+        init_self_cspace,
+        NsPolicy::Subtree {
+            path: b"/bin",
+            rights: bin_rights,
+        },
+        None,
+        ipc_buf,
+    )
     {
         return None;
     }
@@ -1045,7 +1178,7 @@ pub fn create_crasher_suspended_from_file(
     ipc_buf: *mut u64,
 ) -> Option<(u32, u32, u64)>
 {
-    let walked = walk::walk_to_file(system_root_cap, b"/bin/crasher", ipc_buf)?;
+    let walked = walk::walk_to_file(system_root_cap, b"/bin/crasher", 0xFFFF, ipc_buf)?;
 
     let (tokened_creator, child_token) = derive_tokened_creator(bootstrap_ep)?;
 
@@ -1078,7 +1211,18 @@ pub fn create_crasher_suspended_from_file(
     let process_handle = reply_caps[0];
     let thread_cap = reply_caps[1];
 
-    if !configure_child_namespace(process_handle, system_root_cap, init_self_cspace, ipc_buf)
+    // crasher is an intentional fault-test process — it touches no
+    // filesystem and never opens a file. Spawn with no namespace
+    // cap; svcmgr re-applies the same `NsPolicy::None` on every
+    // restart via the policy descriptor in `ServiceRegistration`.
+    if !configure_child_namespace(
+        process_handle,
+        system_root_cap,
+        init_self_cspace,
+        NsPolicy::None,
+        None,
+        ipc_buf,
+    )
     {
         // configure_child_namespace destroyed process_handle on failure;
         // release the thread cap that was extracted in the same scope.
@@ -1124,7 +1268,7 @@ pub fn create_and_run_usertest(
     ipc_buf: *mut u64,
 )
 {
-    let Some(walked) = walk::walk_to_file(system_root_cap, b"/bin/usertest", ipc_buf)
+    let Some(walked) = walk::walk_to_file(system_root_cap, b"/bin/usertest", 0xFFFF, ipc_buf)
     else
     {
         log("phase 3: usertest walk failed");
@@ -1193,7 +1337,28 @@ pub fn create_and_run_usertest(
         let _ = syscall::cap_delete(reply_caps[1]);
     }
 
-    if !configure_child_namespace(process_handle, system_root_cap, init_self_cspace, ipc_buf)
+    // usertest exercises the namespace tests end-to-end and asserts
+    // on the cwd surface — hand it the universal root, plus a
+    // pre-walked cwd cap addressing `/srv` so `current_dir_cap()` is
+    // non-zero from the first instruction. `std::env::current_dir()`
+    // still returns `Unsupported` until a path string is registered
+    // (the cap and the path-string surface are independent — see
+    // `env_cwd_unset_phase`). The cwd rights mirror what a normal
+    // directory cap needs for `readdir` + per-entry stat + read.
+    let cwd_rights = u64::from(
+        namespace_protocol::rights::LOOKUP
+            | namespace_protocol::rights::READDIR
+            | namespace_protocol::rights::STAT
+            | namespace_protocol::rights::READ,
+    );
+    if !configure_child_namespace(
+        process_handle,
+        system_root_cap,
+        init_self_cspace,
+        NsPolicy::Universal,
+        Some((b"/srv", cwd_rights)),
+        ipc_buf,
+    )
     {
         return;
     }
@@ -1293,24 +1458,31 @@ pub struct ServiceRegistration<'a>
     /// services. Mutually exclusive with `module_cap` at the protocol level
     /// (presence is signalled by a non-zero `vfs_path_len` in the label).
     pub vfs_path: &'a [u8],
+    /// Namespace-policy kind svcmgr re-applies on every restart of
+    /// this service. One of
+    /// [`svcmgr_labels::NS_POLICY_UNIVERSAL`],
+    /// [`svcmgr_labels::NS_POLICY_NONE`],
+    /// [`svcmgr_labels::NS_POLICY_SUBTREE`]. The descriptor must
+    /// match what init installed via `configure_child_namespace` at
+    /// first spawn; otherwise the post-restart `system_root_cap`
+    /// differs from the initial one.
+    pub ns_policy_kind: u8,
+    /// Subtree path for [`svcmgr_labels::NS_POLICY_SUBTREE`]. Empty
+    /// for the other two kinds. Bounded by [`ipc::MAX_PATH_LEN`].
+    pub ns_subtree_path: &'a [u8],
+    /// Rights mask requested per hop when svcmgr walks
+    /// `ns_subtree_path` from its own root. Only the low 24 bits are
+    /// meaningful per `namespace-protocol`; the wire reserves the
+    /// upper 8 of the descriptor's 32 bits for future expansion.
+    pub ns_subtree_rights: u32,
 }
 
 /// Register a service with svcmgr via `REGISTER_SERVICE`.
 ///
-/// Label layout:
-///   bits [0..16]  = opcode
-///   bits [16..32] = `name_len`
-///   bits [32..48] = `vfs_path_len` (0 = module-loaded, >0 = VFS-loaded)
-///
-/// Data layout (in order):
-///   word 0:                        `SVCMGR_LABELS_VERSION` (handshake)
-///   word 1:                        `restart_policy`
-///   word 2:                        `criticality`
-///   words 3..:                     name bytes (`name_words`)
-///   word `bundle_name_len_word`:   `bundle_name_len`
-///   words ..:                      `bundle_name` bytes (`bundle_name_words`)
-///   words ..:                      `vfs_path` bytes (`vfs_path_words`; only
-///                                  when `vfs_path_len` > 0)
+/// See [`svcmgr_labels::REGISTER_SERVICE`] for the authoritative wire
+/// format. The descriptor at the tail (one packed word plus optional
+/// subtree-path bytes) is what svcmgr re-applies on every restart of
+/// this service, so attenuation survives crash cycles.
 ///
 /// Cap layout depends on the load mode:
 ///   module-loaded (`vfs_path_len` == 0): [thread, module, optional bundle]
@@ -1344,7 +1516,22 @@ pub fn register_service(svcmgr_ep: u32, ipc_buf: *mut u64, reg: &ServiceRegistra
     let bundle_name_words = bundle_name_len.div_ceil(8);
     let vfs_path_word = bundle_name_len_word + 1 + bundle_name_words;
 
-    let data_count = vfs_path_word + vfs_path_words;
+    // Namespace-policy descriptor: one packed word + optional path bytes.
+    let ns_policy_word = vfs_path_word + vfs_path_words;
+    let ns_subtree_path_len = if reg.ns_policy_kind == svcmgr_labels::NS_POLICY_SUBTREE
+    {
+        reg.ns_subtree_path.len()
+    }
+    else
+    {
+        0
+    };
+    let ns_subtree_path_words = ns_subtree_path_len.div_ceil(8);
+    let ns_packed = u64::from(reg.ns_policy_kind)
+        | ((ns_subtree_path_len as u64) << 16)
+        | (u64::from(reg.ns_subtree_rights) << 32);
+
+    let data_count = ns_policy_word + 1 + ns_subtree_path_words;
     let label = svcmgr_labels::REGISTER_SERVICE
         | ((reg.name.len() as u64) << 16)
         | ((vfs_path_len as u64) << 32);
@@ -1365,6 +1552,14 @@ pub fn register_service(svcmgr_ep: u32, ipc_buf: *mut u64, reg: &ServiceRegistra
     if vfs_path_len > 0
     {
         builder = builder.bytes(vfs_path_word, reg.vfs_path);
+    }
+    builder = builder.word(ns_policy_word, ns_packed);
+    if ns_subtree_path_len > 0
+    {
+        builder = builder.bytes(
+            ns_policy_word + 1,
+            &reg.ns_subtree_path[..ns_subtree_path_len],
+        );
     }
     builder = builder.word_count(data_count);
 
@@ -1491,6 +1686,11 @@ pub fn phase3_svcmgr_handover(
                 bundle_name: b"svcmgr",
                 bundle_cap: svcmgr_service_ep,
                 vfs_path: b"/bin/crasher",
+                // crasher was spawned with no namespace cap; svcmgr
+                // restarts it with the same `NsPolicy::None` shape.
+                ns_policy_kind: svcmgr_labels::NS_POLICY_NONE,
+                ns_subtree_path: b"",
+                ns_subtree_rights: 0,
             },
         );
 
@@ -1741,7 +1941,7 @@ pub fn create_and_start_logd(
     ipc_buf: *mut u64,
 ) -> bool
 {
-    let Some(walked) = walk::walk_to_file(system_root_cap, b"/bin/logd", ipc_buf)
+    let Some(walked) = walk::walk_to_file(system_root_cap, b"/bin/logd", 0xFFFF, ipc_buf)
     else
     {
         log("logd: walk /bin/logd failed");
@@ -1787,7 +1987,17 @@ pub fn create_and_start_logd(
         let _ = syscall::cap_delete(reply_caps[1]);
     }
 
-    if !configure_child_namespace(process_handle, system_root_cap, init_self_cspace, ipc_buf)
+    // logd owns the master log endpoint RECV plus arch serial
+    // authority (IoPortRange on x86-64, SbiControl on RISC-V); it
+    // does no filesystem I/O. Spawn with no namespace cap.
+    if !configure_child_namespace(
+        process_handle,
+        system_root_cap,
+        init_self_cspace,
+        NsPolicy::None,
+        None,
+        ipc_buf,
+    )
     {
         return false;
     }
@@ -1999,16 +2209,24 @@ fn create_service_endpoint_pair() -> Option<(u32, u32)>
 /// used by `create_and_start_logd` and `create_and_start_svcmgr`.
 /// Returns `(process_handle, child_token)`; caller is responsible for
 /// `destroy_partial_child` on any subsequent failure.
+///
+/// `policy` and `cwd` are forwarded to `configure_child_namespace`.
+/// The driver/service helpers that use this path (rtc driver, timed)
+/// pass `NsPolicy::None` because neither touches the filesystem after
+/// `_start`.
+#[allow(clippy::too_many_arguments)]
 fn walk_and_create_from_file(
     path: &[u8],
     procmgr_ep: u32,
     bootstrap_ep: u32,
     system_root_cap: u32,
     init_self_cspace: u32,
+    policy: NsPolicy<'_>,
+    cwd: Option<(&[u8], u64)>,
     ipc_buf: *mut u64,
 ) -> Option<(u32, u64)>
 {
-    let walked = walk::walk_to_file(system_root_cap, path, ipc_buf)?;
+    let walked = walk::walk_to_file(system_root_cap, path, 0xFFFF, ipc_buf)?;
     let (tokened_creator, child_token) = derive_tokened_creator(bootstrap_ep)?;
     let create_msg = IpcMessage::builder(procmgr_labels::CREATE_FROM_FILE)
         .word(0, walked.size)
@@ -2032,7 +2250,14 @@ fn walk_and_create_from_file(
     {
         let _ = syscall::cap_delete(reply_caps[1]);
     }
-    if !configure_child_namespace(process_handle, system_root_cap, init_self_cspace, ipc_buf)
+    if !configure_child_namespace(
+        process_handle,
+        system_root_cap,
+        init_self_cspace,
+        policy,
+        cwd,
+        ipc_buf,
+    )
     {
         return None;
     }
@@ -2096,12 +2321,17 @@ pub fn create_and_start_rtc_driver(
         return None;
     };
 
+    // RTC driver owns its arch-specific hardware authority cap
+    // (IoPortRange on x86-64, MmioRegion on RISC-V) and serves a
+    // single read-only IPC. No filesystem access.
     let Some((process_handle, child_token)) = walk_and_create_from_file(
         binary_path,
         procmgr_ep,
         bootstrap_ep,
         system_root_cap,
         init_self_cspace,
+        NsPolicy::None,
+        None,
         ipc_buf,
     )
     else
@@ -2164,12 +2394,16 @@ pub fn create_and_start_timed(
 {
     let (svc_source, svc_recv) = create_service_endpoint_pair()?;
 
+    // timed queries the svcmgr registry for `rtc.primary` then
+    // serves GET_WALL_TIME. No filesystem access.
     let Some((process_handle, child_token)) = walk_and_create_from_file(
         b"/bin/timed",
         procmgr_ep,
         bootstrap_ep,
         system_root_cap,
         init_self_cspace,
+        NsPolicy::None,
+        None,
         ipc_buf,
     )
     else

--- a/services/init/src/walk.rs
+++ b/services/init/src/walk.rs
@@ -3,14 +3,24 @@
 
 // init/src/walk.rs
 
-//! No-std namespace walk helper for init.
+//! No-std namespace walk helpers for init.
 //!
 //! Init holds a tokened SEND on vfsd's namespace endpoint (the seed
 //! cap obtained from `vfsd_labels::GET_SYSTEM_ROOT_CAP`) and uses it to
-//! resolve binary paths into per-file caps before issuing
-//! `procmgr_labels::CREATE_FROM_FILE`. Mirrors the per-component
-//! `NS_LOOKUP` walk std performs in `runtime/ruststd/src/sys/fs/seraph.rs`,
-//! reduced to `no_std` primitives.
+//!
+//!   * resolve binary paths into per-file caps before issuing
+//!     `procmgr_labels::CREATE_FROM_FILE` ([`walk_to_file`]);
+//!   * derive attenuated subtree / cwd caps to install on children via
+//!     `procmgr_labels::CONFIGURE_NAMESPACE` ([`walk_to_dir`]).
+//!
+//! Both helpers mirror the per-component `NS_LOOKUP` walk std performs
+//! in `runtime/ruststd/src/sys/fs/seraph.rs`, reduced to `no_std`
+//! primitives. `requested_rights` is the rights mask sent on every
+//! intermediate hop; namespace-protocol intersects it against each
+//! entry's `max_rights`, so the returned cap carries at most
+//! `requested_rights` on every bit. Callers wanting "everything
+//! permitted" pass `0xFFFF` (the sentinel that selects each entry's
+//! full `max_rights`).
 
 use ipc::{IpcMessage, ns_labels};
 
@@ -24,21 +34,79 @@ pub struct WalkedFile
     pub size: u64,
 }
 
-/// Walk `path` from `root_cap` via per-component `NS_LOOKUP`. Each
-/// non-final hop must resolve to a directory; the final hop must
-/// resolve to a file.
+/// Walk `path` from `root_cap` requesting `requested_rights` per hop
+/// and return the resolved file cap.
+///
+/// Each non-final hop must resolve to a directory; the final hop must
+/// resolve to a file (kind 0).
 ///
 /// Returns `None` on any failure. On error, any partially-derived cap
 /// the helper owns is `cap_delete`d before returning.
-pub fn walk_to_file(root_cap: u32, path: &[u8], ipc_buf: *mut u64) -> Option<WalkedFile>
+pub fn walk_to_file(
+    root_cap: u32,
+    path: &[u8],
+    requested_rights: u64,
+    ipc_buf: *mut u64,
+) -> Option<WalkedFile>
+{
+    let WalkResult { cap, kind, size } = walk(root_cap, path, requested_rights, ipc_buf)?;
+    if kind != 0
+    {
+        let _ = syscall::cap_delete(cap);
+        return None;
+    }
+    Some(WalkedFile {
+        file_cap: cap,
+        size,
+    })
+}
+
+/// Walk `path` from `root_cap` requesting `requested_rights` per hop
+/// and return the resolved directory cap.
+///
+/// Every hop (including the final) must resolve to a directory
+/// (kind 1). Used to derive attenuated subtree / cwd caps for
+/// `CONFIGURE_NAMESPACE`.
+///
+/// Returns `None` on any failure. On error, any partially-derived cap
+/// the helper owns is `cap_delete`d before returning.
+pub fn walk_to_dir(
+    root_cap: u32,
+    path: &[u8],
+    requested_rights: u64,
+    ipc_buf: *mut u64,
+) -> Option<u32>
+{
+    let WalkResult { cap, kind, .. } = walk(root_cap, path, requested_rights, ipc_buf)?;
+    if kind != 1
+    {
+        let _ = syscall::cap_delete(cap);
+        return None;
+    }
+    Some(cap)
+}
+
+struct WalkResult
+{
+    cap: u32,
+    kind: u64,
+    size: u64,
+}
+
+/// Shared per-component walk used by [`walk_to_file`] and [`walk_to_dir`].
+/// Returns the cap, kind, and size hint reported by the final hop.
+/// Refuses empty paths (an empty walk would hand back the caller's
+/// own input cap, which the helper does not own).
+fn walk(root_cap: u32, path: &[u8], requested_rights: u64, ipc_buf: *mut u64)
+-> Option<WalkResult>
 {
     let mut current_cap = root_cap;
     let mut current_owns = false;
+    let mut last_kind: u64 = 0;
     let mut size_hint: u64 = 0;
+    let mut hop_count: usize = 0;
 
     let mut iter = PathComponents::new(path);
-    let mut last_kind: u64 = 0;
-    let mut hop_count: usize = 0;
     while let Some(name) = iter.next_component()
     {
         if name.is_empty() || name.len() > 255
@@ -61,7 +129,7 @@ pub fn walk_to_file(root_cap: u32, path: &[u8], ipc_buf: *mut u64) -> Option<Wal
 
         let label = ns_labels::NS_LOOKUP | ((name.len() as u64) << 16);
         let msg = IpcMessage::builder(label)
-            .word(0, 0xFFFF)
+            .word(0, requested_rights)
             .bytes(1, name)
             .build();
 
@@ -112,15 +180,9 @@ pub fn walk_to_file(root_cap: u32, path: &[u8], ipc_buf: *mut u64) -> Option<Wal
         return None;
     }
 
-    // Final hop must address a file (kind 0 per namespace-protocol).
-    if last_kind != 0
-    {
-        let _ = syscall::cap_delete(current_cap);
-        return None;
-    }
-
-    Some(WalkedFile {
-        file_cap: current_cap,
+    Some(WalkResult {
+        cap: current_cap,
+        kind: last_kind,
         size: size_hint,
     })
 }

--- a/services/svcmgr/README.md
+++ b/services/svcmgr/README.md
@@ -28,14 +28,43 @@ svcmgr/
 ## Responsibilities
 
 - **Service registration** — accept service registrations from init during
-  bootstrap; record the service name, capability set, and restart policy
+  bootstrap; record the service name, capability set, restart policy, and
+  namespace-policy descriptor (`ns_policy_kind` / `ns_subtree_path` /
+  `ns_subtree_rights`)
 - **Health monitoring** — hold thread lifecycle notification capabilities for
   monitored services; detect crashes via async notifications
 - **Restart management** — on detected crash, request a restart through procmgr
-  with the service's recorded initial capability set
+  with the service's recorded initial capability set; re-apply the stored
+  namespace policy on every restart so attenuation survives crash cycles
 - **procmgr fallback** — if procmgr crashes, use raw syscall capabilities to
   recreate procmgr from its boot module, then resume normal service monitoring
 - **Shutdown** — coordinate ordered service shutdown when requested
+
+---
+
+## Namespace authority
+
+Init spawns svcmgr with a namespace cap attenuated to the `/bin`
+subtree at `LOOKUP|STAT|READ` rights (the precise mask the ELF
+loader needs to walk and read child binaries). All svcmgr-side path
+operations therefore start from a `/bin`-rooted cap:
+
+- **Restart-time binary lookup** — when a registered VFS-loaded
+  service crashes, svcmgr strips the `/bin/` prefix from the
+  registered `vfs_path` (`b"/bin/crasher"` → `b"crasher"`) and walks
+  its attenuated root. A registered path outside `/bin/` is rejected
+  fail-closed; the partial child is torn down before the supervision
+  loop retries.
+- **Restart-time `NS_POLICY_SUBTREE` re-application** — the same
+  `/bin/` strip applies to the stored subtree path; the walk uses
+  the stored rights mask. The recovered directory cap is delivered
+  to the restarted child via `procmgr_labels::CONFIGURE_NAMESPACE`.
+
+The descriptor consumed by both paths arrives on the
+`REGISTER_SERVICE` wire — see
+[shared/ipc/src/lib.rs](../../shared/ipc/src/lib.rs) for the layout
+and [docs/restart-protocol.md](docs/restart-protocol.md) for the
+restart sequencing.
 
 ---
 

--- a/services/svcmgr/docs/restart-protocol.md
+++ b/services/svcmgr/docs/restart-protocol.md
@@ -63,17 +63,34 @@ When a restart is permitted:
    - VFS-loaded service (`vfs_path_len > 0`): walk svcmgr's own
      `root_dir_cap` (delivered at svcmgr's bootstrap via
      `procmgr_labels::CONFIGURE_NAMESPACE`) to the stored path → file
-     cap, then send `CREATE_FROM_FILE` to procmgr. No file cap is
-     persisted across restarts; the walk re-runs on every restart so
-     the latest binary on disk is always loaded.
+     cap, then send `CREATE_FROM_FILE` to procmgr. svcmgr's root is
+     itself attenuated by init to the `/bin` subtree, so the stored
+     absolute path is stripped of its `/bin/` prefix before the walk
+     (e.g. registered path `/bin/crasher` walks as `crasher`); any
+     vfs path outside `/bin` fails closed. No file cap is persisted
+     across restarts; the walk re-runs on every restart so the latest
+     binary on disk is always loaded.
 
    The two are mutually exclusive at registration time and surfaced via the
    `vfs_path_len` field in the `REGISTER_SERVICE` label (bits [32..48]).
 
-   After the create reply, send `procmgr_labels::CONFIGURE_NAMESPACE`
-   to the new process handle with a `cap_copy` of svcmgr's own
-   `root_dir_cap` so the restarted child inherits svcmgr's namespace
-   view (parent-inherit default).
+   After the create reply, re-apply the per-service namespace policy
+   recorded at registration via `procmgr_labels::CONFIGURE_NAMESPACE`:
+
+   - `NS_POLICY_NONE` → skip the IPC entirely; the child's
+     `system_root_cap` stays zero (matches first-spawn shape).
+   - `NS_POLICY_UNIVERSAL` → `cap_copy` of svcmgr's own root and
+     deliver. Because svcmgr's own root is `/bin`-rooted under the
+     current init policy, this hands the child the same `/bin`
+     subtree; no registered service uses this variant today.
+   - `NS_POLICY_SUBTREE` → walk svcmgr's root for the stored
+     subtree path (also `/bin/`-prefix-stripped) with the stored
+     rights mask, deliver the resulting directory cap.
+
+   The descriptor lives on `ServiceEntry` and is bumped to the wire
+   by `REGISTER_SERVICE`; see [ipc-interface.md](ipc-interface.md)
+   and `shared/ipc/src/lib.rs::svcmgr_labels::REGISTER_SERVICE` for
+   the layout.
 
 3. **Inject capabilities.** Using the child CSpace cap returned by procmgr,
    inject the stored restart recipe caps (e.g., log endpoint) into the new
@@ -103,6 +120,9 @@ For the initial implementation, the recipe consists of:
   - VFS path bytes — svcmgr re-walks `root_dir_cap` to the path on
     every restart and uses `CREATE_FROM_FILE`.
 - Log endpoint Send capability (injected into child CSpace)
+- Namespace-policy descriptor (`ns_policy_kind` + optional
+  `ns_subtree_path` + `ns_subtree_rights`) — svcmgr re-applies this
+  on every restart so attenuation survives a crash-restart cycle.
 
 Future services may require additional caps (procmgr endpoint, device
 endpoints, etc.), which can be added to the recipe as needed. The IPC cap

--- a/services/svcmgr/src/main.rs
+++ b/services/svcmgr/src/main.rs
@@ -53,6 +53,7 @@ const REGISTRY_CAPACITY: usize = 8;
 /// label bits [32..48]:
 ///   - module-loaded (`vfs_path_len` == 0): caps = [thread, module, optional bundle]
 ///   - VFS-loaded    (`vfs_path_len`  > 0): caps = [thread, optional bundle]
+#[allow(clippy::too_many_lines)]
 fn handle_register(
     msg: &IpcMessage,
     services: &mut [ServiceEntry; MAX_SERVICES],
@@ -97,6 +98,36 @@ fn handle_register(
     let vfs_path_word = bundle_name_len_word + 1 + bundle_name_words;
     let vfs_loaded = vfs_path_len > 0;
 
+    // Namespace-policy descriptor: one packed word at the tail, plus
+    // optional subtree-path bytes when kind == NS_POLICY_SUBTREE.
+    let vfs_path_words = vfs_path_len.div_ceil(8);
+    let ns_policy_word = vfs_path_word + vfs_path_words;
+    let ns_packed = msg.word(ns_policy_word);
+    let ns_policy_kind = (ns_packed & 0xFF) as u8;
+    let ns_subtree_path_len = ((ns_packed >> 16) & 0xFFFF) as usize;
+    let ns_subtree_rights = (ns_packed >> 32) as u32;
+    if !matches!(
+        ns_policy_kind,
+        ipc::svcmgr_labels::NS_POLICY_UNIVERSAL
+            | ipc::svcmgr_labels::NS_POLICY_NONE
+            | ipc::svcmgr_labels::NS_POLICY_SUBTREE,
+    )
+    {
+        return ipc::svcmgr_errors::INVALID_NAME;
+    }
+    if ns_subtree_path_len > ipc::MAX_PATH_LEN
+    {
+        return ipc::svcmgr_errors::INVALID_NAME;
+    }
+    if ns_policy_kind != ipc::svcmgr_labels::NS_POLICY_SUBTREE && ns_subtree_path_len > 0
+    {
+        return ipc::svcmgr_errors::INVALID_NAME;
+    }
+    if ns_policy_kind == ipc::svcmgr_labels::NS_POLICY_SUBTREE && ns_subtree_path_len == 0
+    {
+        return ipc::svcmgr_errors::INVALID_NAME;
+    }
+
     let recv_caps = msg.caps();
     let cap_count = recv_caps.len();
 
@@ -136,6 +167,17 @@ fn handle_register(
         read_path_bytes(msg, vfs_path_word, vfs_path_len, &mut vfs_path_buf);
     }
 
+    let mut ns_subtree_path_buf = [0u8; ipc::MAX_PATH_LEN];
+    if ns_subtree_path_len > 0
+    {
+        read_path_bytes(
+            msg,
+            ns_policy_word + 1,
+            ns_subtree_path_len,
+            &mut ns_subtree_path_buf,
+        );
+    }
+
     services[idx] = ServiceEntry {
         name,
         name_len: name_len as u8,
@@ -155,6 +197,10 @@ fn handle_register(
         active: true,
         bootstrap_token: 0,
         process_handle: 0,
+        ns_policy_kind,
+        ns_subtree_path_len: ns_subtree_path_len as u8,
+        ns_subtree_path: ns_subtree_path_buf,
+        ns_subtree_rights,
     };
 
     // If a bundle cap was sent alongside, stash it in the first bundle slot.

--- a/services/svcmgr/src/restart.rs
+++ b/services/svcmgr/src/restart.rs
@@ -200,11 +200,20 @@ fn restart_process(svc: &mut ServiceEntry, ctx: &RestartCtx, correlator: u32) ->
     rebind_death_notification(svc, ctx.deaths_eq, new_thread_cap, correlator)
 }
 
+/// svcmgr's attenuated `root_dir_cap` addresses the `/bin` subtree
+/// (init installs this via `NsPolicy::Subtree { path: b"/bin", … }`),
+/// so any absolute path stored in `ServiceEntry.vfs_path` for an
+/// ELF restart MUST start with this prefix and is stripped before
+/// being walked.
+const VFS_BIN_PREFIX: &str = "/bin/";
+
 /// Spawn a fresh instance of `svc` via procmgr. Branches on the recorded
-/// restart source: VFS path → walk svcmgr's `root_dir_cap` to the binary
-/// then `CREATE_FROM_FILE`; module cap → `CREATE_PROCESS`. After create,
-/// installs a `cap_copy` of svcmgr's root cap on the child via
-/// `CONFIGURE_NAMESPACE`. Returns `(process_handle, thread, child_token)`.
+/// restart source: VFS path → walk svcmgr's `root_dir_cap` (stripping
+/// the `/bin/` prefix because svcmgr's root is attenuated to `/bin`)
+/// to the binary, then `CREATE_FROM_FILE`; module cap →
+/// `CREATE_PROCESS`. After create, applies the per-service namespace
+/// policy recorded at registration via `CONFIGURE_NAMESPACE`.
+/// Returns `(process_handle, thread, child_token)`.
 fn create_process(svc: &ServiceEntry, ctx: &RestartCtx) -> Option<(u32, u32, u64)>
 {
     // Allocate a fresh bootstrap token for this child.
@@ -232,16 +241,26 @@ fn create_process(svc: &ServiceEntry, ctx: &RestartCtx) -> Option<(u32, u32, u64
             let _ = syscall::cap_delete(tokened_creator);
             return None;
         };
-        let (file_cap, file_size) = match std::os::seraph::namespace_lookup_file(root_cap, path_str)
+        // svcmgr's root cap addresses `/bin`; the registered absolute
+        // path must be re-rooted to that subtree before the walk.
+        let Some(path_relative) = path_str.strip_prefix(VFS_BIN_PREFIX)
+        else
         {
-            Ok(p) => p,
-            Err(e) =>
-            {
-                std::os::seraph::log!("restart: NS_LOOKUP {path_str:?} failed: {e}");
-                let _ = syscall::cap_delete(tokened_creator);
-                return None;
-            }
+            std::os::seraph::log!("restart: vfs_path {path_str:?} outside /bin");
+            let _ = syscall::cap_delete(tokened_creator);
+            return None;
         };
+        let (file_cap, file_size) =
+            match std::os::seraph::namespace_lookup_file(root_cap, path_relative)
+            {
+                Ok(p) => p,
+                Err(e) =>
+                {
+                    std::os::seraph::log!("restart: NS_LOOKUP {path_relative:?} failed: {e}");
+                    let _ = syscall::cap_delete(tokened_creator);
+                    return None;
+                }
+            };
         IpcMessage::builder(procmgr_labels::CREATE_FROM_FILE)
             .word(0, file_size)
             .cap(file_cap)
@@ -275,52 +294,141 @@ fn create_process(svc: &ServiceEntry, ctx: &RestartCtx) -> Option<(u32, u32, u64
     let process_handle = reply_caps[0];
     let thread_cap = reply_caps[1];
 
-    // Install a `cap_copy` of svcmgr's own root cap on the child. The
-    // restart-created child needs its own namespace cap installed
-    // explicitly because procmgr no longer holds a broadcast root.
-    // A failure here means the restarted service would boot without
-    // namespace authority, presenting to the operator as "running but
-    // broken" — destroy the partial child instead so the supervision
-    // loop retries on the next death tick.
-    let info = std::os::seraph::try_startup_info()?;
-    let root_cap = std::os::seraph::root_dir_cap();
-    if root_cap != 0
+    if !apply_namespace_policy(svc, process_handle, thread_cap, ctx)
     {
-        let Ok(ns_cap) = syscall::cap_copy(root_cap, info.self_cspace, syscall::RIGHTS_SEND)
-        else
-        {
-            std::os::seraph::log!("restart: cap_copy of root for child failed");
-            destroy_partial_child(process_handle, thread_cap, ctx.ipc_buf);
-            return None;
-        };
-        let ns_msg = IpcMessage::builder(procmgr_labels::CONFIGURE_NAMESPACE)
-            .cap(ns_cap)
-            .build();
-        // SAFETY: ctx.ipc_buf is the registered IPC buffer.
-        let ns_reply = unsafe { ipc::ipc_call(process_handle, &ns_msg, ctx.ipc_buf) };
-        // The kernel transferred the cap on the IPC regardless of the
-        // reply label; release svcmgr's source slot unconditionally.
-        let _ = syscall::cap_delete(ns_cap);
-        match ns_reply
-        {
-            Ok(r) if r.label == 0 =>
-            {}
-            Ok(r) =>
-            {
-                std::os::seraph::log!("restart: CONFIGURE_NAMESPACE returned {:#x}", r.label);
-                destroy_partial_child(process_handle, thread_cap, ctx.ipc_buf);
-                return None;
-            }
-            Err(_) =>
-            {
-                std::os::seraph::log!("restart: CONFIGURE_NAMESPACE syscall failed");
-                destroy_partial_child(process_handle, thread_cap, ctx.ipc_buf);
-                return None;
-            }
-        }
+        return None;
     }
 
     Some((process_handle, thread_cap, child_token))
+}
+
+/// Re-apply the namespace policy recorded at registration to a
+/// freshly-created (suspended) restart child.
+///
+/// * `NS_POLICY_NONE` → skip `CONFIGURE_NAMESPACE`; the child's
+///   `system_root_cap` stays zero (matches first-spawn shape).
+/// * `NS_POLICY_UNIVERSAL` → `cap_copy` of svcmgr's own root. NOTE
+///   that under the current init policy svcmgr itself runs with an
+///   attenuated `/bin`-rooted cap, so this variant hands the child
+///   the same attenuated cap — not the full system root. Today no
+///   registered service uses it. If a future service legitimately
+///   needs the full root after restart, init must hand svcmgr the
+///   universal cap (or a dedicated mint cap) so this branch can
+///   actually deliver one.
+/// * `NS_POLICY_SUBTREE` → walk svcmgr's root for the stored
+///   subtree path with the stored rights mask, hand the resulting
+///   directory cap to the child.
+///
+/// On any failure the partial child is destroyed and `false` is
+/// returned (caller treats handle as no longer usable).
+fn apply_namespace_policy(
+    svc: &ServiceEntry,
+    process_handle: u32,
+    thread_cap: u32,
+    ctx: &RestartCtx,
+) -> bool
+{
+    if svc.ns_policy_kind == ipc::svcmgr_labels::NS_POLICY_NONE
+    {
+        return true;
+    }
+
+    let root_cap = std::os::seraph::root_dir_cap();
+    if root_cap == 0
+    {
+        std::os::seraph::log!("restart: no root_dir_cap for CONFIGURE_NAMESPACE");
+        destroy_partial_child(process_handle, thread_cap, ctx.ipc_buf);
+        return false;
+    }
+    let Some(info) = std::os::seraph::try_startup_info()
+    else
+    {
+        std::os::seraph::log!("restart: no startup info for cap_copy");
+        destroy_partial_child(process_handle, thread_cap, ctx.ipc_buf);
+        return false;
+    };
+
+    let ns_cap = match svc.ns_policy_kind
+    {
+        ipc::svcmgr_labels::NS_POLICY_UNIVERSAL =>
+        {
+            let Ok(c) = syscall::cap_copy(root_cap, info.self_cspace, syscall::RIGHTS_SEND)
+            else
+            {
+                std::os::seraph::log!("restart: cap_copy of root for child failed");
+                destroy_partial_child(process_handle, thread_cap, ctx.ipc_buf);
+                return false;
+            };
+            c
+        }
+        ipc::svcmgr_labels::NS_POLICY_SUBTREE =>
+        {
+            let path = &svc.ns_subtree_path[..svc.ns_subtree_path_len as usize];
+            let Ok(path_str) = core::str::from_utf8(path)
+            else
+            {
+                std::os::seraph::log!("restart: ns_subtree_path not UTF-8");
+                destroy_partial_child(process_handle, thread_cap, ctx.ipc_buf);
+                return false;
+            };
+            // svcmgr's root is itself attenuated to `/bin`; the
+            // subtree path is therefore relative to that node, so the
+            // stored path must start with `/bin/` and is stripped
+            // here exactly as in the ELF-load branch.
+            let Some(path_relative) = path_str.strip_prefix(VFS_BIN_PREFIX)
+            else
+            {
+                std::os::seraph::log!("restart: ns_subtree_path {path_str:?} outside /bin");
+                destroy_partial_child(process_handle, thread_cap, ctx.ipc_buf);
+                return false;
+            };
+            match std::os::seraph::namespace_lookup_dir(
+                root_cap,
+                path_relative,
+                u64::from(svc.ns_subtree_rights),
+            )
+            {
+                Ok(c) => c,
+                Err(e) =>
+                {
+                    std::os::seraph::log!("restart: subtree walk {path_relative:?} failed: {e}");
+                    destroy_partial_child(process_handle, thread_cap, ctx.ipc_buf);
+                    return false;
+                }
+            }
+        }
+        _ =>
+        {
+            std::os::seraph::log!("restart: unknown ns_policy_kind");
+            destroy_partial_child(process_handle, thread_cap, ctx.ipc_buf);
+            return false;
+        }
+    };
+
+    let ns_msg = IpcMessage::builder(procmgr_labels::CONFIGURE_NAMESPACE)
+        .cap(ns_cap)
+        .build();
+    // SAFETY: ctx.ipc_buf is the registered IPC buffer.
+    let ns_reply = unsafe { ipc::ipc_call(process_handle, &ns_msg, ctx.ipc_buf) };
+    // The kernel transferred the cap on the IPC regardless of the
+    // reply label; release svcmgr's source slot unconditionally.
+    let _ = syscall::cap_delete(ns_cap);
+    match ns_reply
+    {
+        Ok(r) if r.label == 0 => true,
+        Ok(r) =>
+        {
+            std::os::seraph::log!("restart: CONFIGURE_NAMESPACE returned {:#x}", r.label);
+            destroy_partial_child(process_handle, thread_cap, ctx.ipc_buf);
+            false
+        }
+        Err(_) =>
+        {
+            std::os::seraph::log!("restart: CONFIGURE_NAMESPACE syscall failed");
+            destroy_partial_child(process_handle, thread_cap, ctx.ipc_buf);
+            false
+        }
+    }
 }
 
 /// Tear down a partially-created child: send `DESTROY_PROCESS` over its

--- a/services/svcmgr/src/service.rs
+++ b/services/svcmgr/src/service.rs
@@ -83,6 +83,19 @@ pub struct ServiceEntry
     /// Zero for the initial instance (which svcmgr never created — init
     /// did), so the first death cannot destroy; subsequent deaths can.
     pub process_handle: u32,
+    /// Namespace-policy kind init recorded at registration; one of
+    /// `ipc::svcmgr_labels::NS_POLICY_*`. svcmgr re-applies this
+    /// shape on every restart so attenuation survives a crash cycle.
+    pub ns_policy_kind: u8,
+    /// Length of `ns_subtree_path` in bytes (0 for non-`Subtree`).
+    pub ns_subtree_path_len: u8,
+    /// Subtree path svcmgr walks against its own root for
+    /// `NS_POLICY_SUBTREE`.
+    pub ns_subtree_path: [u8; ipc::MAX_PATH_LEN],
+    /// Rights mask svcmgr requests per hop when walking
+    /// `ns_subtree_path`. Only the low 24 bits are meaningful per
+    /// `namespace-protocol`.
+    pub ns_subtree_rights: u32,
 }
 
 impl ServiceEntry
@@ -109,6 +122,10 @@ impl ServiceEntry
             active: false,
             bootstrap_token: 0,
             process_handle: 0,
+            ns_policy_kind: ipc::svcmgr_labels::NS_POLICY_UNIVERSAL,
+            ns_subtree_path_len: 0,
+            ns_subtree_path: [0; ipc::MAX_PATH_LEN],
+            ns_subtree_rights: 0,
         }
     }
 

--- a/services/svcmgr/src/service.rs
+++ b/services/svcmgr/src/service.rs
@@ -122,7 +122,13 @@ impl ServiceEntry
             active: false,
             bootstrap_token: 0,
             process_handle: 0,
-            ns_policy_kind: ipc::svcmgr_labels::NS_POLICY_UNIVERSAL,
+            // Fail-safe default: an empty slot has no installed
+            // policy yet, so `None` (no namespace cap delivered) is
+            // the correct shape if any code path were to inspect it
+            // before `handle_register` overwrites every field.
+            // Universal would silently grant the most permissive cap
+            // on a programmer error.
+            ns_policy_kind: ipc::svcmgr_labels::NS_POLICY_NONE,
             ns_subtree_path_len: 0,
             ns_subtree_path: [0; ipc::MAX_PATH_LEN],
             ns_subtree_rights: 0,

--- a/shared/ipc/src/lib.rs
+++ b/shared/ipc/src/lib.rs
@@ -396,12 +396,53 @@ pub mod procmgr_process_state
     pub const EXITED: u64 = 3;
 }
 
-pub const SVCMGR_LABELS_VERSION: u32 = 1;
+pub const SVCMGR_LABELS_VERSION: u32 = 2;
 /// IPC labels for the service manager (`svcmgr`).
 pub mod svcmgr_labels
 {
     /// Register a service for health monitoring.
+    ///
+    /// Wire format (data words, in order):
+    /// * word 0: `SVCMGR_LABELS_VERSION` handshake.
+    /// * word 1: `restart_policy` byte.
+    /// * word 2: `criticality` byte.
+    /// * words 3..: `name` bytes (length in label bits 16..32).
+    /// * one word: `bundle_name_len`.
+    /// * following words: `bundle_name` bytes when length > 0.
+    /// * following words: `vfs_path` bytes when length > 0 (length in
+    ///   label bits 32..48).
+    /// * one word: namespace-policy descriptor (`ns_policy_packed`):
+    ///     - bits  0..  8: kind (`NS_POLICY_UNIVERSAL` / `_NONE` /
+    ///       `_SUBTREE`).
+    ///     - bits 16.. 32: subtree-path length (0 for non-Subtree).
+    ///     - bits 32.. 64: subtree rights mask (u32; only the low 24
+    ///       bits are meaningful per `namespace-protocol`).
+    /// * following words: subtree-path bytes (only when kind ==
+    ///   `NS_POLICY_SUBTREE`).
+    ///
+    /// svcmgr stores the descriptor on the `ServiceEntry` and
+    /// re-applies it on every restart (walking its own
+    /// `root_dir_cap` for `Subtree`), so attenuation survives a
+    /// crash-restart cycle.
     pub const REGISTER_SERVICE: u64 = 1;
+
+    /// Namespace-policy descriptor: hand the child a `cap_copy` of
+    /// the spawner's seed root at full rights. The default for
+    /// services that legitimately need the whole namespace
+    /// (currently only `usertest`).
+    pub const NS_POLICY_UNIVERSAL: u8 = 0;
+    /// Namespace-policy descriptor: do not deliver any namespace
+    /// cap. The child's `ProcessInfo.system_root_cap` stays zero
+    /// (`Unsupported` on absolute-path fs ops in std). Suitable for
+    /// services that own only hardware / IPC authority and never
+    /// touch the filesystem.
+    pub const NS_POLICY_NONE: u8 = 1;
+    /// Namespace-policy descriptor: walk the spawner's seed root to
+    /// a per-service path with a per-service rights mask, and hand
+    /// the resulting directory cap. Path and rights live in the same
+    /// `REGISTER_SERVICE` body so svcmgr can reproduce the walk on
+    /// restart against its own root.
+    pub const NS_POLICY_SUBTREE: u8 = 2;
     /// Signal that init handover is complete.
     pub const HANDOVER_COMPLETE: u64 = 2;
     /// Publish a named endpoint into the discovery registry.

--- a/xtask/src/rust_src.rs
+++ b/xtask/src/rust_src.rs
@@ -1284,7 +1284,7 @@ fn apply_fs_overlay(rust_src: &Path, overlay_root: &Path) -> Result<()>
          // seraph-overlay: std::fs::File via vfsd OPEN + fs-driver FS_READ/FS_READ_FRAME\n    \
          target_os = \"seraph\" => {\n        mod seraph;\n        \
          use seraph as imp;\n        \
-         pub(crate) use seraph::{walk_path_to_file, walk_path_to_dir, WalkedFile, WalkedDir};\n    }\n",
+         pub(crate) use seraph::{walk_path_to_file, walk_path_to_dir, walk_path_to_dir_with_rights, WalkedFile, WalkedDir};\n    }\n",
     )
 }
 


### PR DESCRIPTION
Closes #11.

## Summary

- Wires the first production consumers of the `CONFIGURE_NAMESPACE` mechanism that landed in `6f94c36`. Adds an `NsPolicy` enum (`Universal` / `Subtree{path,rights}` / `None`) in `services/init/src/service.rs`, refactors `configure_child_namespace` to dispatch on it, and pipes a per-spawn descriptor through every Phase-3 spawn site in init and through `REGISTER_SERVICE` into svcmgr's restart path.
- Per-service lockdown matrix:

  | Service | Policy |
  |---|---|
  | `svcmgr` | `Subtree { /bin, LOOKUP\|STAT\|READ }` |
  | `usertest` | `Universal` + `cwd = /srv` |
  | `crasher`, `pwrmgr`, `logd`, `timed`, `cmos-rtc` / `goldfish-rtc` | `None` |

  Tier-1/tier-2 infrastructure (`memmgr`, `procmgr`, `devmgr`, `vfsd`) was already zero by construction and is unchanged.
- svcmgr re-applies the stored policy on every restart so attenuation survives a crash cycle. Because svcmgr's own root is `/bin`-rooted, any registered absolute path (`vfs_path` for ELF loads, `ns_subtree_path` for `Subtree`) is stripped of its `/bin/` prefix before walking, and a path outside `/bin` fails closed. The descriptor travels init → svcmgr as one packed word + optional path bytes; `SVCMGR_LABELS_VERSION` is bumped 1 → 2.
- std (`runtime/ruststd`) gains a rights-parameterised internal `walk_path_to_dir_with_rights` and a matching public `namespace_lookup_dir(root, path, rights)`. The xtask std-overlay patch is updated to re-export the new symbol.
- New end-to-end test phases in `base/usertest/src/main.rs`:
  - `ns_bin_subtree_phase` — mirrors svcmgr's exact policy and asserts via a child re-entry that `/usertest` opens and `/srv/test.txt` fails.
  - `ns_startup_cwd_phase` — confirms init's cwd cap actually addresses `/srv` via an `NS_LOOKUP` on `test.txt`.
  - `env_cwd_unset_phase` and `fs_open_relative_phase` pre-conditions flipped to reflect the new startup shape (cwd cap non-zero, path string still unset).

## Test plan

- [x] `cargo xtask clean && cargo xtask build --arch x86_64 && cargo xtask run --arch x86_64` → all existing `ns_*`, `fs_*`, `cwd_*`, sandbox, fall-through phases pass; new phases pass; usertest reaches `ALL TESTS PASSED`; pwrmgr-driven QEMU shutdown succeeds.
- [x] `cargo xtask clean && cargo xtask build --arch riscv64 && cargo xtask run --arch riscv64` → same.
- [x] svcmgr crasher restart cycle exercised (one restart + degraded marker after `MAX_RESTARTS`) on both arches — `NS_POLICY_None` re-application works end-to-end.