### PR TITLE
ktest: narrow IoPortRange grants via ioport_split

### DIFF
--- a/core/ktest/README.md
+++ b/core/ktest/README.md
@@ -37,7 +37,7 @@ kernel's own source layout.
 | `wait_set.rs` | `SYS_WAIT_SET_ADD/REMOVE/WAIT` |
 | `ipc.rs` | `SYS_IPC_CALL`, `SYS_IPC_REPLY`, `SYS_IPC_RECV`, `SYS_IPC_BUFFER_SET` |
 | `thread.rs` | `SYS_THREAD_START/STOP/YIELD/EXIT/CONFIGURE/SET_PRIORITY/SET_AFFINITY/READ_REGS/WRITE_REGS` |
-| `hw.rs` | `SYS_MMIO_MAP`, `SYS_DMA_GRANT`, `SYS_IRQ_REGISTER/ACK`, `SYS_IOPORT_BIND` |
+| `hw.rs` | `SYS_MMIO_MAP`, `SYS_DMA_GRANT`, `SYS_IRQ_REGISTER/ACK`, `SYS_IOPORT_BIND`, `SYS_IOPORT_SPLIT` |
 | `sysinfo.rs` | `SYS_SYSTEM_INFO` |
 
 Adding a new syscall means adding a section in the appropriate file here.
@@ -98,8 +98,11 @@ Defined in `src/main.rs`:
 - `TestResult` — `Result<(), &'static str>` — no heap, no allocation.
 - `run_test!(name, body)` — macro that logs the test name, runs `body`,
   records PASS or FAIL (with reason), and never panics.
-- `TestContext` — thin struct carrying `aspace_cap` and the IPC buffer pointer,
-  passed by reference to every test function.
+- `TestContext` — thin struct carrying `aspace_cap`, `cspace_cap`, and the
+  IPC buffer pointer, passed by reference to every test function. `cspace_cap`
+  is queried via `cap_info(_, CAP_INFO_CSPACE_CAPACITY)` by hardware tests
+  whose scans must cover slots populated after `aspace_cap` (e.g. narrow
+  `IoPortRange` caps carved by `ioport::bind_port_range` on `x86_64`).
 - `PASS_COUNT` / `FAIL_COUNT` — atomic counters updated by `run_test!`.
 - `log(msg)` / `log_u64(prefix, value)` — heap-free logging utilities.
 

--- a/core/ktest/src/acpi_shutdown.rs
+++ b/core/ktest/src/acpi_shutdown.rs
@@ -11,11 +11,19 @@
 //!
 //! All ACPI parsing happens in userspace — the kernel and bootloader are not
 //! involved beyond providing Frame caps for the firmware table regions.
+//!
+//! I/O port permission for `PM1a_CNT_BLK` is obtained at shutdown time via
+//! `ioport::bind_port_range`, which carves a narrow `IoPortRange` cap
+//! covering exactly the `PM1a` control register from the residual wide
+//! cap left by earlier consumers.
 
 use init_protocol::{CapType, InitInfo};
 
 /// ACPI PM1 control register: `SLP_EN` bit (bit 13).
 const SLP_EN: u16 = 1 << 13;
+
+/// `PM1a_CNT_BLK` register width — 2 bytes per ACPI 6.x § 4.8.3.2.1.
+const PM1A_CNT_PORTS: u16 = 2;
 
 /// Virtual address base for mapping ACPI tables.
 const ACPI_MAP_BASE: u64 = 0x4000_0000;
@@ -51,13 +59,7 @@ pub fn shutdown(info: &InitInfo)
         return;
     };
 
-    let Some(ioport_slot) = find_cap_by_type(info, CapType::IoPortRange)
-    else
-    {
-        crate::log("ktest: shutdown failed (IoPortRange cap not found)");
-        return;
-    };
-    if syscall::ioport_bind(info.thread_cap, ioport_slot).is_err()
+    if !crate::ioport::bind_port_range(info.thread_cap, pm1a_cnt_blk, PM1A_CNT_PORTS)
     {
         crate::log("ktest: shutdown failed (ioport_bind)");
         return;
@@ -65,8 +67,9 @@ pub fn shutdown(info: &InitInfo)
 
     let value = (slp_typa << 10) | SLP_EN;
 
-    // SAFETY: `PM1a_CNT_BLK` is a valid I/O port from FADT; IOPB permits access
-    // after ioport_bind; writing `SLP_TYPa`|`SLP_EN` triggers ACPI S5.
+    // SAFETY: `PM1a_CNT_BLK` is a valid I/O port from FADT; the IOPB grant
+    // for [PM1a_CNT_BLK, +2) was established by the bind_port_range call
+    // above; writing `SLP_TYPa | SLP_EN` triggers ACPI S5.
     unsafe {
         core::arch::asm!(
             "out dx, ax",
@@ -334,19 +337,6 @@ fn descriptors(info: &InitInfo) -> &[init_protocol::CapDescriptor]
             info.cap_descriptor_count as usize,
         )
     }
-}
-
-/// Find the first cap matching `wanted_type`.
-fn find_cap_by_type(info: &InitInfo, wanted_type: CapType) -> Option<u32>
-{
-    for desc in descriptors(info)
-    {
-        if desc.cap_type == wanted_type
-        {
-            return Some(desc.slot);
-        }
-    }
-    None
 }
 
 /// Read a little-endian u32 at byte offset `off` from virtual address `vaddr`.

--- a/core/ktest/src/ioport.rs
+++ b/core/ktest/src/ioport.rs
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// ktest/src/ioport.rs
+
+//! Per-thread I/O port access for ktest (x86-64).
+//!
+//! Owns the kernel-minted root [`CapType::IoPortRange`] cap and derives
+//! narrow sub-range caps via `ioport_split` as consumers (`serial`,
+//! `acpi_shutdown`) request specific ports. This keeps each grant
+//! confined to the ports the consumer actually drives instead of
+//! binding the full 64K I/O port space at startup.
+//!
+//! Once `ioport_bind` succeeds for a thread, the IOPB grant for those
+//! ports is per-thread state that outlives the cap itself (see
+//! `core/kernel/src/sched/thread.rs::TCB::iopb`), so narrow caps
+//! produced here may be freely consumed afterwards (e.g. by Tier-1
+//! unit tests that exercise `ioport_split`) without disturbing the
+//! established permission.
+
+use init_protocol::{CapType, InitInfo};
+
+/// Widest live `IoPortRange` cap, plus the port range it covers.
+#[derive(Clone, Copy)]
+struct WideCap
+{
+    /// `CSpace` slot of the cap. 0 means uninitialised or exhausted.
+    slot: u32,
+    /// First port covered by the cap.
+    base: u32,
+    /// One past the last port covered by the cap.
+    end: u32,
+}
+
+// SAFETY: ktest is single-threaded on every path that touches this.
+static mut WIDE: WideCap = WideCap {
+    slot: 0,
+    base: 0,
+    end: 0,
+};
+
+/// Seed the wide cap from the root `IoPortRange` descriptor in `InitInfo`.
+///
+/// Idempotent: a second call with the same `info` overwrites the prior
+/// state; intended to be called once from `main::run` before any
+/// `bind_port_range` consumer.
+pub fn init(info: &InitInfo)
+{
+    let Some((slot, base, end)) = find_root(info)
+    else
+    {
+        return;
+    };
+    // SAFETY: ktest is single-threaded on this initialisation path.
+    unsafe {
+        WIDE = WideCap { slot, base, end };
+    }
+}
+
+/// Bind `[port, port + count)` to `thread_cap`. Returns `true` on
+/// success.
+///
+/// Splits the wide cap to carve out exactly the requested sub-range,
+/// binds the carved cap, and stores the residual (if any) as the new
+/// wide cap. A request whose range falls outside the residual wide
+/// cap fails.
+pub fn bind_port_range(thread_cap: u32, port: u16, count: u16) -> bool
+{
+    let port_start = u32::from(port);
+    let port_end = port_start + u32::from(count);
+    // SAFETY: ktest is single-threaded.
+    let WideCap {
+        mut slot,
+        base,
+        end,
+    } = unsafe { WIDE };
+    if slot == 0 || port_start < base || port_end > end
+    {
+        return false;
+    }
+
+    if port_start > base
+    {
+        // port_start <= 0xFFFF because the caller supplied a u16; safe cast.
+        #[allow(clippy::cast_possible_truncation)]
+        let Ok((prefix, rest)) = syscall::ioport_split(slot, port_start as u16)
+        else
+        {
+            return false;
+        };
+        // ktest itself never drives the prefix range [base, port_start),
+        // but the carved-off prefix cap is left alive in the cspace so
+        // that any consumer (test harness, future module, debug probe)
+        // that wants to claim those ports can find an IoPortRange
+        // covering them. See `core/ktest/src/unit/hw.rs::ioport_split`
+        // for the test that relies on this for coverage of the
+        // `ioport_split` syscall.
+        let _ = prefix;
+        slot = rest;
+    }
+
+    if port_end < end
+    {
+        // port_end < end <= 0x10000 and we took this branch because
+        // port_end != end, so port_end <= 0xFFFF; safe cast.
+        #[allow(clippy::cast_possible_truncation)]
+        let Ok((target, residual)) = syscall::ioport_split(slot, port_end as u16)
+        else
+        {
+            return false;
+        };
+        // SAFETY: ktest is single-threaded.
+        unsafe {
+            WIDE = WideCap {
+                slot: residual,
+                base: port_end,
+                end,
+            };
+        }
+        return syscall::ioport_bind(thread_cap, target).is_ok();
+    }
+
+    // port_end == end: bind what's left and exhaust the wide cap.
+    // SAFETY: ktest is single-threaded.
+    unsafe {
+        WIDE = WideCap {
+            slot: 0,
+            base: 0,
+            end: 0,
+        };
+    }
+    syscall::ioport_bind(thread_cap, slot).is_ok()
+}
+
+/// Locate the root `IoPortRange` descriptor in `InitInfo`.
+fn find_root(info: &InitInfo) -> Option<(u32, u32, u32)>
+{
+    let base = core::ptr::from_ref::<InitInfo>(info).cast::<u8>();
+    // SAFETY: cap_descriptors_offset and _count are set by the kernel.
+    #[allow(clippy::cast_ptr_alignment)]
+    let descs = unsafe {
+        core::slice::from_raw_parts(
+            base.add(info.cap_descriptors_offset as usize)
+                .cast::<init_protocol::CapDescriptor>(),
+            info.cap_descriptor_count as usize,
+        )
+    };
+    for d in descs
+    {
+        if d.cap_type == CapType::IoPortRange
+        {
+            // aux0 = base port, aux1 = size in ports. The kernel emits
+            // aux1 = 0x10000 directly for the full 64K root cap
+            // (`core/kernel/src/cap/mod.rs`); the aux1 == 0 branch is
+            // defensive against a future change that adopts the in-object
+            // `IoPortRangeObject.size == 0` encoding at this surface.
+            #[allow(clippy::cast_possible_truncation)]
+            let base_u32 = d.aux0 as u32;
+            #[allow(clippy::cast_possible_truncation)]
+            let size_u32 = if d.aux1 == 0 { 0x10000 } else { d.aux1 as u32 };
+            return Some((d.slot, base_u32, base_u32 + size_u32));
+        }
+    }
+    None
+}

--- a/core/ktest/src/ioport.rs
+++ b/core/ktest/src/ioport.rs
@@ -41,9 +41,9 @@ static mut WIDE: WideCap = WideCap {
 
 /// Seed the wide cap from the root `IoPortRange` descriptor in `InitInfo`.
 ///
-/// Idempotent: a second call with the same `info` overwrites the prior
-/// state; intended to be called once from `main::run` before any
-/// `bind_port_range` consumer.
+/// Called once from `main::run` before any `bind_port_range` consumer.
+/// A second call would overwrite the residual-cap slot tracked here
+/// without recovering any carve products already produced.
 pub fn init(info: &InitInfo)
 {
     let Some((slot, base, end)) = find_root(info)
@@ -66,6 +66,10 @@ pub fn init(info: &InitInfo)
 /// cap fails.
 pub fn bind_port_range(thread_cap: u32, port: u16, count: u16) -> bool
 {
+    if count == 0
+    {
+        return false;
+    }
     let port_start = u32::from(port);
     let port_end = port_start + u32::from(count);
     // SAFETY: ktest is single-threaded.

--- a/core/ktest/src/main.rs
+++ b/core/ktest/src/main.rs
@@ -34,6 +34,8 @@ mod unit;
 
 #[cfg(target_arch = "x86_64")]
 mod acpi_shutdown;
+#[cfg(target_arch = "x86_64")]
+mod ioport;
 #[cfg(target_arch = "riscv64")]
 mod sbi_shutdown;
 
@@ -126,6 +128,15 @@ pub struct TestContext
     /// bound to an address space), and hardware access tests.
     pub aspace_cap: u32,
 
+    /// ktest's own `CSpace` capability slot, provided by the kernel.
+    ///
+    /// Used by tests that need to discover the cspace's slot capacity at
+    /// runtime via `cap_info(_, CAP_INFO_CSPACE_CAPACITY)` so their scans
+    /// cover every slot the kernel may have populated, including those
+    /// allocated after `aspace_cap` (e.g. carve-time `ioport::init`
+    /// products on `x86_64`).
+    pub cspace_cap: u32,
+
     /// Pointer to the registered IPC buffer page (4 KiB, page-aligned).
     ///
     /// Registered with `ipc_buffer_set` before any tests run. Passed into
@@ -213,6 +224,12 @@ fn run(info_ptr: u64) -> !
         halt();
     }
 
+    // Seed the I/O port subdivider with the root IoPortRange cap so
+    // `serial::init` and `acpi_shutdown::shutdown` can each carve only
+    // the ports they need instead of binding the full 64K range.
+    #[cfg(target_arch = "x86_64")]
+    ioport::init(info);
+
     // Initialise direct serial output before any logging.
     // SAFETY: called once, single-threaded, InitInfo is valid.
     unsafe { serial::init(info, info.aspace_cap, info.thread_cap) };
@@ -243,6 +260,7 @@ fn run(info_ptr: u64) -> !
 
     let ctx = TestContext {
         aspace_cap,
+        cspace_cap: info.cspace_cap,
         ipc_buf: ipc_buf_ptr,
         memory_frame_base: info.memory_frame_base,
     };

--- a/core/ktest/src/main.rs
+++ b/core/ktest/src/main.rs
@@ -133,8 +133,9 @@ pub struct TestContext
     /// Used by tests that need to discover the cspace's slot capacity at
     /// runtime via `cap_info(_, CAP_INFO_CSPACE_CAPACITY)` so their scans
     /// cover every slot the kernel may have populated, including those
-    /// allocated after `aspace_cap` (e.g. carve-time `ioport::init`
-    /// products on `x86_64`).
+    /// allocated after `aspace_cap` (e.g. narrow `IoPortRange` caps minted
+    /// by `ioport::bind_port_range` callers such as `serial::init` on
+    /// `x86_64`).
     pub cspace_cap: u32,
 
     /// Pointer to the registered IPC buffer page (4 KiB, page-aligned).

--- a/core/ktest/src/serial.rs
+++ b/core/ktest/src/serial.rs
@@ -76,15 +76,14 @@ mod arch
     /// from the root cap (via `ioport::bind_port_range`) and binds it to
     /// the current thread, then programs the UART to 115200 8N1.
     ///
+    /// `InitInfo` is consumed centrally by `ioport::init`; serial only
+    /// needs the narrow COM1 bind.
+    ///
     /// # Safety
     /// Must be called once, from the main thread, after `InitInfo` is
     /// mapped and `ioport::init` has run.
-    pub unsafe fn init(info: &super::InitInfo, thread_cap: u32)
+    pub unsafe fn init(_info: &super::InitInfo, thread_cap: u32)
     {
-        // info is consumed via ioport::init() in main; serial only needs
-        // the narrow COM1 bind.
-        let _ = info;
-
         if !crate::ioport::bind_port_range(thread_cap, COM1, COM1_PORTS)
         {
             return; // no IoPortRange cap, or carve/bind failed

--- a/core/ktest/src/serial.rs
+++ b/core/ktest/src/serial.rs
@@ -59,21 +59,6 @@ fn find_cap(info: &InitInfo, wanted_type: CapType, wanted_aux0: u64) -> Option<u
     None
 }
 
-/// Scan the `CapDescriptor` array for the first cap matching `wanted_type`.
-/// Returns the `CSpace` slot index if found.
-#[allow(dead_code)] // Used on x86-64 (IoPortRange lookup), not on RISC-V.
-fn find_cap_by_type(info: &InitInfo, wanted_type: CapType) -> Option<u32>
-{
-    for d in descriptors(info)
-    {
-        if d.cap_type == wanted_type
-        {
-            return Some(d.slot);
-        }
-    }
-    None
-}
-
 // ── x86-64: COM1 via I/O ports ───────────────────────────────────────────────
 
 #[cfg(target_arch = "x86_64")]
@@ -82,27 +67,31 @@ mod arch
     /// COM1 base I/O port.
     const COM1: u16 = 0x3F8;
 
+    /// COM1 register width — 8 ports starting at [`COM1`].
+    const COM1_PORTS: u16 = 8;
+
     /// Initialise COM1 serial output.
     ///
-    /// Finds the `IoPortRange` cap covering COM1, binds it to the current
-    /// thread, then programs the UART to 115200 8N1.
+    /// Carves a narrow `IoPortRange` cap covering exactly COM1's 8 ports
+    /// from the root cap (via `ioport::bind_port_range`) and binds it to
+    /// the current thread, then programs the UART to 115200 8N1.
     ///
     /// # Safety
-    /// Must be called once, from the main thread, after `InitInfo` is mapped.
+    /// Must be called once, from the main thread, after `InitInfo` is
+    /// mapped and `ioport::init` has run.
     pub unsafe fn init(info: &super::InitInfo, thread_cap: u32)
     {
-        let Some(slot) = super::find_cap_by_type(info, super::CapType::IoPortRange)
-        else
-        {
-            return; // no IoPortRange cap — serial stays uninitialised
-        };
+        // info is consumed via ioport::init() in main; serial only needs
+        // the narrow COM1 bind.
+        let _ = info;
 
-        if syscall::ioport_bind(thread_cap, slot).is_err()
+        if !crate::ioport::bind_port_range(thread_cap, COM1, COM1_PORTS)
         {
-            return;
+            return; // no IoPortRange cap, or carve/bind failed
         }
 
-        // SAFETY: ioport_bind succeeded; I/O port access is permitted.
+        // SAFETY: bind_port_range succeeded; I/O port access for [COM1,
+        // COM1+COM1_PORTS) is permitted on this thread.
         unsafe { serial_hw_init() };
 
         // SAFETY: single-threaded; serial hardware ready.

--- a/core/ktest/src/unit/hw.rs
+++ b/core/ktest/src/unit/hw.rs
@@ -23,6 +23,13 @@ use crate::{TestContext, TestResult};
 /// Test virtual address for MMIO mapping. 1.25 GiB — above ktest's load address.
 const MMIO_TEST_VA: u64 = 0x5000_0000;
 
+/// Kernel pin: every `CSpace` is clamped to at most `L1_SIZE * L2_SIZE`
+/// (256 * 64 = 16384) slots. Used as a fallback if `cap_info` ever
+/// returns a value larger than `u32::MAX`, which the kernel's own
+/// invariants forbid today.
+#[cfg(target_arch = "x86_64")]
+const ROOT_CSPACE_MAX_SLOTS: u32 = 16384;
+
 // ── SYS_MMIO_MAP ──────────────────────────────────────────────────────────────
 
 /// `mmio_map` maps a hardware MMIO region into the address space.
@@ -101,6 +108,11 @@ pub fn irq_register_ack(ctx: &TestContext) -> TestResult
 /// On RISC-V this syscall is not supported and must return `NotSupported`.
 /// On `x86_64`, scans for the first `IoPortRange` cap and binds it to a test
 /// thread. If no `IoPortRange` cap is found, the test is skipped.
+///
+/// The scan bound is the cspace's `max_slots` (queried at runtime via
+/// `cap_info`) so the test stays robust against changes to cap mint
+/// order or post-init carve products landing at slot indices above
+/// `aspace_cap`.
 // needless_return: cfg-gated early return is required to terminate the riscv64
 // path; the x86_64 path follows in the same function body.
 #[allow(clippy::needless_return)]
@@ -126,7 +138,18 @@ pub fn ioport_bind(ctx: &TestContext) -> TestResult
         let th = cap_create_thread(ctx.memory_frame_base, ctx.aspace_cap, cs)
             .map_err(|_| "cap_create_thread for ioport_bind test failed")?;
 
-        for slot in 1..ctx.aspace_cap
+        let max_slots = if let Ok(n) =
+            syscall::cap_info(ctx.cspace_cap, syscall_abi::CAP_INFO_CSPACE_CAPACITY)
+        {
+            u32::try_from(n).unwrap_or(ROOT_CSPACE_MAX_SLOTS)
+        }
+        else
+        {
+            syscall::cap_delete(th).ok();
+            syscall::cap_delete(cs).ok();
+            return Err("cap_info(CAP_INFO_CSPACE_CAPACITY) failed");
+        };
+        for slot in 1u32..max_slots
         {
             match syscall::ioport_bind(th, slot)
             {
@@ -198,7 +221,7 @@ pub fn ioport_split(ctx: &TestContext) -> TestResult
         let max_slots =
             match syscall::cap_info(ctx.cspace_cap, syscall_abi::CAP_INFO_CSPACE_CAPACITY)
             {
-                Ok(n) => u32::try_from(n).unwrap_or(u32::MAX),
+                Ok(n) => u32::try_from(n).unwrap_or(ROOT_CSPACE_MAX_SLOTS),
                 Err(_) => return Err("cap_info(CAP_INFO_CSPACE_CAPACITY) failed"),
             };
         for slot in 1u32..max_slots

--- a/core/ktest/src/unit/hw.rs
+++ b/core/ktest/src/unit/hw.rs
@@ -155,11 +155,13 @@ pub fn ioport_bind(ctx: &TestContext) -> TestResult
 /// `ioport_split` divides an `IoPortRange` cap into two non-overlapping children.
 ///
 /// On RISC-V this syscall is not supported and must return `NotSupported`.
-/// On `x86_64`, scans for the first `IoPortRange` cap and splits it at port
-/// 0x80 (a well-known reserved port that lies inside any legacy port range).
-/// Validates: both child slots are non-zero and distinct; re-splitting the
-/// now-consumed parent slot fails; out-of-range splits fail with
-/// `InvalidArgument`. If no `IoPortRange` cap is found, the test is skipped.
+/// On `x86_64`, scans the cspace for the first `IoPortRange` cap whose
+/// range covers port 0x80 and splits it there. Slots whose cap is the
+/// wrong type or an `IoPortRange` not covering 0x80 are skipped
+/// non-destructively. Validates: both child slots are non-zero and
+/// distinct; re-splitting the now-consumed parent slot fails;
+/// out-of-range splits fail with `InvalidArgument`. If no such
+/// `IoPortRange` is found, the test is skipped.
 ///
 /// The original cap is consumed by the split; this is the documented
 /// semantics. No later test depends on the same slot.
@@ -180,20 +182,33 @@ pub fn ioport_split(ctx: &TestContext) -> TestResult
         return Ok(());
     }
 
-    // x86_64: find an IoPortRange cap by probing with ioport_split.
-    // ioport_split returns InvalidCapability for wrong cap types and
-    // InvalidArgument for an IoPortRange whose range doesn't cover the
-    // split point. Either result lets us identify the slot's type
-    // non-destructively, since neither consumes the cap.
+    // x86_64: find an IoPortRange cap covering 0x80 by probing with
+    // `ioport_split`. `ioport_split` returns `InvalidCapability` for
+    // wrong cap types and `InvalidArgument` for an `IoPortRange` whose
+    // range doesn't cover the split point. Either result lets us
+    // identify the slot's type non-destructively, since neither
+    // consumes the cap.
+    //
+    // The scan bound is the cspace's `max_slots` (queried at runtime
+    // via `cap_info`) so post-init carve products from `ioport::init`
+    // — which land at slot indices above `aspace_cap` — are always
+    // reachable, regardless of how the cspace has grown.
     #[cfg(target_arch = "x86_64")]
     {
-        for slot in 1..ctx.aspace_cap
+        let max_slots =
+            match syscall::cap_info(ctx.cspace_cap, syscall_abi::CAP_INFO_CSPACE_CAPACITY)
+            {
+                Ok(n) => u32::try_from(n).unwrap_or(u32::MAX),
+                Err(_) => return Err("cap_info(CAP_INFO_CSPACE_CAPACITY) failed"),
+            };
+        for slot in 1u32..max_slots
         {
             // Try splitting at 0x80. If the slot is not an IoPortRange we
             // get InvalidCapability and keep scanning. If it is an
-            // IoPortRange that doesn't cover 0x80 we get InvalidArgument
-            // (cap not consumed) and the test reports SKIP. If it
-            // succeeds we validate and clean up.
+            // IoPortRange that doesn't cover 0x80 (e.g. a narrow
+            // sub-range carved by `ioport::bind_port_range`) we also keep
+            // scanning — another slot may hold a wider IoPortRange that
+            // does cover the probe point.
             match syscall::ioport_split(slot, 0x80)
             {
                 Err(e) if e == SyscallError::InvalidCapability as i64 =>
@@ -202,15 +217,8 @@ pub fn ioport_split(ctx: &TestContext) -> TestResult
                 }
                 Err(e) if e == SyscallError::InvalidArgument as i64 =>
                 {
-                    // Slot is an IoPortRange but doesn't cover 0x80. Cap
-                    // is intact. Try a port that the test harness's
-                    // typical range definitely covers: any port in
-                    // [base, base+size) is valid. Without knowing the
-                    // range, skip cleanly.
-                    crate::log(
-                        "ktest: hw::ioport_split SKIP (IoPortRange found but doesn't cover 0x80)",
-                    );
-                    return Ok(());
+                    // IoPortRange whose range doesn't cover 0x80; cap is
+                    // intact. Keep scanning for another candidate.
                 }
                 Err(_) =>
                 {
@@ -228,10 +236,8 @@ pub fn ioport_split(ctx: &TestContext) -> TestResult
                         return Err("re-split of consumed parent succeeded");
                     }
                     // Out-of-range split on a child must fail with
-                    // InvalidArgument. 0xFFFF likely lies in the upper
-                    // child's range (which covers [0x80, end)); test
-                    // both children with split values guaranteed
-                    // out-of-bounds (0 is always invalid).
+                    // InvalidArgument. 0 is always invalid (would yield
+                    // an empty lower half).
                     let oob = syscall::ioport_split(slot1, 0);
                     if !matches!(oob, Err(e) if e == SyscallError::InvalidArgument as i64)
                     {
@@ -245,7 +251,9 @@ pub fn ioport_split(ctx: &TestContext) -> TestResult
             }
         }
 
-        crate::log("ktest: hw::ioport_split SKIP (no IoPortRange caps in initial cap set)");
+        crate::log(
+            "ktest: hw::ioport_split SKIP (no IoPortRange covering 0x80 in initial cap set)",
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
ktest's `serial::init` bound the kernel-minted root `IoPortRange` cap
(full 64 K) to the main thread; the Tier-1 `hw::ioport_split` test then
consumed that root via `ioport_split`, leaving the InitInfo descriptor
stale. `acpi_shutdown` looked up the stale slot via
`find_cap_by_type`, `ioport_bind` failed with `InvalidCapability`,
shutdown fell through to `thread_exit`, and QEMU idled until
`run-parallel`'s 180 s watchdog SIGKILL. Move I/O-port management into
a small `ioport` module that owns the root cap and carves narrow
sub-range caps via `ioport_split` on demand: `serial::init` now binds
only `[0x3F8, 0x400)` (COM1), and `acpi_shutdown` binds only
`[PM1a_CNT_BLK, +2)` after FADT parse.

Closes #97

## Acceptance
- [x] Identify which `acpi_shutdown` leg fails on x86_64 (FADT / PM1a / DSDT / ioport_bind / hardware-side).
- [x] Fix or document the root cause.
- [x] x86_64 ktest single-shot completes in < 30s wall (matching riscv64's ~11s).
- [x] No regression on riscv64 ktest shutdown.

## Test plan
- [x] `cargo xtask build` (x86_64) — clean.
- [x] `cargo xtask run --arch x86_64` against `init=ktest`: pass marker `[1.294528] ktest: ALL TESTS PASSED`, QEMU exits cleanly in ~8 s wall.
- [x] `cargo xtask build --arch riscv64` — clean.
- [x] `cargo xtask run --arch riscv64` against `init=ktest`: pass marker `[0.784911] ktest: ALL TESTS PASSED`, exits in 13.33 s.
- [x] CI-equivalent `cargo xtask run-parallel --arch x86_64 --parallel 1 --runs 1 --timeout 180` against `init=ktest`: PASS in ~8 s wall, no SIGKILL (was 180 s).
- [x] CI-equivalent run-parallel against default `init=init` (`usertest`): x86_64 PASS in 49.56 s, riscv64 PASS in 118.55 s — both within the workflow's 180 s watchdog, no regression vs baseline.
- [x] Tier-1 `hw::ioport_bind` PASS and `hw::ioport_split` now PASS with the split syscall actually exercised (was reporting SKIP after an earlier iteration of the fix discarded the carved-off prefix; current code keeps the prefix alive and the test scans past non-covering caps).
- [x] `cargo xtask test` (host-side): 364/364 pass across 7 crates (boot=53, boot_protocol=9, init_protocol=0, kernel=186, namespace_protocol=55, process_abi=0, xtask=61).

## Notes
The failing leg was identified by local reproduction (`cargo xtask run
--arch x86_64` against `init=ktest`) because `run-parallel` discards the
serial log on PASS classification when the watchdog also fires
(documented outcome-precedence behaviour at `xtask/README.md:163`).
This is intended — full logs are retained on real failures, where the
pass regex doesn't match.

Design choice — the new `ioport` module is x86-only and tiny (~110
LoC). It stores the residual wide cap in a `static mut` rather than a
mutex; ktest is single-threaded on every path that touches it (called
from `_start` before any thread is spawned, and from
`acpi_shutdown::shutdown` after all child threads have exited). The
IOPB grant established by each `bind_port_range` call is per-thread
state that outlives the cap; the narrow caps produced may be freely
consumed afterwards without disturbing the established permission.

Carved prefixes (the `[base, port_start)` half left over when a
consumer asks for a port range that doesn't start at the wide cap's
base) are intentionally kept alive in the cspace, so that the Tier-1
`hw::ioport_split` test continues to find an IoPortRange covering port
0x80 even after `ioport::init`'s narrowing.