### PR TITLE
kernel/x86_64 fpu: lazy XSAVE/XRSTOR via per-CPU fpu_owner cache

### DIFF
--- a/core/kernel/docs/scheduling-internals.md
+++ b/core/kernel/docs/scheduling-internals.md
@@ -229,7 +229,7 @@ The window during which the BSP is live but SMP state is not yet steady. Begins 
 
 ## IPI Taxonomy
 
-The kernel sends two IPIs. Each has a defined purpose and correctness role.
+The kernel sends three IPIs. Each has a defined purpose and correctness role.
 
 ### x86_64
 
@@ -239,6 +239,7 @@ The kernel sends two IPIs. Each has a defined purpose and correctness role.
 |---|---|---|---|---|
 | 250 | `IPI_VECTOR_TLB_SHOOTDOWN` | TLB invalidation cascade | Flushes per-CPU TLB entries staged by the issuer. | Required: a writer that modifies a page-table entry MUST shoot down peer CPUs' TLBs before guaranteeing the change is observable. |
 | 251 | `IPI_VECTOR_WAKEUP` | Wake target CPU from `hlt` | EOI only (no work). | Required for the wake protocol's "always-IPI" invariant. The handler does no real work; the IPI's value is the trap entry itself, which exits `hlt` and re-enters the idle loop's check. |
+| 252 | `IPI_VECTOR_FPU_FLUSH` | Lazy-FPU owner flush on cross-CPU thread migration | Reads `FPU_FLUSH_PENDING[cpu]`, calls `fpu::flush_owner_if(target)` (CAS owner→null, XSAVE target's regs to its TCB area), clears the pending slot, EOI. | Required: the per-CPU `fpu_owner` cache marks which TCB owns the live extended-state registers. When a thread migrates to a new CPU, the destination's `#NM` handler XRSTORs from the TCB's XSAVE area; that area must be canonical, i.e. flushed from the source CPU's hardware registers before the migration commits. Issuer is the source-CPU side of `sched::flush_owner_remote` (called from `enqueue_and_wake` and `migrate_ready_thread` pre-lock). Sender spins for ack with interrupts ENABLED and preemption DISABLED, mirroring `mm::tlb_shootdown::shootdown` — required to avoid IF-versus-IPI circular deadlocks against another CPU initiating its own flush. |
 
 ### riscv64
 
@@ -248,9 +249,11 @@ The riscv64 build uses one SBI IPI extension (EID `0x735049`, FID `0`) for both 
 
 The same correctness rules apply: shootdown is required for TLB coherence; wakeup is required for the wake protocol.
 
+The lazy-FPU flush IPI is x86-64 only. RISC-V uses `sstatus.FS/VS` dirty tracking, which the trap path's `lazy_restore_fp_v` already keeps coherent across migration without a cross-hart IPI; `arch::riscv64::fpu::flush_owner_remote` is a no-op for arch-dispatch symmetry.
+
 ### Future IPIs (out of scope)
 
-Process-stop ("kill process across all CPUs"), TLB-shootdown-with-PCID variants, and scheduler-quiesce IPIs are not in the current kernel. If added, they MUST be documented in this section before landing.
+Process-stop ("kill process across all CPUs"), TLB-shootdown-with-PCID variants, scheduler-quiesce IPIs, and AVX-512 FPU-flush extensions are not in the current kernel. If added, they MUST be documented in this section before landing.
 
 ---
 

--- a/core/kernel/docs/thread-lifecycle-and-sleep.md
+++ b/core/kernel/docs/thread-lifecycle-and-sleep.md
@@ -138,11 +138,24 @@ The teardown sequence binds the following ordered steps. Each step's preconditio
 9. If running_on was recorded, spin (re-acquire that CPU's lock per iteration)
    until scheduler_for(run_cpu).current != tcb.
 10. Spin on tcb.context_saved.load(Acquire) == 1 (UNCONDITIONAL — see invariant 4).
-10a. (x86_64 only) Clear any per-CPU `fpu_owner` slot still naming this TCB
-    via compare_exchange(tcb, null, AcqRel, Acquire) for every CPU. Placed
-    AFTER steps 9-10 so the dying thread has switched out on every CPU and
-    taken no further `#NM`; closes the dangling-pointer window before
-    storage is reclaimed in step 16. See invariant 5a.
+10a. (x86_64 only) Two-stage clear of any per-CPU `fpu_owner` slot still
+    naming this TCB:
+      - Stage A: inside the all-CPU-locks region (between step 4 and
+        step 5), sweep `compare_exchange(tcb, null, AcqRel, Acquire)`
+        for every CPU. Captures any owner pointer that was settled at
+        the moment we committed `state = Exited`.
+      - Stage B: AFTER steps 9-10 and BEFORE storage reclaim (step 16),
+        repeat the sweep. Catches any re-installation that a still-
+        running thread's `#NM` performed between all-locks release and
+        the final switch-out, before storage is reclaimed.
+    Two stages are necessary in concert: stage A alone leaves a
+    re-installation window (invariant 4a); stage B alone destabilises
+    parallel-test boot under TCG, where the all-locks-region clear
+    happens to break a wake-IPI cycle the spin path otherwise
+    deadlocks under (the dealloc's `context_saved` spin runs with
+    `IF=0`, so any peer CPU sending a flush IPI to the deallocing CPU
+    stalls until the spin exits — observed locally and on
+    `ubuntu-latest` CI).
 11. Acquire the source IPC lock for tcb's blocked_on_object (if any) and unlink
     tcb from the source's wait queue / waiter slot. Branches:
       - BlockedOnSend / BlockedOnRecv: ep.lock; unlink_from_wait_queue.
@@ -170,7 +183,9 @@ The teardown sequence binds the following ordered steps. Each step's preconditio
 
 3. **Step 9's `running_on` spin is bounded.** The remote CPU is mid-`schedule()`; once it sets `current = next_tcb` (which happens *before* the arch switch on x86 due to `release_lock_only`), the spin exits.
 
-4a. **Step 10a's `fpu_owner` sweep closes the lazy-FPU dangling-pointer window.** The `#NM` handler writes `fpu_owner_for(cpu).store(current_tcb, Release)` on every trap, so as long as the dying thread can still take an `#NM`, its pointer can land in a per-CPU `fpu_owner` slot. Steps 9-10 guarantee the thread has switched out on every CPU and `context_saved == 1`, so no further `#NM` can name it. The compare_exchange sweep then drops the dangling pointer from every remaining slot before step 16 reclaims storage. The sweep MUST be placed AFTER step 10 — placing it before allows a still-running thread to re-install itself as `fpu_owner` via `#NM` after the sweep but before storage is freed, leaving a use-after-free for the next `#NM` consumer (the swap-out path reads `(*prev).extended.area` on a freed pointer).
+4a. **Step 10a's two-stage `fpu_owner` sweep closes the lazy-FPU dangling-pointer window AND avoids a TCG IPI-spin deadlock.** Stage A (inside all-locks) clears every owner pointer visible at the `state = Exited` commit. Stage B (post-spin) drops any pointer re-installed by a still-running thread's `#NM` between the all-locks release and the final switch-out. Both stages are required:
+    - Stage B alone leaves stage A's window open: under TCG, a peer CPU initiating a flush IPI targeted at the dealloc'ing CPU during the `context_saved` spin will stall until the spin exits (the dealloc spins with `IF=0`); two peer CPUs deadlocked on each other's spins were observed locally and on `ubuntu-latest` CI.
+    - Stage A alone is invariant 4a's original concern: the `#NM` handler stores `fpu_owner_for(cpu) = current_tcb` on every trap, so a still-running dying thread can re-install its pointer after the all-locks release. Stage B catches that. Steps 9-10 guarantee no further `#NM` can name the thread, so the post-spin sweep is the final fence before storage reclaim in step 16.
 
 4. **Step 10's `context_saved` spin is the load-bearing UAF gate, and is unconditional.** On x86 (TSO), `schedule()` calls `set_current(next)` and `release_lock_only(sched.lock)` *before* `switch()` saves the dying thread's registers into `tcb.saved_state`. A peer CPU acquiring the same lock at any moment after the release can therefore observe `sched.current = idle` while `switch()` is still mid-save into `tcb.saved_state`. Freeing the TCB at that point lets the next allocation reuse the memory; `switch()` then corrupts the new allocation, producing hangs (`stress::thread_churn`, `bench thread_lifecycle`) or worse. Step 10 closes the window: `context_saved` is cleared by `schedule()` *before* the save and written `1` (Release) by `switch()` *after* the save; spinning on the Acquire load until it observes `1` guarantees the save has fully published. The spin is unconditional on the result of `running_on`, because the all-locks `running_on` snapshot can race past the lock release and miss the in-flight switch entirely. New TCBs initialise `context_saved = 1`, so the wait is bounded for threads that never ran.
 

--- a/core/kernel/docs/thread-lifecycle-and-sleep.md
+++ b/core/kernel/docs/thread-lifecycle-and-sleep.md
@@ -138,6 +138,11 @@ The teardown sequence binds the following ordered steps. Each step's preconditio
 9. If running_on was recorded, spin (re-acquire that CPU's lock per iteration)
    until scheduler_for(run_cpu).current != tcb.
 10. Spin on tcb.context_saved.load(Acquire) == 1 (UNCONDITIONAL — see invariant 4).
+10a. (x86_64 only) Clear any per-CPU `fpu_owner` slot still naming this TCB
+    via compare_exchange(tcb, null, AcqRel, Acquire) for every CPU. Placed
+    AFTER steps 9-10 so the dying thread has switched out on every CPU and
+    taken no further `#NM`; closes the dangling-pointer window before
+    storage is reclaimed in step 16. See invariant 5a.
 11. Acquire the source IPC lock for tcb's blocked_on_object (if any) and unlink
     tcb from the source's wait queue / waiter slot. Branches:
       - BlockedOnSend / BlockedOnRecv: ep.lock; unlink_from_wait_queue.
@@ -164,6 +169,8 @@ The teardown sequence binds the following ordered steps. Each step's preconditio
 2. **Step 3 (state = Exited) commits under all locks.** No `schedule()` on any CPU can subsequently observe this TCB as `Ready` or `Running` for purposes of re-enqueue — the protection in `schedule()` reads `state` while holding its CPU's scheduler.lock and refuses to re-enqueue if `state ∈ {Exited, Stopped}`. `enqueue_and_wake` performs the same check before enqueueing (see [scheduling-internals.md § Lock Hierarchy](scheduling-internals.md#lock-hierarchy) rule 9).
 
 3. **Step 9's `running_on` spin is bounded.** The remote CPU is mid-`schedule()`; once it sets `current = next_tcb` (which happens *before* the arch switch on x86 due to `release_lock_only`), the spin exits.
+
+4a. **Step 10a's `fpu_owner` sweep closes the lazy-FPU dangling-pointer window.** The `#NM` handler writes `fpu_owner_for(cpu).store(current_tcb, Release)` on every trap, so as long as the dying thread can still take an `#NM`, its pointer can land in a per-CPU `fpu_owner` slot. Steps 9-10 guarantee the thread has switched out on every CPU and `context_saved == 1`, so no further `#NM` can name it. The compare_exchange sweep then drops the dangling pointer from every remaining slot before step 16 reclaims storage. The sweep MUST be placed AFTER step 10 — placing it before allows a still-running thread to re-install itself as `fpu_owner` via `#NM` after the sweep but before storage is freed, leaving a use-after-free for the next `#NM` consumer (the swap-out path reads `(*prev).extended.area` on a freed pointer).
 
 4. **Step 10's `context_saved` spin is the load-bearing UAF gate, and is unconditional.** On x86 (TSO), `schedule()` calls `set_current(next)` and `release_lock_only(sched.lock)` *before* `switch()` saves the dying thread's registers into `tcb.saved_state`. A peer CPU acquiring the same lock at any moment after the release can therefore observe `sched.current = idle` while `switch()` is still mid-save into `tcb.saved_state`. Freeing the TCB at that point lets the next allocation reuse the memory; `switch()` then corrupts the new allocation, producing hangs (`stress::thread_churn`, `bench thread_lifecycle`) or worse. Step 10 closes the window: `context_saved` is cleared by `schedule()` *before* the save and written `1` (Release) by `switch()` *after* the save; spinning on the Acquire load until it observes `1` guarantees the save has fully published. The spin is unconditional on the result of `running_on`, because the all-locks `running_on` snapshot can race past the lock release and miss the in-flight switch entirely. New TCBs initialise `context_saved = 1`, so the wait is bounded for threads that never ran.
 

--- a/core/kernel/docs/thread-lifecycle-and-sleep.md
+++ b/core/kernel/docs/thread-lifecycle-and-sleep.md
@@ -138,24 +138,20 @@ The teardown sequence binds the following ordered steps. Each step's preconditio
 9. If running_on was recorded, spin (re-acquire that CPU's lock per iteration)
    until scheduler_for(run_cpu).current != tcb.
 10. Spin on tcb.context_saved.load(Acquire) == 1 (UNCONDITIONAL — see invariant 4).
-10a. (x86_64 only) Two-stage clear of any per-CPU `fpu_owner` slot still
-    naming this TCB:
-      - Stage A: inside the all-CPU-locks region (between step 4 and
-        step 5), sweep `compare_exchange(tcb, null, AcqRel, Acquire)`
-        for every CPU. Captures any owner pointer that was settled at
-        the moment we committed `state = Exited`.
-      - Stage B: AFTER steps 9-10 and BEFORE storage reclaim (step 16),
-        repeat the sweep. Catches any re-installation that a still-
-        running thread's `#NM` performed between all-locks release and
-        the final switch-out, before storage is reclaimed.
-    Two stages are necessary in concert: stage A alone leaves a
-    re-installation window (invariant 4a); stage B alone destabilises
-    parallel-test boot under TCG, where the all-locks-region clear
-    happens to break a wake-IPI cycle the spin path otherwise
-    deadlocks under (the dealloc's `context_saved` spin runs with
-    `IF=0`, so any peer CPU sending a flush IPI to the deallocing CPU
-    stalls until the spin exits — observed locally and on
-    `ubuntu-latest` CI).
+    Steps 9-10 run with `preempt_disable` and interrupts enabled
+    (`save_and_disable_interrupts` → `enable`); the local CPU MUST be
+    able to service incoming flush / TLB-shootdown IPIs during the
+    spin or it deadlocks against a peer CPU sending an IPI to it
+    (observed locally and on `ubuntu-latest` CI). Preemption is
+    disabled so a timer tick mid-spin cannot reschedule the dealloc
+    caller off this CPU (which would invalidate the `running_on`
+    snapshot captured at step 6).
+10a. (x86_64 only) Clear any per-CPU `fpu_owner` slot still naming
+    this TCB via `compare_exchange(tcb, null, AcqRel, Acquire)` for
+    every CPU. Placed AFTER steps 9-10 so the dying thread has
+    switched out on every CPU and taken no further `#NM`; closes the
+    dangling-pointer window before storage is reclaimed in step 16.
+    See invariant 4a.
 11. Acquire the source IPC lock for tcb's blocked_on_object (if any) and unlink
     tcb from the source's wait queue / waiter slot. Branches:
       - BlockedOnSend / BlockedOnRecv: ep.lock; unlink_from_wait_queue.
@@ -183,9 +179,7 @@ The teardown sequence binds the following ordered steps. Each step's preconditio
 
 3. **Step 9's `running_on` spin is bounded.** The remote CPU is mid-`schedule()`; once it sets `current = next_tcb` (which happens *before* the arch switch on x86 due to `release_lock_only`), the spin exits.
 
-4a. **Step 10a's two-stage `fpu_owner` sweep closes the lazy-FPU dangling-pointer window AND avoids a TCG IPI-spin deadlock.** Stage A (inside all-locks) clears every owner pointer visible at the `state = Exited` commit. Stage B (post-spin) drops any pointer re-installed by a still-running thread's `#NM` between the all-locks release and the final switch-out. Both stages are required:
-    - Stage B alone leaves stage A's window open: under TCG, a peer CPU initiating a flush IPI targeted at the dealloc'ing CPU during the `context_saved` spin will stall until the spin exits (the dealloc spins with `IF=0`); two peer CPUs deadlocked on each other's spins were observed locally and on `ubuntu-latest` CI.
-    - Stage A alone is invariant 4a's original concern: the `#NM` handler stores `fpu_owner_for(cpu) = current_tcb` on every trap, so a still-running dying thread can re-install its pointer after the all-locks release. Stage B catches that. Steps 9-10 guarantee no further `#NM` can name the thread, so the post-spin sweep is the final fence before storage reclaim in step 16.
+4a. **Step 10a's `fpu_owner` sweep closes the lazy-FPU dangling-pointer window.** The `#NM` handler writes `fpu_owner_for(cpu).store(current_tcb, Release)` on every trap, so as long as the dying thread can still take an `#NM`, its pointer can land in a per-CPU `fpu_owner` slot. Steps 9-10 guarantee the thread has switched out on every CPU and `context_saved == 1`, so no further `#NM` can name it. The compare_exchange sweep then drops the dangling pointer from every remaining slot before step 16 reclaims storage. The sweep MUST be placed AFTER step 10 — placing it before allows a still-running thread to re-install itself as `fpu_owner` via `#NM` after the sweep but before storage is freed, leaving a use-after-free for the next `#NM` consumer (the swap-out path reads `(*prev).extended.area` on a freed pointer). Steps 9-10's interrupt-enabled-while-spinning discipline is required to prevent the spin from deadlocking against a peer CPU's flush IPI; without it, the post-spin placement is the same correctness shape but the spin times out (observed on TCG).
 
 4. **Step 10's `context_saved` spin is the load-bearing UAF gate, and is unconditional.** On x86 (TSO), `schedule()` calls `set_current(next)` and `release_lock_only(sched.lock)` *before* `switch()` saves the dying thread's registers into `tcb.saved_state`. A peer CPU acquiring the same lock at any moment after the release can therefore observe `sched.current = idle` while `switch()` is still mid-save into `tcb.saved_state`. Freeing the TCB at that point lets the next allocation reuse the memory; `switch()` then corrupts the new allocation, producing hangs (`stress::thread_churn`, `bench thread_lifecycle`) or worse. Step 10 closes the window: `context_saved` is cleared by `schedule()` *before* the save and written `1` (Release) by `switch()` *after* the save; spinning on the Acquire load until it observes `1` guarantees the save has fully published. The spin is unconditional on the result of `running_on`, because the all-locks `running_on` snapshot can race past the lock release and miss the in-flight switch entirely. New TCBs initialise `context_saved = 1`, so the wait is bounded for threads that never ran.
 

--- a/core/kernel/src/arch/riscv64/fpu.rs
+++ b/core/kernel/src/arch/riscv64/fpu.rs
@@ -343,6 +343,33 @@ pub unsafe fn switch_in_restore(_tcb: *mut crate::sched::thread::ThreadControlBl
 #[cfg(test)]
 pub unsafe fn switch_in_restore(_tcb: *mut crate::sched::thread::ThreadControlBlock) {}
 
+/// No-op on RISC-V: there is no per-CPU lazy-FPU owner cache. The
+/// `switch_out_save` path eagerly persists F/D state to the per-TCB area
+/// on `sstatus.FS=Dirty`, so by the time a thread is moved between harts
+/// its saved area is already current. The function exists for arch-
+/// dispatch symmetry with x86-64.
+///
+/// # Safety
+/// Accepts the unified arch-dispatch signature; ring discipline is
+/// enforced by the caller.
+#[cfg(not(test))]
+#[inline]
+pub unsafe fn flush_owner_remote(
+    _src_cpu: usize,
+    _tcb: *mut crate::sched::thread::ThreadControlBlock,
+)
+{
+}
+
+/// No-op test stub.
+#[cfg(test)]
+pub unsafe fn flush_owner_remote(
+    _src_cpu: usize,
+    _tcb: *mut crate::sched::thread::ThreadControlBlock,
+)
+{
+}
+
 /// Lazy-trap handler body: promote live `sstatus.FS` and `sstatus.VS` from
 /// Off to Initial, restore the F/D and V register files from `area` (when
 /// non-null), then mirror the resulting live FS/VS bits into `frame.sstatus`

--- a/core/kernel/src/arch/x86_64/fpu.rs
+++ b/core/kernel/src/arch/x86_64/fpu.rs
@@ -356,14 +356,18 @@ pub unsafe fn switch_in_restore(_tcb: *mut crate::sched::thread::ThreadControlBl
 /// clear the owner slot. Idempotent: a no-op when this CPU's owner has
 /// already been swapped to another value (e.g. by a concurrent `#NM`).
 ///
-/// Called from the IPI handler in idt.rs after the sender (a migration
-/// helper on another CPU) wrote `tcb` into this CPU's `FPU_FLUSH_PENDING`
-/// slot and delivered the IPI.
+/// Called from two contexts: (a) the IPI handler in idt.rs after the
+/// sender (a migration helper on another CPU) wrote `tcb` into this
+/// CPU's `FPU_FLUSH_PENDING` slot and delivered the IPI; (b) the local
+/// fast-path of `flush_owner_remote` when the caller's CPU is itself
+/// the source CPU (no IPI required).
 ///
 /// # Safety
-/// Must execute at ring 0 in IPI context. `tcb` must be a valid TCB
-/// pointer whose `extended.area` is allocated for the TCB's lifetime
-/// (or null, in which case this function does nothing).
+/// Must execute at ring 0 with interrupts disabled (the IPI-handler
+/// caller runs under an interrupt gate; the local-call path is invoked
+/// from syscall context with `IF=0`). `tcb` must be a valid TCB pointer
+/// whose `extended.area` is allocated for the TCB's lifetime, or null,
+/// in which case this function does nothing.
 #[cfg(not(test))]
 pub unsafe fn flush_owner_if(tcb: *mut crate::sched::thread::ThreadControlBlock)
 {

--- a/core/kernel/src/arch/x86_64/fpu.rs
+++ b/core/kernel/src/arch/x86_64/fpu.rs
@@ -6,9 +6,31 @@
 //! x86-64 extended-state (x87 / SSE / AVX) control primitives.
 //!
 //! Concentrates the unsafe surface for FPU/SIMD state management:
-//! CR0 access (TS bit for lazy-trap discipline), XSETBV/XCR0 setup, the
-//! per-CPU XSAVE enablement performed at boot, and the per-thread XSAVE
-//! area allocation plus save/restore used by the lazy save/restore path.
+//! CR0.TS (lazy-trap discipline gate), XSETBV/XCR0 setup, per-CPU XSAVE
+//! enablement performed at boot, the per-thread XSAVE area allocation,
+//! and the lazy save/restore primitives consumed by the `#NM` handler,
+//! the context-switch fast path, and the cross-CPU FPU-flush IPI handler.
+//!
+//! ## Lazy save/restore discipline
+//!
+//! On any CPU `C` at any time, exactly one of the following holds:
+//! - `(CR0.TS=1, fpu_owner=null)` — no live state worth saving; the next
+//!   user FP instruction raises `#NM`.
+//! - `(CR0.TS=1, fpu_owner=T)`    — T's data is still in the registers
+//!   but the next FP instruction (from any thread) raises `#NM`.
+//! - `(CR0.TS=0, fpu_owner=T)`    — T owns the live regs; FP runs trap-free.
+//!
+//! `(CR0.TS=0, fpu_owner=null)` is forbidden.
+//!
+//! [`switch_out_save`] sets TS=1 (no XSAVE — the regs stay live for the
+//! next thread to reuse or for the migration IPI to flush). [`switch_in_restore`]
+//! clears TS when the incoming thread is already the owner (fast re-run);
+//! otherwise it leaves TS=1 so the first FP op traps. The `#NM` handler
+//! (`idt.rs::nm_handler`) saves the previous owner's regs to its TCB area
+//! before `XRSTOR`ing the trapping thread's area. The migration helper
+//! (`sched/mod.rs`) flushes a stale remote owner via the FPU-flush IPI
+//! (`idt.rs::ipi_fpu_flush_handler` → [`flush_owner_if`]) before enqueuing
+//! a migrated thread on its destination CPU.
 
 use core::sync::atomic::{AtomicUsize, Ordering};
 
@@ -247,55 +269,41 @@ pub unsafe fn restore_from(area: *const u8)
     }
 }
 
-/// Context-switch hook called on switch-out of a user thread (the caller
-/// supplies a TCB whose `extended.area` is non-null): XSAVEOPT the live
-/// x87/SSE/AVX register file to the thread's per-TCB area and re-arm the
-/// `#NM` lazy trap by setting CR0.TS.
+/// Context-switch hook called on switch-out of any thread.
 ///
-/// XSAVEOPT performs hardware-tracked dirty filtering via the XINUSE bits
-/// it maintains internally — components untouched since the last XRSTOR
-/// are not written. The cost on a thread that has not dirtied any FPU
-/// state since its last restore is ~50 cycles (instruction decode +
-/// XINUSE check, no memory traffic). This is the discipline Linux and
-/// most modern x86-64 kernels run.
+/// Re-arms the `#NM` lazy trap by setting CR0.TS. Performs **no XSAVE**:
+/// the live x87/SSE/AVX register file stays in the hardware registers and
+/// the per-CPU `fpu_owner` slot is left untouched. If the outgoing thread
+/// is rescheduled on this CPU before any other thread touches FP, the
+/// matching [`switch_in_restore`] clears TS and resumes trap-free. If a
+/// different thread tries to use FP first, the resulting `#NM` saves the
+/// previous owner's registers into its TCB area lazily. If the outgoing
+/// thread is migrated to another CPU, the migration-side flush IPI
+/// (sched/mod.rs → [`flush_owner_if`]) extracts the live regs into the
+/// thread's area before the destination CPU's `#NM` reloads them.
 ///
 /// # Safety
 /// Must execute at ring 0 with interrupts disabled, before the scheduler
-/// lock release that publishes this thread's state to other CPUs. `tcb`
-/// must be a valid TCB pointer; its `extended.area` must satisfy the
-/// alignment and size requirements of [`save_to`].
+/// lock release that publishes this thread's state to other CPUs. `_tcb`
+/// must be a valid TCB pointer.
 #[cfg(not(test))]
 #[inline]
-pub unsafe fn switch_out_save(tcb: *mut crate::sched::thread::ThreadControlBlock)
+pub unsafe fn switch_out_save(_tcb: *mut crate::sched::thread::ThreadControlBlock)
 {
-    // SAFETY: caller guarantees tcb is valid; the area is allocated for the
-    // TCB's lifetime when non-null.
-    let area = unsafe { (*tcb).extended.area };
-    if area.is_null()
-    {
-        return;
-    }
-    // Eager save: the live extended-state register file always belongs to
-    // the outgoing thread because [`switch_in_restore`] reloaded it on
-    // switch-in. CR0.TS dirty-tracking is intentionally not used; the
-    // lazy-trap path varies in correctness across TCG versions
-    // (observed on QEMU 8.2 under `ubuntu-latest`).
-    // CR0.TS may already be clear (the matching switch_in_restore cleared
-    // it); ensure it is for XSAVE, which faults on TS=1.
-    // SAFETY: ring 0.
+    // SAFETY: ring 0; CR0.TS=1 is the architected lazy-trap arm.
     unsafe {
-        cr0_clear_ts();
-        save_to(area);
+        cr0_set_ts();
     }
 }
 
-/// Context-switch hook called on switch-in of a user thread (the caller
-/// supplies a TCB whose `extended.area` is non-null): XRSTOR the saved
-/// register file into the live x87/SSE/AVX registers and clear CR0.TS so
-/// the thread resumes without an `#NM` trap.
+/// Context-switch hook called on switch-in of any thread.
 ///
-/// Paired with [`switch_out_save`] to form an eager save/restore
-/// discipline that does not depend on `#NM`/CR0.TS lazy-trap semantics.
+/// Fast path: if this CPU's lazy-FPU owner is already `tcb` (i.e. `tcb`
+/// re-runs on the same CPU it last ran on, and no other thread has used
+/// FP since), clear CR0.TS so the thread resumes trap-free without any
+/// XRSTOR. Otherwise leave/arm CR0.TS=1; the next FP instruction by
+/// `tcb` (or by any later thread on this CPU) traps to `#NM`, which
+/// saves the prior owner's regs and XRSTORs the trapping thread's area.
 ///
 /// # Safety
 /// Must execute at ring 0 with interrupts disabled, after this thread's
@@ -306,18 +314,30 @@ pub unsafe fn switch_out_save(tcb: *mut crate::sched::thread::ThreadControlBlock
 #[inline]
 pub unsafe fn switch_in_restore(tcb: *mut crate::sched::thread::ThreadControlBlock)
 {
+    let cpu = super::cpu::current_cpu() as usize;
+    let owner = crate::percpu::fpu_owner_for(cpu).load(core::sync::atomic::Ordering::Acquire);
     // SAFETY: caller guarantees tcb is valid; the area is allocated for the
     // TCB's lifetime when non-null.
-    let area = unsafe { (*tcb).extended.area };
-    if area.is_null()
+    let area_nonnull = !tcb.is_null() && !unsafe { (*tcb).extended.area }.is_null();
+    if owner == tcb && area_nonnull
     {
-        return;
+        // Fast re-run path: live regs already hold this thread's state.
+        // SAFETY: ring 0; invariant `(owner == tcb) ⇒ regs are tcb's` holds
+        // because the owner slot is only written by the `#NM` handler and
+        // by `flush_owner_if`, both of which keep the slot/regs coherent.
+        unsafe {
+            cr0_clear_ts();
+        }
     }
-    // SAFETY: caller's contract; XRSTOR requires OSXSAVE which the boot
-    // path established.
-    unsafe {
-        cr0_clear_ts();
-        restore_from(area);
+    else
+    {
+        // Trap-on-first-FP path: the live regs (if any) belong to some
+        // other thread; force `#NM` on the next FP op so the handler
+        // saves the prior owner and reloads this thread's area.
+        // SAFETY: ring 0.
+        unsafe {
+            cr0_set_ts();
+        }
     }
 }
 
@@ -328,3 +348,124 @@ pub unsafe fn switch_out_save(_tcb: *mut crate::sched::thread::ThreadControlBloc
 /// No-op test stub.
 #[cfg(test)]
 pub unsafe fn switch_in_restore(_tcb: *mut crate::sched::thread::ThreadControlBlock) {}
+
+// ── Cross-CPU FPU-flush IPI ───────────────────────────────────────────────────
+
+/// Local body of the FPU-flush IPI: if this CPU still owns `tcb`'s live
+/// extended-state register file, XSAVE it into `tcb.extended.area` and
+/// clear the owner slot. Idempotent: a no-op when this CPU's owner has
+/// already been swapped to another value (e.g. by a concurrent `#NM`).
+///
+/// Called from the IPI handler in idt.rs after the sender (a migration
+/// helper on another CPU) wrote `tcb` into this CPU's `FPU_FLUSH_PENDING`
+/// slot and delivered the IPI.
+///
+/// # Safety
+/// Must execute at ring 0 in IPI context. `tcb` must be a valid TCB
+/// pointer whose `extended.area` is allocated for the TCB's lifetime
+/// (or null, in which case this function does nothing).
+#[cfg(not(test))]
+pub unsafe fn flush_owner_if(tcb: *mut crate::sched::thread::ThreadControlBlock)
+{
+    if tcb.is_null()
+    {
+        return;
+    }
+    let cpu = super::cpu::current_cpu() as usize;
+    let owner = crate::percpu::fpu_owner_for(cpu);
+    // Try to take ownership: if the slot still names `tcb`, claim it.
+    if owner
+        .compare_exchange(
+            tcb,
+            core::ptr::null_mut(),
+            core::sync::atomic::Ordering::AcqRel,
+            core::sync::atomic::Ordering::Acquire,
+        )
+        .is_err()
+    {
+        // Owner already differs (another `#NM` or flush displaced us).
+        // The live regs no longer belong to `tcb`; nothing to extract.
+        return;
+    }
+    // SAFETY: tcb is valid; we observed ownership; XSAVE requires the
+    // hardware regs to be accessible (CR0.TS=0 during the instruction).
+    let area = unsafe { (*tcb).extended.area };
+    if area.is_null()
+    {
+        // Defensive: if the area is missing the regs cannot be persisted;
+        // a thread that has ever been an owner must have had its area
+        // lazy-allocated in the `#NM` handler, so this branch is
+        // unreachable in normal operation. Re-arm TS for safety.
+        // SAFETY: ring 0.
+        unsafe {
+            cr0_set_ts();
+        }
+        return;
+    }
+    // SAFETY: ring 0; the area is valid for this TCB's lifetime, and we
+    // hold logical ownership of the live regs (no other CPU writes them).
+    unsafe {
+        cr0_clear_ts();
+        save_to(area);
+        cr0_set_ts();
+    }
+}
+
+/// Test stub for [`flush_owner_if`].
+#[cfg(test)]
+pub unsafe fn flush_owner_if(_tcb: *mut crate::sched::thread::ThreadControlBlock) {}
+
+/// Sender side of the cross-CPU FPU-flush IPI. Invoked from sched migration
+/// helpers (active migration, load-balancer pull) on the path that moves
+/// `tcb` from `src_cpu`'s run queue to a different CPU's run queue.
+///
+/// Early-outs if `src_cpu`'s owner slot does not currently name `tcb`
+/// (the common case — most threads are not the lazy-FPU owner of the CPU
+/// they're being migrated off of). Otherwise delegates to the arch-level
+/// synchronous IPI sender, which writes the per-CPU `FPU_FLUSH_PENDING`
+/// slot, fires the IPI vector, and spins for ack.
+///
+/// # Safety
+/// Must execute at ring 0. `src_cpu` must be < `MAX_CPUS`. `tcb` must be
+/// a valid TCB pointer that the caller is in the process of migrating
+/// off `src_cpu`.
+#[cfg(not(test))]
+pub unsafe fn flush_owner_remote(src_cpu: usize, tcb: *mut crate::sched::thread::ThreadControlBlock)
+{
+    if tcb.is_null()
+    {
+        return;
+    }
+    if src_cpu == super::cpu::current_cpu() as usize
+    {
+        // Local invalidation: do the work directly, no IPI.
+        // SAFETY: ring 0; same contract as the IPI handler.
+        unsafe {
+            flush_owner_if(tcb);
+        }
+        return;
+    }
+    let owner = crate::percpu::fpu_owner_for(src_cpu).load(core::sync::atomic::Ordering::Acquire);
+    if owner != tcb
+    {
+        // Common case: the source CPU does not currently own `tcb`'s
+        // live regs. Either `tcb` has never touched FP, or a later
+        // thread on the source CPU has displaced it via `#NM`. The
+        // canonical state in `tcb.extended.area` is already fresh.
+        return;
+    }
+    // SAFETY: src_cpu validated < MAX_CPUS by caller; tcb is the
+    // migration target.
+    unsafe {
+        super::interrupts::send_fpu_flush_ipi(src_cpu, tcb);
+    }
+}
+
+/// Test stub for [`flush_owner_remote`].
+#[cfg(test)]
+pub unsafe fn flush_owner_remote(
+    _src_cpu: usize,
+    _tcb: *mut crate::sched::thread::ThreadControlBlock,
+)
+{
+}

--- a/core/kernel/src/arch/x86_64/idt.rs
+++ b/core/kernel/src/arch/x86_64/idt.rs
@@ -665,23 +665,31 @@ unsafe extern "C" fn isr_nm()
     );
 }
 
-/// `#NM` handler body.
+/// `#NM` handler body — lazy-FPU dispatch.
 ///
-/// Clears CR0.TS and XRSTORs the current thread's saved register file
-/// from its per-TCB XSAVE area. The trapping x87/SSE/AVX instruction
-/// then proceeds on re-execution. The area is allocated as page N+1 of
-/// the Thread retype slot (see `sys_cap_create_thread` layout), so user
-/// threads always have a non-null area; the slot zero-init makes the
-/// first XRSTOR restore the architected initial state.
+/// Saves the previous owner's live register file into its TCB XSAVE
+/// area (if any), clears CR0.TS, XRSTORs the trapping thread's area into
+/// the live registers, and installs the trapping thread as this CPU's
+/// new `fpu_owner`. The trapping x87/SSE/AVX instruction then proceeds
+/// on re-execution. The area is allocated as page N+1 of the Thread
+/// retype slot (see `sys_cap_create_thread` layout), so user threads
+/// always have a non-null area; the slot zero-init makes the first
+/// XRSTOR restore the architected initial state.
+///
+/// Preemption is disabled across the handler body so a timer tick mid-
+/// sequence cannot reschedule between the prev-owner save and the new-
+/// owner restore, which would leave the per-CPU `fpu_owner` invariant
+/// transiently violated.
 #[cfg(not(test))]
 extern "C" fn nm_handler()
 {
-    // SAFETY: ring 0 exception context; clearing TS is the architected
-    // lazy-FPU enable. Must precede XRSTOR because XRSTOR itself executes
-    // an FP instruction.
-    unsafe {
-        super::fpu::cr0_clear_ts();
-    }
+    crate::percpu::preempt_disable();
+
+    let cpu = super::cpu::current_cpu() as usize;
+    let owner_slot = crate::percpu::fpu_owner_for(cpu);
+    // Take ownership atomically so a concurrent flush IPI either races
+    // ahead (clears the slot first) or sees us holding the regs.
+    let prev = owner_slot.swap(core::ptr::null_mut(), core::sync::atomic::Ordering::AcqRel);
 
     // SAFETY: current_tcb returns this CPU's running thread; valid in
     // exception context because we entered from a user FP instruction
@@ -690,7 +698,30 @@ extern "C" fn nm_handler()
     let tcb = unsafe { crate::syscall::current_tcb() };
     if tcb.is_null()
     {
+        // No current thread — should not happen at #NM but be defensive.
+        // Re-establish the (TS=1, owner=null) state.
+        // SAFETY: ring 0.
+        unsafe {
+            super::fpu::cr0_set_ts();
+        }
+        crate::percpu::preempt_enable();
         return;
+    }
+
+    if !prev.is_null() && prev != tcb
+    {
+        // SAFETY: prev was the live owner; its extended.area is page-
+        // resident for the TCB's lifetime when non-null. XSAVE requires
+        // TS=0; clear it before the save instruction.
+        let prev_area = unsafe { (*prev).extended.area };
+        if !prev_area.is_null()
+        {
+            // SAFETY: ring 0; prev_area satisfies XSAVE alignment and size.
+            unsafe {
+                super::fpu::cr0_clear_ts();
+                super::fpu::save_to(prev_area);
+            }
+        }
     }
 
     // SAFETY: tcb validated non-null. extended.area is page-resident in
@@ -698,12 +729,27 @@ extern "C" fn nm_handler()
     let area = unsafe { (*tcb).extended.area };
     if area.is_null()
     {
+        // A user thread without a backing area cannot legitimately take
+        // an FP trap, but we observed one. Re-arm TS for safety and bail.
+        // SAFETY: ring 0.
+        unsafe {
+            super::fpu::cr0_set_ts();
+        }
+        crate::percpu::preempt_enable();
         return;
     }
-    // SAFETY: area is the per-thread XSAVE buffer carved at TCB construction.
+
+    // SAFETY: ring 0; area is a valid XSAVE buffer; we hold logical
+    // ownership of the live regs (prev was swapped out atomically).
     unsafe {
+        super::fpu::cr0_clear_ts();
         super::fpu::restore_from(area);
     }
+    // Publish new ownership. Release pairs with Acquire loads in
+    // switch_in_restore / flush_owner_remote / flush_owner_if.
+    owner_slot.store(tcb, core::sync::atomic::Ordering::Release);
+
+    crate::percpu::preempt_enable();
 }
 
 /// TLB shootdown IPI handler stub (vector 250).
@@ -736,6 +782,41 @@ unsafe extern "C" fn ipi_tlb_shootdown_stub()
         "pop rax",
         "iretq",
         handler = sym ipi_tlb_shootdown_handler,
+    );
+}
+
+/// FPU-flush IPI handler stub (vector 252).
+///
+/// Receives a cross-CPU request to extract this CPU's live x87/SSE/AVX
+/// register file into a migrating thread's XSAVE area. Reads the per-CPU
+/// `FPU_FLUSH_PENDING` slot, calls `fpu::flush_owner_if`, then clears the
+/// slot so the sender's ack-spin returns.
+#[cfg(not(test))]
+#[unsafe(naked)]
+unsafe extern "C" fn ipi_fpu_flush_stub()
+{
+    core::arch::naked_asm!(
+        "push rax",
+        "push rcx",
+        "push rdx",
+        "push rsi",
+        "push rdi",
+        "push r8",
+        "push r9",
+        "push r10",
+        "push r11",
+        "call {handler}",
+        "pop r11",
+        "pop r10",
+        "pop r9",
+        "pop r8",
+        "pop rdi",
+        "pop rsi",
+        "pop rdx",
+        "pop rcx",
+        "pop rax",
+        "iretq",
+        handler = sym ipi_fpu_flush_handler,
     );
 }
 
@@ -832,6 +913,32 @@ extern "C" fn ipi_wakeup_handler()
     super::interrupts::acknowledge(u32::from(super::interrupts::IPI_VECTOR_WAKEUP));
 }
 
+/// FPU-flush IPI handler (vector 252).
+///
+/// Reads this CPU's pending flush target from `FPU_FLUSH_PENDING`,
+/// extracts the live x87/SSE/AVX register file into the target's XSAVE
+/// area if this CPU still owns it, clears the pending slot so the
+/// sender's ack-spin returns, and acknowledges via EOI.
+#[cfg(not(test))]
+extern "C" fn ipi_fpu_flush_handler()
+{
+    let cpu = super::cpu::current_cpu() as usize;
+    // Acquire pairs with the sender's Release in send_fpu_flush_ipi.
+    let target =
+        super::interrupts::FPU_FLUSH_PENDING[cpu].load(core::sync::atomic::Ordering::Acquire);
+    // SAFETY: target is either null (spurious / race) or a valid TCB
+    // pointer published by the sender, who guarantees the TCB outlives
+    // the ack-spin.
+    unsafe {
+        super::fpu::flush_owner_if(target);
+    }
+    // Release pairs with the sender's Acquire load when polling for ack.
+    super::interrupts::FPU_FLUSH_PENDING[cpu]
+        .store(core::ptr::null_mut(), core::sync::atomic::Ordering::Release);
+    // SAFETY: Vector 252 is the FPU-flush IPI vector.
+    super::interrupts::acknowledge(u32::from(super::interrupts::IPI_VECTOR_FPU_FLUSH));
+}
+
 // ── IDT population ────────────────────────────────────────────────────────────
 
 /// Populate the IDT and execute `lidt`.
@@ -902,6 +1009,13 @@ pub unsafe fn init()
     set(
         usize::from(super::interrupts::IPI_VECTOR_WAKEUP),
         ipi_wakeup_stub,
+        0,
+    );
+
+    // FPU-flush IPI.
+    set(
+        usize::from(super::interrupts::IPI_VECTOR_FPU_FLUSH),
+        ipi_fpu_flush_stub,
         0,
     );
 

--- a/core/kernel/src/arch/x86_64/interrupts.rs
+++ b/core/kernel/src/arch/x86_64/interrupts.rs
@@ -207,6 +207,22 @@ const ICR_SIPI_BASE: u32 = 0x0000_4600;
 pub const IPI_VECTOR_TLB_SHOOTDOWN: u8 = 250;
 /// IPI vector for waking idle CPUs.
 pub const IPI_VECTOR_WAKEUP: u8 = 251;
+/// IPI vector for lazy-FPU owner flush on thread migration.
+pub const IPI_VECTOR_FPU_FLUSH: u8 = 252;
+
+/// Per-CPU "flush this TCB if you own it" slot, written by the sender
+/// (a migration helper on another CPU) immediately before raising
+/// [`IPI_VECTOR_FPU_FLUSH`] at the target CPU. The IPI handler reads the
+/// slot, calls `fpu::flush_owner_if`, then resets the slot to null,
+/// which the sender spins on to detect ack.
+///
+/// One pending flush per CPU is sufficient because cross-CPU migrations
+/// involving a given source CPU serialize on its scheduler lock.
+#[cfg(not(test))]
+pub static FPU_FLUSH_PENDING: [core::sync::atomic::AtomicPtr<
+    crate::sched::thread::ThreadControlBlock,
+>; crate::sched::MAX_CPUS] =
+    [const { core::sync::atomic::AtomicPtr::new(core::ptr::null_mut()) }; crate::sched::MAX_CPUS];
 
 /// Read this CPU's local APIC ID (bits [31:24] of the APIC ID register).
 #[allow(dead_code)] // Part of the arch interface; will be used by future SMP topology code.
@@ -322,6 +338,90 @@ pub unsafe fn send_wakeup_ipi(target_apic_id: u32)
     unsafe {
         apic_write(APIC_ICR_LOW, u32::from(IPI_VECTOR_WAKEUP));
     }
+}
+
+/// Send a synchronous lazy-FPU owner-flush IPI to `target_cpu` and spin
+/// until the receiver acknowledges by clearing its `FPU_FLUSH_PENDING`
+/// slot. Invoked by sched migration helpers before enqueueing a migrated
+/// thread on its destination CPU; the receiver `XSAVE`s `tcb`'s live
+/// regs into `tcb.extended.area` if it still owns them.
+///
+/// Mirrors the `mm::tlb_shootdown::shootdown` interrupt-enable-while-
+/// spinning discipline: the spin-ack loop runs with interrupts enabled
+/// so a concurrent flush/shootdown IPI targeting this CPU can fire and
+/// service even though we entered the syscall with `IF=0`. Without this,
+/// two CPUs simultaneously initiating flush IPIs to each other deadlock
+/// (both spin with `IF=0`, neither processes the other's IPI). Preemption
+/// is disabled across the spin so a timer tick cannot reschedule the
+/// caller mid-IPI.
+///
+/// # Safety
+/// Must execute at ring 0. `target_cpu` must be < `MAX_CPUS` and != the
+/// current CPU (a local invalidation goes through `fpu::flush_owner_if`
+/// directly without raising an IPI). `tcb` must be a valid TCB pointer
+/// for the duration of the call. The caller's invariants (e.g. holding
+/// no scheduler lock) must permit this CPU to temporarily enable
+/// interrupts.
+#[cfg(not(test))]
+pub unsafe fn send_fpu_flush_ipi(
+    target_cpu: usize,
+    tcb: *mut crate::sched::thread::ThreadControlBlock,
+)
+{
+    debug_assert!(target_cpu < crate::sched::MAX_CPUS);
+    debug_assert!(target_cpu != cpu::current_cpu() as usize);
+    // SAFETY: cpu validated; CPU_APIC_IDS is read-only after init.
+    let target_apic_id = unsafe { crate::percpu::apic_id_for(target_cpu) };
+
+    // Publish the request before delivering the IPI. Release pairs with
+    // the Acquire load in ipi_fpu_flush_handler.
+    FPU_FLUSH_PENDING[target_cpu].store(tcb, core::sync::atomic::Ordering::Release);
+
+    // Disable preemption so the timer tick does not reschedule us while
+    // interrupts are temporarily enabled below.
+    crate::percpu::preempt_disable();
+    // Save current IF and unconditionally disable, then re-enable. This
+    // captures the caller's IF state for restoration even when we entered
+    // already with IF=0 (the common syscall case).
+    // SAFETY: ring 0.
+    let saved_int = unsafe { cpu::save_and_disable_interrupts() };
+    // SAFETY: IDT loaded; preempt-disabled; enabling IF here lets us
+    // service incoming flush / TLB-shootdown IPIs that would otherwise
+    // circular-wait against us.
+    unsafe { enable() };
+
+    // Wait for any in-flight ICR write, then send our IPI.
+    // SAFETY: wait_icr_idle polls ICR_LOW until delivery status clears.
+    unsafe { wait_icr_idle() };
+    // SAFETY: APIC MMIO; ICR_HIGH takes destination in bits [31:24].
+    unsafe {
+        apic_write(APIC_ICR_HIGH, target_apic_id << 24);
+    }
+    // SAFETY: Fixed delivery, vector 252, level=0, trigger=edge.
+    unsafe {
+        apic_write(APIC_ICR_LOW, u32::from(IPI_VECTOR_FPU_FLUSH));
+    }
+
+    // Spin until the receiver clears the pending slot.
+    let mut n = 0u64;
+    while !FPU_FLUSH_PENDING[target_cpu]
+        .load(core::sync::atomic::Ordering::Acquire)
+        .is_null()
+    {
+        core::hint::spin_loop();
+        n += 1;
+        if n >= 100_000_000
+        {
+            crate::fatal("send_fpu_flush_ipi: target CPU never acknowledged");
+        }
+    }
+
+    // Restore the caller's interrupt state and preemption.
+    // SAFETY: saved_int from save_and_disable_interrupts on this CPU.
+    unsafe {
+        cpu::restore_interrupts(saved_int);
+    }
+    crate::percpu::preempt_enable();
 }
 
 /// Start an AP using the INIT + 2×SIPI sequence (Intel SDM Vol. 3A §8.4.4.1).

--- a/core/kernel/src/cap/object.rs
+++ b/core/kernel/src/cap/object.rs
@@ -1286,29 +1286,6 @@ unsafe fn dealloc_object_one(
                         crate::sched::scheduler_for(cpu).remove_from_queue(tcb, prio);
                     }
 
-                    // x86-64 lazy-FPU: clear any per-CPU `fpu_owner` slot
-                    // still naming this TCB. Two-stage discipline:
-                    //   (a) here, inside the all-CPU-locks region — catches
-                    //       owners visible at the moment we commit
-                    //       state=Exited.
-                    //   (b) again after the running_on / context_saved
-                    //       spins — catches any re-installation by a still-
-                    //       running thread's `#NM` between all-locks release
-                    //       and the final switch-out, before storage is
-                    //       reclaimed.
-                    // No-op on RISC-V (the slot exists but is never written).
-                    // See `docs/thread-lifecycle-and-sleep.md` § Drain
-                    // Protocol step 10a and invariant 4a.
-                    for cpu in 0..cpu_count
-                    {
-                        let _ = crate::percpu::fpu_owner_for(cpu).compare_exchange(
-                            tcb,
-                            core::ptr::null_mut(),
-                            core::sync::atomic::Ordering::AcqRel,
-                            core::sync::atomic::Ordering::Acquire,
-                        );
-                    }
-
                     // Wake any reply-bound client with Interrupted; otherwise
                     // they would remain BlockedOnReply with a dangling
                     // blocked_on_object pointing at this freed server.
@@ -1376,6 +1353,22 @@ unsafe fn dealloc_object_one(
                     // running_on snapshot can race past schedule()'s
                     // pre-save lock release. See
                     // docs/scheduling-internals.md § Cross-CPU TCB Ownership.
+                    //
+                    // The spin runs with interrupts ENABLED and preemption
+                    // DISABLED, mirroring `mm::tlb_shootdown::shootdown`. We
+                    // enter dealloc from a syscall with `IF=0`; spinning here
+                    // with `IF=0` blocks incoming IPIs (FPU flush, TLB
+                    // shootdown) targeted at this CPU and deadlocks them.
+                    // Enabling IF lets us service those, while
+                    // `preempt_disable` keeps the scheduler from migrating us
+                    // mid-dealloc (which would invalidate the `running_on`
+                    // snapshot we captured under the all-locks region).
+                    crate::percpu::preempt_disable();
+                    // SAFETY: ring 0; saved in matching restore below.
+                    let saved_int = crate::arch::current::cpu::save_and_disable_interrupts();
+                    // SAFETY: ring 0; IDT loaded; preempt disabled.
+                    crate::arch::current::interrupts::enable();
+
                     if let Some(run_cpu) = running_on
                     {
                         let sched = crate::sched::scheduler_for(run_cpu);
@@ -1397,6 +1390,11 @@ unsafe fn dealloc_object_one(
                         core::hint::spin_loop();
                     }
 
+                    // Restore the caller's interrupt state and preemption.
+                    // SAFETY: saved_int from save_and_disable_interrupts above.
+                    crate::arch::current::cpu::restore_interrupts(saved_int);
+                    crate::percpu::preempt_enable();
+
                     // x86-64 lazy-FPU: clear any per-CPU `fpu_owner` slot
                     // still naming this TCB. Placed AFTER the `running_on`
                     // and `context_saved` spins so the dying thread is
@@ -1408,6 +1406,8 @@ unsafe fn dealloc_object_one(
                     // O(MAX_CPUS) atomic CAS and locks out the stale-
                     // pointer hazard before storage is reclaimed below.
                     // No-op on RISC-V (the slot exists but is never written).
+                    // See `docs/thread-lifecycle-and-sleep.md` § Drain
+                    // Protocol step 10a and invariant 4a.
                     for cpu in 0..cpu_count
                     {
                         let _ = crate::percpu::fpu_owner_for(cpu).compare_exchange(

--- a/core/kernel/src/cap/object.rs
+++ b/core/kernel/src/cap/object.rs
@@ -1286,6 +1286,29 @@ unsafe fn dealloc_object_one(
                         crate::sched::scheduler_for(cpu).remove_from_queue(tcb, prio);
                     }
 
+                    // x86-64 lazy-FPU: clear any per-CPU `fpu_owner` slot
+                    // still naming this TCB. Two-stage discipline:
+                    //   (a) here, inside the all-CPU-locks region — catches
+                    //       owners visible at the moment we commit
+                    //       state=Exited.
+                    //   (b) again after the running_on / context_saved
+                    //       spins — catches any re-installation by a still-
+                    //       running thread's `#NM` between all-locks release
+                    //       and the final switch-out, before storage is
+                    //       reclaimed.
+                    // No-op on RISC-V (the slot exists but is never written).
+                    // See `docs/thread-lifecycle-and-sleep.md` § Drain
+                    // Protocol step 10a and invariant 4a.
+                    for cpu in 0..cpu_count
+                    {
+                        let _ = crate::percpu::fpu_owner_for(cpu).compare_exchange(
+                            tcb,
+                            core::ptr::null_mut(),
+                            core::sync::atomic::Ordering::AcqRel,
+                            core::sync::atomic::Ordering::Acquire,
+                        );
+                    }
+
                     // Wake any reply-bound client with Interrupted; otherwise
                     // they would remain BlockedOnReply with a dangling
                     // blocked_on_object pointing at this freed server.

--- a/core/kernel/src/cap/object.rs
+++ b/core/kernel/src/cap/object.rs
@@ -1286,6 +1286,23 @@ unsafe fn dealloc_object_one(
                         crate::sched::scheduler_for(cpu).remove_from_queue(tcb, prio);
                     }
 
+                    // Defensive: clear any per-CPU lazy-FPU ownership that
+                    // still names this TCB. By construction (migration-flush
+                    // IPI in sched/mod.rs) only the CPU on which this thread
+                    // last ran can legitimately still own it at death, but
+                    // sweeping all CPUs is bounded by `cpu_count` and locks
+                    // out a stale-pointer hazard if an invariant is violated.
+                    // No-op on RISC-V (the slot exists but is never written).
+                    for cpu in 0..cpu_count
+                    {
+                        let _ = crate::percpu::fpu_owner_for(cpu).compare_exchange(
+                            tcb,
+                            core::ptr::null_mut(),
+                            core::sync::atomic::Ordering::AcqRel,
+                            core::sync::atomic::Ordering::Acquire,
+                        );
+                    }
+
                     // Wake any reply-bound client with Interrupted; otherwise
                     // they would remain BlockedOnReply with a dangling
                     // blocked_on_object pointing at this freed server.

--- a/core/kernel/src/cap/object.rs
+++ b/core/kernel/src/cap/object.rs
@@ -1286,23 +1286,6 @@ unsafe fn dealloc_object_one(
                         crate::sched::scheduler_for(cpu).remove_from_queue(tcb, prio);
                     }
 
-                    // Defensive: clear any per-CPU lazy-FPU ownership that
-                    // still names this TCB. By construction (migration-flush
-                    // IPI in sched/mod.rs) only the CPU on which this thread
-                    // last ran can legitimately still own it at death, but
-                    // sweeping all CPUs is bounded by `cpu_count` and locks
-                    // out a stale-pointer hazard if an invariant is violated.
-                    // No-op on RISC-V (the slot exists but is never written).
-                    for cpu in 0..cpu_count
-                    {
-                        let _ = crate::percpu::fpu_owner_for(cpu).compare_exchange(
-                            tcb,
-                            core::ptr::null_mut(),
-                            core::sync::atomic::Ordering::AcqRel,
-                            core::sync::atomic::Ordering::Acquire,
-                        );
-                    }
-
                     // Wake any reply-bound client with Interrupted; otherwise
                     // they would remain BlockedOnReply with a dangling
                     // blocked_on_object pointing at this freed server.
@@ -1389,6 +1372,27 @@ unsafe fn dealloc_object_one(
                         == 0
                     {
                         core::hint::spin_loop();
+                    }
+
+                    // x86-64 lazy-FPU: clear any per-CPU `fpu_owner` slot
+                    // still naming this TCB. Placed AFTER the `running_on`
+                    // and `context_saved` spins so the dying thread is
+                    // guaranteed to have switched out on every CPU and
+                    // taken no further `#NM` (which would have re-stored
+                    // its pointer into a CPU's owner slot). At this point
+                    // the only legitimate residue is the slot of the CPU
+                    // the thread last ran on; sweeping every CPU costs
+                    // O(MAX_CPUS) atomic CAS and locks out the stale-
+                    // pointer hazard before storage is reclaimed below.
+                    // No-op on RISC-V (the slot exists but is never written).
+                    for cpu in 0..cpu_count
+                    {
+                        let _ = crate::percpu::fpu_owner_for(cpu).compare_exchange(
+                            tcb,
+                            core::ptr::null_mut(),
+                            core::sync::atomic::Ordering::AcqRel,
+                            core::sync::atomic::Ordering::Acquire,
+                        );
                     }
                 }
 

--- a/core/kernel/src/percpu.rs
+++ b/core/kernel/src/percpu.rs
@@ -29,13 +29,18 @@
 //! | `PERCPU_USER_RSP_OFFSET` | 16 | `user_rsp` |
 //! | `PERCPU_SCRATCH_OFFSET` | 24 | `scratch` |
 //! | `PERCPU_TSS_PTR_OFFSET` | 32 | `tss_ptr` |
+//! | `PERCPU_PREEMPT_COUNT_OFFSET` | 40 | `preempt_count` |
+//! | `PERCPU_FPU_OWNER_OFFSET` | 48 | `fpu_owner` |
 //!
 //! ## Adding new fields
 //! Append fields at the end of the struct. Update the constant table above,
 //! add a test in the `tests` module, and update any assembly that addresses
 //! the struct by offset.
 
+use core::sync::atomic::AtomicPtr;
+
 use crate::sched::MAX_CPUS;
+use crate::sched::thread::ThreadControlBlock;
 
 // ── APIC ID mapping ───────────────────────────────────────────────────────────
 
@@ -115,6 +120,10 @@ pub const PERCPU_TSS_PTR_OFFSET: usize = 32;
 // Not accessed from assembly; used by preempt_disable/preempt_enable.
 #[allow(dead_code)]
 pub const PERCPU_PREEMPT_COUNT_OFFSET: usize = 40;
+/// Byte offset of `PerCpuData::fpu_owner`. GS-relative: `gs:[48]`.
+// Not accessed from assembly; included for layout discipline.
+#[allow(dead_code)]
+pub const PERCPU_FPU_OWNER_OFFSET: usize = 48;
 
 // ── PerCpuData ────────────────────────────────────────────────────────────────
 
@@ -124,7 +133,6 @@ pub const PERCPU_PREEMPT_COUNT_OFFSET: usize = 40;
 /// no locks are required. The struct is `#[repr(C)]` to guarantee the
 /// byte layout expected by GS-relative assembly.
 #[repr(C)]
-#[derive(Clone, Copy)]
 pub struct PerCpuData
 {
     /// Logical CPU index (0-based). x86-64: readable as `gs:[0]`.
@@ -148,6 +156,13 @@ pub struct PerCpuData
     /// sections such as TLB shootdown spin-waits.
     pub preempt_count: u32,
     _pad1: u32,
+    /// x86-64 lazy-FPU per-CPU owner cache: the TCB whose extended-state
+    /// register file is currently believed live in this CPU's hardware
+    /// XMM/YMM/x87 registers (null if none). Maintained by the `#NM`
+    /// handler, the context-switch fast path, and the migration-side
+    /// flush IPI; defines the invariant `(CR0.TS=0) ⇔ (fpu_owner != null)`.
+    /// Unused on RISC-V (lazy via `sstatus.FS/VS`).
+    pub fpu_owner: AtomicPtr<ThreadControlBlock>,
 }
 
 impl PerCpuData
@@ -163,6 +178,7 @@ impl PerCpuData
             tss_ptr: 0,
             preempt_count: 0,
             _pad1: 0,
+            fpu_owner: AtomicPtr::new(core::ptr::null_mut()),
         }
     }
 }
@@ -180,10 +196,7 @@ impl PerCpuData
 /// access occurs after the entry is published (sequenced by the AP
 /// synchronization barrier in SMP startup).
 #[cfg(not(test))]
-pub static mut PER_CPU: [PerCpuData; MAX_CPUS] = {
-    const D: PerCpuData = PerCpuData::new();
-    [D; MAX_CPUS]
-};
+pub static mut PER_CPU: [PerCpuData; MAX_CPUS] = [const { PerCpuData::new() }; MAX_CPUS];
 
 // ── BSP initialisation ────────────────────────────────────────────────────────
 
@@ -285,6 +298,29 @@ pub fn preemption_disabled() -> bool
     unsafe { PER_CPU[cpu].preempt_count > 0 }
 }
 
+// ── Lazy-FPU owner cache (x86-64) ────────────────────────────────────────────
+
+/// Return a reference to CPU `cpu`'s lazy-FPU owner slot.
+///
+/// Used cross-CPU: the migration-side flush IPI sender atomically reads the
+/// target CPU's slot to decide whether to skip the IPI, and the IPI handler
+/// (on the target CPU) atomically CASes the slot from the migrating TCB to
+/// null. Local readers (the `#NM` handler, the context-switch fast path)
+/// resolve the slot for the current CPU index.
+///
+/// # Safety
+/// `cpu` must be < [`MAX_CPUS`]. The returned reference is `'static` because
+/// `PER_CPU` outlives any conceivable caller; concurrent access is safe via
+/// the [`AtomicPtr`] interior mutability.
+#[cfg(not(test))]
+pub fn fpu_owner_for(cpu: usize) -> &'static AtomicPtr<ThreadControlBlock>
+{
+    debug_assert!(cpu < MAX_CPUS);
+    // SAFETY: cpu validated < MAX_CPUS; AtomicPtr permits concurrent access
+    // through a shared reference, and PER_CPU is alive for the program lifetime.
+    unsafe { &*core::ptr::addr_of!(PER_CPU[cpu].fpu_owner) }
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -324,11 +360,11 @@ mod tests
     }
 
     #[test]
-    fn percpu_size_is_48_bytes()
+    fn percpu_size_is_56_bytes()
     {
         // cpu_id(4) + _pad0(4) + kernel_rsp(8) + user_rsp(8) + scratch(8) + tss_ptr(8)
-        // + preempt_count(4) + _pad1(4) = 48
-        assert_eq!(core::mem::size_of::<PerCpuData>(), 48);
+        // + preempt_count(4) + _pad1(4) + fpu_owner(8) = 56
+        assert_eq!(core::mem::size_of::<PerCpuData>(), 56);
     }
 
     #[test]
@@ -338,5 +374,11 @@ mod tests
             offset_of!(PerCpuData, preempt_count),
             PERCPU_PREEMPT_COUNT_OFFSET
         );
+    }
+
+    #[test]
+    fn percpu_fpu_owner_offset_matches_constant()
+    {
+        assert_eq!(offset_of!(PerCpuData, fpu_owner), PERCPU_FPU_OWNER_OFFSET);
     }
 }

--- a/core/kernel/src/percpu.rs
+++ b/core/kernel/src/percpu.rs
@@ -160,8 +160,12 @@ pub struct PerCpuData
     /// register file is currently believed live in this CPU's hardware
     /// XMM/YMM/x87 registers (null if none). Maintained by the `#NM`
     /// handler, the context-switch fast path, and the migration-side
-    /// flush IPI; defines the invariant `(CR0.TS=0) ⇔ (fpu_owner != null)`.
-    /// Unused on RISC-V (lazy via `sstatus.FS/VS`).
+    /// flush IPI. The invariant on each CPU is the one-way implication
+    /// `(CR0.TS=0) ⇒ (fpu_owner != null)`; equivalently, the forbidden
+    /// state is `(CR0.TS=0, fpu_owner=null)`. The states
+    /// `(TS=1, owner=null)`, `(TS=1, owner=T)`, and `(TS=0, owner=T)`
+    /// are all valid. See `arch/x86_64/fpu.rs` module docs for the
+    /// transition table. Unused on RISC-V (lazy via `sstatus.FS/VS`).
     pub fpu_owner: AtomicPtr<ThreadControlBlock>,
 }
 

--- a/core/kernel/src/sched/mod.rs
+++ b/core/kernel/src/sched/mod.rs
@@ -1442,17 +1442,19 @@ unsafe fn pull_unpinned_ready(src_cpu: usize, dst_cpu: usize)
     // SAFETY: ascending-CPU order satisfies lock-hierarchy rule 4.
     let saved_hi = unsafe { hi_sched.lock.lock_raw() };
 
-    // SAFETY: src_cpu valid; lock held. Predicate is read-only.
-    //
-    // Skip threads currently named as `src_cpu`'s lazy-FPU owner: those
-    // hold live extended-state on src_cpu's hardware registers; their
-    // per-thread XSAVE area is stale. A safe pull would require a flush
-    // IPI to src_cpu, but issuing a synchronous IPI while holding both
-    // scheduler locks risks circular-wait deadlock against another CPU
-    // doing the same. Skipping such threads from load-balance pulls
-    // costs at most one balance-tick of imbalance (the thread runs on
-    // src_cpu's next FP-using context and ceases being the owner via
-    // `#NM`), and is cheap and lock-free to detect.
+    // Skip-owner predicate: load-balance pulls cannot freshen a
+    // candidate's XSAVE area when the candidate is still named as
+    // `src_cpu`'s lazy-FPU owner. The only mechanism that would
+    // canonicalise the area is a synchronous flush IPI to `src_cpu`,
+    // but issuing an IPI while holding both `src_cpu` and `dst_cpu`
+    // scheduler locks would circular-wait against another CPU
+    // initiating its own migration (see Lock Hierarchy rule 4 and
+    // the `send_fpu_flush_ipi` deadlock-avoidance discipline in
+    // `arch/x86_64/interrupts.rs`). Skipping owner-named candidates
+    // is the deadlock-free alternative: the missed candidate stays
+    // Ready on `src_cpu` and gets picked by `src_cpu`'s next schedule
+    // tick. Detection is a single Acquire load of the per-CPU owner
+    // slot and a pointer-equality test inside the existing predicate.
     let fpu_owner_on_src =
         crate::percpu::fpu_owner_for(src_cpu).load(core::sync::atomic::Ordering::Acquire);
     // SAFETY: src_cpu valid; lock held; predicate is read-only.

--- a/core/kernel/src/sched/mod.rs
+++ b/core/kernel/src/sched/mod.rs
@@ -1184,6 +1184,18 @@ pub unsafe fn migrate_ready_thread(
         return false;
     }
 
+    // Flush a stale lazy-FPU owner on src_cpu BEFORE acquiring scheduler
+    // locks. A synchronous flush IPI sent while holding the source/dest
+    // scheduler locks can circular-wait when the target CPU is acquiring
+    // those same locks for its own migration/wake (deadlock). The flush
+    // is harmless if src_cpu no longer owns the TCB (early-out in
+    // `flush_owner_remote`) — speculation cost is bounded. No-op on RISC-V.
+    // SAFETY: src_cpu validated < cpu_count above; tcb valid by caller; no
+    // scheduler locks held — IPI cannot circular-wait on lock acquisition.
+    unsafe {
+        crate::arch::current::fpu::flush_owner_remote(src_cpu, tcb);
+    }
+
     let (lo, hi) = if src_cpu < dst_cpu
     {
         (src_cpu, dst_cpu)
@@ -1431,8 +1443,23 @@ unsafe fn pull_unpinned_ready(src_cpu: usize, dst_cpu: usize)
     let saved_hi = unsafe { hi_sched.lock.lock_raw() };
 
     // SAFETY: src_cpu valid; lock held. Predicate is read-only.
+    //
+    // Skip threads currently named as `src_cpu`'s lazy-FPU owner: those
+    // hold live extended-state on src_cpu's hardware registers; their
+    // per-thread XSAVE area is stale. A safe pull would require a flush
+    // IPI to src_cpu, but issuing a synchronous IPI while holding both
+    // scheduler locks risks circular-wait deadlock against another CPU
+    // doing the same. Skipping such threads from load-balance pulls
+    // costs at most one balance-tick of imbalance (the thread runs on
+    // src_cpu's next FP-using context and ceases being the owner via
+    // `#NM`), and is cheap and lock-free to detect.
+    let fpu_owner_on_src =
+        crate::percpu::fpu_owner_for(src_cpu).load(core::sync::atomic::Ordering::Acquire);
+    // SAFETY: src_cpu valid; lock held; predicate is read-only.
     let pick = unsafe {
-        (*scheduler_ptr(src_cpu)).find_runnable(|tcb| (*tcb).cpu_affinity == AFFINITY_ANY)
+        (*scheduler_ptr(src_cpu)).find_runnable(|tcb| {
+            (*tcb).cpu_affinity == AFFINITY_ANY && !core::ptr::eq(tcb, fpu_owner_on_src)
+        })
     };
 
     let Some((tcb, priority)) = pick
@@ -1455,6 +1482,12 @@ unsafe fn pull_unpinned_ready(src_cpu: usize, dst_cpu: usize)
         unsafe { lo_sched.lock.unlock_raw(saved_lo) };
         return;
     }
+
+    // No flush IPI here: the `find_runnable` predicate skipped any
+    // candidate currently named as src_cpu's `fpu_owner`, so this tcb's
+    // XSAVE area is canonical. Issuing a synchronous IPI under both
+    // scheduler locks would risk circular-wait deadlock (see the
+    // `enqueue_and_wake` rationale).
 
     // SAFETY: tcb is no longer on src; dst_cpu scheduler is valid.
     unsafe { scheduler_for(dst_cpu).enqueue(tcb, priority) };
@@ -1499,6 +1532,32 @@ pub unsafe fn enqueue_and_wake(tcb: *mut ThreadControlBlock, target_cpu: usize, 
             "enqueue_and_wake: target_cpu={target_cpu} >= MAX_CPUS, tid={tid}, prio={priority}"
         );
     }
+
+    // Flush a stale lazy-FPU owner on the thread's previous CPU BEFORE
+    // acquiring any scheduler lock. A thread that was Blocked between
+    // #NM-time on `old_preferred` and this wake may still be `fpu_owner`
+    // over there with stale extended-state contents in its TCB area; the
+    // destination CPU's `#NM` would XRSTOR a stale area. The flush IPI
+    // must run outside the lock-held region: a synchronous IPI sent while
+    // holding a scheduler lock can circular-wait when the target CPU is
+    // also acquiring that same lock (deadlock). The thread is not Ready/
+    // Running (it is being woken from Blocked/Stopped/Created), so its
+    // `preferred_cpu` is stable for the duration of this call — an
+    // unlocked read is safe. No-op on RISC-V (lazy via `sstatus.FS/VS`).
+    let cpu_count_for_flush = CPU_COUNT.load(core::sync::atomic::Ordering::Relaxed) as usize;
+    // SAFETY: tcb valid by caller contract; preferred_cpu is a u32 field
+    // and aligned reads are atomic on x86-64.
+    let old_preferred =
+        unsafe { core::ptr::read_volatile(core::ptr::addr_of!((*tcb).preferred_cpu)) } as usize;
+    if old_preferred < cpu_count_for_flush && old_preferred != target_cpu
+    {
+        // SAFETY: old_preferred validated < CPU_COUNT; tcb valid; no
+        // scheduler locks held — IPI cannot circular-wait on lock acquisition.
+        unsafe {
+            crate::arch::current::fpu::flush_owner_remote(old_preferred, tcb);
+        }
+    }
+
     // SAFETY: caller guarantees tcb is valid and target_cpu is initialized.
     let sched = unsafe { scheduler_for(target_cpu) };
 
@@ -1990,17 +2049,21 @@ pub unsafe fn schedule(requeue_current: bool)
         }
     }
 
-    // Save the current thread's extended FPU/SIMD/V state to its per-TCB
-    // area before any other CPU can observe this thread as no-longer-current,
-    // then load the incoming thread's state into the live registers. The
-    // x86-64 path is eager (unconditional XSAVE + XRSTOR here); the RISC-V
-    // path keeps lazy FS/VS trap restore so `switch_in_restore` is a no-op
-    // there. Both calls no-op for kernel-only / idle threads (extended.area
-    // is null on those TCBs).
+    // Lazy-FPU context-switch hooks. Both arches use lazy save/restore:
+    // - x86-64: a per-CPU `fpu_owner` cache plus CR0.TS gating. switch_out_save
+    //   sets CR0.TS=1 (no XSAVE; the live regs stay for fast re-run or for
+    //   the migration flush IPI to extract). switch_in_restore clears TS
+    //   only when the incoming thread is already the owner — otherwise it
+    //   leaves TS=1 so the first FP op traps to `#NM`, which saves the
+    //   prior owner and XRSTORs the new thread's area.
+    // - RISC-V: lazy via `sstatus.FS/VS` dirty tracking. switch_out_save
+    //   reads FS/VS and saves to the area only on Dirty; switch_in_restore
+    //   is a no-op (the trap path's `lazy_restore_fp_v` reloads on first use).
+    // Both calls no-op for kernel-only / idle threads (extended.area is null).
     if !current.is_null()
     {
         // SAFETY: ring-0 with interrupts disabled and the scheduler lock
-        // held; arch fpu::switch_out_save handles the per-arch save.
+        // held; arch fpu::switch_out_save honours the per-arch lazy discipline.
         unsafe {
             crate::arch::current::fpu::switch_out_save(current);
         }
@@ -2008,7 +2071,7 @@ pub unsafe fn schedule(requeue_current: bool)
     if !next.is_null()
     {
         // SAFETY: ring-0 with interrupts disabled and the scheduler lock
-        // held; arch fpu::switch_in_restore handles the per-arch restore.
+        // held; arch fpu::switch_in_restore honours the per-arch lazy discipline.
         unsafe {
             crate::arch::current::fpu::switch_in_restore(next);
         }

--- a/core/ktest/src/unit/fpu.rs
+++ b/core/ktest/src/unit/fpu.rs
@@ -14,12 +14,18 @@
 //! verifies both captures match the pattern the child wrote. Any
 //! cross-thread bleed surfaces as a mismatch and fails the test.
 
+#[cfg(target_arch = "x86_64")]
+use core::sync::atomic::AtomicU32;
 use core::sync::atomic::{AtomicU64, Ordering};
 
+#[cfg(target_arch = "x86_64")]
+use syscall::system_info;
 use syscall::{
     cap_copy, cap_create_cspace, cap_create_signal, cap_create_thread, cap_delete, signal_send,
     signal_wait, thread_configure, thread_exit, thread_set_affinity, thread_start,
 };
+#[cfg(target_arch = "x86_64")]
+use syscall_abi::SystemInfoType;
 
 use crate::{ChildStack, TestContext, TestResult};
 
@@ -431,4 +437,258 @@ pub fn preempt_isolation(ctx: &TestContext) -> TestResult
         return Err("thread B observed extended-state corruption across preemption");
     }
     Ok(())
+}
+
+// ── Cross-CPU preemption-isolation (Issue #65 lazy-FPU flush IPI) ────────────
+
+/// Per-thread stack for the cross-CPU child.
+#[cfg(target_arch = "x86_64")]
+static mut STACK_CROSS: ChildStack = ChildStack::ZERO;
+/// Signal indices passed into the cross-CPU child by index (the child's
+/// cspace cap is published here so the inline-asm syscall sites can read
+/// them without crossing a Rust function boundary that would clobber
+/// xmm0..xmm15).
+#[cfg(target_arch = "x86_64")]
+static CROSS_SIG_READY: AtomicU32 = AtomicU32::new(0);
+#[cfg(target_arch = "x86_64")]
+static CROSS_SIG_RESUME: AtomicU32 = AtomicU32::new(0);
+#[cfg(target_arch = "x86_64")]
+static CROSS_SIG_DONE: AtomicU32 = AtomicU32::new(0);
+/// Mismatch count written by the cross-CPU child after the post-migration
+/// register capture. The parent reads it only after the `done` signal so
+/// the zero default is never mistaken for a pass.
+#[cfg(target_arch = "x86_64")]
+static CROSS_MISMATCHES: AtomicU64 = AtomicU64::new(0);
+/// CPU id observed by the cross-CPU child after migration, sanity-checked
+/// by the parent to confirm the migration actually happened.
+#[cfg(target_arch = "x86_64")]
+static CROSS_OBSERVED_CPU: AtomicU32 = AtomicU32::new(u32::MAX);
+
+/// Cross-CPU child entry: load `PATTERN_A` into xmm0..xmm15, signal "ready",
+/// block on "resume", then capture xmm0..xmm15 back to a stack buffer.
+///
+/// The entire load → block → capture sequence runs inside a single inline-
+/// asm block so no intervening Rust call clobbers xmm. The syscall ABI is
+/// embedded directly: rax = syscall number, rdi/rsi = args; the kernel
+/// preserves the live FP register file across the block because (a) the
+/// kernel itself is soft-float and (b) the lazy-FPU discipline keeps the
+/// child as `fpu_owner` of its current CPU until either another thread
+/// takes an `#NM` or the migration-flush IPI fires on wake.
+#[cfg(target_arch = "x86_64")]
+extern "C" fn child_cross_entry(_arg: u64) -> !
+{
+    // 128-bit pattern (xmm lane width).
+    let pat128 = [PATTERN_A, PATTERN_A];
+    let mut buf = [[0u64; 2]; 16];
+    let sig_ready = CROSS_SIG_READY.load(Ordering::Acquire);
+    let sig_resume = CROSS_SIG_RESUME.load(Ordering::Acquire);
+    // Brief spin between FP load and signal_send so timer ticks fire while
+    // we are fpu_owner on the source CPU.
+    let spin: u64 = 50_000;
+
+    // SAFETY: inline asm loads pat128 into xmm0..xmm15, issues two raw
+    // syscalls (SIGNAL_SEND, SIGNAL_WAIT) preserving the live FP register
+    // file across both, then stores xmm0..xmm15 into buf. All operands
+    // have matching lifetimes; rcx/r11 are syscall-clobber-only.
+    unsafe {
+        core::arch::asm!(
+            "vmovdqu xmm0,  [{p}]",
+            "vmovdqu xmm1,  [{p}]",
+            "vmovdqu xmm2,  [{p}]",
+            "vmovdqu xmm3,  [{p}]",
+            "vmovdqu xmm4,  [{p}]",
+            "vmovdqu xmm5,  [{p}]",
+            "vmovdqu xmm6,  [{p}]",
+            "vmovdqu xmm7,  [{p}]",
+            "vmovdqu xmm8,  [{p}]",
+            "vmovdqu xmm9,  [{p}]",
+            "vmovdqu xmm10, [{p}]",
+            "vmovdqu xmm11, [{p}]",
+            "vmovdqu xmm12, [{p}]",
+            "vmovdqu xmm13, [{p}]",
+            "vmovdqu xmm14, [{p}]",
+            "vmovdqu xmm15, [{p}]",
+            "2:",
+            "pause",
+            "dec {it}",
+            "jnz 2b",
+            // Syscall SYS_SIGNAL_SEND(sig_ready, 0x1). rax = 3.
+            "mov rax, 3",
+            "mov edi, {sig_ready:e}",
+            "mov esi, 1",
+            "syscall",
+            // Syscall SYS_SIGNAL_WAIT(sig_resume, 0). rax = 4.
+            "mov rax, 4",
+            "mov edi, {sig_resume:e}",
+            "mov esi, 0",
+            "syscall",
+            // Now resumed on the migration target CPU. Capture xmm0..xmm15.
+            "vmovdqu [{b} + 0x000], xmm0",
+            "vmovdqu [{b} + 0x010], xmm1",
+            "vmovdqu [{b} + 0x020], xmm2",
+            "vmovdqu [{b} + 0x030], xmm3",
+            "vmovdqu [{b} + 0x040], xmm4",
+            "vmovdqu [{b} + 0x050], xmm5",
+            "vmovdqu [{b} + 0x060], xmm6",
+            "vmovdqu [{b} + 0x070], xmm7",
+            "vmovdqu [{b} + 0x080], xmm8",
+            "vmovdqu [{b} + 0x090], xmm9",
+            "vmovdqu [{b} + 0x0a0], xmm10",
+            "vmovdqu [{b} + 0x0b0], xmm11",
+            "vmovdqu [{b} + 0x0c0], xmm12",
+            "vmovdqu [{b} + 0x0d0], xmm13",
+            "vmovdqu [{b} + 0x0e0], xmm14",
+            "vmovdqu [{b} + 0x0f0], xmm15",
+            p = in(reg) pat128.as_ptr(),
+            b = in(reg) buf.as_mut_ptr(),
+            it = inout(reg) spin => _,
+            sig_ready = in(reg) sig_ready,
+            sig_resume = in(reg) sig_resume,
+            out("rax") _, out("rcx") _, out("rdi") _, out("rsi") _, out("r11") _,
+            out("xmm0") _, out("xmm1") _, out("xmm2") _, out("xmm3") _,
+            out("xmm4") _, out("xmm5") _, out("xmm6") _, out("xmm7") _,
+            out("xmm8") _, out("xmm9") _, out("xmm10") _, out("xmm11") _,
+            out("xmm12") _, out("xmm13") _, out("xmm14") _, out("xmm15") _,
+            options(nostack),
+        );
+    }
+
+    let mut mismatches = 0u64;
+    for lane in &buf
+    {
+        if lane[0] != PATTERN_A || lane[1] != PATTERN_A
+        {
+            mismatches += 1;
+        }
+    }
+    CROSS_MISMATCHES.store(mismatches, Ordering::Release);
+    let cpu = system_info(SystemInfoType::CurrentCpu as u64).unwrap_or(u64::MAX);
+    CROSS_OBSERVED_CPU.store(u32::try_from(cpu).unwrap_or(u32::MAX), Ordering::Release);
+
+    let _ = signal_send(CROSS_SIG_DONE.load(Ordering::Acquire), 0x1);
+    thread_exit();
+}
+
+/// Cross-CPU lazy-FPU-flush correctness: a thread that became `fpu_owner`
+/// on CPU 0, blocked, then was woken with affinity changed to CPU 1, must
+/// observe its register file intact post-migration. Exercises the
+/// migration-flush IPI path added in Issue #65 via the `enqueue_and_wake`
+/// → `flush_owner_remote(old_preferred_cpu, tcb)` call.
+///
+/// Requires SMP; skips otherwise. Skipped on RISC-V (out of scope for #65).
+#[cfg(target_arch = "riscv64")]
+#[allow(clippy::unnecessary_wraps)]
+pub fn preempt_isolation_cross_cpu(_ctx: &TestContext) -> TestResult
+{
+    crate::log("ktest: fpu::preempt_isolation_cross_cpu SKIP (RISC-V out of scope for #65)");
+    Ok(())
+}
+
+/// Cross-CPU lazy-FPU-flush correctness (x86-64 only); see the
+/// architecture-neutral doc comment above.
+#[cfg(target_arch = "x86_64")]
+pub fn preempt_isolation_cross_cpu(ctx: &TestContext) -> TestResult
+{
+    {
+        let cpus = system_info(SystemInfoType::CpuCount as u64)
+            .map_err(|_| "system_info(CpuCount) for preempt_isolation_cross_cpu failed")?;
+        if cpus < 2
+        {
+            crate::log("ktest: fpu::preempt_isolation_cross_cpu SKIP (requires SMP)");
+            return Ok(());
+        }
+
+        CROSS_MISMATCHES.store(0, Ordering::Release);
+        CROSS_OBSERVED_CPU.store(u32::MAX, Ordering::Release);
+
+        let sig_ready = cap_create_signal(ctx.memory_frame_base)
+            .map_err(|_| "create_signal ready for preempt_isolation_cross_cpu failed")?;
+        let sig_resume = cap_create_signal(ctx.memory_frame_base)
+            .map_err(|_| "create_signal resume for preempt_isolation_cross_cpu failed")?;
+        let sig_done = cap_create_signal(ctx.memory_frame_base)
+            .map_err(|_| "create_signal done for preempt_isolation_cross_cpu failed")?;
+        let cs = cap_create_cspace(ctx.memory_frame_base, 0, 4, 16)
+            .map_err(|_| "create_cspace for preempt_isolation_cross_cpu failed")?;
+
+        let child_ready = cap_copy(sig_ready, cs, RIGHTS_SIGNAL)
+            .map_err(|_| "cap_copy ready for preempt_isolation_cross_cpu failed")?;
+        let child_resume = cap_copy(sig_resume, cs, RIGHTS_SIGNAL)
+            .map_err(|_| "cap_copy resume for preempt_isolation_cross_cpu failed")?;
+        let child_done = cap_copy(sig_done, cs, RIGHTS_SIGNAL)
+            .map_err(|_| "cap_copy done for preempt_isolation_cross_cpu failed")?;
+
+        CROSS_SIG_READY.store(child_ready, Ordering::Release);
+        CROSS_SIG_RESUME.store(child_resume, Ordering::Release);
+        CROSS_SIG_DONE.store(child_done, Ordering::Release);
+
+        let th = cap_create_thread(ctx.memory_frame_base, ctx.aspace_cap, cs)
+            .map_err(|_| "cap_create_thread for preempt_isolation_cross_cpu failed")?;
+
+        // Pin to CPU 0 initially: child must run and become CPU 0's
+        // `fpu_owner` before the migration step.
+        thread_set_affinity(th, 0)
+            .map_err(|_| "initial thread_set_affinity(0) for preempt_isolation_cross_cpu failed")?;
+
+        let stack_top = ChildStack::top(core::ptr::addr_of!(STACK_CROSS));
+        thread_configure(th, child_cross_entry as *const () as u64, stack_top, 0)
+            .map_err(|_| "thread_configure for preempt_isolation_cross_cpu failed")?;
+        thread_start(th).map_err(|_| "thread_start for preempt_isolation_cross_cpu failed")?;
+
+        // Wait for the child to become `fpu_owner` on CPU 0 and signal ready.
+        // The parent blocks (yielding CPU 0) so the child can run; the child
+        // then loads PATTERN_A, briefly spins, signals ready, and blocks on
+        // sig_resume.
+        let _ = signal_wait(sig_ready)
+            .map_err(|_| "signal_wait ready for preempt_isolation_cross_cpu failed")?;
+
+        // Change affinity to CPU 1 while the child is Blocked. This just
+        // updates the affinity field; the migration happens at wake time.
+        thread_set_affinity(th, 1)
+            .map_err(|_| "thread_set_affinity(1) for preempt_isolation_cross_cpu failed")?;
+
+        // Wake the child. The wake path calls `enqueue_and_wake(target=1)`
+        // → `flush_owner_remote(old_preferred=0, tcb)` → synchronous flush
+        // IPI on CPU 0 → CPU 0's `fpu_owner_if` saves the live regs into
+        // the child's XSAVE area. The child then runs on CPU 1; the first
+        // FP op (the capture vmovdqu) traps to `#NM`, which XRSTORs the
+        // freshly-saved area into CPU 1's hardware before the store
+        // executes.
+        signal_send(sig_resume, 0x1)
+            .map_err(|_| "signal_send resume for preempt_isolation_cross_cpu failed")?;
+
+        let _ = signal_wait(sig_done)
+            .map_err(|_| "signal_wait done for preempt_isolation_cross_cpu failed")?;
+
+        let mismatches = CROSS_MISMATCHES.load(Ordering::Acquire);
+        let observed_cpu = CROSS_OBSERVED_CPU.load(Ordering::Acquire);
+
+        cap_delete(th).map_err(|_| "cap_delete th after preempt_isolation_cross_cpu failed")?;
+        cap_delete(sig_ready)
+            .map_err(|_| "cap_delete sig_ready after preempt_isolation_cross_cpu failed")?;
+        cap_delete(sig_resume)
+            .map_err(|_| "cap_delete sig_resume after preempt_isolation_cross_cpu failed")?;
+        cap_delete(sig_done)
+            .map_err(|_| "cap_delete sig_done after preempt_isolation_cross_cpu failed")?;
+        cap_delete(cs).map_err(|_| "cap_delete cs after preempt_isolation_cross_cpu failed")?;
+
+        crate::log_u64(
+            "fpu::preempt_isolation_cross_cpu observed_cpu=",
+            u64::from(observed_cpu),
+        );
+        crate::log_u64("fpu::preempt_isolation_cross_cpu mismatches=", mismatches);
+        if mismatches != 0
+        {
+            return Err("cross-CPU child observed extended-state corruption after migration");
+        }
+        // The migration was either actually cross-CPU (observed != 0) or the
+        // scheduler kept the child on its original CPU. In either case, the
+        // FP state must be intact. The flush IPI path is exercised when the
+        // wake target differs from the thread's prior `preferred_cpu`; this
+        // can happen via affinity-driven `select_target_cpu` or via
+        // load-balance pull on the destination. We log the observed CPU for
+        // diagnostics but do not gate the test on it — the existing
+        // `thread::affinity_migrate_ready_queued` test already covers strict
+        // affinity enforcement.
+        Ok(())
+    }
 }

--- a/core/ktest/src/unit/mod.rs
+++ b/core/ktest/src/unit/mod.rs
@@ -407,6 +407,10 @@ pub fn run_all(ctx: &TestContext)
 
     // ── Extended-state (FPU / SIMD / V) isolation ────────────────────────────
     run_test!("fpu::preempt_isolation", fpu::preempt_isolation(ctx));
+    run_test!(
+        "fpu::preempt_isolation_cross_cpu",
+        fpu::preempt_isolation_cross_cpu(ctx)
+    );
 
     // ── Hardware access syscalls ──────────────────────────────────────────────
     run_test!("hw::mmio_map", hw::mmio_map(ctx));


### PR DESCRIPTION
## Summary

- Reinstates lazy x86-64 FPU save/restore via the classic Linux per-CPU `fpu_owner` cache plus CR0.TS-gated `#NM` dispatch. The eager XSAVE/XRSTOR shim from #62 / PR #64 is gone.
- Steady-state cost on the FPU-save axis for threads that have not touched extended state since the previous switch: **0 XSAVE, 0 XRSTOR** (down from ~300-600 cycles per switch on x86-64-v3).
- Plain XSAVE (not XSAVEOPT) is preserved — the prior CR0.TS lazy path that broke on QEMU 8.2.2 TCG used XSAVEOPT; the new design does not regress that choice.

## How it works

Invariant on each CPU `C`: exactly one of
- `(TS=1, owner=null)` — no live state; first FP op traps.
- `(TS=1, owner=T)` — T's data still in registers, trap on next FP op.
- `(TS=0, owner=T)` — T owns live regs; FP runs trap-free.

Forbidden: `(TS=0, owner=null)`. The relation between `CR0.TS` and `fpu_owner` is the one-way implication `(TS=0) ⇒ (owner != null)`.

| Event | Action |
|---|---|
| `switch_out_save(T)` | `cr0_set_ts()`. No XSAVE. Owner unchanged. |
| `switch_in_restore(T)` | `cr0_clear_ts()` iff owner == T; else `cr0_set_ts()`. |
| `#NM` on T_curr | `preempt_disable`; swap owner→null; XSAVE prev.area if prev != current; XRSTOR T_curr.area; `cr0_clear_ts`; owner = T_curr; `preempt_enable`. |
| Migration / cross-CPU wake | Synchronous flush IPI to the prior CPU before enqueuing T on the new CPU; the IPI handler XSAVEs T's live regs into T.area. |

## Migration-flush IPI

New IPI vector `IPI_VECTOR_FPU_FLUSH = 252` mirrors the existing TLB-shootdown machinery. The sender (`send_fpu_flush_ipi` in `interrupts.rs`) spins for ack with interrupts enabled and preemption disabled — same discipline `mm::tlb_shootdown::shootdown` uses to avoid IF-versus-IPI circular deadlocks against another CPU simultaneously initiating its own flush.

`flush_owner_remote(src_cpu, tcb)` is called **before** acquiring any scheduler lock in `enqueue_and_wake` and `migrate_ready_thread`. Issuing the IPI inside a scheduler-locked region is fatal (target spins on a lock the sender holds; sender spins for ack with IF=0; deadlock). `pull_unpinned_ready` instead skips candidates currently named as src_cpu's `fpu_owner`, which keeps load-balance pulls deadlock-free without needing the IPI under the held source/dest lock pair.

## TCB dealloc dangling-pointer closure

`cap/object.rs` Thread dealloc sweeps every CPU's `fpu_owner` slot via `compare_exchange(tcb, null)` immediately AFTER the existing `running_on` and `context_saved` spins, before storage is reclaimed. Placement is load-bearing — placing the sweep before the spins allows a still-running dying TCB to take an `#NM` and re-install its pointer; the post-spin placement guarantees the dying thread has switched out on every CPU and taken no further `#NM`, so the sweep drops the last legitimate residue before the free. See `docs/thread-lifecycle-and-sleep.md` § Drain Protocol step 10a and invariant 4a.

## Files

Critical:
- `core/kernel/src/percpu.rs` — `PerCpuData::fpu_owner` field, helpers, layout tests.
- `core/kernel/src/arch/x86_64/fpu.rs` — rewritten `switch_out_save` / `switch_in_restore`, new `flush_owner_if` and `flush_owner_remote`.
- `core/kernel/src/arch/x86_64/idt.rs` — extended `nm_handler`, new flush-IPI stub + handler, IDT registration.
- `core/kernel/src/arch/x86_64/interrupts.rs` — new vector, per-CPU pending slot, sync sender with interrupt-enable-during-spin.
- `core/kernel/src/sched/mod.rs` — pre-lock flush in `enqueue_and_wake` / `migrate_ready_thread`; skip-owner predicate in `pull_unpinned_ready`; cross-arch comment update.

Supporting:
- `core/kernel/src/cap/object.rs` — post-spin `fpu_owner` sweep in Thread dealloc, before storage free.
- `core/kernel/src/arch/riscv64/fpu.rs` — no-op `flush_owner_remote` for arch-dispatch symmetry (RISC-V out of scope; sstatus.FS/VS already lazy).
- `core/kernel/docs/scheduling-internals.md` — IPI taxonomy updated with vector 252.
- `core/kernel/docs/thread-lifecycle-and-sleep.md` — drain protocol step 10a + invariant 4a.
- `core/ktest/src/unit/fpu.rs` — new `preempt_isolation_cross_cpu` test exercising migration-flush via an inline-asm load-block-capture sequence.
- `core/ktest/src/unit/mod.rs` — register new test.

## Test plan

- [x] `cargo xtask clean` then `cargo xtask build` for both arches (debug + release).
- [x] x86-64 debug ktest: 148 passed, 0 failed.
- [x] x86-64 release ktest: 148 passed, 0 failed.
- [x] x86-64 debug usertest: ALL TESTS PASSED.
- [x] x86-64 release usertest: ALL TESTS PASSED.
- [x] riscv64 debug ktest: 148 passed, 0 failed.
- [x] riscv64 release ktest: 148 passed, 0 failed.
- [x] riscv64 debug usertest: ALL TESTS PASSED.
- [x] riscv64 release usertest: ALL TESTS PASSED.
- [x] CI green on `ubuntu-latest` (QEMU 8.2.2 TCG) across all four `validate (arch, profile)` cells — the acceptance signal for the QEMU 8.2 TCG concern from #65 (confirmed at run 26096417660; re-verifying on the audit-fix commit).

Closes #65.