### PR TITLE
ci: bump JS actions to Node 24 majors

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,14 +14,11 @@ concurrency:
 permissions:
   contents: read
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   host-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
@@ -45,7 +42,7 @@ jobs:
         arch: [x86_64, riscv64]
         profile: [debug, release]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install QEMU and firmware
         run: |
@@ -112,7 +109,7 @@ jobs:
 
       - name: Upload run-parallel logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: run-parallel-${{ matrix.arch }}-${{ matrix.profile }}
           path: target/xtask/run-parallel/**/*.log

--- a/.github/workflows/burnin.yml
+++ b/.github/workflows/burnin.yml
@@ -12,9 +12,6 @@ concurrency:
 permissions:
   contents: read
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   burnin:
     runs-on: ubuntu-latest
@@ -24,7 +21,7 @@ jobs:
         arch: [x86_64, riscv64]
         profile: [debug, release]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install QEMU and firmware
         run: |
@@ -68,7 +65,7 @@ jobs:
 
       - name: Upload usertest logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: burnin-usertest-${{ matrix.arch }}-${{ matrix.profile }}
           path: target/xtask/run-parallel/**/*.log
@@ -97,7 +94,7 @@ jobs:
 
       - name: Upload ktest logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: burnin-ktest-${{ matrix.arch }}-${{ matrix.profile }}
           path: target/xtask/run-parallel/**/*.log

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,6 @@ concurrency:
 permissions:
   contents: write
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   build-image:
     # Guard workflow_dispatch from running against a branch ref — release
@@ -27,7 +24,7 @@ jobs:
       matrix:
         arch: [x86_64, riscv64]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install QEMU, firmware, and zstd
         run: |
@@ -67,7 +64,7 @@ jobs:
           sha256sum "${OUT}" > "${OUT}.sha256"
 
       - name: Upload arch artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: image-${{ matrix.arch }}
           path: |
@@ -80,10 +77,10 @@ jobs:
     needs: build-image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download all build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` v4 → v6, `actions/upload-artifact` v4 → v7, `actions/download-artifact` v4 → v8 across `build-test.yml`, `burnin.yml`, `release.yml`. Each target major declares `using: node24` in its `action.yml`, clearing the Node 20 deprecation warnings GitHub Actions surfaces.
- Drop the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` env var from all three workflows — it was an escape hatch that becomes a no-op once the actions are natively on Node 24.
- `Swatinem/rust-cache@v2` already resolves to v2.9.1 (node24); left pinned to the floating major.

## Verification (action.yml at the new pins)
- `actions/checkout@v6.0.2` → `using: node24`
- `actions/upload-artifact@v7.0.1` → `using: 'node24'`
- `actions/download-artifact@v8.0.1` → `using: 'node24'`
- `Swatinem/rust-cache@v2.9.1` → `using: "node24"`

## Test plan
- [x] `build-test` workflow runs green on this PR (host-tests + validate matrix x86_64/riscv64 × debug/release).
- [x] Workflow logs contain no `Node.js 20 actions are deprecated` warnings.
- [x] `burnin` and `release` are tag-driven; manual `workflow_dispatch` smoke is optional but the action-pin changes are mechanically identical to those covered by `build-test`.