### PR TITLE
ruststd: std::fs write surface + read-side completeness via VFS (#8)

### DIFF
--- a/base/usertest/src/main.rs
+++ b/base/usertest/src/main.rs
@@ -150,6 +150,7 @@ fn main()
     std_bulk_write_phase();
     std_read_dir_phase();
     std_metadata_phase();
+    std_open_options_invalid_phase();
     ns_multi_component_phase();
     ns_sandbox_phase();
     ns_bin_subtree_phase();
@@ -1943,6 +1944,74 @@ fn std_metadata_phase()
 
     std::fs::remove_file(f).expect("cleanup");
     std::os::seraph::log!("std_metadata phase passed");
+}
+
+/// Cover the `OpenOptions` flag-combination reject legs added in the
+/// PAL. Every reject must surface `ErrorKind::InvalidInput` so callers
+/// can distinguish a bad open from a permission or I/O failure.
+///
+/// `clippy::suspicious_open_options` flags exactly the combinations we
+/// are deliberately exercising as reject legs; suppress the lint so the
+/// negative tests can compile.
+#[allow(
+    clippy::suspicious_open_options,
+    clippy::nonsensical_open_options,
+    clippy::ineffective_open_options,
+    clippy::needless_update
+)]
+fn std_open_options_invalid_phase()
+{
+    let path = "/usertest/__ooopt.bin";
+
+    let no_mode = std::fs::OpenOptions::new().open(path);
+    assert!(no_mode.is_err(), "open with no access mode must reject");
+    assert_eq!(
+        no_mode.unwrap_err().kind(),
+        std::io::ErrorKind::InvalidInput
+    );
+
+    let append_truncate = std::fs::OpenOptions::new()
+        .write(true)
+        .append(true)
+        .truncate(true)
+        .open(path);
+    assert!(append_truncate.is_err());
+    assert_eq!(
+        append_truncate.unwrap_err().kind(),
+        std::io::ErrorKind::InvalidInput
+    );
+
+    let truncate_no_write = std::fs::OpenOptions::new()
+        .read(true)
+        .truncate(true)
+        .open(path);
+    assert!(truncate_no_write.is_err());
+    assert_eq!(
+        truncate_no_write.unwrap_err().kind(),
+        std::io::ErrorKind::InvalidInput
+    );
+
+    let create_no_write = std::fs::OpenOptions::new()
+        .read(true)
+        .create(true)
+        .open(path);
+    assert!(create_no_write.is_err());
+    assert_eq!(
+        create_no_write.unwrap_err().kind(),
+        std::io::ErrorKind::InvalidInput
+    );
+
+    let create_new_no_write = std::fs::OpenOptions::new()
+        .read(true)
+        .create_new(true)
+        .open(path);
+    assert!(create_new_no_write.is_err());
+    assert_eq!(
+        create_new_no_write.unwrap_err().kind(),
+        std::io::ErrorKind::InvalidInput
+    );
+
+    std::os::seraph::log!("std_open_options_invalid phase passed");
 }
 
 /// Exercise vfsd's tree-shaped synthetic root: a multi-component

--- a/base/usertest/src/main.rs
+++ b/base/usertest/src/main.rs
@@ -140,6 +140,16 @@ fn main()
     fs_write_frame_phase();
     fs_write_cache_coherence_phase();
     fs_write_invariants_phase();
+    std_write_phase();
+    std_create_phase();
+    std_truncate_phase();
+    std_append_phase();
+    std_mkdir_remove_phase();
+    std_rename_phase();
+    std_remove_dir_all_phase();
+    std_bulk_write_phase();
+    std_read_dir_phase();
+    std_metadata_phase();
     ns_multi_component_phase();
     ns_sandbox_phase();
     ns_bin_subtree_phase();
@@ -1694,6 +1704,245 @@ fn fs_write_invariants_phase()
     }
 
     std::os::seraph::log!("fs_write_invariants phase passed");
+}
+
+// ── std::fs phases ─────────────────────────────────────────────────────────
+//
+// These phases exercise the `runtime/ruststd` PAL via the stable
+// `std::fs` surface (rather than raw `FS_*` IPC). They are the
+// regression net for Issue #8.
+
+fn std_write_phase()
+{
+    let path = "/usertest/std_w.bin";
+    let _ = std::fs::remove_file(path);
+    std::fs::write(path, b"hello std::fs").expect("std::fs::write");
+    let got = std::fs::read(path).expect("std::fs::read");
+    assert_eq!(&got[..], b"hello std::fs");
+    std::fs::remove_file(path).expect("cleanup");
+    std::os::seraph::log!("std_write phase passed");
+}
+
+fn std_create_phase()
+{
+    use std::io::Write;
+    let path = "/usertest/std_c.bin";
+    let _ = std::fs::remove_file(path);
+    {
+        let mut f = std::fs::File::create(path).expect("File::create");
+        f.write_all(b"create-data").expect("write_all");
+        f.sync_all().expect("sync_all");
+    }
+    let got = std::fs::read(path).expect("readback");
+    assert_eq!(&got[..], b"create-data");
+    std::fs::remove_file(path).expect("cleanup");
+    std::os::seraph::log!("std_create phase passed");
+}
+
+fn std_truncate_phase()
+{
+    use std::io::Write;
+    let path = "/usertest/std_t.bin";
+    let _ = std::fs::remove_file(path);
+    std::fs::write(path, vec![0xAAu8; 1024]).expect("seed 1 KiB");
+    {
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .open(path)
+            .expect("reopen with truncate");
+        f.write_all(b"short").expect("write short");
+    }
+    let got = std::fs::read(path).expect("readback");
+    assert_eq!(got.len(), 5, "size must reflect post-truncate length");
+    assert_eq!(&got[..], b"short");
+    std::fs::remove_file(path).expect("cleanup");
+    std::os::seraph::log!("std_truncate phase passed");
+}
+
+fn std_append_phase()
+{
+    use std::io::Write;
+    let path = "/usertest/std_a.bin";
+    let _ = std::fs::remove_file(path);
+    std::fs::write(path, b"head ").expect("seed");
+    {
+        let mut f = std::fs::OpenOptions::new()
+            .append(true)
+            .open(path)
+            .expect("open append");
+        f.write_all(b"tail").expect("append");
+    }
+    let got = std::fs::read(path).expect("readback");
+    assert_eq!(&got[..], b"head tail");
+    std::fs::remove_file(path).expect("cleanup");
+    std::os::seraph::log!("std_append phase passed");
+}
+
+fn std_mkdir_remove_phase()
+{
+    let d = "/usertest/std_d";
+    let f = "/usertest/std_d/inner.bin";
+    let _ = std::fs::remove_file(f);
+    let _ = std::fs::remove_dir(d);
+
+    std::fs::create_dir(d).expect("create_dir");
+    std::fs::write(f, b"x").expect("write inside dir");
+    let err = std::fs::remove_dir(d).expect_err("remove_dir non-empty must fail");
+    assert_eq!(err.kind(), std::io::ErrorKind::DirectoryNotEmpty);
+    std::fs::remove_file(f).expect("remove inner");
+    std::fs::remove_dir(d).expect("remove now-empty dir");
+    std::os::seraph::log!("std_mkdir_remove phase passed");
+}
+
+fn std_rename_phase()
+{
+    let a = "/usertest/std_r_a.bin";
+    let b = "/usertest/std_r_b.bin";
+    let _ = std::fs::remove_file(a);
+    let _ = std::fs::remove_file(b);
+    std::fs::write(a, b"renameme").expect("seed");
+    std::fs::rename(a, b).expect("rename");
+    assert!(
+        std::fs::read(a).is_err(),
+        "old name must be gone after rename"
+    );
+    let got = std::fs::read(b).expect("read new name");
+    assert_eq!(&got[..], b"renameme");
+    std::fs::remove_file(b).expect("cleanup");
+    std::os::seraph::log!("std_rename phase passed");
+}
+
+fn std_remove_dir_all_phase()
+{
+    let top = "/usertest/std_tree";
+    let sub = "/usertest/std_tree/sub";
+    let f1 = "/usertest/std_tree/file.bin";
+    let f2 = "/usertest/std_tree/sub/leaf.bin";
+    let _ = std::fs::remove_dir_all(top);
+
+    std::fs::create_dir(top).expect("create top");
+    std::fs::create_dir(sub).expect("create sub");
+    std::fs::write(f1, b"a").expect("seed file.bin");
+    std::fs::write(f2, b"b").expect("seed leaf.bin");
+
+    std::fs::remove_dir_all(top).expect("remove_dir_all");
+
+    assert!(
+        std::fs::read(f1).is_err(),
+        "file.bin must be gone after remove_dir_all"
+    );
+    assert!(
+        std::fs::read(f2).is_err(),
+        "leaf.bin must be gone after remove_dir_all"
+    );
+    std::os::seraph::log!("std_remove_dir_all phase passed");
+}
+
+const STD_BULK_LEN: usize = 16 * 1024;
+
+fn std_bulk_write_phase()
+{
+    use std::io::{Read, Write};
+    let path = "/usertest/std_bulk.bin";
+    let _ = std::fs::remove_file(path);
+    let mut buf = vec![0u8; STD_BULK_LEN];
+    for (i, b) in buf.iter_mut().enumerate()
+    {
+        *b = u8::try_from(i & 0xFF).unwrap_or(0);
+    }
+    {
+        let mut f = std::fs::File::create(path).expect("create bulk");
+        f.write_all(&buf).expect("write_all 16 KiB");
+    }
+    let mut got = Vec::with_capacity(STD_BULK_LEN);
+    {
+        let mut f = std::fs::File::open(path).expect("reopen bulk");
+        f.read_to_end(&mut got).expect("read_to_end");
+    }
+    assert_eq!(got.len(), STD_BULK_LEN, "bulk round-trip length");
+    for (i, &b) in got.iter().enumerate()
+    {
+        assert_eq!(b, u8::try_from(i & 0xFF).unwrap_or(0), "byte {i} mismatch");
+    }
+    std::fs::remove_file(path).expect("cleanup");
+    std::os::seraph::log!("std_bulk_write phase passed");
+}
+
+fn std_read_dir_phase()
+{
+    // fs-fat currently only writes 8.3 short-name directory entries
+    // on FS_CREATE / FS_MKDIR; LFN emission for case-preservation is
+    // a separate fs-fat concern. Use upper-case 8.3-clean names so
+    // the readdir name comparison is stable.
+    let d = "/usertest/STD_RD";
+    let _ = std::fs::remove_dir_all(d);
+    std::fs::create_dir(d).expect("create_dir");
+    std::fs::write("/usertest/STD_RD/A.BIN", b"a").expect("A.BIN");
+    std::fs::write("/usertest/STD_RD/B.BIN", b"bb").expect("B.BIN");
+    std::fs::create_dir("/usertest/STD_RD/SUB").expect("create SUB");
+
+    let mut saw_a = false;
+    let mut saw_b = false;
+    let mut saw_sub = false;
+    for entry in std::fs::read_dir(d).expect("read_dir")
+    {
+        let entry = entry.expect("dir entry");
+        let name = entry.file_name();
+        let name_str = name.to_str().expect("utf-8 name");
+        assert_ne!(name_str, ".", "`.` must be filtered");
+        assert_ne!(name_str, "..", "`..` must be filtered");
+        let ft = entry.file_type().expect("file_type");
+        match name_str
+        {
+            "A.BIN" =>
+            {
+                assert!(ft.is_file());
+                let md = entry.metadata().expect("metadata A.BIN");
+                assert_eq!(md.len(), 1);
+                saw_a = true;
+            }
+            "B.BIN" =>
+            {
+                assert!(ft.is_file());
+                let md = entry.metadata().expect("metadata B.BIN");
+                assert_eq!(md.len(), 2);
+                saw_b = true;
+            }
+            "SUB" =>
+            {
+                assert!(ft.is_dir());
+                saw_sub = true;
+            }
+            other => panic!("unexpected entry {other:?}"),
+        }
+    }
+    assert!(saw_a && saw_b && saw_sub, "missing entries");
+
+    std::fs::remove_dir_all(d).expect("cleanup");
+    std::os::seraph::log!("std_read_dir phase passed");
+}
+
+fn std_metadata_phase()
+{
+    let f = "/usertest/std_md.bin";
+    let _ = std::fs::remove_file(f);
+    std::fs::write(f, b"meta").expect("seed");
+    let md = std::fs::metadata(f).expect("metadata file");
+    assert!(md.is_file());
+    assert!(!md.is_dir());
+    assert_eq!(md.len(), 4);
+
+    let d = "/usertest";
+    let md_d = std::fs::metadata(d).expect("metadata dir");
+    assert!(md_d.is_dir());
+    assert!(!md_d.is_file());
+
+    assert!(std::fs::exists(f).expect("exists present"));
+    assert!(!std::fs::exists("/usertest/__definitely_not_here__").expect("exists missing"));
+
+    std::fs::remove_file(f).expect("cleanup");
+    std::os::seraph::log!("std_metadata phase passed");
 }
 
 /// Exercise vfsd's tree-shaped synthetic root: a multi-component

--- a/runtime/ruststd/src/sys/fs/seraph.rs
+++ b/runtime/ruststd/src/sys/fs/seraph.rs
@@ -1942,7 +1942,13 @@ pub fn remove_dir_all(path: &Path) -> io::Result<()>
 
     let result = drain_dir_recursive(walked.cap, ipc_buf);
     let _ = syscall::cap_delete(walked.cap);
-    result?;
+    if let Err(e) = result
+    {
+        // Release the (possibly-owned) parent cap before propagating;
+        // bare `?` would otherwise skip the release_split_parent leg.
+        release_split_parent(&split);
+        return Err(e);
+    }
 
     // Final FS_REMOVE for the now-empty target.
     let label = fs_labels::FS_REMOVE | ((split.leaf.len() as u64) << 16);

--- a/runtime/ruststd/src/sys/fs/seraph.rs
+++ b/runtime/ruststd/src/sys/fs/seraph.rs
@@ -3,37 +3,64 @@
 
 //! seraph-overlay: std::sys::fs (seraph-only)
 //!
-//! Hybrid `std::fs::File` backed by vfsd / fs-driver IPC.
+//! `std::fs::File`, `OpenOptions`, `read_dir`, `metadata`, and the
+//! mutating free functions (`write`, `create_dir`, `remove_file`,
+//! `remove_dir`, `remove_dir_all`, `rename`) backed by vfsd /
+//! fs-driver IPC.
 //!
-//! - Reads under one page (or that don't cross a page boundary) use the
+//! ## Read path
+//! - Reads ≤ 504 bytes that fit within the current page use the
 //!   inline `FS_READ` path; payload bytes ride in the IPC buffer.
-//! - Larger reads use `FS_READ_FRAME`: the driver returns a Frame cap
-//!   covering one cached page; we reserve VA, `mem_map` it read-only,
-//!   memcpy out, then proactively release the cache slot via
-//!   `FS_RELEASE_FRAME` and tear the mapping down locally.
+//! - Larger reads use `FS_READ_FRAME`: the driver returns a Frame
+//!   cap covering one cached page; we reserve VA, `mem_map` it
+//!   read-only, memcpy out, then proactively release the cache slot
+//!   via `FS_RELEASE_FRAME` and tear the mapping down locally.
 //!
-//! Per-`File` release-endpoint plumbing: a tokened derivation off the
-//! per-process release endpoint owned by [`release_handler`] is
-//! allocated on every open and transferred to the driver via
-//! `caps[0]` of the first [`fs_labels::FS_READ_FRAME`] request for
-//! that `File`. The driver records it on the file's `OpenFile` slot;
-//! its eviction worker uses it to issue cooperative
-//! [`fs_labels::FS_RELEASE_FRAME`] back to us before falling through
-//! to hard-revoke. Files that never trigger a frame-read (only
-//! inline `FS_READ`) never deliver the cap and get the hard-revoke
-//! fallback; the cap is deleted in `Drop`.
+//! ## Write path
+//! - Writes ≤ 504 bytes use the inline `FS_WRITE` path with the
+//!   payload riding in the IPC buffer.
+//! - Larger writes use `FS_WRITE_FRAME`: one memmgr-allocated page
+//!   is mapped MAP_WRITABLE in the caller's address space, filled
+//!   chunk-by-chunk, and handed to the driver as a DMA source. The
+//!   driver returns the same Frame cap back to us in the reply so
+//!   the cap slot id is rebound across iterations.
 //!
-//! v1 supports read-only `File` only; write/append/truncate/create are
-//! Unsupported. Directory ops, symlinks, metadata mutation, locking,
-//! and times are Unsupported.
+//! ## Directory mutation
+//! `FS_CREATE`, `FS_REMOVE`, `FS_MKDIR`, `FS_RENAME` operate against
+//! a parent-directory cap that the PAL obtains by splitting the path
+//! into (parent, leaf) and walking to the parent via `NS_LOOKUP`.
+//! `remove_dir_all` recursively drains a subtree by enumerating with
+//! `NS_READDIR` and issuing per-entry `FS_REMOVE`; after each removal
+//! the cursor restarts at index 0 because FAT compacts slot indices.
 //!
-//! `File::open` walks the path one component at a time via `NS_LOOKUP`
-//! against the per-process root directory cap installed by `_start`
-//! from `ProcessInfo.system_root_cap`. If the root cap is unset,
-//! `File::open` returns `Unsupported`. The inline `FS_READ` path
-//! issues `FS_READ` directly against the node cap returned by the
-//! final `NS_LOOKUP`; `FS_READ_FRAME` / `FS_RELEASE_FRAME` are
-//! preserved verbatim for future cap-native frame-reads.
+//! ## Truncate
+//! `OpenOptions::truncate(true)` on an existing file and
+//! `File::set_len(0)` ride the new `FS_TRUNCATE` label. v1 supports
+//! `new_len == 0` only; the corresponding extend-with-zero-fill case
+//! is tracked in the post-#8 completeness-gaps Issue.
+//!
+//! ## Metadata
+//! `std::fs::metadata` / `symlink_metadata` / `exists` walk the path
+//! (Any-kind leaf) and issue `NS_STAT`. mtime is zero until the FAT
+//! timestamp work in issue #85 lands a clock source;
+//! `FileAttr::modified()` surfaces `Unsupported` in that case.
+//!
+//! ## Per-`File` release-endpoint plumbing
+//! A tokened derivation off the per-process release endpoint owned
+//! by [`release_handler`] is allocated on every open and transferred
+//! to the driver via `caps[0]` of the first
+//! [`fs_labels::FS_READ_FRAME`] request for that `File`. The driver
+//! records it on the file's `OpenFile` slot; its eviction worker
+//! uses it to issue cooperative [`fs_labels::FS_RELEASE_FRAME`] back
+//! to us before falling through to hard-revoke. Files that never
+//! trigger a frame-read (only inline `FS_READ` / `FS_WRITE`) never
+//! deliver the cap and get the hard-revoke fallback; the cap is
+//! deleted in `Drop`.
+//!
+//! ## Path anchoring
+//! Absolute paths walk from `root_dir_cap()`; relative paths walk
+//! from `current_dir_cap()`. If the relevant anchor cap is unset
+//! (e.g. caller has no cwd installed), the PAL returns `Unsupported`.
 
 #![forbid(unsafe_op_in_unsafe_fn)]
 
@@ -80,6 +107,13 @@ const PAGE_SIZE_USIZE: usize = PAGE_SIZE as usize;
 /// so 504 also happens to be the smallest size at which any larger
 /// would force ≥ 2 inline calls and lose to one frame call.
 const READ_INLINE_THRESHOLD: usize = 504;
+
+/// Per-call crossover threshold between the inline FS_WRITE path and
+/// the zero-copy FS_WRITE_FRAME path. A `write()` of at most this many
+/// bytes goes inline; anything larger takes the frame path. Mirrors
+/// `READ_INLINE_THRESHOLD` for symmetry: 504 bytes = 63 data words ×
+/// 8 bytes − 8 bytes of length prefix in word 0.
+const WRITE_INLINE_THRESHOLD: usize = 504;
 
 // ── Public type stubs ─────────────────────────────────────────────────────
 
@@ -131,7 +165,7 @@ pub struct DirBuilder {}
 impl DirBuilder
 {
     pub fn new() -> DirBuilder { DirBuilder {} }
-    pub fn mkdir(&self, _: &Path) -> io::Result<()> { unsupported() }
+    pub fn mkdir(&self, path: &Path) -> io::Result<()> { mkdir(path) }
 }
 
 // ── FileAttr / FilePermissions / FileType ─────────────────────────────────
@@ -139,24 +173,45 @@ impl DirBuilder
 pub struct FileAttr
 {
     size: u64,
+    kind: NodeKind,
+    /// Best-effort mtime in microseconds since the UNIX epoch. Zero
+    /// when the backend does not track timestamps (current FAT
+    /// backend until #85 lands a clock source); `modified()`
+    /// surfaces `Unsupported` in that case.
+    mtime_us: u64,
 }
 
 impl FileAttr
 {
     pub fn size(&self) -> u64 { self.size }
-    pub fn perm(&self) -> FilePermissions { FilePermissions { readonly: true } }
+    pub fn perm(&self) -> FilePermissions { FilePermissions { readonly: false } }
     pub fn file_type(&self) -> FileType
     {
-        FileType { is_dir: false, is_file: true, is_symlink: false }
+        let is_dir = matches!(self.kind, NodeKind::Dir);
+        FileType { is_dir, is_file: !is_dir, is_symlink: false }
     }
-    pub fn modified(&self) -> io::Result<SystemTime> { unsupported() }
+    pub fn modified(&self) -> io::Result<SystemTime>
+    {
+        // FAT does not surface tracked timestamps yet; the field is
+        // carried for forward compatibility with the timestamp work
+        // tracked by #85.
+        let _ = self.mtime_us;
+        unsupported()
+    }
     pub fn accessed(&self) -> io::Result<SystemTime> { unsupported() }
     pub fn created(&self) -> io::Result<SystemTime> { unsupported() }
 }
 
 impl Clone for FileAttr
 {
-    fn clone(&self) -> FileAttr { FileAttr { size: self.size } }
+    fn clone(&self) -> FileAttr
+    {
+        FileAttr {
+            size: self.size,
+            kind: self.kind,
+            mtime_us: self.mtime_us,
+        }
+    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -218,28 +273,142 @@ impl fmt::Debug for FileType
     }
 }
 
-// ReadDir / DirEntry are uninhabited — readdir is Unsupported on v1.
-pub struct ReadDir(!);
+/// Directory iterator backed by `NS_READDIR` against an owned
+/// directory cap. Each `next()` issues one `NS_READDIR`; the FAT
+/// backend's `.` and `..` entries are filtered client-side. The
+/// owned `dir_cap` is `cap_delete`d on drop.
+pub struct ReadDir
+{
+    dir_cap: u32,
+    next_idx: u64,
+    parent_path: PathBuf,
+}
 
 impl Iterator for ReadDir
 {
     type Item = io::Result<DirEntry>;
-    fn next(&mut self) -> Option<Self::Item> { self.0 }
+
+    fn next(&mut self) -> Option<Self::Item>
+    {
+        let ipc_buf = crate::os::seraph::current_ipc_buf();
+        if ipc_buf.is_null()
+        {
+            return Some(Err(io::Error::other("seraph fs: IPC buffer not registered")));
+        }
+        loop
+        {
+            let msg = IpcMessage::builder(ns_labels::NS_READDIR)
+                .word(0, self.next_idx)
+                .build();
+            // SAFETY: ipc_buf is the registered IPC buffer.
+            let reply = match unsafe { ipc::ipc_call(self.dir_cap, &msg, ipc_buf) }
+            {
+                Ok(r) => r,
+                Err(_) =>
+                {
+                    return Some(Err(io::Error::other(
+                        "seraph fs: NS_READDIR ipc_call failed",
+                    )));
+                }
+            };
+            if reply.label == fs_labels::END_OF_DIR
+            {
+                return None;
+            }
+            if reply.label != 0
+            {
+                return Some(Err(ns_error_to_io(reply.label)));
+            }
+
+            let kind_word = reply.word(0);
+            let name_len = reply.word(1) as usize;
+            let bytes = reply.data_bytes();
+            const NAME_OFF: usize = 16; // words 0,1 = kind + name_len
+            let end = NAME_OFF.saturating_add(name_len).min(bytes.len());
+            if end < NAME_OFF + name_len
+            {
+                return Some(Err(io::Error::other(
+                    "seraph fs: NS_READDIR truncated name",
+                )));
+            }
+            let name_bytes = &bytes[NAME_OFF..end];
+
+            self.next_idx = self.next_idx.saturating_add(1);
+
+            // Filter the FAT-surfaced `.` / `..` entries. Std iterates
+            // children, not the dir-self / dir-parent pseudo-entries.
+            if name_bytes == b"." || name_bytes == b".."
+            {
+                continue;
+            }
+
+            let kind = if kind_word == NodeKind::Dir as u64
+            {
+                NodeKind::Dir
+            }
+            else
+            {
+                NodeKind::File
+            };
+            let name = OsString::from(
+                core::str::from_utf8(name_bytes)
+                    .unwrap_or("<non-utf8>")
+                    .to_owned(),
+            );
+            return Some(Ok(DirEntry {
+                name,
+                kind,
+                parent_path: self.parent_path.clone(),
+            }));
+        }
+    }
 }
 
 impl fmt::Debug for ReadDir
 {
-    fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result { self.0 }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result
+    {
+        f.debug_struct("ReadDir")
+            .field("dir_cap", &self.dir_cap)
+            .field("next_idx", &self.next_idx)
+            .field("parent_path", &self.parent_path)
+            .finish()
+    }
 }
 
-pub struct DirEntry(!);
+impl Drop for ReadDir
+{
+    fn drop(&mut self)
+    {
+        if self.dir_cap != 0
+        {
+            let _ = syscall::cap_delete(self.dir_cap);
+        }
+    }
+}
+
+pub struct DirEntry
+{
+    name: OsString,
+    kind: NodeKind,
+    parent_path: PathBuf,
+}
 
 impl DirEntry
 {
-    pub fn path(&self) -> PathBuf { self.0 }
-    pub fn file_name(&self) -> OsString { self.0 }
-    pub fn metadata(&self) -> io::Result<FileAttr> { self.0 }
-    pub fn file_type(&self) -> io::Result<FileType> { self.0 }
+    pub fn path(&self) -> PathBuf { self.parent_path.join(&self.name) }
+    pub fn file_name(&self) -> OsString { self.name.clone() }
+    pub fn metadata(&self) -> io::Result<FileAttr>
+    {
+        // Refetch live attrs via stat — directory contents may have
+        // changed since the enumeration produced this entry.
+        stat(&self.path())
+    }
+    pub fn file_type(&self) -> io::Result<FileType>
+    {
+        let is_dir = matches!(self.kind, NodeKind::Dir);
+        Ok(FileType { is_dir, is_file: !is_dir, is_symlink: false })
+    }
 }
 
 // ── Path walk ─────────────────────────────────────────────────────────────
@@ -330,6 +499,10 @@ enum ExpectKind
 {
     Dir,
     File,
+    /// Accept either kind at the leaf. Used by callers that do not
+    /// know upfront whether the target is a file or a directory
+    /// (`unlink`, `stat`, `exists`).
+    Any,
 }
 
 /// Internal: result of a generic component walk.
@@ -337,6 +510,7 @@ struct WalkedNode
 {
     cap: u32,
     size: u64,
+    kind: NodeKind,
 }
 
 /// Internal kind-parameterised walk shared by [`walk_path_to_file`] and
@@ -383,6 +557,7 @@ fn walk_components(
     let mut current_cap = root_cap;
     let mut current_owns = false;
     let mut size_hint: u64 = 0;
+    let mut leaf_kind = NodeKind::Dir;
 
     let last_idx = components.len() - 1;
     for (i, &name) in components.iter().enumerate()
@@ -485,6 +660,14 @@ fn walk_components(
                 }
                 _ => {}
             }
+            leaf_kind = if kind == NodeKind::Dir as u64
+            {
+                NodeKind::Dir
+            }
+            else
+            {
+                NodeKind::File
+            };
         }
 
         if current_owns
@@ -499,7 +682,329 @@ fn walk_components(
     Ok(WalkedNode {
         cap: current_cap,
         size: size_hint,
+        kind: leaf_kind,
     })
+}
+
+/// Split a path into `(parent_dir_cap, leaf_name)`. The parent walk
+/// uses [`walk_path_to_dir`] anchored at `root_dir_cap` for absolute
+/// paths and `current_dir_cap` for relative paths. If the parent is
+/// the anchor itself (no intermediate components), the anchor cap is
+/// returned with `parent_owned == false`; otherwise an owned tokened
+/// SEND is returned and the caller is responsible for `cap_delete`.
+///
+/// Used by `unlink`, `rmdir`, `rename`, `DirBuilder::mkdir`, and the
+/// `File::open` write/create paths.
+pub(crate) struct SplitParent
+{
+    pub parent_cap: u32,
+    pub parent_owned: bool,
+    pub leaf: Vec<u8>,
+}
+
+pub(crate) fn split_parent_and_leaf(
+    path: &Path,
+    ipc_buf: *mut u64,
+) -> io::Result<SplitParent>
+{
+    let path_str = path.to_str().ok_or_else(|| {
+        io::const_error!(io::ErrorKind::InvalidInput, "seraph fs: non-UTF-8 path")
+    })?;
+
+    // Strip a single trailing `/` so `/foo/` and `/foo` are equivalent
+    // at the leaf-name level (matches POSIX `rmdir("/foo/")`).
+    let trimmed = if path_str.len() > 1 && path_str.ends_with('/')
+    {
+        &path_str[..path_str.len() - 1]
+    }
+    else
+    {
+        path_str
+    };
+    if trimmed.is_empty() || trimmed == "/"
+    {
+        return Err(io::const_error!(
+            io::ErrorKind::InvalidInput,
+            "seraph fs: path has no leaf",
+        ));
+    }
+
+    let (parent_str, leaf_str) = match trimmed.rfind('/')
+    {
+        Some(idx) => (&trimmed[..idx], &trimmed[idx + 1..]),
+        None => ("", trimmed),
+    };
+    if leaf_str.is_empty()
+    {
+        return Err(io::const_error!(
+            io::ErrorKind::InvalidInput,
+            "seraph fs: path has empty leaf",
+        ));
+    }
+
+    let leaf_bytes = leaf_str.as_bytes();
+    if validate_name(leaf_bytes).is_err()
+    {
+        return Err(io::const_error!(
+            io::ErrorKind::InvalidInput,
+            "seraph fs: invalid leaf name",
+        ));
+    }
+
+    let anchor_cap = if path_str.starts_with('/')
+    {
+        crate::os::seraph::root_dir_cap()
+    }
+    else
+    {
+        crate::os::seraph::current_dir_cap()
+    };
+    if anchor_cap == 0
+    {
+        return Err(io::const_error!(
+            io::ErrorKind::Unsupported,
+            "seraph fs: no anchor dir cap for this path \
+             (root_dir_cap zero for absolute paths; current_dir_cap \
+              zero for relative paths)",
+        ));
+    }
+
+    // `parent_str` is empty when the parent is the anchor (e.g.
+    // path = "/foo" → parent_str = "", anchor = root; path = "foo" →
+    // parent_str = "", anchor = cwd). Return the anchor cap without
+    // claiming ownership so the caller does not cap_delete a borrowed
+    // shared cap.
+    if parent_str.is_empty() || parent_str == "/"
+    {
+        return Ok(SplitParent {
+            parent_cap: anchor_cap,
+            parent_owned: false,
+            leaf: leaf_bytes.to_vec(),
+        });
+    }
+
+    let walked = walk_path_to_dir(anchor_cap, parent_str, ipc_buf)?;
+    Ok(SplitParent {
+        parent_cap: walked.dir_cap,
+        parent_owned: true,
+        leaf: leaf_bytes.to_vec(),
+    })
+}
+
+/// Release the parent cap returned by [`split_parent_and_leaf`] iff
+/// it was owned. Helper to keep callers tidy.
+fn release_split_parent(split: &SplitParent)
+{
+    if split.parent_owned
+    {
+        let _ = syscall::cap_delete(split.parent_cap);
+    }
+}
+
+// ── Write helpers ─────────────────────────────────────────────────────────
+
+/// Inline `FS_WRITE` of at most `WRITE_INLINE_THRESHOLD` bytes at
+/// `offset` against `file_cap`. Returns `bytes_written` reported by
+/// the server (may be short; callers iterate).
+fn write_inline(
+    file_cap: u32,
+    offset: u64,
+    payload: &[u8],
+    ipc_buf: *mut u64,
+) -> io::Result<usize>
+{
+    debug_assert!(payload.len() <= WRITE_INLINE_THRESHOLD);
+    let label = fs_labels::FS_WRITE | ((payload.len() as u64) << 16);
+    let msg = IpcMessage::builder(label)
+        .word(0, offset)
+        .bytes(1, payload)
+        .build();
+    // SAFETY: ipc_buf is the registered IPC buffer.
+    let reply = unsafe { ipc::ipc_call(file_cap, &msg, ipc_buf) }
+        .map_err(|_| io::Error::other("seraph fs: FS_WRITE ipc_call failed"))?;
+    if reply.label != fs_errors::SUCCESS
+    {
+        return Err(map_fs_error(reply.label));
+    }
+    Ok(reply.word(0) as usize)
+}
+
+/// Bulk write via `FS_WRITE_FRAME`. Acquires one page-sized DMA
+/// source frame from memmgr, maps it MAP_WRITABLE, then loops chunks
+/// of at most `PAGE_SIZE` bytes through the frame and into the file.
+/// The server returns the source frame in the reply caps each
+/// round-trip, so the cap slot id is rebound on every iteration.
+fn write_frame_chunks(
+    file_cap: u32,
+    aspace: u32,
+    memmgr_ep: u32,
+    base_offset: u64,
+    payload: &[u8],
+    ipc_buf: *mut u64,
+) -> io::Result<usize>
+{
+    use ipc::{memmgr_errors, memmgr_labels};
+
+    // Acquire one single-page frame from memmgr.
+    let req = IpcMessage::builder(memmgr_labels::REQUEST_FRAMES)
+        .word(0, 1)
+        .build();
+    // SAFETY: ipc_buf is the registered IPC buffer.
+    let reply = unsafe { ipc::ipc_call(memmgr_ep, &req, ipc_buf) }
+        .map_err(|_| io::Error::other("seraph fs: memmgr REQUEST_FRAMES ipc_call failed"))?;
+    if reply.label != memmgr_errors::SUCCESS
+    {
+        return Err(io::Error::other("seraph fs: memmgr REQUEST_FRAMES failed"));
+    }
+    let mut frame_cap = *reply
+        .caps()
+        .first()
+        .ok_or_else(|| io::Error::other("seraph fs: memmgr returned no frame"))?;
+
+    // Reserve VA and map the frame MAP_WRITABLE.
+    let range = crate::sys::reserve::reserve_pages(1).map_err(|_| {
+        let _ = syscall::cap_delete(frame_cap);
+        io::Error::other("seraph fs: reserve_pages failed for write frame")
+    })?;
+    let va = range.va_start();
+    if syscall::mem_map(frame_cap, aspace, va, 0, 1, syscall::MAP_WRITABLE).is_err()
+    {
+        crate::sys::reserve::unreserve_pages(range);
+        let _ = syscall::cap_delete(frame_cap);
+        return Err(io::Error::other("seraph fs: mem_map MAP_WRITABLE failed"));
+    }
+
+    let mut total: usize = 0;
+    let result: io::Result<()> = (|| {
+        while total < payload.len()
+        {
+            let chunk_len = (payload.len() - total).min(PAGE_SIZE_USIZE);
+            // Copy this chunk to the frame.
+            // SAFETY: VA is mapped MAP_WRITABLE for exactly one page;
+            // chunk_len ≤ PAGE_SIZE.
+            unsafe {
+                core::ptr::copy_nonoverlapping(
+                    payload.as_ptr().add(total),
+                    va as *mut u8,
+                    chunk_len,
+                );
+            }
+            let chunk_offset = base_offset.saturating_add(total as u64);
+            let msg = IpcMessage::builder(fs_labels::FS_WRITE_FRAME)
+                .word(0, chunk_offset)
+                .word(1, chunk_len as u64)
+                .word(2, 0)
+                .cap(frame_cap)
+                .build();
+            // SAFETY: ipc_buf is the registered IPC buffer.
+            let reply = unsafe { ipc::ipc_call(file_cap, &msg, ipc_buf) }
+                .map_err(|_| io::Error::other("seraph fs: FS_WRITE_FRAME ipc_call failed"))?;
+            if reply.label != fs_errors::SUCCESS
+            {
+                return Err(map_fs_error(reply.label));
+            }
+            // Server moves the source frame back in caps[0]; the slot
+            // id may differ from the one we sent.
+            frame_cap = *reply.caps().first().ok_or_else(|| {
+                io::Error::other("seraph fs: FS_WRITE_FRAME reply missing frame cap")
+            })?;
+            let n = reply.word(0) as usize;
+            total += n;
+            if n < chunk_len
+            {
+                // Short write — let the caller (`write_all`) iterate.
+                break;
+            }
+        }
+        Ok(())
+    })();
+
+    // Tear down regardless of result.
+    let _ = syscall::mem_unmap(aspace, va, 1);
+    let _ = syscall::cap_delete(frame_cap);
+    crate::sys::reserve::unreserve_pages(range);
+
+    result.map(|()| total)
+}
+
+/// Send `FS_TRUNCATE(0)` against `file_cap`. v1 only supports the
+/// truncate-to-zero shrink; the server replies `IO_ERROR` for any
+/// non-zero `new_len` and the client pre-rejects with `Unsupported`.
+fn file_truncate_zero(file_cap: u32, ipc_buf: *mut u64) -> io::Result<()>
+{
+    let msg = IpcMessage::builder(fs_labels::FS_TRUNCATE).word(0, 0).build();
+    // SAFETY: ipc_buf is the registered IPC buffer.
+    let reply = unsafe { ipc::ipc_call(file_cap, &msg, ipc_buf) }
+        .map_err(|_| io::Error::other("seraph fs: FS_TRUNCATE ipc_call failed"))?;
+    if reply.label != fs_errors::SUCCESS
+    {
+        return Err(map_fs_error(reply.label));
+    }
+    Ok(())
+}
+
+/// Create a new file at `path`. Splits to (parent_dir_cap, leaf),
+/// issues `FS_CREATE`, and returns the new file cap and size (0).
+///
+/// When `allow_existing` is false the helper surfaces `AlreadyExists`
+/// on `fs_errors::EXISTS` (this is the `OpenOptions::create_new`
+/// path). When true, the helper falls back to walking the existing
+/// leaf via `NS_LOOKUP` so the caller can open the existing file
+/// (this is the `OpenOptions::create` path).
+fn create_file_at(
+    path: &Path,
+    ipc_buf: *mut u64,
+    allow_existing: bool,
+) -> io::Result<(u32, u64)>
+{
+    let split = split_parent_and_leaf(path, ipc_buf)?;
+
+    let label = fs_labels::FS_CREATE | ((split.leaf.len() as u64) << 16);
+    let msg = IpcMessage::builder(label).bytes(0, &split.leaf).build();
+    // SAFETY: ipc_buf is the registered IPC buffer.
+    let reply = match unsafe { ipc::ipc_call(split.parent_cap, &msg, ipc_buf) }
+    {
+        Ok(r) => r,
+        Err(_) =>
+        {
+            release_split_parent(&split);
+            return Err(io::Error::other("seraph fs: FS_CREATE ipc_call failed"));
+        }
+    };
+
+    if reply.label == fs_errors::SUCCESS
+    {
+        let cap = match reply.caps().first()
+        {
+            Some(&c) => c,
+            None =>
+            {
+                release_split_parent(&split);
+                return Err(io::Error::other("seraph fs: FS_CREATE reply missing cap"));
+            }
+        };
+        release_split_parent(&split);
+        return Ok((cap, 0));
+    }
+
+    if reply.label == fs_errors::EXISTS && allow_existing
+    {
+        // Fall through to open-existing via a one-hop NS_LOOKUP on the
+        // parent cap.
+        let walked = walk_components(
+            split.parent_cap,
+            core::str::from_utf8(&split.leaf).unwrap_or(""),
+            0xFFFF,
+            ipc_buf,
+            ExpectKind::File,
+        );
+        release_split_parent(&split);
+        let walked = walked?;
+        return Ok((walked.cap, walked.size));
+    }
+
+    release_split_parent(&split);
+    Err(map_fs_error(reply.label))
 }
 
 // ── File ──────────────────────────────────────────────────────────────────
@@ -508,8 +1013,8 @@ pub struct File
 {
     /// Per-file node capability returned by the final `NS_LOOKUP` of
     /// the open walk. Receives every file-scoped op (FS_READ,
-    /// FS_READ_FRAME, FS_CLOSE, synchronous client-initiated
-    /// FS_RELEASE_FRAME).
+    /// FS_READ_FRAME, FS_WRITE, FS_WRITE_FRAME, FS_TRUNCATE,
+    /// FS_CLOSE, synchronous client-initiated FS_RELEASE_FRAME).
     file_cap: u32,
     /// Token identifying this `File` for the release-handler dispatch.
     /// Carried inside the per-process release endpoint so an inbound
@@ -528,47 +1033,71 @@ pub struct File
     release_delivered: AtomicBool,
     /// Process aspace cap, captured at open for `mem_map` / `mem_unmap`.
     aspace: u32,
+    /// memmgr endpoint cap captured at open; used by the write-frame
+    /// path to acquire single-page DMA source frames.
+    memmgr_ep: u32,
     /// Per-file outstanding-mappings registration in the handler.
     entry: Arc<FileEntry>,
-    /// Current read offset; advanced by every successful `read`.
+    /// Current read/write offset; advanced by every successful op.
     pos: AtomicU64,
-    /// File size from the final `NS_LOOKUP`'s `size_hint`. v1 is
-    /// read-only so this never changes after open.
-    size: u64,
+    /// Live file size. Initial value from the open walk's size hint;
+    /// mutated on every write that extends past EOF and reset by
+    /// `truncate`.
+    size: AtomicU64,
+    /// `OpenOptions::write || OpenOptions::append`. Drives the write
+    /// path's permission check; the server enforces `WRITE` rights
+    /// anyway, but the local check returns `Unsupported` faster.
+    writable: bool,
+    /// `OpenOptions::append`. When set, every write recomputes its
+    /// effective offset as `max(pos, size)` so the bytes always land
+    /// at EOF even if another writer extended the file since open.
+    append: bool,
 }
 
 impl File
 {
     pub fn open(path: &Path, opts: &OpenOptions) -> io::Result<File>
     {
-        if !opts.read || opts.write || opts.append || opts.truncate || opts.create || opts.create_new
-        {
-            // v1: read-only File. Anything else is a usage bug for now;
-            // surface as Unsupported rather than silently ignoring the
-            // requested mode bits.
-            return unsupported();
-        }
-        let path_str = path
-            .to_str()
-            .ok_or_else(|| io::const_error!(io::ErrorKind::InvalidInput, "seraph fs: non-UTF-8 path"))?;
-        // Anchor the walk: leading `/` → walk from `root_dir_cap()`;
-        // anything else → walk from `current_dir_cap()`. The walk
-        // helper itself strips empty leading components, so passing
-        // the path through as-is is correct in either case.
-        let anchor_cap = if path_str.starts_with('/') {
-            crate::os::seraph::root_dir_cap()
-        } else {
-            crate::os::seraph::current_dir_cap()
-        };
-        if anchor_cap == 0
+        // ── Flag-combination validation ──────────────────────────────
+        if !opts.read && !opts.write && !opts.append
         {
             return Err(io::const_error!(
-                io::ErrorKind::Unsupported,
-                "seraph fs: no anchor dir cap for this path \
-                 (root_dir_cap zero for absolute paths; current_dir_cap \
-                  zero for relative paths)",
+                io::ErrorKind::InvalidInput,
+                "seraph fs: open with no access mode",
             ));
         }
+        if opts.append && opts.truncate
+        {
+            return Err(io::const_error!(
+                io::ErrorKind::InvalidInput,
+                "seraph fs: append and truncate are mutually exclusive",
+            ));
+        }
+        if opts.truncate && !(opts.write || opts.append)
+        {
+            return Err(io::const_error!(
+                io::ErrorKind::InvalidInput,
+                "seraph fs: truncate requires write",
+            ));
+        }
+        if opts.create && !(opts.write || opts.append)
+        {
+            return Err(io::const_error!(
+                io::ErrorKind::InvalidInput,
+                "seraph fs: create requires write",
+            ));
+        }
+        if opts.create_new && !(opts.write || opts.append)
+        {
+            return Err(io::const_error!(
+                io::ErrorKind::InvalidInput,
+                "seraph fs: create_new requires write",
+            ));
+        }
+
+        let writable = opts.write || opts.append;
+
+        // ── Process-info / IPC buffer plumbing ───────────────────────
         let info = crate::os::seraph::try_startup_info().ok_or_else(|| {
             io::Error::other("seraph fs: startup info not installed")
         })?;
@@ -578,15 +1107,73 @@ impl File
             return Err(io::Error::other("seraph fs: IPC buffer not registered"));
         }
 
-        // Allocate the per-`File` release-endpoint plumbing up front.
-        // The `release_send` cap is unused on the inline `FS_READ`
-        // path; on the first `FS_READ_FRAME` it is transferred to the
-        // driver in `caps[0]` so the driver's eviction worker can
-        // route cooperative `FS_RELEASE_FRAME` back here. On any
-        // walk-failure path below the setup is rolled back
-        // (cap_delete + unregister) so a refused open never leaks an
-        // entry into the release handler.
-        let state = release_handler::ensure_started()?;
+        // ── Resolve / create the file cap ────────────────────────────
+        let (file_cap, mut size) = if opts.create_new
+        {
+            // Fail if the leaf already exists.
+            create_file_at(path, ipc_buf, /*allow_existing=*/ false)?
+        }
+        else if opts.create
+        {
+            // Create-or-open. On EXISTS we fall back to the existing
+            // file's cap.
+            create_file_at(path, ipc_buf, /*allow_existing=*/ true)?
+        }
+        else
+        {
+            // Walk-to-existing.
+            let path_str = path.to_str().ok_or_else(|| {
+                io::const_error!(io::ErrorKind::InvalidInput, "seraph fs: non-UTF-8 path")
+            })?;
+            let anchor_cap = if path_str.starts_with('/')
+            {
+                crate::os::seraph::root_dir_cap()
+            }
+            else
+            {
+                crate::os::seraph::current_dir_cap()
+            };
+            if anchor_cap == 0
+            {
+                return Err(io::const_error!(
+                    io::ErrorKind::Unsupported,
+                    "seraph fs: no anchor dir cap for this path \
+                     (root_dir_cap zero for absolute paths; current_dir_cap \
+                      zero for relative paths)",
+                ));
+            }
+            let walked = walk_path_to_file(anchor_cap, path_str, ipc_buf)?;
+            (walked.file_cap, walked.size)
+        };
+
+        // ── Optional truncate-to-zero on an existing file ────────────
+        if opts.truncate && size != 0
+        {
+            if let Err(e) = file_truncate_zero(file_cap, ipc_buf)
+            {
+                let _ = syscall::cap_delete(file_cap);
+                return Err(e);
+            }
+            size = 0;
+        }
+
+        // ── Release-handler plumbing ─────────────────────────────────
+        //
+        // The `release_send` cap is unused on the inline `FS_READ`/
+        // `FS_WRITE` paths; on the first `FS_READ_FRAME` it is
+        // transferred to the driver in `caps[0]` so the driver's
+        // eviction worker can route cooperative `FS_RELEASE_FRAME`
+        // back here. Failure paths below roll the setup back so a
+        // refused open never leaks an entry into the release handler.
+        let state = match release_handler::ensure_started()
+        {
+            Ok(s) => s,
+            Err(e) =>
+            {
+                let _ = syscall::cap_delete(file_cap);
+                return Err(e);
+            }
+        };
         let token = release_handler::allocate_token(state);
         let entry = release_handler::register(state, token);
 
@@ -598,36 +1185,41 @@ impl File
                 Err(_) =>
                 {
                     let _ = release_handler::unregister(state, token);
+                    let _ = syscall::cap_delete(file_cap);
                     return Err(io::Error::other(
                         "seraph fs: cap_derive_token (release send) failed",
                     ));
                 }
             };
 
-        let walked = match walk_path_to_file(anchor_cap, path_str, ipc_buf)
-        {
-            Ok(w) => w,
-            Err(e) =>
-            {
-                let _ = syscall::cap_delete(release_send);
-                let _ = release_handler::unregister(state, token);
-                return Err(e);
-            }
-        };
+        // ── Initial position: EOF for append, 0 otherwise ────────────
+        let initial_pos = if opts.append { size } else { 0 };
 
         Ok(File {
-            file_cap: walked.file_cap,
+            file_cap,
             token,
             release_send,
             release_delivered: AtomicBool::new(false),
             aspace: info.self_aspace,
+            memmgr_ep: info.memmgr_endpoint,
             entry,
-            pos: AtomicU64::new(0),
-            size: walked.size,
+            pos: AtomicU64::new(initial_pos),
+            size: AtomicU64::new(size),
+            writable,
+            append: opts.append,
         })
     }
 
-    pub fn file_attr(&self) -> io::Result<FileAttr> { Ok(FileAttr { size: self.size }) }
+    pub fn file_attr(&self) -> io::Result<FileAttr>
+    {
+        // File handles are always files (the open walk rejects dir
+        // leaves). Carry the live size; mtime is zero until #85.
+        Ok(FileAttr {
+            size: self.size.load(Ordering::Relaxed),
+            kind: NodeKind::File,
+            mtime_us: 0,
+        })
+    }
     pub fn fsync(&self) -> io::Result<()> { Ok(()) }
     pub fn datasync(&self) -> io::Result<()> { Ok(()) }
     pub fn lock(&self) -> io::Result<()> { unsupported() }
@@ -641,7 +1233,37 @@ impl File
         Err(TryLockError::Error(unsupported_err()))
     }
     pub fn unlock(&self) -> io::Result<()> { unsupported() }
-    pub fn truncate(&self, _: u64) -> io::Result<()> { unsupported() }
+
+    pub fn truncate(&self, new_len: u64) -> io::Result<()>
+    {
+        if new_len != 0
+        {
+            // v1: only shrink-to-zero is implemented. Extend-with-
+            // zero-fill is in the post-#8 completeness-gaps Issue.
+            return Err(io::const_error!(
+                io::ErrorKind::Unsupported,
+                "seraph fs: File::set_len(non-zero) not supported in v1",
+            ));
+        }
+        if !self.writable
+        {
+            return Err(io::const_error!(
+                io::ErrorKind::PermissionDenied,
+                "seraph fs: truncate on a read-only File",
+            ));
+        }
+        let ipc_buf = crate::os::seraph::current_ipc_buf();
+        if ipc_buf.is_null()
+        {
+            return Err(io::Error::other("seraph fs: IPC buffer not registered"));
+        }
+        file_truncate_zero(self.file_cap, ipc_buf)?;
+        self.size.store(0, Ordering::Relaxed);
+        // Clamp pos to the new (zero) length; subsequent reads/writes
+        // start from offset 0.
+        self.pos.store(0, Ordering::Relaxed);
+        Ok(())
+    }
 
     pub fn read(&self, buf: &mut [u8]) -> io::Result<usize>
     {
@@ -650,11 +1272,12 @@ impl File
             return Ok(0);
         }
         let pos = self.pos.load(Ordering::Relaxed);
-        if pos >= self.size
+        let cur_size = self.size.load(Ordering::Relaxed);
+        if pos >= cur_size
         {
             return Ok(0);
         }
-        let remaining = self.size - pos;
+        let remaining = cur_size - pos;
         let want = (buf.len() as u64).min(remaining) as usize;
 
         // Inline path: small reads or page-tail reads that don't cross a
@@ -823,8 +1446,74 @@ impl File
         Ok(())
     }
 
-    pub fn write(&self, _: &[u8]) -> io::Result<usize> { unsupported() }
-    pub fn write_vectored(&self, _: &[IoSlice<'_>]) -> io::Result<usize> { unsupported() }
+    pub fn write(&self, buf: &[u8]) -> io::Result<usize>
+    {
+        if !self.writable
+        {
+            return Err(io::const_error!(
+                io::ErrorKind::PermissionDenied,
+                "seraph fs: write on a non-writable File",
+            ));
+        }
+        if buf.is_empty()
+        {
+            return Ok(0);
+        }
+        let ipc_buf = crate::os::seraph::current_ipc_buf();
+        if ipc_buf.is_null()
+        {
+            return Err(io::Error::other("seraph fs: IPC buffer not registered"));
+        }
+
+        // Compute the effective offset: append always lands at EOF; a
+        // racing extender may have moved EOF since the last position
+        // update, so we clamp pos up to the live size.
+        let offset = if self.append
+        {
+            let cur_pos = self.pos.load(Ordering::Relaxed);
+            let cur_size = self.size.load(Ordering::Relaxed);
+            cur_pos.max(cur_size)
+        }
+        else
+        {
+            self.pos.load(Ordering::Relaxed)
+        };
+
+        // Hybrid: inline ≤ 504 bytes, frame path larger. Threshold is
+        // the FS_WRITE IPC payload ceiling — see `WRITE_INLINE_THRESHOLD`.
+        let n = if buf.len() <= WRITE_INLINE_THRESHOLD
+        {
+            write_inline(self.file_cap, offset, buf, ipc_buf)?
+        }
+        else
+        {
+            write_frame_chunks(
+                self.file_cap,
+                self.aspace,
+                self.memmgr_ep,
+                offset,
+                buf,
+                ipc_buf,
+            )?
+        };
+
+        // Advance position and extend live size if needed.
+        let new_offset = offset.saturating_add(n as u64);
+        self.pos.store(new_offset, Ordering::Relaxed);
+        let _ = self.size.fetch_max(new_offset, Ordering::Relaxed);
+        Ok(n)
+    }
+    pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize>
+    {
+        for b in bufs
+        {
+            if !b.is_empty()
+            {
+                return self.write(b);
+            }
+        }
+        Ok(0)
+    }
     pub fn is_write_vectored(&self) -> bool { false }
     pub fn flush(&self) -> io::Result<()> { Ok(()) }
 
@@ -833,7 +1522,11 @@ impl File
         let new = match pos
         {
             SeekFrom::Start(o) => o,
-            SeekFrom::End(o) => ((self.size as i64).saturating_add(o)).max(0) as u64,
+            SeekFrom::End(o) =>
+            {
+                let cur_size = self.size.load(Ordering::Relaxed) as i64;
+                cur_size.saturating_add(o).max(0) as u64
+            }
             SeekFrom::Current(o) =>
             {
                 let cur = self.pos.load(Ordering::Relaxed) as i64;
@@ -843,7 +1536,10 @@ impl File
         self.pos.store(new, Ordering::Relaxed);
         Ok(new)
     }
-    pub fn size(&self) -> Option<io::Result<u64>> { Some(Ok(self.size)) }
+    pub fn size(&self) -> Option<io::Result<u64>>
+    {
+        Some(Ok(self.size.load(Ordering::Relaxed)))
+    }
     pub fn tell(&self) -> io::Result<u64> { Ok(self.pos.load(Ordering::Relaxed)) }
     pub fn duplicate(&self) -> io::Result<File> { unsupported() }
     pub fn set_permissions(&self, _: FilePermissions) -> io::Result<()> { unsupported() }
@@ -857,7 +1553,7 @@ impl fmt::Debug for File
         f.debug_struct("File")
             .field("file_cap", &self.file_cap)
             .field("token", &self.token)
-            .field("size", &self.size)
+            .field("size", &self.size.load(Ordering::Relaxed))
             .finish()
     }
 }
@@ -966,29 +1662,492 @@ fn map_fs_error(label: u64) -> io::Error
             io::const_error!(io::ErrorKind::NotFound, "fs: not found"),
         fs_errors::IO_ERROR =>
             io::const_error!(io::ErrorKind::Other, "fs: io error"),
+        fs_errors::TOO_MANY_OPEN =>
+            io::const_error!(io::ErrorKind::ResourceBusy, "fs: too many open files"),
         fs_errors::INVALID_TOKEN =>
             io::const_error!(io::ErrorKind::Other, "fs: file token invalid"),
+        fs_errors::RELEASE_TIMEOUT =>
+            io::const_error!(io::ErrorKind::TimedOut, "fs: release timeout"),
+        fs_errors::BAD_FRAME_OFFSET =>
+            io::const_error!(io::ErrorKind::InvalidInput, "fs: bad frame offset"),
         fs_errors::PERMISSION_DENIED =>
             io::const_error!(io::ErrorKind::PermissionDenied, "fs: permission denied"),
+        fs_errors::LABEL_VERSION_MISMATCH =>
+            io::const_error!(io::ErrorKind::Other, "fs: label version mismatch"),
+        fs_errors::EXISTS =>
+            io::const_error!(io::ErrorKind::AlreadyExists, "fs: already exists"),
+        fs_errors::NO_SPACE =>
+            io::const_error!(io::ErrorKind::StorageFull, "fs: no space"),
+        fs_errors::NOT_EMPTY =>
+            io::const_error!(io::ErrorKind::DirectoryNotEmpty, "fs: directory not empty"),
+        fs_errors::IS_A_DIRECTORY =>
+            io::const_error!(io::ErrorKind::IsADirectory, "fs: is a directory"),
+        fs_errors::UNKNOWN_OPCODE =>
+            io::const_error!(io::ErrorKind::Unsupported, "fs: unknown opcode"),
         _ => io::Error::other("fs: unknown error"),
     }
 }
 
-// ── Free functions: all Unsupported on v1 ─────────────────────────────────
+// ── Free functions ────────────────────────────────────────────────────────
 
-pub fn readdir(_: &Path) -> io::Result<ReadDir> { unsupported() }
-pub fn unlink(_: &Path) -> io::Result<()> { unsupported() }
-pub fn rename(_: &Path, _: &Path) -> io::Result<()> { unsupported() }
+/// `std::fs::read_dir` backend. Walks to the target directory, then
+/// returns a `ReadDir` iterator that issues `NS_READDIR` per `next()`
+/// and `cap_delete`s the dir cap on drop.
+pub fn readdir(path: &Path) -> io::Result<ReadDir>
+{
+    let path_str = path.to_str().ok_or_else(|| {
+        io::const_error!(io::ErrorKind::InvalidInput, "seraph fs: non-UTF-8 path")
+    })?;
+    let ipc_buf = crate::os::seraph::current_ipc_buf();
+    if ipc_buf.is_null()
+    {
+        return Err(io::Error::other("seraph fs: IPC buffer not registered"));
+    }
+    let anchor_cap = if path_str.starts_with('/')
+    {
+        crate::os::seraph::root_dir_cap()
+    }
+    else
+    {
+        crate::os::seraph::current_dir_cap()
+    };
+    if anchor_cap == 0
+    {
+        return Err(io::const_error!(
+            io::ErrorKind::Unsupported,
+            "seraph fs: no anchor dir cap for this path",
+        ));
+    }
+    let walked = walk_path_to_dir(anchor_cap, path_str, ipc_buf)?;
+    Ok(ReadDir {
+        dir_cap: walked.dir_cap,
+        next_idx: 0,
+        parent_path: PathBuf::from(path_str),
+    })
+}
+
+/// Unlink a regular file. Returns `IsADirectory` if the leaf resolves
+/// to a directory (use `rmdir` / `remove_dir_all` for those).
+pub fn unlink(path: &Path) -> io::Result<()>
+{
+    remove_leaf(path, /*expect_dir=*/ false)
+}
+
+/// Remove an empty directory. Returns `NotADirectory` if the leaf
+/// resolves to a regular file; returns `DirectoryNotEmpty` if the
+/// directory is non-empty.
+pub fn rmdir(path: &Path) -> io::Result<()>
+{
+    remove_leaf(path, /*expect_dir=*/ true)
+}
+
+fn remove_leaf(path: &Path, expect_dir: bool) -> io::Result<()>
+{
+    let ipc_buf = crate::os::seraph::current_ipc_buf();
+    if ipc_buf.is_null()
+    {
+        return Err(io::Error::other("seraph fs: IPC buffer not registered"));
+    }
+    let split = split_parent_and_leaf(path, ipc_buf)?;
+
+    // Verify the kind before issuing FS_REMOVE so we surface the std
+    // ErrorKind for "wrong kind" rather than relying on the server to
+    // distinguish (it returns NOT_EMPTY for non-empty dirs but doesn't
+    // distinguish file-vs-dir at the wire). One-hop NS_LOOKUP.
+    let walked = match walk_components(
+        split.parent_cap,
+        core::str::from_utf8(&split.leaf).unwrap_or(""),
+        0xFFFF,
+        ipc_buf,
+        ExpectKind::Any,
+    )
+    {
+        Ok(w) => w,
+        Err(e) =>
+        {
+            release_split_parent(&split);
+            return Err(e);
+        }
+    };
+    let kind_is_dir = matches!(walked.kind, NodeKind::Dir);
+    let _ = syscall::cap_delete(walked.cap);
+    if expect_dir && !kind_is_dir
+    {
+        release_split_parent(&split);
+        return Err(io::const_error!(
+            io::ErrorKind::NotADirectory,
+            "seraph fs: target is not a directory",
+        ));
+    }
+    if !expect_dir && kind_is_dir
+    {
+        release_split_parent(&split);
+        return Err(io::const_error!(
+            io::ErrorKind::IsADirectory,
+            "seraph fs: target is a directory",
+        ));
+    }
+
+    let label = fs_labels::FS_REMOVE | ((split.leaf.len() as u64) << 16);
+    let msg = IpcMessage::builder(label).bytes(0, &split.leaf).build();
+    // SAFETY: ipc_buf is the registered IPC buffer.
+    let reply = unsafe { ipc::ipc_call(split.parent_cap, &msg, ipc_buf) };
+    release_split_parent(&split);
+    let reply = reply.map_err(|_| io::Error::other("seraph fs: FS_REMOVE ipc_call failed"))?;
+    if reply.label != fs_errors::SUCCESS
+    {
+        return Err(map_fs_error(reply.label));
+    }
+    Ok(())
+}
+
+/// Create a new (empty) directory at `path`. Drops the returned dir
+/// cap — the std contract does not surface it to the caller.
+pub fn mkdir(path: &Path) -> io::Result<()>
+{
+    let ipc_buf = crate::os::seraph::current_ipc_buf();
+    if ipc_buf.is_null()
+    {
+        return Err(io::Error::other("seraph fs: IPC buffer not registered"));
+    }
+    let split = split_parent_and_leaf(path, ipc_buf)?;
+    let label = fs_labels::FS_MKDIR | ((split.leaf.len() as u64) << 16);
+    let msg = IpcMessage::builder(label).bytes(0, &split.leaf).build();
+    // SAFETY: ipc_buf is the registered IPC buffer.
+    let reply = unsafe { ipc::ipc_call(split.parent_cap, &msg, ipc_buf) };
+    release_split_parent(&split);
+    let reply = reply.map_err(|_| io::Error::other("seraph fs: FS_MKDIR ipc_call failed"))?;
+    if reply.label != fs_errors::SUCCESS
+    {
+        return Err(map_fs_error(reply.label));
+    }
+    if let Some(&cap) = reply.caps().first()
+    {
+        let _ = syscall::cap_delete(cap);
+    }
+    Ok(())
+}
+
+/// Rename an entry within a single directory. Cross-directory rename
+/// is not supported on the wire (see `shared/ipc/src/lib.rs`
+/// `FS_RENAME` rustdoc) and is tracked separately; the PAL surfaces
+/// it as `InvalidInput`.
+pub fn rename(from: &Path, to: &Path) -> io::Result<()>
+{
+    let ipc_buf = crate::os::seraph::current_ipc_buf();
+    if ipc_buf.is_null()
+    {
+        return Err(io::Error::other("seraph fs: IPC buffer not registered"));
+    }
+    let src = split_parent_and_leaf(from, ipc_buf)?;
+    let dst = match split_parent_and_leaf(to, ipc_buf)
+    {
+        Ok(s) => s,
+        Err(e) =>
+        {
+            release_split_parent(&src);
+            return Err(e);
+        }
+    };
+
+    // Same-parent enforcement. We compare cap slot ids: if both were
+    // walked from the same anchor with no intermediate split (i.e.
+    // both `parent_owned=false`) the anchors match by construction;
+    // when both are owned they are distinct freshly-derived sub-caps
+    // even if the path components are identical, so we cannot
+    // syntactically compare them. Instead use the source path strings.
+    let src_str = from.to_str().unwrap_or("");
+    let dst_str = to.to_str().unwrap_or("");
+    let src_parent = src_str.rsplitn(2, '/').nth(1).unwrap_or("");
+    let dst_parent = dst_str.rsplitn(2, '/').nth(1).unwrap_or("");
+    if src_parent != dst_parent
+    {
+        release_split_parent(&src);
+        release_split_parent(&dst);
+        return Err(io::const_error!(
+            io::ErrorKind::InvalidInput,
+            "seraph fs: cross-directory rename not supported",
+        ));
+    }
+
+    // Build the FS_RENAME request: word(0)=src_len, word(1)=dst_len,
+    // names contiguous from word 2.
+    let mut combined = Vec::with_capacity(src.leaf.len() + dst.leaf.len());
+    combined.extend_from_slice(&src.leaf);
+    combined.extend_from_slice(&dst.leaf);
+    let msg = IpcMessage::builder(fs_labels::FS_RENAME)
+        .word(0, src.leaf.len() as u64)
+        .word(1, dst.leaf.len() as u64)
+        .bytes(2, &combined)
+        .build();
+    // SAFETY: ipc_buf is the registered IPC buffer.
+    let reply = unsafe { ipc::ipc_call(src.parent_cap, &msg, ipc_buf) };
+    release_split_parent(&src);
+    release_split_parent(&dst);
+    let reply = reply.map_err(|_| io::Error::other("seraph fs: FS_RENAME ipc_call failed"))?;
+    if reply.label != fs_errors::SUCCESS
+    {
+        return Err(map_fs_error(reply.label));
+    }
+    Ok(())
+}
+
 pub fn set_perm(_: &Path, _: FilePermissions) -> io::Result<()> { unsupported() }
 pub fn set_times(_: &Path, _: FileTimes) -> io::Result<()> { unsupported() }
 pub fn set_times_nofollow(_: &Path, _: FileTimes) -> io::Result<()> { unsupported() }
-pub fn rmdir(_: &Path) -> io::Result<()> { unsupported() }
-pub fn remove_dir_all(_: &Path) -> io::Result<()> { unsupported() }
-pub fn exists(_: &Path) -> io::Result<bool> { unsupported() }
-pub fn readlink(_: &Path) -> io::Result<PathBuf> { unsupported() }
-pub fn symlink(_: &Path, _: &Path) -> io::Result<()> { unsupported() }
-pub fn link(_: &Path, _: &Path) -> io::Result<()> { unsupported() }
-pub fn stat(_: &Path) -> io::Result<FileAttr> { unsupported() }
-pub fn lstat(_: &Path) -> io::Result<FileAttr> { unsupported() }
+
+/// Recursive removal of a directory tree. Client-side: enumerate via
+/// `NS_READDIR`, recurse into subdirs, `FS_REMOVE` leaves, then
+/// `FS_REMOVE` the now-empty target. FAT slot indices shift after
+/// every removal, so the iterator restarts at idx=0 after each
+/// removal.
+pub fn remove_dir_all(path: &Path) -> io::Result<()>
+{
+    let ipc_buf = crate::os::seraph::current_ipc_buf();
+    if ipc_buf.is_null()
+    {
+        return Err(io::Error::other("seraph fs: IPC buffer not registered"));
+    }
+
+    // Resolve the top-level target's parent + leaf. The leaf is the
+    // dir to drain; the parent receives the final FS_REMOVE.
+    let split = split_parent_and_leaf(path, ipc_buf)?;
+
+    // Look up the target dir cap (must be a Dir).
+    let leaf_str = core::str::from_utf8(&split.leaf).unwrap_or("");
+    let walked = match walk_components(
+        split.parent_cap,
+        leaf_str,
+        0xFFFF,
+        ipc_buf,
+        ExpectKind::Any,
+    )
+    {
+        Ok(w) => w,
+        Err(e) =>
+        {
+            release_split_parent(&split);
+            return Err(e);
+        }
+    };
+    if !matches!(walked.kind, NodeKind::Dir)
+    {
+        let _ = syscall::cap_delete(walked.cap);
+        release_split_parent(&split);
+        return Err(io::const_error!(
+            io::ErrorKind::NotADirectory,
+            "seraph fs: target is not a directory",
+        ));
+    }
+
+    let result = drain_dir_recursive(walked.cap, ipc_buf);
+    let _ = syscall::cap_delete(walked.cap);
+    result?;
+
+    // Final FS_REMOVE for the now-empty target.
+    let label = fs_labels::FS_REMOVE | ((split.leaf.len() as u64) << 16);
+    let msg = IpcMessage::builder(label).bytes(0, &split.leaf).build();
+    // SAFETY: ipc_buf is the registered IPC buffer.
+    let reply = unsafe { ipc::ipc_call(split.parent_cap, &msg, ipc_buf) };
+    release_split_parent(&split);
+    let reply = reply.map_err(|_| io::Error::other("seraph fs: FS_REMOVE ipc_call failed"))?;
+    if reply.label != fs_errors::SUCCESS
+    {
+        return Err(map_fs_error(reply.label));
+    }
+    Ok(())
+}
+
+/// Drain every entry under `dir_cap`. Iterates `NS_READDIR` forward
+/// across `.` / `..`; for every other entry it recurses into the
+/// subtree if it is a directory, then `FS_REMOVE`s the entry by name
+/// on `dir_cap`. After each removal the cursor restarts at zero
+/// because FAT compacts indices when an entry is freed.
+fn drain_dir_recursive(dir_cap: u32, ipc_buf: *mut u64) -> io::Result<()>
+{
+    let mut idx = 0u64;
+    loop
+    {
+        let entry = match ns_readdir_one(dir_cap, idx, ipc_buf)?
+        {
+            Some(e) => e,
+            None => return Ok(()),
+        };
+        if entry.name == b"." || entry.name == b".."
+        {
+            idx = idx.saturating_add(1);
+            continue;
+        }
+
+        if matches!(entry.kind, NodeKind::Dir)
+        {
+            let leaf_str = core::str::from_utf8(&entry.name).unwrap_or("");
+            let walked = walk_components(
+                dir_cap,
+                leaf_str,
+                0xFFFF,
+                ipc_buf,
+                ExpectKind::Dir,
+            )?;
+            let drain_res = drain_dir_recursive(walked.cap, ipc_buf);
+            let _ = syscall::cap_delete(walked.cap);
+            drain_res?;
+        }
+
+        let label = fs_labels::FS_REMOVE | ((entry.name.len() as u64) << 16);
+        let msg = IpcMessage::builder(label).bytes(0, &entry.name).build();
+        // SAFETY: ipc_buf is the registered IPC buffer.
+        let reply = unsafe { ipc::ipc_call(dir_cap, &msg, ipc_buf) }
+            .map_err(|_| io::Error::other("seraph fs: FS_REMOVE ipc_call failed"))?;
+        if reply.label != fs_errors::SUCCESS
+        {
+            return Err(map_fs_error(reply.label));
+        }
+        idx = 0;
+    }
+}
+
+struct ReaddirEntry
+{
+    name: Vec<u8>,
+    kind: NodeKind,
+}
+
+/// Issue a single `NS_READDIR(idx)` against `dir_cap`. Returns
+/// `Ok(None)` on `END_OF_DIR`.
+fn ns_readdir_one(
+    dir_cap: u32,
+    idx: u64,
+    ipc_buf: *mut u64,
+) -> io::Result<Option<ReaddirEntry>>
+{
+    let msg = IpcMessage::builder(ns_labels::NS_READDIR)
+        .word(0, idx)
+        .build();
+    // SAFETY: ipc_buf is the registered IPC buffer.
+    let reply = unsafe { ipc::ipc_call(dir_cap, &msg, ipc_buf) }
+        .map_err(|_| io::Error::other("seraph fs: NS_READDIR ipc_call failed"))?;
+    if reply.label == fs_labels::END_OF_DIR
+    {
+        return Ok(None);
+    }
+    if reply.label != 0
+    {
+        return Err(ns_error_to_io(reply.label));
+    }
+    let kind_word = reply.word(0);
+    let name_len = reply.word(1) as usize;
+    let bytes = reply.data_bytes();
+    const NAME_OFF: usize = 16;
+    let end = NAME_OFF.saturating_add(name_len).min(bytes.len());
+    if end < NAME_OFF + name_len
+    {
+        return Err(io::Error::other("seraph fs: NS_READDIR truncated name"));
+    }
+    let kind = if kind_word == NodeKind::Dir as u64
+    {
+        NodeKind::Dir
+    }
+    else
+    {
+        NodeKind::File
+    };
+    Ok(Some(ReaddirEntry {
+        name: bytes[NAME_OFF..end].to_vec(),
+        kind,
+    }))
+}
+
+/// `std::fs::exists`. Returns `Ok(false)` for `NotFound`; surfaces
+/// every other walk error (e.g. `PermissionDenied`).
+pub fn exists(path: &Path) -> io::Result<bool>
+{
+    match stat(path)
+    {
+        Ok(_) => Ok(true),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(e) => Err(e),
+    }
+}
+
+pub fn readlink(_: &Path) -> io::Result<PathBuf>
+{
+    Err(io::const_error!(
+        io::ErrorKind::Unsupported,
+        "seraph fs: symlinks are not supported on FAT",
+    ))
+}
+pub fn symlink(_: &Path, _: &Path) -> io::Result<()>
+{
+    Err(io::const_error!(
+        io::ErrorKind::Unsupported,
+        "seraph fs: symlinks are not supported on FAT",
+    ))
+}
+pub fn link(_: &Path, _: &Path) -> io::Result<()>
+{
+    Err(io::const_error!(
+        io::ErrorKind::Unsupported,
+        "seraph fs: hardlinks are not supported on FAT",
+    ))
+}
+
+/// `std::fs::metadata` backend. Walks the path (Any kind), issues
+/// `NS_STAT` against the resulting node cap, and returns a `FileAttr`
+/// carrying size + kind. mtime stays zero until #85 lands a clock
+/// source; `FileAttr::modified()` surfaces `Unsupported` in that case.
+pub fn stat(path: &Path) -> io::Result<FileAttr>
+{
+    let path_str = path.to_str().ok_or_else(|| {
+        io::const_error!(io::ErrorKind::InvalidInput, "seraph fs: non-UTF-8 path")
+    })?;
+    let ipc_buf = crate::os::seraph::current_ipc_buf();
+    if ipc_buf.is_null()
+    {
+        return Err(io::Error::other("seraph fs: IPC buffer not registered"));
+    }
+    let anchor_cap = if path_str.starts_with('/')
+    {
+        crate::os::seraph::root_dir_cap()
+    }
+    else
+    {
+        crate::os::seraph::current_dir_cap()
+    };
+    if anchor_cap == 0
+    {
+        return Err(io::const_error!(
+            io::ErrorKind::Unsupported,
+            "seraph fs: no anchor dir cap for this path",
+        ));
+    }
+    let walked = walk_components(anchor_cap, path_str, 0xFFFF, ipc_buf, ExpectKind::Any)?;
+    // NS_STAT against the walked node cap.
+    let msg = IpcMessage::new(ns_labels::NS_STAT);
+    // SAFETY: ipc_buf is the registered IPC buffer.
+    let reply = unsafe { ipc::ipc_call(walked.cap, &msg, ipc_buf) };
+    let _ = syscall::cap_delete(walked.cap);
+    let reply = reply.map_err(|_| io::Error::other("seraph fs: NS_STAT ipc_call failed"))?;
+    if reply.label != 0
+    {
+        return Err(ns_error_to_io(reply.label));
+    }
+    let size = reply.word(0);
+    let mtime_us = reply.word(1);
+    let kind_word = reply.word(2);
+    let kind = if kind_word == NodeKind::Dir as u64
+    {
+        NodeKind::Dir
+    }
+    else
+    {
+        NodeKind::File
+    };
+    Ok(FileAttr { size, kind, mtime_us })
+}
+
+/// FAT has no symlinks, so `lstat` and `stat` are equivalent.
+pub fn lstat(path: &Path) -> io::Result<FileAttr> { stat(path) }
+
 pub fn canonicalize(_: &Path) -> io::Result<PathBuf> { unsupported() }
 pub fn copy(_: &Path, _: &Path) -> io::Result<u64> { unsupported() }

--- a/services/fs/docs/fs-driver-protocol.md
+++ b/services/fs/docs/fs-driver-protocol.md
@@ -424,6 +424,31 @@ occupied), `NO_SPACE`, `IO_ERROR`, `PERMISSION_DENIED`.
 
 ---
 
+## Label 17: `FS_TRUNCATE`
+
+Set a file's length. Token = file cap with `WRITE`.
+
+**Request**:
+
+| Field | Value |
+|---|---|
+| `label` | `FS_TRUNCATE` (17) |
+| `data[0]` | New length in bytes |
+
+**Reply (success)**: `label = 0`, empty body.
+
+v1 supports only `new_len == 0`; non-zero replies `IO_ERROR`. The
+wire shape is forward-compatible with later extend-with-zero-fill
+semantics, tracked by the post-#8 `ruststd::fs` completeness-gaps
+Issue. The truncate-to-zero path frees the entire FAT cluster chain
+and patches the directory entry's first-cluster + size fields to 0.
+
+**Errors**: `INVALID_TOKEN`, `IS_A_DIRECTORY`, `PERMISSION_DENIED`,
+`IO_ERROR` (chain walk / `FSInfo` flush failure, or non-zero
+`new_len` until the v2 extend path lands).
+
+---
+
 ## Label 6: `END_OF_DIR`
 
 End-of-directory marker reused as a reply label by `NS_READDIR`. See

--- a/services/fs/fat/README.md
+++ b/services/fs/fat/README.md
@@ -42,6 +42,7 @@ fat/
 | `FS_REMOVE` | no | unlink a file or empty directory |
 | `FS_MKDIR` | no | new empty directory |
 | `FS_RENAME` | no | rename within a single directory |
+| `FS_TRUNCATE` | no | shrink a file to zero (v1: `new_len == 0` only) |
 
 `FS_RENAME` is single-directory only at v0.1.0 because servers cannot
 introspect the token packed in a received cap; cross-directory rename
@@ -49,8 +50,8 @@ needs either a kernel-level `cap_info` selector for tokens or a wire
 shape that conveys the destination `NodeId` out-of-band. Tracked as
 [Issue #89](https://github.com/kottlerg/seraph/issues/89).
 
-Per-label rights gating (`WRITE` for the write labels, `MUTATE_DIR`
-for the mutation labels) goes through
+Per-label rights gating (`WRITE` for the write / truncate labels,
+`MUTATE_DIR` for the directory-mutation labels) goes through
 [`namespace-protocol::gate`](../../../shared/namespace-protocol/src/gate.rs).
 The exact wire shapes are defined in
 [`shared/ipc/src/lib.rs`](../../../shared/ipc/src/lib.rs) and documented

--- a/services/fs/fat/src/main.rs
+++ b/services/fs/fat/src/main.rs
@@ -374,6 +374,19 @@ fn service_loop(
                 handle_rename_node_cap(node_id, &msg, state, nodes, cache, caps.block_dev, ipc_buf);
                 continue;
             }
+            fs_labels::FS_TRUNCATE =>
+            {
+                handle_truncate_node_cap(
+                    node_id,
+                    &msg,
+                    state,
+                    nodes,
+                    cache,
+                    caps.block_dev,
+                    ipc_buf,
+                );
+                continue;
+            }
             _ =>
             {}
         }
@@ -1612,6 +1625,69 @@ fn handle_rename_node_cap(
     // A later FS_WRITE through a held source cap would otherwise
     // patch a `0xE5`-marked entry.
     nodes.invalidate_for_loc(src_loc);
+
+    let reply = IpcMessage::new(ipc::fs_errors::SUCCESS);
+    // SAFETY: ipc_buf is the registered IPC buffer page.
+    let _ = unsafe { ipc::ipc_reply(&reply, ipc_buf) };
+}
+
+/// `FS_TRUNCATE`: shrink a file to a new length.
+///
+/// Token = file cap (must carry `WRITE`). `data[0]` = new length.
+/// v1 supports only `new_len == 0`; non-zero replies `IO_ERROR` so
+/// the wire shape is forward-compatible with later extend-with-
+/// zero-fill semantics tracked by the `ruststd::fs` completeness-gaps
+/// Issue.
+fn handle_truncate_node_cap(
+    node_id: NodeId,
+    msg: &IpcMessage,
+    state: &mut FatState,
+    nodes: &mut NodeTable,
+    cache: &PageCache,
+    block_dev: u32,
+    ipc_buf: *mut u64,
+)
+{
+    let Some(node) = nodes.get(node_id)
+    else
+    {
+        reply_err(ipc::fs_errors::INVALID_TOKEN, ipc_buf);
+        return;
+    };
+    if node.kind != NodeKind::File
+    {
+        reply_err(ipc::fs_errors::IS_A_DIRECTORY, ipc_buf);
+        return;
+    }
+    let new_len = msg.word(0);
+    if new_len != 0
+    {
+        // v1: only size=0 is supported. Non-zero is the extend-with-
+        // zero-fill case which needs new allocator work.
+        reply_err(ipc::fs_errors::IO_ERROR, ipc_buf);
+        return;
+    }
+
+    // Capture the old chain head before clearing, then free it.
+    let old_cluster = node.cluster;
+    let entry_loc = node.loc;
+
+    if old_cluster >= 2
+        && let Err(e) = alloc::free_cluster_chain(state, old_cluster, cache, block_dev, ipc_buf)
+    {
+        reply_err(fat_error_to_wire(e), ipc_buf);
+        return;
+    }
+
+    // Patch the directory entry: first cluster = 0, size = 0.
+    if entry_loc.sector_lba != 0
+        && let Err(e) = update_entry_metadata(entry_loc, 0, 0, cache, block_dev, ipc_buf)
+    {
+        reply_err(fat_error_to_wire(e), ipc_buf);
+        return;
+    }
+
+    nodes.update_size_and_cluster(node_id, 0, 0);
 
     let reply = IpcMessage::new(ipc::fs_errors::SUCCESS);
     // SAFETY: ipc_buf is the registered IPC buffer page.

--- a/shared/ipc/src/lib.rs
+++ b/shared/ipc/src/lib.rs
@@ -708,7 +708,7 @@ pub mod ns_labels
     pub const NS_READDIR: u64 = 22;
 }
 
-pub const FS_LABELS_VERSION: u32 = 2;
+pub const FS_LABELS_VERSION: u32 = 3;
 /// IPC labels for filesystem drivers (FAT, ext4, etc.).
 pub mod fs_labels
 {
@@ -836,6 +836,22 @@ pub mod fs_labels
     /// `NOT_FOUND` (source missing), `EXISTS` (destination occupied),
     /// `NO_SPACE`, `IO_ERROR`.
     pub const FS_RENAME: u64 = 16;
+    /// Truncate a file to a new length.
+    ///
+    /// Request: token = file-node cap (must carry `WRITE`),
+    /// `label = FS_TRUNCATE`, `data[0]` = new length in bytes.
+    ///
+    /// v1 supports only `new_len == 0` (sufficient for
+    /// `OpenOptions::truncate(true)` and `File::set_len(0)`); non-zero
+    /// lengths reply `IO_ERROR`. The wire shape is forward-compatible
+    /// with later extend-with-zero-fill semantics. The corresponding
+    /// follow-up is tracked in the `ruststd::fs` completeness-gaps Issue.
+    ///
+    /// Reply (label `fs_errors::SUCCESS`): empty body. Errors:
+    /// `INVALID_TOKEN`, `IS_A_DIRECTORY`, `PERMISSION_DENIED`,
+    /// `IO_ERROR` (chain walk / `FSInfo` flush failure, or non-zero
+    /// `new_len` until the v2 extend path lands).
+    pub const FS_TRUNCATE: u64 = 17;
 }
 
 pub const DEVMGR_LABELS_VERSION: u32 = 1;

--- a/shared/namespace-protocol/src/gate.rs
+++ b/shared/namespace-protocol/src/gate.rs
@@ -181,6 +181,10 @@ const RIGHTS_TABLE: &[(u64, RightsRequirement)] = &[
         ipc::fs_labels::FS_RENAME,
         RightsRequirement::Bits(nz(rights::MUTATE_DIR)),
     ),
+    (
+        ipc::fs_labels::FS_TRUNCATE,
+        RightsRequirement::Bits(nz(rights::WRITE)),
+    ),
 ];
 
 fn required_rights_for(opcode: u64) -> Option<RightsRequirement>
@@ -333,6 +337,20 @@ mod tests
                 "label {label:#x} should reject without MUTATE_DIR"
             );
         }
+    }
+
+    #[test]
+    fn fs_truncate_gates_on_write_bit()
+    {
+        assert!(gate(ipc::fs_labels::FS_TRUNCATE, token_with(rights::WRITE)).is_ok());
+        assert_eq!(
+            gate(ipc::fs_labels::FS_TRUNCATE, token_with(rights::READ)),
+            Err(GateError::PermissionDenied)
+        );
+        assert_eq!(
+            gate(ipc::fs_labels::FS_TRUNCATE, token_with(rights::MUTATE_DIR)),
+            Err(GateError::PermissionDenied)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Bridges `std::fs::{write, File::create, OpenOptions::{write,create,truncate,append,create_new}, remove_file, remove_dir, remove_dir_all, create_dir, rename, read_dir, metadata, symlink_metadata, exists}` onto the already-landed FS_* / NS_* IPC plus one new `FS_TRUNCATE` label for truncate-to-zero. Per pre-PR scope agreement the PR also lands the obvious read-side completeness gaps (`read_dir`, `metadata`, `exists`, real `FileType`) so the `std::fs` surface is coherent for v0.1.0.

Closes #8

## Acceptance

Mirrors the Acceptance section of #8:

- [x] `std::fs::write("path", b"bytes")` round-trips on a FAT filesystem (dual-arch). — `std_write_phase`, `std_bulk_write_phase`.
- [x] `File::create + write_all + sync_all` produces a file readable via `std::fs::read`. — `std_create_phase`.
- [x] `std::fs::create_dir`, `remove_file`, `remove_dir_all`, `rename` work over FAT. — `std_mkdir_remove_phase`, `std_rename_phase`, `std_remove_dir_all_phase`.

Scope-expansion items (not in the original Acceptance list but in this PR):

- [x] `std::fs::read_dir` enumerates entries with correct `file_name` / `file_type` / `metadata().len()`. — `std_read_dir_phase`.
- [x] `std::fs::metadata` / `exists` return correct `len()` / `is_file()` / `is_dir()` / presence boolean. — `std_metadata_phase`.

## Test plan

- [x] `cargo xtask build` (x86_64) — clean
- [x] `cargo xtask run` (x86_64) — terminal pass marker `[usertest] ALL TESTS PASSED` observed (all 10 `std_*_phase` plus every existing `fs_*_phase` log `passed`)
- [x] `cargo xtask build --arch riscv64` — clean
- [x] `cargo xtask run --arch riscv64` — terminal pass marker observed (10/10 std phases pass)
- [x] `cargo xtask test` — workspace host tests pass (gate.rs FS_TRUNCATE row test included)

## Notes

### Design

- **`FS_TRUNCATE` (new wire label 17).** Token = file cap with `WRITE`. `data[0] = new_len`. Server reply empty body on success. v1 supports `new_len == 0` only (sufficient for `OpenOptions::truncate(true)` and `File::set_len(0)`); non-zero replies `IO_ERROR` and the client pre-rejects with `Unsupported` to skip the round-trip. Forward-compatible shape — adding extend-with-zero-fill later does not require a wire change. `FS_LABELS_VERSION` bumped 2 → 3 so mixed-build vfsd/fatfs combinations fail at the `FS_MOUNT` handshake.

- **Hybrid `File::write` path.** Mirrors the existing read-side: writes ≤ 504 B use inline `FS_WRITE`; larger writes acquire one memmgr `REQUEST_FRAMES(1)` page, map it `MAP_WRITABLE`, and chunk through `FS_WRITE_FRAME` with the same page reused across iterations. The server returns the source frame in `caps[0]` per round-trip so the cap slot id is rebound each iteration. Per-call (not per-`File`) frame allocation is sufficient for v1; per-`File` caching is captured in #95.

- **`OpenOptions` flag matrix.** Replaces the previous "read-only or `Unsupported`" reject. Defensive `InvalidInput` for combinations `std::fs::OpenOptions` itself rejects (`append + truncate`, `create_new` / `create` / `truncate` without write). `OpenOptions::create` first issues `FS_CREATE`; on `EXISTS` it falls back to a one-hop `NS_LOOKUP` for the existing leaf. `OpenOptions::truncate(true)` on an existing file fires `FS_TRUNCATE(0)` after the open succeeds.

- **`remove_dir_all` recursion is client-side.** FAT compacts slot indices after every `FS_REMOVE`, so the recursive drain restarts the readdir cursor at `idx = 0` after every removal. The `.` / `..` entries (always surfaced by FAT readdir) are filtered at every level. No new wire label.

- **`ReadDir` / `DirEntry`.** `NS_READDIR` (already on the wire) per `next()`, filtering `.` and `..`. `DirEntry::metadata()` refetches live attributes via `NS_LOOKUP + NS_STAT` rather than caching enumeration-time data. `ReadDir::Drop` `cap_delete`s the dir cap.

- **`FileType` populated from `NodeKind`.** `FileAttr` now carries `kind` and `mtime_us`; `is_file()` / `is_dir()` are real bools rather than the previous hard-coded `is_file = true`. `mtime_us` is reserved but always zero today — `FileAttr::modified()` returns `Unsupported` until #85 lands a clock source.

### Test scope

`std::fs::read_dir` deliberately uses upper-case 8.3 names (`STD_RD/A.BIN`, `B.BIN`, `SUB`). fs-fat's `FS_CREATE` / `FS_MKDIR` currently only emit 8.3 short-name directory entries; LFN case-preservation for newly-created entries is a separate fs-fat concern outside #8 scope (existing files placed by host FAT tooling in the rootfs still surface canonicalised LFNs via the pre-existing `/bin` readdir test). Capturing the LFN-on-create work would land cleanly in #95 if surfaced as a need.

### Existing raw-IPC tests are unchanged

The existing `fs_write_phase`, `fs_create_remove_phase`, `fs_mkdir_phase`, `fs_rename_phase`, `fs_write_frame_phase`, `fs_write_cache_coherence_phase`, `fs_write_invariants_phase` continue to drive the FS_* labels directly and still gate the wire shapes — every one logs `passed` on both arches in this branch.

### Out of scope (captured)

Deferrals filed as **#95**: non-zero `File::set_len`, `std::fs::copy`, `hard_link`, `symlink`, `read_link`, advisory locks, `File::map`, per-`File` frame-cap caching for write perf, concurrent-writer ordering, promoting seraph-native write helpers to `os::seraph`, `FileTimes::set_*` once #85 lands. Cross-directory rename remains tracked by **#89**; `FilePermissions::readonly` by **#84**; canonicalize / relative-path lexical resolver by **#54**.