### PR TITLE
docs: scope-trim top-level system docs to authoritative content

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,8 @@ Seraph is a microkernel operating system written in Rust, targeting x86-64 and R
 - Architecture-specific code isolated behind shared traits
 - Self-hosting as a long-term goal
 
-Summarized from the Project Goals and Philosophy sections of
-[docs/architecture.md](docs/architecture.md); see there for the authoritative
-statement and the reasoning behind each goal.
+Summarized from [docs/architecture.md](docs/architecture.md); see there
+for the authoritative statement.
 
 ## Structure
 
@@ -75,7 +74,6 @@ Overall project design documents live in [`docs/`](docs/):
 - [IPC Design](docs/ipc-design.md) — message passing, endpoints, synchronous vs async
 - [Capability Model](docs/capability-model.md) — permissions, delegation, revocation
 - [Namespace Model](docs/namespace-model.md) — node capabilities, per-entry rights and visibility, walking, sandboxing as cap-distribution
-- [Boot Protocol ABI crate](abi/boot-protocol/) — kernel-entry contract: `BootInfo` layout, `BOOT_PROTOCOL_VERSION`, and compliant-bootloader requirements
 - [System Bootstrap](docs/bootstrap.md) — end-to-end boot lifecycle summary (bootloader steps, kernel phases, init bootstrap)
 - [Device Management](docs/device-management.md) — platform enumeration, devmgr, driver binding, DMA safety
 - [Build System](docs/build-system.md) — toolchain, workspace layout, sysroot, xtask commands

--- a/abi/boot-protocol/README.md
+++ b/abi/boot-protocol/README.md
@@ -71,7 +71,7 @@ A compliant bootloader MUST NOT:
 
 ## Summarized By
 
-[README.md](../../README.md), [core/boot/README.md](../../core/boot/README.md),
+[core/boot/README.md](../../core/boot/README.md),
 [docs/bootstrap.md](../../docs/bootstrap.md),
 [docs/build-system.md](../../docs/build-system.md),
 [docs/architecture.md](../../docs/architecture.md),

--- a/base/README.md
+++ b/base/README.md
@@ -1,11 +1,23 @@
 # base
 
-General-purpose userspace applications and utilities: terminal emulator, shell
-(gksh), text editor, coreutils equivalents, and network utilities.
+General-purpose userspace applications and utilities. These are
+applications, not services — they have no special privileges beyond
+what their capabilities grant. They interact with the system through
+the IPC interfaces exposed by vfs, net, and other services.
 
-These are applications, not services — they have no special privileges beyond what
-their capabilities grant. They interact with the system through the IPC interfaces
-exposed by vfs, net, and other services.
+---
+
+## Source Layout
+
+| Crate | Purpose |
+|---|---|
+| `crasher` | Deliberate-crash fixture for svcmgr restart-path validation. |
+| `fsbench` | `FS_READ` vs `FS_READ_FRAME` crossover benchmark. |
+| `hello` | Tier-2 hello-world; std-only, no Seraph cap awareness. |
+| `pipefault` | Piped-stdio fault fixture for the pipe death-bridge regression test. |
+| `stackoverflow` | Stack-overflow fixture for the `PROCESS_STACK_GUARD_VA` regression test. |
+| `stdiotest` | Tier-2 stdin↔stdout proof. |
+| `usertest` | Generic userspace test driver; first std-built consumer of the ruststd overlay. |
 
 ---
 

--- a/core/kernel/docs/initialization.md
+++ b/core/kernel/docs/initialization.md
@@ -273,15 +273,39 @@ Phase 7, and `KERNEL_MMIO` is populated.
    e. One SbiControl capability (RISC-V only; Call rights) for init to
       forward SBI calls.
    f. (Thread and process capabilities for init are added in Phase 9)
-4. Record the root CSpace pointer in a global for use in Phase 9
-5. Emit: "capability system initialised, N slots populated"
+4. Mint reclaimable Frame caps from `BootInfo.reclaim_ranges` via
+   `cap::mint_reclaim_frame_caps`:
+   - One cap per range with `owns_memory = true` and full byte ledger;
+     inserted into the root CSpace so the cap reaches init through the
+     standard `CapDescriptor` walk in Phase 9.
+   - The buddy ledger records each range via `register_owned_range`
+     so cap teardown returns the pages via `dealloc_object` →
+     `free_range` with the `total / free` ratio well-defined.
+   - Whether init donates each cap onward to memmgr or lets it cascade
+     back to the buddy on CSpace teardown is a userspace policy
+     decision; the kernel does not impose a route.
+   - Ranges flagged `RECLAIM_FLAG_LATE` are skipped here and minted in
+     Phase 8 (see Late-Reclaim below).
+5. Record the root CSpace pointer in a global for use in Phase 9
+6. Emit: "capability system initialised, N slots populated"
 ```
 
 **Failure mode:** Allocation failure during CSpace construction halts with
 "fatal: cannot initialise capability system".
 
 **Completion criterion:** Root CSpace exists and contains capabilities for all
-boot-provided hardware resources.
+boot-provided hardware resources, including the reclaimable Frame caps
+covering bootloader scratch pages (`BootInfo` page, descriptor arrays,
+MMIO aperture array, reclaim-array page, cmdline page, transient page-
+table frames).
+
+### Cmdline-page snapshot
+
+The cmdline page lands in `reclaim_ranges` like every other early entry,
+but only after the kernel snapshots its contents into a small BSS
+buffer during earlier kernel-phase processing. The Phase-9 `InitInfo`
+copy reads from the snapshot, leaving the bootloader page reclaim-safe
+by the time this phase mints its Frame cap.
 
 ---
 
@@ -313,6 +337,16 @@ boot-provided hardware resources.
    cspace_layout so init sees the cap through the standard CSpace
    handoff in Phase 9.
 ```
+
+The AP SIPI trampoline page is flagged `RECLAIM_FLAG_LATE` in
+`BootInfo.reclaim_ranges`. `cap::mint_reclaim_frame_caps` skips it in
+Phase 7; this phase mints it after SMP bringup completes and
+`mm::paging::unmap_identity_page` retires the low-VA identity-RWX
+mapping. (Both arches install this identity mapping in Phase 3 — the
+trampoline must remain executable at its PA while PC walks the
+post-`csrw satp` / post-CR3-write instructions.) The late-mint
+completes before Phase 9 consumes `cspace_layout`, so the descriptor
+still flows through the standard CSpace handoff.
 
 APs depend only on Phase 5/8 state (interrupts, percpu, scheduler
 idle threads); they never touch init's address space or any Phase-9

--- a/core/kernel/docs/initialization.md
+++ b/core/kernel/docs/initialization.md
@@ -303,9 +303,9 @@ table frames).
 
 The cmdline page lands in `reclaim_ranges` like every other early entry,
 but only after the kernel snapshots its contents into a small BSS
-buffer during earlier kernel-phase processing. The Phase-9 `InitInfo`
-copy reads from the snapshot, leaving the bootloader page reclaim-safe
-by the time this phase mints its Frame cap.
+buffer during Phase 4. The Phase-9 `InitInfo` copy reads from the
+snapshot, leaving the bootloader page reclaim-safe by the time this
+phase mints its Frame cap.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,8 +13,11 @@ kernel mechanisms and userspace policy.
 - Architecture-specific code isolated behind shared traits
 - Self-hosting as a long-term goal
 
-Seraph does not provide binary compatibility with other operating systems.
-32-bit and legacy x86 are not targeted.
+Seraph defines its own native interfaces; POSIX API compatibility is not
+a goal. Filesystem formats and network protocols may be adopted as data
+formats, not as API commitments. Seraph does not provide binary
+compatibility with other operating systems. 32-bit and legacy x86 are
+not targeted.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,19 +18,6 @@ Seraph does not provide binary compatibility with other operating systems.
 
 ---
 
-## Philosophy
-
-Seraph is a microkernel‑based operating system. The kernel is a minimal, trusted
-component that provides only core mechanisms: isolation, communication, scheduling,
-memory management, and capability enforcement.
-
-All policy and services live in userspace.
-
-Expanding kernel scope increases the TCB and MUST be treated as an architectural
-decision.
-
----
-
 ## Kernel Responsibilities
 
 The kernel provides only the core mechanisms required to support the system.
@@ -78,72 +65,56 @@ services and applications. All services communicate exclusively via IPC and oper
 under explicit capability grants.
 
 **init**
-First userspace process. Starts memmgr and procmgr, requests early services
-(devmgr, svcmgr, drivers, vfsd), delegates capabilities, then hands its own
-`AddressSpace` / `CSpace` / `Thread` caps plus every reclaimable Frame cap
-(segments, stack, `InitInfo` pages, IPC buffer) to procmgr via
-`REGISTER_INIT_TEARDOWN` and exits. Procmgr's death-EQ observer fires on
-the exit and reclaims every init resource — kernel objects torn down,
-Frame caps donated to memmgr's pool. After reap, zero init residue
-remains in the system. See [`abi/boot-protocol/`](../abi/boot-protocol/),
-[`process-lifecycle.md`](process-lifecycle.md) §"Init reap", and
-`services/procmgr/src/init_reap.rs`.
+First userspace process. Bootstraps tier-1 services (memmgr, procmgr),
+spawns the remaining early services, delegates per-service capabilities,
+then exits. See [`process-lifecycle.md`](process-lifecycle.md) and
+[`services/init/README.md`](../services/init/README.md).
 
 **memmgr**
-Owns the userspace RAM frame pool. Receives all RAM Frame caps from init at
-boot and serves frame allocation IPC to all std-built services. Tracks
-per-process frame ownership and reclaims on process death. `no_std`. See
-[`process-lifecycle.md`](process-lifecycle.md) and
-[`userspace-memory-model.md`](userspace-memory-model.md).
+Owns the userspace RAM frame pool and serves frame-allocation IPC to
+std-built services. `no_std`. See
+[`userspace-memory-model.md`](userspace-memory-model.md) and
+[`services/memmgr/README.md`](../services/memmgr/README.md).
 
 **procmgr**
-Process lifecycle manager. All post-boot process creation, ELF loading, and
-teardown go through procmgr. Procmgr is itself a memmgr client and
-bootstraps its heap by calling memmgr.
+Process lifecycle manager. All post-boot process creation, ELF loading,
+and teardown go through procmgr. See
+[`process-lifecycle.md`](process-lifecycle.md) and
+[`services/procmgr/README.md`](../services/procmgr/README.md).
 
 **svcmgr**
-Service health monitor. Detects crashes and requests restarts via procmgr; holds
-direct process-creation capabilities to restart procmgr itself.
+Service health monitor. Detects crashes and requests restarts via
+procmgr; holds the fallback capabilities needed to restart procmgr
+itself. See [`services/svcmgr/README.md`](../services/svcmgr/README.md).
 
 **devmgr**
-Device manager. Receives platform resource capabilities from init, enumerates devices,
-spawns driver processes, and delegates per-device capabilities.
-See [device-management.md](device-management.md).
+Device manager. Enumerates platform hardware, spawns driver processes,
+and delegates per-device capabilities. See
+[device-management.md](device-management.md).
 
 **pwrmgr**
-Power manager. Sole holder of the raw platform shutdown caps (ACPI
-reclaimable Frame caps + `IoPortRange` on x86-64; `SbiControl` on
-RISC-V). Exposes `SHUTDOWN` / `REBOOT` over IPC, gated by a
-`SHUTDOWN_AUTHORITY` token bit. usertest invokes `SHUTDOWN` through a
-tokened cap on the success path so naked `cargo xtask run` exits
-cleanly. See [`services/pwrmgr/README.md`](../services/pwrmgr/README.md).
+Power manager. Owns the platform shutdown surface and serves
+`SHUTDOWN` / `REBOOT` IPC. See
+[`services/pwrmgr/README.md`](../services/pwrmgr/README.md).
 
 **drivers**
-Isolated userspace processes. Access hardware only through capabilities granted by
-devmgr.
+Isolated userspace processes. Access hardware only through capabilities
+granted by devmgr.
 
 **vfsd**
-Unified filesystem namespace over separate fs driver processes. Delegates operations
-to the appropriate driver.
+Unified filesystem namespace over separate fs driver processes.
 
 **fs drivers**
-Separate binaries in `fs/` (FAT, ext4, tmpfs, etc.), launched by vfsd. Communicate
-with block drivers via IPC.
+Separate binaries in `fs/` (FAT, ext4, tmpfs, etc.), launched by vfsd.
 
 **netd**
-Network stack. Manages interfaces via driver IPC and exposes socket-like endpoints
-to applications.
+Network stack. Manages interfaces via driver IPC and exposes socket-
+like endpoints to applications.
 
 **logd**
-Post-mount owner of the master log endpoint. Every userspace
-process holds a pre-installed tokened SEND cap on the same kernel
-endpoint (seeded by procmgr at spawn time into
-`ProcessInfo.log_send_cap`); logd drains the RECV side. Init runs an
-interim `init-logd` thread until logd is launched at the end of init's
-Phase 2, then hands over via `log_labels::HANDOVER_PULL` (the kernel
-endpoint object is unchanged across the handover, so existing tokened
-SEND caps survive without re-derivation). Subscribes to procmgr's
-death-notification cascade for per-sender slot reclamation.
+Owner of the master log endpoint; drains log messages from every
+process holding a pre-installed log SEND cap. See
+[`services/logd/README.md`](../services/logd/README.md).
 
 **base**
 Unprivileged applications (shell, terminal, editor, core tools).
@@ -248,32 +219,16 @@ Seraph targets 64‑bit architectures with modern MMU and privilege support.
 
 **x86‑64**
 Uses APIC and PCIDs. IOMMU hardware, when present, is discovered and
-programmed by devmgr in userspace; the kernel does not touch it. 32-bit
-and legacy x86 are not supported. The kernel is soft-float (no SSE/AVX/MMX);
-userspace targets the **x86-64-v3** psABI feature level (ratified 2020) —
-SSE2/3/SSSE3/SSE4.1/4.2, AVX, AVX2, FMA, BMI1/2, LZCNT, MOVBE, F16C, POPCNT.
+programmed by devmgr in userspace; the kernel does not touch it.
 
 **RISC‑V**
-The kernel is **RV64IMAC** soft-float (LP64 ABI); userspace targets the
-**RVA23U64** profile (RVA23 v1.0, ratified 2024-10-21) — IMAFDCV plus the
-Zba/Zbb/Zbs bitmanip set, hard-float LP64D ABI. Embedded or non-standard
-configurations are not targeted. The kernel never touches F/D/V state
-itself; userspace FP/V state is preserved across preemption by a lazy
-save/restore discipline.
+Embedded or non-standard configurations are not targeted.
 
-See [coding-standards.md#c-architecture-invariants](coding-standards.md#c-architecture-invariants)
-for the architectural code isolation rules.
-
----
-
-## Non-Goals
-
-**POSIX API compatibility.**
-Seraph defines its own native interfaces. Filesystem formats and network protocols
-may be adopted as data formats, not as API commitments.
-
-**Binary compatibility with other operating systems.**
-Seraph does not aim to run Linux or other OS binaries.
+Per-arch kernel and userspace target specifications (soft-float / FP
+profile, psABI feature floor, microarchitecture pins) are in
+[`build-system.md`](build-system.md#custom-targets). Architectural code
+isolation rules are in
+[coding-standards.md#c-architecture-invariants](coding-standards.md#c-architecture-invariants).
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -237,5 +237,12 @@ isolation rules are in
 
 ## Summarized By
 
-[README.md](../README.md), [init/README.md](../services/init/README.md), [memmgr/README.md](../services/memmgr/README.md), [procmgr/README.md](../services/procmgr/README.md)
+[README.md](../README.md),
+[devmgr/README.md](../services/devmgr/README.md),
+[init/README.md](../services/init/README.md),
+[logd/README.md](../services/logd/README.md),
+[memmgr/README.md](../services/memmgr/README.md),
+[procmgr/README.md](../services/procmgr/README.md),
+[pwrmgr/README.md](../services/pwrmgr/README.md),
+[svcmgr/README.md](../services/svcmgr/README.md)
 

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -102,4 +102,8 @@ Once init exits, svcmgr is the resident supervisor. See
 
 ## Summarized By
 
-[README.md](../README.md)
+[README.md](../README.md),
+[abi/boot-protocol/README.md](../abi/boot-protocol/README.md),
+[init/README.md](../services/init/README.md),
+[logd/README.md](../services/logd/README.md),
+[svcmgr/README.md](../services/svcmgr/README.md)

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -1,9 +1,10 @@
 # System Bootstrap
 
-End-to-end summary of the boot lifecycle from power-on through handover to
-svcmgr. This document is a routing summary; every stage below is authoritatively
-owned by a component-scope document, and the full specification of any stage
-is found by following the link.
+End-to-end summary of the boot lifecycle from power-on through handover to svcmgr.
+
+Every stage below is authoritatively owned by a component-scope
+document; the full specification of any stage is found by following
+the link.
 
 ---
 
@@ -69,49 +70,36 @@ first call. Init then requests procmgr to start the remaining early services
 subsets of its initial capability set to each service, registers services
 with svcmgr, and exits.
 
-At the end of init's Phase 2 — after the root mount completes but before
-Phase 3 spawns any other service — init spawns real `logd` from
-`/bin/logd` and hands it the receive side of the master log endpoint
-via `log_labels::HANDOVER_PULL`. init-logd's receive loop terminates
-on the final handover reply. The kernel endpoint object is unchanged
-across the transition, so every pre-existing tokened SEND cap (held
-by memmgr, procmgr, every tier-1 service) continues to work without
-re-derivation; only the holder of the RECV cap changes. See
-[`services/logd/README.md`](../services/logd/README.md) and
-[`services/logd/docs/handover-protocol.md`](../services/logd/docs/handover-protocol.md). The system-scope userspace boot order lives in
-[`process-lifecycle.md`](process-lifecycle.md); role-level description is in
-[`services/init/README.md`](../services/init/README.md); authoritative stage
-enumeration lives in
+At the end of init's Phase 2, init spawns real `logd` and hands it
+the receive side of the master log endpoint. The kernel endpoint
+object is unchanged across the transition, so existing tokened SEND
+caps continue to work without re-derivation. See
+[`services/logd/docs/handover-protocol.md`](../services/logd/docs/handover-protocol.md).
+
+The system-scope userspace boot order lives in
+[`process-lifecycle.md`](process-lifecycle.md); role-level description
+is in [`services/init/README.md`](../services/init/README.md);
+authoritative stage enumeration lives in
 [`services/init/docs/bootstrap.md`](../services/init/docs/bootstrap.md).
 Alternative init binaries (for example
-[`core/ktest/README.md`](../core/ktest/README.md)) may occupy the init slot
-for specialized purposes and follow their own bootstrap shape.
+[`core/ktest/README.md`](../core/ktest/README.md)) may occupy the init
+slot for specialised purposes and follow their own bootstrap shape.
 
 ---
 
 ## Handover to svcmgr
 
-At the end of Phase 3, init signs over its own kernel-object caps
-(`AddressSpace`, `CSpace`, main `Thread`, init-logd `Thread`) and every
-reclaimable Frame cap (segments + stack + `InitInfo` pages + IPC buffer)
-to procmgr via `procmgr_labels::REGISTER_INIT_TEARDOWN`, then
-`sys_thread_exit`s. Procmgr binds a death-EQ observer on init's main
-thread with `procmgr_labels::INIT_REAP_CORRELATOR`; the event delivered
-by the exit triggers procmgr's reap path, which (1) reclaims both
-TCBs, (2) tears down init's `AddressSpace` (PT chunks freed, mappings
-gone), (3) donates the Frame caps to memmgr's pool with `DONATE_FRAMES`,
-and (4) tears down init's `CSpace` (cascade reclaims the remaining
-endpoint and slab caps). After reap, no init-related kernel object
-exists and the segment / stack / `InitInfo` / IPC-buffer pages are back
-in memmgr's pool. See `services/procmgr/src/init_reap.rs`.
+At the end of Phase 3, init transfers its kernel-object and
+reclaimable Frame capabilities to procmgr via
+`REGISTER_INIT_TEARDOWN` and exits; procmgr reaps the kernel objects
+and reclaims the frames. See
+[`process-lifecycle.md`](process-lifecycle.md) §"Init reap".
 
-Once init exits, svcmgr is the resident supervisor: it monitors registered
-services, handles restarts, and holds the direct process-creation
-capabilities needed to recover procmgr itself. See
+Once init exits, svcmgr is the resident supervisor. See
 [`services/svcmgr/README.md`](../services/svcmgr/README.md).
 
 ---
 
 ## Summarized By
 
-None
+[README.md](../README.md)

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -199,10 +199,10 @@ table lives in [`xtask/README.md`](../xtask/README.md#environment-variables).
 
 **Minimum QEMU version:** QEMU ≥ 8.0 (V extension support) is required;
 `xtask/src/qemu.rs` passes `-cpu rv64,v=true,zba=true,zbb=true,zbs=true`
-for RISC-V and `-cpu max,migratable=no` on x86-64 TCG. The named
-`-cpu rva23s64` model arrived in QEMU 9.1 (2024-09) and is the preferred
-swap once the CI runner floor ships it; until then the explicit feature
-string is the source of truth.
+for RISC-V and `-cpu max,migratable=no` on x86-64 TCG. The explicit
+feature string is the source of truth. The named `-cpu rva23s64`
+single-flag equivalent (QEMU ≥ 9.1, 2024-09) is a documented
+configuration alternative when the CI runner floor supports it.
 
 ---
 
@@ -216,8 +216,8 @@ tree, scheduler run queues) keep hardware dependencies behind trait boundaries. 
 to run these modules on the host under the standard test harness.
 
 **QEMU integration tests** — Code requiring real hardware (page tables, interrupts, context
-switching) is tested under QEMU with a custom harness that runs tests sequentially and reports
-results over serial. This harness will be implemented when arch code is written.
+switching) is tested under QEMU by the [`core/ktest`](../core/ktest/README.md) harness, which
+runs tests sequentially and reports results over serial.
 
 ### Running Tests
 
@@ -227,7 +227,7 @@ cargo xtask test --component kernel     # single crate
 ```
 
 For test naming conventions and requirements (what must be tested, what should not), see
-[coding-standards.md](coding-standards.md#testing).
+[coding-standards.md](coding-standards.md#d-testing-invariants).
 
 ---
 

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -80,9 +80,7 @@ floor for userspace SIMD / Vector codegen:
   XSAVE/XSAVEOPT for the lazy save/restore discipline.
 - `riscv64a23-seraph.json` — **RVA23U64** userspace profile (RVA23 v1.0,
   ratified 2024-10-21): IMAFDCV plus the Zba/Zbb/Zbs bitmanip set,
-  hard-float LP64D ABI. Further RVA23 mandates (Zfa, Zfhmin, Zihintntl,
-  Zicond, Zimop, Zcmop, Zcb, Zvfhmin, Zvbb, Zvkt, Zkt) will land as LLVM
-  and QEMU coverage broadens.
+  hard-float LP64D ABI.
 
 Userspace correctness under preemption is provided by lazy FP/SIMD/V
 save/restore in the kernel scheduler — switch-out save on dirty, switch-in
@@ -95,10 +93,8 @@ custom JSON is needed. The RISC-V bootloader uses
 
 Custom targets require `-Zbuild-std` (`core,alloc,compiler_builtins` for
 kernel/no_std triples; `core,alloc,std,panic_abort` for std-userspace
-triples) to rebuild the standard library from source. This is passed
-explicitly by the build scripts rather than via `.cargo/config.toml`, to
-avoid interfering with `cargo test` (which builds for the host target and
-does not need `build-std`).
+triples) to rebuild the standard library from source. The build scripts
+pass the flag explicitly.
 
 ---
 
@@ -245,6 +241,27 @@ See [`xtask/README.md`](../xtask/README.md) for the full command reference and
 
 ---
 
+## Continuous Integration
+
+CI workflows live in `.github/workflows/`. Local equivalents are the
+`cargo xtask` commands documented above.
+
+| Workflow | Trigger | Purpose |
+|---|---|---|
+| `build-test.yml` | push to `master`, PR to `master`, manual dispatch | Light validation: one `host-tests` job runs `cargo xtask test`; the matrix `validate` job builds each `arch × profile` cell, runs one usertest iteration against the default `boot.conf`, then swaps `boot.conf` to `init=ktest` and runs one ktest iteration. |
+| `burnin.yml` | tag push (`v*.*.*`), manual dispatch | Heavy validation: per `arch × profile` cell, builds and runs `4 × 20` usertest iterations against the default `boot.conf`, then swaps to ktest and runs `4 × 20` ktest iterations. |
+| `release.yml` | tag push (`v*.*.*`), manual dispatch | Builds release-profile disk images per architecture, compresses with zstd, generates `SHA256SUMS`, creates a draft GitHub Release whose body is `docs/releases/<tag>.md`. |
+
+`build-test.yml` cancels stacked runs on the same ref
+(`cancel-in-progress: true`). `burnin.yml` and `release.yml` do not
+cancel on the same ref — a tag-push run completes even if a later tag
+pushes.
+
+The merge-gating rule (CI must pass green before merge) lives in
+[conventions.md](conventions.md#branch-and-pr-workflow).
+
+---
+
 ## Summarized By
 
-[README.md](../README.md)
+[README.md](../README.md), [conventions.md](conventions.md)

--- a/docs/capability-model.md
+++ b/docs/capability-model.md
@@ -250,94 +250,28 @@ chain that would produce the well-known constant can produce any other u64.
 Security comes from controlling *who holds an un-tokened cap*, not from secrecy
 of the token bits.
 
-### Examples in this codebase
-
-- **Memmgr** allocates a per-client tokened SEND on its own endpoint inside
-  `REGISTER_PROCESS` (`services/memmgr/src/main.rs:781`). The un-tokened source
-  cap on memmgr's endpoint never leaves memmgr's CSpace; clients see only the
-  set-once tokened copy minted for them.
-- **Procmgr** derives a tokened SEND_GRANT on its own endpoint per child during
-  `populate_child_info` (`services/procmgr/src/process.rs`). Children cannot
-  re-tokenize to mint `DEATH_EQ_AUTHORITY` or any other procmgr-side authority
-  bit. The un-tokened source stays in procmgr's own CSpace, and in init's CSpace
-  until init reaps.
-- **Pwrmgr** is similar: init mints both an authorised tokened cap
-  (`SHUTDOWN_AUTHORITY`) and a deliberately-non-authorised tokened cap
-  (sentinel `1`) for the negative-test path. Even the deny-test cap is tokened,
-  preventing the test recipient from re-deriving a privileged twin.
-
 ### Verb-bit authority pattern
 
-Some endpoints serve a mix of unprivileged read-style verbs (e.g.
-`QUERY_ENDPOINT`) and privileged mutate-style verbs (e.g.
-`PUBLISH_ENDPOINT`). Rather than splitting them across two endpoints
-(and two separate `service_*_cap` slots in `ProcessInfo`), Seraph uses
-a single endpoint and lets the server gate per-label on a **verb-bit**
-in the caller's token.
-
-Each privileged verb reserves one high bit of the u64 token namespace
-as its authority marker (`1u64 << 63` is the convention for the
-endpoint's first verb-bit). The set-once token rules above mean:
-
-- The server and its trusted bootstrap-time minters (init, and any
-  distributor init has delegated the un-tokened source to — devmgr
-  receives such a cap for `PUBLISH_AUTHORITY` in this codebase) are
-  the only entities that can mint a token with the verb-bit set. Every
-  other client holds only the tokened copies these distributors
-  chose to give them.
-- Distribution of an "authority" cap and an "unprivileged" cap differ
-  only in whether the trusted distributor sets the verb-bit in the
-  token passed to `cap_derive_token`. In this codebase the authority
-  cap's token is the verb-bit alone (no per-publisher identity in the
-  low bits); per-publisher attenuation (e.g. restricting registrations
-  to a name prefix) is the future-work shape and is tracked as a
-  follow-up issue.
-- A holder of an unprivileged cap **cannot** re-derive an authority
-  cap: set-once rules forbid changing the token, and re-deriving from
-  the un-tokened source requires a source the caller doesn't have.
-- The server's dispatcher checks `msg.token & VERB_BIT != 0` before
-  servicing the privileged label and replies `UNAUTHORIZED` otherwise
-  (`svcmgr_labels::PUBLISH_AUTHORITY`, `pwrmgr_labels::SHUTDOWN_AUTHORITY`).
-
-This collapses what would otherwise be one `ProcessInfo` slot per
-server-verb pairing into one slot per server endpoint, and keeps the
-authority/distribution decisions local to the trusted minter (init at
-boot, devmgr/svcmgr post-handover) without adding new kernel surface.
+Endpoints that serve a mix of unprivileged and privileged labels gate
+the privileged labels on a verb-bit in the caller's token, rather than
+splitting across separate endpoints. By convention the high bit
+(`1u64 << 63`) is the first verb-bit. The set-once token rules above
+mean only the server and its trusted bootstrap-time minters can set
+the verb-bit; a holder of an unprivileged cap cannot re-derive an
+authority cap. The server's dispatcher checks
+`msg.token & VERB_BIT != 0` before servicing the privileged label and
+replies `UNAUTHORIZED` otherwise.
 
 ---
 
 ## Capabilities as Namespaces
 
-The capability mechanism above suffices to express filesystem
-namespaces, sandbox views, and per-process roots without any kernel
-support beyond what is already documented. A **node capability** in
-Seraph is a tokened SEND on an IPC endpoint owned by a server
-process; the token's bits encode a server-private node identifier
-plus a per-cap rights mask, decoded by the server on every request.
-
-This composition gives:
-
-- **The capability is the namespace.** Holding a directory cap is
-  the authority to walk that directory; no path string carries
-  authority.
-- **Sandboxing as cap distribution.** A child process whose initial
-  bootstrap cap is a different node cap (or no cap at all) sees a
-  different root, with no kernel mount table or chroot syscall
-  involved.
-- **Per-child distribution at spawn.** procmgr installs each child's
-  `ProcessInfo.system_root_cap` from either the universal default
-  (a tokened SEND on vfsd's namespace endpoint) or a spawner-supplied
-  override. Spawners override via the `CONFIGURE_NAMESPACE` IPC
-  between create and start, transferring an attenuated cap they
-  obtained by walk-and-attenuate from a cap they already hold.
-  procmgr never mints namespace caps itself.
-- **Attenuation through rights bits.** The rights field in the token
-  narrows on every walk under server enforcement, mirroring the
-  derivation-tree attenuation the kernel enforces on the cap itself.
-
-The system-scope authority for the namespace model is
+The capability and token primitives above compose into Seraph's
+filesystem namespace mechanism (node capabilities, attenuation through
+rights bits, sandboxing by cap distribution) without any kernel support
+beyond what this document specifies. The full model is in
 [`namespace-model.md`](namespace-model.md); the wire format and
-dispatch crate are
+dispatch crate are in
 [`shared/namespace-protocol/README.md`](../shared/namespace-protocol/README.md).
 
 ---
@@ -500,4 +434,4 @@ The kernel does not provide:
 
 ## Summarized By
 
-[Architecture Overview](architecture.md), [init](../services/init/README.md)
+[README.md](../README.md), [Architecture Overview](architecture.md), [init](../services/init/README.md), [namespace-model.md](namespace-model.md)

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -149,17 +149,12 @@ gives the PR-level linear view.
   acceptance rule under "Backlog Tracking" above.
 - Edit via `gh pr edit <N> --body "$(cat <<'EOF' …EOF)"` or the web UI.
 
-## CI Workflows
+## CI Gating
 
-| Workflow file | Trigger | Purpose |
-|---|---|---|
-| `.github/workflows/build-test.yml` | push to `master`, PR to `master`, manual dispatch | Light validation: one `host-tests` job runs `cargo xtask test`; the matrix `validate` job builds each `arch × profile` cell, runs one usertest iteration against the default `boot.conf`, then swaps `boot.conf` to `init=ktest` and runs one ktest iteration. |
-| `.github/workflows/burnin.yml` | tag push (`v*.*.*`), manual dispatch | Heavy validation: per `arch × profile` cell, builds and runs `4 × 20` usertest iterations against the default `boot.conf`, then swaps to ktest and runs `4 × 20` ktest iterations. |
-| `.github/workflows/release.yml` | tag push (`v*.*.*`), manual dispatch | Builds release-profile disk images per architecture, compresses with zstd, generates `SHA256SUMS`, creates a draft GitHub Release whose body is `docs/releases/<tag>.md`. |
-
-`build-test.yml` cancels stacked runs on the same ref (`cancel-in-progress: true`). `burnin.yml` and `release.yml` do not cancel on the same ref — a tag-push run completes even if a later tag pushes.
-
-Local equivalents of the CI runs are documented in [build-system.md](build-system.md) and the `xtask` command surface lives in [`xtask/README.md`](../xtask/README.md).
+CI status checks MUST pass before merge. The authoritative workflow
+inventory and per-workflow shape live in
+[build-system.md](build-system.md#continuous-integration); local
+equivalents are the `cargo xtask` commands documented there.
 
 ## Release Production
 

--- a/docs/device-management.md
+++ b/docs/device-management.md
@@ -41,22 +41,12 @@ binding in a running system.
 
 ### What devmgr receives from init
 
-At startup, devmgr receives from init (via `SYS_CAP_INSERT`):
-
-- **MMIO aperture capabilities** — one `MmioRegion` cap per
-  `BootInfo.mmio_apertures` entry, covering coarse non-RAM physical
-  regions. Init narrows these into device-sized sub-caps as needed and
-  delegates them to drivers.
-- **Interrupt capabilities** — produced on demand via the runtime
-  IRQ-registration syscall (`SYS_IRQ_REGISTER`) after init has walked
-  firmware tables and located the relevant GSI / PLIC source.
-- **Firmware-table access** — access to ACPI and DTB physical memory so
-  devmgr can resolve per-device descriptors that the bootloader no longer
-  enumerates.
-- **SchedControl capability** — for assigning elevated priorities to latency-sensitive
-  driver threads.
-
-Init retains derived copies to revoke devmgr's authority if devmgr crashes.
+devmgr receives from init a platform capability set sufficient for
+enumeration and per-driver delegation (MMIO apertures, firmware-table
+access, SchedControl, IRQ-registration authority). Init retains derived
+copies to revoke devmgr's authority if devmgr crashes. See
+[`services/devmgr/README.md`](../services/devmgr/README.md) for the
+authoritative cap-by-cap list.
 
 ### What devmgr does
 
@@ -102,31 +92,29 @@ possible. A driver may still be authorised by devmgr to DMA in this mode,
 but no hardware enforcement constrains the device; a compromised driver
 can reach any physical address the device can address.
 
-devmgr is responsible for detecting the platform IOMMU situation, deciding
-per-device policy, and programming the IOMMU itself when present. For
-devices that require DMA on a platform without IOMMU protection, devmgr may:
-- Refuse to bind the driver.
-- Bind the driver after warning the operator.
-- Bind the driver in a restricted mode that avoids DMA entirely.
+devmgr is responsible for detecting the platform IOMMU situation,
+deciding per-device policy, and programming the IOMMU itself when
+present. Policy on platforms without IOMMU protection is devmgr-
+defined; see [`services/devmgr/README.md`](../services/devmgr/README.md).
 
-This decision is entirely userspace policy. The kernel is agnostic to DMA
-mode: it does not read or write IOMMU registers, does not track per-device
-DMA state, and does not return a DMA-safety verdict.
+The kernel is agnostic to DMA mode: it does not read or write IOMMU
+registers, does not track per-device DMA state, and does not return a
+DMA-safety verdict.
 
 ---
 
 ## IOMMU Discovery and Programming
 
-IOMMU topology is a userspace concern. The bootloader does **not** emit a
-dedicated resource variant for IOMMU units; it passes ACPI and DTB tables
-through unchanged via `PlatformTable` entries, and `devmgr` performs the
-IOMMU-topology walk itself (DMAR on x86-64, `iommu` / `iommu-map` nodes on
-RISC-V).
+IOMMU topology is a userspace concern. The bootloader does **not** emit
+a dedicated resource variant for IOMMU units; it passes ACPI and DTB
+tables through unchanged via `PlatformTable` entries, and `devmgr`
+performs the IOMMU-topology walk itself. Discovery specifics live in
+[`services/devmgr/README.md`](../services/devmgr/README.md).
 
-For each IOMMU discovered, `devmgr` acquires an MMIO-region capability for
-that IOMMU's register range and programs the translation tables directly.
-The kernel does not read or write IOMMU registers and holds no per-IOMMU
-state.
+For each IOMMU discovered, `devmgr` acquires an MMIO-region capability
+for that IOMMU's register range and programs the translation tables
+directly. The kernel does not read or write IOMMU registers and holds
+no per-IOMMU state.
 
 When devmgr binds a DMA-capable driver, devmgr (a) programs the IOMMU
 translation tables for that driver's device, and (b) derives and transfers a
@@ -164,4 +152,4 @@ managed by init's bootstrap sequence (for early boot) and svcmgr (for restarts).
 
 ## Summarized By
 
-[Architecture Overview](architecture.md), [devmgr](../services/devmgr/README.md), [drivers](../services/drivers/README.md)
+[README.md](../README.md), [Architecture Overview](architecture.md), [devmgr](../services/devmgr/README.md), [drivers](../services/drivers/README.md)

--- a/docs/ipc-design.md
+++ b/docs/ipc-design.md
@@ -1,11 +1,16 @@
 # IPC Design
 
-All communication between processes goes through the kernel's IPC mechanism. Two
-processes that do not share an IPC capability cannot communicate.
+All communication between processes goes through the kernel's IPC mechanism.
+
+---
+
+## Overview
+
+Two processes that do not share an IPC capability cannot communicate.
 
 - **Synchronous calls** for structured request/reply between services.
-- **Asynchronous primitives** for event delivery: signals (coalescing bitmask) and
-  event queues (ordered ring).
+- **Asynchronous primitives** for event delivery: signals (coalescing
+  bitmask) and event queues (ordered ring).
 
 ---
 
@@ -149,4 +154,4 @@ The kernel does not provide:
 
 ## Summarized By
 
-[Architecture Overview](architecture.md)
+[README.md](../README.md), [Architecture Overview](architecture.md)

--- a/docs/ipc-design.md
+++ b/docs/ipc-design.md
@@ -154,4 +154,10 @@ The kernel does not provide:
 
 ## Summarized By
 
-[README.md](../README.md), [Architecture Overview](architecture.md)
+[README.md](../README.md),
+[Architecture Overview](architecture.md),
+[devmgr/README.md](../services/devmgr/README.md),
+[logd/README.md](../services/logd/README.md),
+[memmgr/README.md](../services/memmgr/README.md),
+[procmgr/README.md](../services/procmgr/README.md),
+[vfsd/README.md](../services/vfsd/README.md)

--- a/docs/memory-model.md
+++ b/docs/memory-model.md
@@ -1,6 +1,7 @@
 # Memory Model
 
-System-scope virtual address space layout, paging, and physical memory management for both supported architectures.
+System-scope virtual address space layout, paging, and physical memory
+management for both supported architectures.
 
 ---
 

--- a/docs/memory-model.md
+++ b/docs/memory-model.md
@@ -1,5 +1,11 @@
 # Memory Model
 
+System-scope virtual address space layout, paging, and physical memory management for both supported architectures.
+
+---
+
+## Overview
+
 Seraph uses a conventional higher-half kernel layout on both supported architectures.
 The kernel occupies the upper portion of the virtual address space; userspace processes
 occupy the lower portion. Each process has its own isolated address space. The kernel
@@ -81,9 +87,6 @@ maps segments as directed by the binary format. The general convention is:
   0x0000000000400000 ┘  Program image (text, rodata, data, bss)
 ```
 
-Stack and heap placement will be randomised (ASLR) once the kernel's random number
-source is available. Exact base addresses are not fixed at this stage.
-
 Concrete VA management surfaces, the frame-allocation contract, and ownership
 boundaries between the kernel, memmgr, procmgr, and `std::sys::seraph` are
 documented in [userspace-memory-model.md](userspace-memory-model.md). The
@@ -155,38 +158,13 @@ boot modules, and reserved regions is marked unavailable.
 
 ### Bootloader Scratch Reclamation
 
-Pages the bootloader allocated for its own scratch use — the `BootInfo`
-struct, the module descriptor array, the memory-map entry array, the
-MMIO aperture array, the reclaim-array page itself, the cmdline page,
-the AP SIPI trampoline page, and every transient page-table frame —
-are recorded in `BootInfo.reclaim_ranges` (boot protocol v7) and
-consumed by `cap::mint_reclaim_frame_caps` during Phase 7. The kernel
-mints one reclaimable Frame cap per range (`owns_memory = true`, full
-byte ledger) and inserts it into the root `CSpace` so the cap reaches
-init through the standard `CapDescriptor` walk. The buddy ledger
-records each range via `register_owned_range` so cap teardown returns
-the pages via the existing `dealloc_object` → `free_range` path with
-the `total / free` ratio well-defined. Whether init donates the cap
-onward to memmgr or lets it cascade back to the buddy on CSpace
-teardown is a userspace policy decision; the kernel does not impose a
-route.
-
-Two entries reach the cap surface through indirect paths:
-
-- The cmdline page lands in `reclaim_ranges` like every other early
-  entry, but only after the kernel snapshots its contents into a small
-  BSS buffer during Phase 4. The Phase-9 `InitInfo` copy reads from the
-  snapshot, leaving the bootloader page reclaim-safe by Phase 7.
-- The AP SIPI trampoline page is flagged `RECLAIM_FLAG_LATE` in
-  `reclaim_ranges`. `cap::mint_reclaim_frame_caps` skips it during the
-  Phase-7 walk; `cap::mint_late_reclaim_frame_caps` mints it later in
-  Phase 8, after SMP bringup completes and
-  `mm::paging::unmap_identity_page` retires the low-VA identity-RWX
-  mapping. (Both arches install this identity mapping in Phase 3 — the
-  trampoline must remain executable at its PA while PC walks the
-  post-`csrw satp` / post-CR3-write instructions.) The late-mint
-  completes before Phase 9 consumes `cspace_layout`, so the descriptor
-  still flows through the standard CSpace handoff.
+Pages the bootloader allocated for its own scratch use are recorded in
+`BootInfo.reclaim_ranges` and minted as reclaimable Frame caps into
+init's CSpace by the kernel-initialisation reclaim-minting steps. See
+[`core/kernel/docs/initialization.md`](../core/kernel/docs/initialization.md)
+Phase 7 (standard reclaim mint) and Phase 8 (`RECLAIM_FLAG_LATE`
+late-mint for the AP SIPI trampoline page) for the authoritative
+mechanism.
 
 ### Buddy Allocator
 
@@ -248,4 +226,4 @@ Kernel heap allocation MUST be handled as fallible at every call site.
 
 ## Summarized By
 
-[Architecture Overview](architecture.md)
+[README.md](../README.md), [Architecture Overview](architecture.md)

--- a/docs/namespace-model.md
+++ b/docs/namespace-model.md
@@ -27,17 +27,12 @@ override.
 
 ## Node Capabilities
 
-A **node capability** is a tokened send capability on a namespace server's
-endpoint. The token encodes:
-
-| Field | Width | Meaning |
-|---|---:|---|
-| `node_id` | 40 bits | Server-private inode identifier |
-| `rights`  | 24 bits | Namespace rights (see below) |
-
-The kernel does not interpret token bits. Token semantics are owned by
-the namespace-protocol contract; servers decode the token on every
-request to identify the addressed node and the caller's rights.
+A **node capability** is a tokened send capability on a namespace
+server's endpoint. The token packs a 40-bit server-private node
+identifier and a 24-bit namespace rights mask (see
+[Namespace Rights](#namespace-rights)). See
+[capability-model.md](capability-model.md) §"Tokens" for the
+kernel-side derivation and set-once semantics that govern these caps.
 
 A node capability is one of two kinds, distinguished only by the rights
 the server permits and the operations the server accepts on the
@@ -56,13 +51,8 @@ distinctions are server-private and surface to clients via the
 
 Every node capability the system ever issues derives from a server's
 **namespace endpoint capability**: an un-tokened send capability the
-server holds in its own CSpace. All node caps a server issues share
-this single kernel-derivation parent.
-
-This is mandated by the kernel's `cap_derive_token` contract, which
-forbids deriving a tokened cap from an already-tokened source. The
-namespace tree therefore lives in server state, not in the kernel's
-derivation graph.
+server holds in its own CSpace. The namespace tree therefore lives in
+server state, not in the kernel's derivation graph.
 
 ### Revocation
 
@@ -96,9 +86,9 @@ rights are only inspected by the server.
 | 1 | `READDIR` | NS_READDIR enumeration of this directory is permitted |
 | 2 | `STAT` | NS_STAT on this node is permitted |
 | 3 | `READ` | NS_READ / NS_READ_FRAME on this file is permitted |
-| 4 | `WRITE` | NS_WRITE on this file is permitted (deferred; reserved) |
+| 4 | `WRITE` | NS_WRITE on this file is permitted |
 | 5 | `EXEC` | This file is executable (consumed by ELF loaders) |
-| 6 | `MUTATE_DIR` | NS_CREATE / NS_UNLINK in this directory are permitted (deferred; reserved) |
+| 6 | `MUTATE_DIR` | NS_CREATE / NS_UNLINK in this directory are permitted |
 | 7 | `ADMIN` | Reserved for visibility gating (see Per-Entry Visibility) |
 | 8..23 | — | Reserved; MUST be zero on derive, ignored on read |
 
@@ -118,20 +108,13 @@ in addition to the child's `node_id` and `kind`:
 - `visible_requires` — the rights the caller's directory capability
   MUST hold for this entry to be visible at lookup or readdir.
 
-`NS_LOOKUP` semantics, executed uniformly by the namespace-protocol
-crate (not by individual drivers):
-
-1. Decode the caller's token into `(parent_node, parent_rights)`.
-2. If `parent_rights & LOOKUP == 0`, reply `PERMISSION_DENIED`.
-3. Validate the requested name (see Naming).
-4. Resolve `(parent_node, name)` to an `EntryView` via the backend.
-5. If `(parent_rights & entry.visible_requires) != entry.visible_requires`,
-   reply `NOT_FOUND`. The caller MUST NOT be able to distinguish
-   "hidden" from "absent."
-6. Compute `returned_rights = parent_rights ∩ entry.max_rights ∩ caller_requested_rights`.
-7. Mint the child capability via `cap_derive_token` from the server's
-   namespace endpoint, with token `(entry.child_node, returned_rights)`.
-8. Reply with the child capability, its `kind`, and a size hint for files.
+On `NS_LOOKUP`, the returned child rights equal
+`parent_rights ∩ entry.max_rights ∩ caller_requested_rights`; entries
+failing the `visible_requires` check appear as `NOT_FOUND` (the caller
+MUST NOT be able to distinguish "hidden" from "absent"). The
+namespace-protocol crate executes this uniformly for every backend; see
+[`shared/namespace-protocol/README.md`](../shared/namespace-protocol/README.md)
+§`NS_LOOKUP` for the wire-level dispatch.
 
 `NS_READDIR` applies the same visibility filter: entries hidden from
 this caller are skipped. Hidden entries do not appear in enumeration.
@@ -275,18 +258,13 @@ There is no chroot syscall, no mount namespace, no per-process mount
 table, and no permission-check syscall. The capability delivered *is*
 the sandbox boundary.
 
-The wire mechanism is `procmgr_labels::CONFIGURE_NAMESPACE`, called
-on a tokened process handle between `CREATE_PROCESS` /
-`CREATE_FROM_FILE` and `START_PROCESS`. The supplied cap is the sole
-source of the child's `ProcessInfo.system_root_cap` — without this
-call the slot stays zero and the child runs with no namespace
-authority. Procmgr holds no namespace cap of its own; the spawner is
-the cap-distribution authority on every spawn. The cap is typically
-either a `cap_copy` of the spawner's own `root_dir_cap` (parent-
-inherit default for `Command::spawn`) or a walk-and-attenuated view
-the spawner constructed for sandboxing. From std, the seraph-
-specific `std::os::seraph::process::CommandExt::namespace_cap`
-extension overrides the parent-inherit default with an explicit cap.
+The spawner is the cap-distribution authority on every spawn: it
+delivers the child's root capability at process-creation time, and
+absent delivery the child has no namespace access. Procmgr holds no
+namespace cap of its own. For the wire mechanism see
+[`services/procmgr/README.md`](../services/procmgr/README.md); for the
+std bindings see
+[`runtime/ruststd/README.md`](../runtime/ruststd/README.md).
 
 ---
 
@@ -310,27 +288,8 @@ This makes the mechanism agnostic to:
   Per-user identity becomes the policy-layer mapping from authenticated
   identity to a particular root capability.
 
-The user/identity layer is deferred. When introduced, it operates
-above this mechanism by composing views and minting per-identity
-capabilities; the namespace surface itself does not change.
-
----
-
-## What This Model Does Not Do
-
-- **No path-based authority.** A path string carries no authority. The
-  authority for any operation is a held capability.
-- **No ambient lookup.** A process cannot ask "what files exist on this
-  system" except through capabilities it holds. Discovery beyond a
-  granted subtree is structurally impossible.
-- **No setuid-equivalent.** A program does not gain rights by being
-  marked or by its on-disk metadata. A program's rights are exactly
-  the capabilities its spawner delivers.
-- **No identity-based override.** No "root user" with implicit
-  override. Authority is held capabilities, nothing else.
-
 ---
 
 ## Summarized By
 
-[docs/capability-model.md](capability-model.md), [shared/namespace-protocol/README.md](../shared/namespace-protocol/README.md), [services/vfsd/docs/namespace-composition.md](../services/vfsd/docs/namespace-composition.md)
+[README.md](../README.md), [docs/capability-model.md](capability-model.md), [shared/namespace-protocol/README.md](../shared/namespace-protocol/README.md), [services/vfsd/docs/namespace-composition.md](../services/vfsd/docs/namespace-composition.md)

--- a/docs/process-lifecycle.md
+++ b/docs/process-lifecycle.md
@@ -1,11 +1,6 @@
 # Process Lifecycle
 
-System-wide model of userspace process creation, identity, and
-destruction. This document covers the userspace half of the boot
-sequence (init onward) and the steady-state process-creation and
--death flows that follow. The bootloader-and-kernel half lives in
-[`bootstrap.md`](bootstrap.md); this document picks up where init
-begins executing.
+System-wide model of userspace process creation, identity, and destruction from init onward.
 
 ---
 
@@ -127,50 +122,17 @@ restart policy.
 ### Init reap
 
 After Phase 3 (svcmgr handover complete, usertest spawned), init signs
-over its own kernel-object caps and every reclaimable Frame cap to
-procmgr via `procmgr_labels::REGISTER_INIT_TEARDOWN` and then
-`sys_thread_exit`s.
+over its own kernel-object caps (`AddressSpace`, `CSpace`, main
+`Thread`, init-logd `Thread`) and every reclaimable Frame cap (ELF
+segments, user stack pages, `InitInfo` pages, IPC buffer) to procmgr
+via `procmgr_labels::REGISTER_INIT_TEARDOWN`, then `sys_thread_exit`s.
 
-Caps moved in the handoff:
-
-1. **Kernel-object caps** (first round):
-   - Init's own `AddressSpace`.
-   - Init's own `CSpace`.
-   - Init's main `Thread`.
-   - Init-logd's `Thread` (already in `Exited` state — TCB lingers
-     until cap death drives the dealloc).
-
-2. **Reclaimable Frame caps** (subsequent rounds, up to 4 caps per IPC):
-   - Init's ELF segment caps (kernel-minted at Phase 9 with
-     `RETYPE` + `owns_memory=true` + `available_bytes = size`).
-   - Init's user stack pages (one cap per page, same flags).
-   - Init's `InitInfo` region pages (one cap per page, same flags).
-   - Init's IPC buffer page (init-created via `FrameAlloc`).
-
-Procmgr binds a death-EQ observer on init's main thread with
-`procmgr_labels::INIT_REAP_CORRELATOR` (reserved `u32::MAX`); when
-init's `sys_thread_exit` posts the death notification, procmgr's
-`dispatch_death` routes to `init_reap::run_reap`:
-
-1. `cap_delete(init-logd thread)` — TCB reclaimed.
-2. `cap_delete(init main thread)` — TCB reclaimed.
-3. `cap_revoke + cap_delete(init AddressSpace)` — `dealloc_object`
-   walks PT chunks and `retype_free`s them; user-page mappings vanish
-   atomically.
-4. `DONATE_FRAMES(donate_caps) → memmgr` — pages enter memmgr's pool.
-   Safe: no aliasing, since init's mappings died at step 3.
-5. `cap_revoke + cap_delete(init CSpace)` — cascade dec_refs every
-   remaining cap (endpoint SENDs, endpoint slab Frame, leftover
-   `FrameAlloc` tails). `owns_memory = true` Frame caps return their
-   pages directly to the kernel buddy via `dealloc_object`'s
-   `buddy.free_range`.
-6. Log: `[procmgr] init reaped: donated N caps = M pages (M KiB) to
-   memmgr; pool reclaim total T pages`.
-
-After reap, no init-related kernel object exists; init's segment / stack
-/ `InitInfo` / IPC-buffer pages are in memmgr's pool; init's endpoint
-slab and any other `FrameAlloc` tails are back in the kernel buddy.
-Authoritative implementation: `services/procmgr/src/init_reap.rs`.
+Procmgr binds a death-EQ observer on init's main thread; on the death
+event procmgr tears down init's kernel objects in order (Threads →
+AddressSpace → donate Frame caps to memmgr → CSpace cascade), leaving
+zero init residue. The implementation is in
+[`services/procmgr/README.md`](../services/procmgr/README.md) §"Init
+reap".
 
 After init's reap completes, svcmgr is the resident supervisor. See
 [`services/svcmgr/README.md`](../services/svcmgr/README.md).
@@ -239,24 +201,14 @@ at creation time. Examples:
 - `InitInfo.memory_frame_base`, `InitInfo.memory_frame_count` — chosen
   by the kernel per init invocation.
 
-### ABI constants today, runtime fields after ASLR
+### ABI constants
 
-Fields that are pinned at well-known virtual addresses today
+Fields that are pinned at well-known virtual addresses
 (`PROCESS_INFO_VADDR`, `PROCESS_STACK_TOP`, `PROCESS_MAIN_TLS_VADDR`,
 `INIT_INFO_VADDR`). Each is declared in its respective ABI crate
 (`abi/process-abi`, `abi/init-protocol`) and consumed by both the
 parent-side populator and the child-side `_start` to find its handover
 page.
-
-The ASLR work (tracked separately) promotes these to runtime fields:
-the parent draws each VA from the system RNG and writes it into a typed
-field on the handover page; the child reads the field to locate the
-page and its bootstrap regions. The mechanism is identical to today's
-runtime-field path; only the source of the value changes.
-
-This document declares the ASLR-transition shape so consumers reading
-the `ProcessInfo` / `InitInfo` ABI today understand which constants are
-expected to migrate.
 
 ### CSpace slot conventions
 
@@ -367,20 +319,17 @@ fault. svcmgr does not restart memmgr.
 
 ---
 
-## Non-Goals
+## Out of Scope
 
-- **`fork()` and copy-on-write.** Seraph does not implement either.
-  Process creation is always from-scratch via `CREATE_PROCESS`. Zero-
-  copy buffer handoff between processes uses Frame-cap moves over IPC,
-  not write-trap CoW.
-- **Kernel-side process abstraction.** The kernel has no Process
-  object. A process is a userspace convention: an `AddressSpace` plus
-  a `CSpace` plus one or more `Thread`s, grouped by procmgr.
-- **Pager protocols and userspace page-fault delivery.** No mechanism
-  delivers page faults to userspace; faulting threads terminate.
+Seraph does not implement `fork()` or copy-on-write. Process creation
+is always from-scratch via `CREATE_PROCESS`; zero-copy buffer handoff
+between processes uses Frame-cap moves over IPC.
+
+Page faults are not delivered to userspace; faulting threads terminate,
+which surfaces through the normal process-death notification flow above.
 
 ---
 
 ## Summarized By
 
-[Architecture Overview](architecture.md), [Bootstrap](bootstrap.md), [Userspace Memory Model](userspace-memory-model.md), [memmgr/README.md](../services/memmgr/README.md), [procmgr/README.md](../services/procmgr/README.md), [init/README.md](../services/init/README.md)
+[README.md](../README.md), [Architecture Overview](architecture.md), [Bootstrap](bootstrap.md), [Userspace Memory Model](userspace-memory-model.md), [memmgr/README.md](../services/memmgr/README.md), [procmgr/README.md](../services/procmgr/README.md), [init/README.md](../services/init/README.md)

--- a/docs/process-lifecycle.md
+++ b/docs/process-lifecycle.md
@@ -215,8 +215,7 @@ page.
 The `ProcessInfo` page also names the well-known CSpace slots that the
 parent populates (see
 [`abi/process-abi/README.md`](../abi/process-abi/README.md) §"Fixed
-CSpace slot conventions"). These are slot indices, not VAs, and are
-unaffected by ASLR.
+CSpace slot conventions"). These are slot indices, not VAs.
 
 ---
 
@@ -270,7 +269,7 @@ A process dies when:
 
 - It calls `sys_thread_exit` on its last thread.
 - Its `AddressSpace` capability is revoked (the "kill process" pattern;
-  see [`capability-model.md`](capability-model.md) §"Kill process pattern").
+  see [`capability-model.md`](capability-model.md) §`"Kill process" pattern`).
 - An unhandled fault terminates its threads.
 
 The death-notification flow:

--- a/docs/process-lifecycle.md
+++ b/docs/process-lifecycle.md
@@ -12,8 +12,7 @@ This document is authoritative for:
   (`init` → `memmgr` → `procmgr` → `svcmgr`).
 - The capability flow at each step — who hands what to whom.
 - The `ProcessInfo` / `InitInfo` handover discipline: which fields are
-  parent-chosen runtime values, which are ABI constants, and how the
-  ASLR transition will reshape the boundary.
+  parent-chosen runtime values and which are ABI constants.
 - The steady-state process-creation flow under procmgr.
 - The process-death notification flow that drives memmgr reclamation.
 - The procmgr-restart fallback when procmgr itself dies.
@@ -331,4 +330,12 @@ which surfaces through the normal process-death notification flow above.
 
 ## Summarized By
 
-[README.md](../README.md), [Architecture Overview](architecture.md), [Bootstrap](bootstrap.md), [Userspace Memory Model](userspace-memory-model.md), [memmgr/README.md](../services/memmgr/README.md), [procmgr/README.md](../services/procmgr/README.md), [init/README.md](../services/init/README.md)
+[README.md](../README.md),
+[Architecture Overview](architecture.md),
+[Bootstrap](bootstrap.md),
+[Userspace Memory Model](userspace-memory-model.md),
+[init/README.md](../services/init/README.md),
+[logd/README.md](../services/logd/README.md),
+[memmgr/README.md](../services/memmgr/README.md),
+[procmgr/README.md](../services/procmgr/README.md),
+[svcmgr/README.md](../services/svcmgr/README.md)

--- a/docs/userspace-memory-model.md
+++ b/docs/userspace-memory-model.md
@@ -102,9 +102,7 @@ the process via the page-reservation allocator inside `std::sys::seraph`.
   for `mem_unmap` before `unreserve_pages`.
 - **Arena.** Each process carves a fixed-size arena out of its own
   address space at `_start` time. The arena base is a deterministic
-  constant for the first cut and is structured so a one-line change
-  switches to RNG-driven randomisation when the kernel RNG is
-  available.
+  constant.
 - **Concurrency.** Reservations are independent across threads; the
   allocator serialises on a spinlock as needed.
 
@@ -145,14 +143,11 @@ the child's `_start` will find them.
   `PROCESS_MAIN_TLS_VADDR` (today an ABI constant); spawned threads
   allocate their TLS blocks from the heap.
 
-Today, the page locations are split between **runtime fields**
+The page locations are split between **runtime fields**
 (`ipc_buffer_vaddr`) and **ABI constants** (`PROCESS_INFO_VADDR`,
-`PROCESS_STACK_TOP`, `PROCESS_MAIN_TLS_VADDR`, `INIT_INFO_VADDR`). The
-ASLR work (tracked separately) promotes the constants to runtime
-fields: the creator draws each VA from the system RNG and writes it
-into a typed field on the handover page, the child reads the field
-to locate the page. The mechanism is identical to today's
-`ipc_buffer_vaddr` path.
+`PROCESS_STACK_TOP`, `PROCESS_MAIN_TLS_VADDR`, `INIT_INFO_VADDR`).
+Each ABI constant is declared in its respective ABI crate
+(`abi/process-abi`, `abi/init-protocol`).
 
 See [`process-lifecycle.md`](process-lifecycle.md) for the full
 handover discipline.
@@ -184,65 +179,32 @@ Authoritative wire shape lives in
 
 ---
 
-## What the Kernel Refuses to Learn
+## Kernel-Side Non-Concerns
 
-- **Process** — not a kernel object. A "process" is an `AddressSpace`
-  plus a `CSpace` plus one or more `Thread`s, grouped by procmgr.
-- **Heap** — unknown to the kernel. The kernel only sees mappings of
-  Frame caps at user-supplied VAs.
+The kernel does not track per-process memory abstractions; userspace
+owns them.
+
+- **Heap** — the kernel only sees mappings of Frame caps at user-
+  supplied VAs.
 - **VA allocation policy** — the kernel enforces page alignment and
   the user-half bound; it does not track or allocate VAs.
-- **Frame ownership beyond the derivation tree** — the kernel does not
-  know which process "owns" a Frame; that information lives in
-  memmgr's per-process tracking.
+- **Frame ownership beyond the derivation tree** — the kernel does
+  not know which process "owns" a Frame.
 - **Process death implications for memory** — when a process's
   `AddressSpace` is revoked, the kernel tears down threads and page
   tables. memmgr's reclamation runs separately, driven by procmgr's
   death notification.
-- **Wall-clock time** — see [`memory-model.md`](memory-model.md) for
-  the broader kernel-scope statement; not a memory concern, but
-  related in spirit.
 
----
+The userspace process abstraction itself is owned by
+[`architecture.md`](architecture.md) §"Kernel Primitives vs.
+Userspace Abstractions".
 
-## ASLR Readiness
-
-The system is ASLR-ready by design and ASLR-pending by implementation:
-
-- The kernel never reads workspace VA constants; every mapping VA is
-  user-supplied at `mem_map` time.
-- memmgr never reads VA constants; it returns Frame caps that are VA-
-  agnostic.
-- `std::sys::seraph` chooses heap and page-reservation VAs at
-  process-startup time, structured so substituting an RNG-derived base
-  is a one-line change.
-- The creator chooses `ProcessInfo`-runtime-field VAs per child today.
-  ASLR promotes the remaining ABI-constant VAs to runtime fields
-  identically.
-
-The randomisation source is the kernel RNG. Until that exists, all
-VAs are deterministic, but no compile-time VA constant lives outside
-the ABI crates and per-component private modules.
-
----
-
-## Non-Goals
-
-These are rejected mechanisms, not deferred work.
-
-- **Copy-on-write.** No kernel write-trap, no refcount-on-write
-  frames, no frame-ownership ambiguity. Seraph does not implement
-  `fork()`. Zero-copy buffer handoff is via Frame-cap moves over IPC.
-- **POSIX file-backed `mmap()`.** No pager protocol, no page-fault
-  delivery to userspace, no page cache as a kernel concern. Zero-copy
-  file access is via fs-driver IPC returning Frame caps for file
-  pages, mapped by the client through the page-reservation
-  allocator.
-- **Wall-clock in the kernel.** The kernel exposes only monotonic
-  elapsed time. Wall-clock is a userspace `timed` service.
+File-backed access via `mmap()` does not exist. Zero-copy file access
+is via fs-driver IPC returning Frame caps for file pages, mapped by
+the client through the page-reservation allocator.
 
 ---
 
 ## Summarized By
 
-[Memory Model](memory-model.md), [Process Lifecycle](process-lifecycle.md), [Architecture Overview](architecture.md), [memmgr/README.md](../services/memmgr/README.md), [procmgr/README.md](../services/procmgr/README.md), [ruststd/README.md](../runtime/ruststd/README.md)
+[README.md](../README.md), [Memory Model](memory-model.md), [Process Lifecycle](process-lifecycle.md), [Architecture Overview](architecture.md), [memmgr/README.md](../services/memmgr/README.md), [procmgr/README.md](../services/procmgr/README.md), [ruststd/README.md](../runtime/ruststd/README.md)

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -2,6 +2,8 @@
 
 Language runtime layers linked into userspace binaries. Seraph-specific; not standalone processes.
 
+## Source Layout
+
 | Component | Purpose |
 |---|---|
 | `libc/` | C standard library / POSIX compatibility layer |
@@ -10,6 +12,15 @@ Language runtime layers linked into userspace binaries. Seraph-specific; not sta
 Neither has a top-level `Cargo.toml`. See
 [`docs/build-system.md`](../docs/build-system.md) for how `xtask`
 materialises the `ruststd/` overlay at build time.
+
+## Relevant Design Documents
+
+| Document | Relevance |
+|---|---|
+| [`docs/architecture.md`](../docs/architecture.md) | Userspace-services / runtime layering. |
+| [`docs/build-system.md`](../docs/build-system.md) | Toolchain, sysroot, and `ruststd/` materialisation. |
+| [`runtime/libc/README.md`](libc/README.md) | libc surface, POSIX compatibility scope, build layout. |
+| [`runtime/ruststd/README.md`](ruststd/README.md) | Rust std platform layer, `std::sys::seraph` integration. |
 
 ---
 

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -7,7 +7,9 @@ Language runtime layers linked into userspace binaries. Seraph-specific; not sta
 | `libc/` | C standard library / POSIX compatibility layer |
 | `ruststd/` | Rust standard library platform layer (`std::sys::seraph`) |
 
-Neither has a top-level `Cargo.toml`. `xtask` materialises the `ruststd/` overlay into a patched toolchain mirror at build time.
+Neither has a top-level `Cargo.toml`. See
+[`docs/build-system.md`](../docs/build-system.md) for how `xtask`
+materialises the `ruststd/` overlay at build time.
 
 ---
 

--- a/services/devmgr/README.md
+++ b/services/devmgr/README.md
@@ -98,4 +98,4 @@ MUST NOT be started independently of devmgr. See
 
 ## Summarized By
 
-None
+[docs/device-management.md](../../docs/device-management.md)

--- a/services/init/README.md
+++ b/services/init/README.md
@@ -201,4 +201,4 @@ Init derives and transfers these to services using the "derive twice" pattern
 
 ## Summarized By
 
-None
+[Architecture Overview](../../docs/architecture.md), [System Bootstrap](../../docs/bootstrap.md), [Process Lifecycle](../../docs/process-lifecycle.md)

--- a/services/logd/README.md
+++ b/services/logd/README.md
@@ -94,7 +94,7 @@ After `HANDOVER_PULL` completes, logd deletes cap[1] (no other use
 for a SEND cap on its own endpoint). The arch cap stays bound to
 logd's main thread for the lifetime of the process.
 
-## Relevant design documents
+## Relevant Design Documents
 
 | Document | Content |
 |---|---|
@@ -111,4 +111,4 @@ logd's main thread for the lifetime of the process.
 
 ## Summarized By
 
-None
+[Architecture Overview](../../docs/architecture.md), [System Bootstrap](../../docs/bootstrap.md)

--- a/services/logd/README.md
+++ b/services/logd/README.md
@@ -58,7 +58,7 @@ process.
 * svcmgr-late-launch migration (parallel to the usertest refactor;
   logd is launched by init for now).
 
-## Source layout
+## Source Layout
 
 ```
 logd/

--- a/services/procmgr/README.md
+++ b/services/procmgr/README.md
@@ -60,14 +60,22 @@ procmgr/
   it retroactively on every existing thread, and bind it on every
   new spawn alongside procmgr's own death observer (correlator =
   process token, equal to logd's per-sender slot key).
-- **Init reap** — accept init's `REGISTER_INIT_TEARDOWN` handoff
-  at end-of-Phase-3 (init's own `AddressSpace` / `CSpace` / `Thread`
-  caps + every reclaimable Frame cap), bind a death-EQ observer on
-  init's main thread with `INIT_REAP_CORRELATOR`, then on the death
-  event (driven by init's `sys_thread_exit`) tear down init's
-  kernel objects in order (Threads → AddressSpace → donate Frame
-  caps to memmgr → CSpace), leaving zero init residue. See
-  [`src/init_reap.rs`](src/init_reap.rs).
+- **Init reap** — accept init's `REGISTER_INIT_TEARDOWN` handoff at
+  end-of-Phase-3 and tear down init's residue. See the
+  [Init reap](#init-reap) subsection below.
+
+---
+
+## Init reap
+
+Procmgr accepts init's `REGISTER_INIT_TEARDOWN` handoff at the end of
+init's Phase 3: init's own `AddressSpace` / `CSpace` / `Thread` caps
+plus every reclaimable Frame cap. Procmgr binds a death-EQ observer
+on init's main thread with `INIT_REAP_CORRELATOR`; on the death event
+(driven by init's `sys_thread_exit`) the reap path tears down init's
+kernel objects in order — Threads → AddressSpace → donate Frame caps
+to memmgr via `DONATE_FRAMES` → CSpace cascade — leaving zero init
+residue. Implementation in [`src/init_reap.rs`](src/init_reap.rs).
 
 ---
 

--- a/services/pwrmgr/README.md
+++ b/services/pwrmgr/README.md
@@ -4,7 +4,7 @@ Userspace power manager. Owns the platform shutdown and reboot path.
 
 ---
 
-## Source layout
+## Source Layout
 
 ```
 pwrmgr/
@@ -114,11 +114,16 @@ between the two trees.
 
 ---
 
-## Documentation hierarchy
+## Relevant Design Documents
 
-- [docs/architecture.md](../../docs/architecture.md) — system-wide
-  service inventory.
-- [shared/ipc/src/lib.rs](../../shared/ipc/src/lib.rs) — authoritative
-  IPC label and error definitions (`pwrmgr_labels`, `pwrmgr_errors`).
-- [services/init/README.md](../init/README.md) — bootstrap order and
-  cap-flow into pwrmgr.
+| Document | Content |
+|---|---|
+| [docs/architecture.md](../../docs/architecture.md) | System-wide service inventory; pwrmgr's role |
+| [shared/ipc/src/lib.rs](../../shared/ipc/src/lib.rs) | Authoritative IPC label and error definitions (`pwrmgr_labels`, `pwrmgr_errors`) |
+| [services/init/README.md](../init/README.md) | Bootstrap order and cap-flow into pwrmgr |
+
+---
+
+## Summarized By
+
+[Architecture Overview](../../docs/architecture.md)

--- a/services/svcmgr/README.md
+++ b/services/svcmgr/README.md
@@ -92,4 +92,4 @@ short window, the service is marked degraded and not restarted automatically.
 
 ## Summarized By
 
-None
+[Architecture Overview](../../docs/architecture.md), [System Bootstrap](../../docs/bootstrap.md), [Process Lifecycle](../../docs/process-lifecycle.md)


### PR DESCRIPTION
## Summary

In-depth review pass over `docs/*.md` (excluding the authoritative
`coding-standards.md` and `documentation-standards.md`) and the
meta-folder router READMEs, applying the rules in
`docs/documentation-standards.md`. The recurring patterns surfaced:
off-topic content, higher-level docs restating lower-level authoritative
content, service-internal mechanism leaking into system-scope docs,
rhetorical / editorial section titles, `Non-Goals` sections used as
dumping grounds, forward-looking / "deferred X" prose in permanent
text, and missing `## Summarized By` backlinks. ~60 defects in the
top-level docs across 14 files; calibration example (the user-cited
`docs/userspace-memory-model.md` with its admitted-off-topic wall-clock
mention) is the heaviest single revision.

A fifth commit closes the service-README Summarized By backlink gaps
surfaced during pre-merge review.

## Acceptance

- [x] Every section across the reviewed docs answers "is this content
      actually about this doc's claimed subject?" — off-topic content
      removed.
- [x] Authoritative content that needed a home is relocated, not lost:
      bootloader-scratch reclamation prose → `core/kernel/docs/initialization.md`
      Phase 7/8; CI workflows table → `docs/build-system.md`
      §"Continuous Integration".
- [x] Forward-looking / "deferred" / "follow-up issue" prose removed
      from `userspace-memory-model.md`, `memory-model.md`,
      `process-lifecycle.md`, `capability-model.md`,
      `namespace-model.md`, `build-system.md`.
- [x] Rhetorical section titles replaced with declarative ones
      (`userspace-memory-model.md` "What the Kernel Refuses to Learn"
      → "Kernel-Side Non-Concerns"; `namespace-model.md` "What This
      Model Does Not Do" deleted as redundant negation of positive
      principles).
- [x] `Non-Goals` sections reviewed per-item: off-topic items deleted
      (wall-clock from `userspace-memory-model.md`, kernel-side process
      abstraction from `process-lifecycle.md`), scope-clarifying items
      folded into positive `## Out of Scope` or body prose where they
      belonged.
- [x] `## Summarized By` lists in `bootstrap.md`, `capability-model.md`,
      `device-management.md`, `ipc-design.md`, `memory-model.md`,
      `namespace-model.md`, `process-lifecycle.md`,
      `userspace-memory-model.md` now backlink `README.md` (every doc
      the root README dash-summarises).
- [x] Root `README.md`: removed the component-crate link (`abi/boot-protocol/`)
      from the system Documentation list; refreshed the stale
      "Philosophy" reference in the Goals-summary paragraph after that
      section's removal from `architecture.md`.
- [x] `base/README.md` brought in line with peer router READMEs (per-
      crate table added).
- [x] No broken intra-repo `.md` links after the edits
      (`find … -name '*.md' | grep -nE '\]\(...\.md'` resolves clean
      across the tree).
- [x] Pre-merge audit findings on this PR addressed in commit 4
      (`docs, services: address pre-merge review`): devmgr/README
      Summarized By backlink, procmgr/README §"Init reap" subsection
      elevation, process-lifecycle.md dangling-ASLR clause removal,
      §-cite spelling fix to capability-model.md, cmdline-snapshot
      Phase 4 precision restored in initialization.md, POSIX-API-compat
      statement restored to architecture.md Project Goals,
      memory-model.md purpose-statement line wrap.
- [x] Pre-existing service-README Summarized By gaps closed in commit
      5 (`services: close pre-existing Summarized By backlink gaps`):
      `services/{init,svcmgr,logd}/README.md` now list their upstream
      summarisers; `services/pwrmgr/README.md` previously lacked the
      section entirely, now has Summarized By plus Source Layout case
      fix and a Relevant Design Documents table replacing the
      `Documentation hierarchy` bullet list.

## Test plan

- [x] `cargo xtask build` (x86_64)
- [x] `cargo xtask run` (x86_64), terminal pass marker observed
      (`[usertest] ALL TESTS PASSED`)
- [x] `cargo xtask build --arch riscv64`
- [x] `cargo xtask run --arch riscv64`, terminal pass marker observed
      (`[usertest] ALL TESTS PASSED`)
- [x] `cargo xtask test` — 364 host tests pass (53+9+186+55+61 across boot, boot_protocol, kernel, namespace_protocol, xtask)

## Notes

No linked Issue. Documentation-quality pass; filed as a `cleanup/`
branch per `docs/conventions.md`.

Six commits, separable for review:

1. `core/kernel: capture bootloader-scratch-reclamation detail in
   initialization.md` — Phase 7 + Phase 8 additions so
   `memory-model.md` has somewhere to point.
2. `docs: scope-trim top-level system docs to authoritative content` —
   the bulk of the changes (11 files).
3. `README, base, runtime: tighten routing-README drift` — root README
   + base/README child-crate table + runtime/README trim.
4. `docs, services: address pre-merge review` — pre-merge audit-fix
   pass #1: devmgr Summarized By backlink, procmgr §"Init reap"
   elevation, §-cite fixes, ASLR-dangling clause removal, cmdline
   Phase 4 precision, POSIX-API-compat restoration, line-wrap nit.
5. `services: close pre-existing Summarized By backlink gaps` —
   `services/{init,svcmgr,logd,pwrmgr}/README.md` Summarized By
   populated; pwrmgr structural-section names normalised.
6. `docs, services: address pre-merge audit #2` — pre-merge audit-fix
   pass #2: process-lifecycle.md ASLR scope bullet removed,
   boot-protocol Summarized By drift closed, build-system.md
   forward-looking prose + broken anchor fixed, runtime/README.md
   Source Layout + Relevant Design Documents added (D3 fold-in),
   architecture/bootstrap/process-lifecycle/ipc-design Summarized By
   lists made bidirectional, services/logd Source Layout casing.

Remaining deferred follow-ups (intentional, to keep scope focused):

- `services/memmgr/docs/frame-pool.md` (out of this review's scope —
  component-internal doc, not top-level) carries a `## Non-Goals`
  section that may exhibit the same dumping-ground pattern. Audit
  pass #2 verified it is well-formed (per-item scope negations, not
  a dumping ground); flagged here for future tracking only.
- `services/{logd,pwrmgr}/README.md` substantive forward-looking
  content (`## Future scope` dumping ground in pwrmgr; "A future PR
  will replace…" prose in logd). Entered this PR's diff only for
  Summarized By gap closure and heading-case fixes in commit 5;
  full prose rewrite would expand scope beyond top-level + routing-
  README cleanup.
- `docs/{coding-standards,documentation-standards}.md` Summarized By
  sections read "None" though the root README dash-summarises them.
  These two docs are the authority documents this PR explicitly
  excludes from its scope statement.

