### PR TITLE
kernel/x86_64: publish context_saved after fs_base store in switch()

### DIFF
--- a/core/kernel/src/arch/x86_64/context.rs
+++ b/core/kernel/src/arch/x86_64/context.rs
@@ -152,24 +152,38 @@ pub unsafe extern "C" fn switch(
         "pushfq",
         "pop rax",
         "mov [rdi + 72], rax",
-        // ── Signal save complete + release lock ───────────────────────────
-        // On x86-64 TSO, stores are globally visible in program order and
-        // the lock was released by release_lock_only() before the call.
-        // Set the context_saved flag for cross-arch consistency. Do this
-        // BEFORE the rdmsr below, which clobbers rdx (the save_flag ptr).
-        "test rdx, rdx",
-        "jz 1f",
-        "mov dword ptr [rdx], 1", // *save_flag = 1 (TSO: implicitly ordered)
-        "1:",
+        // ── Save fs_base, then publish context_saved ──────────────────────
+        // saved_state.fs_base (offset 64) is the last field written during
+        // save. It must be globally visible before context_saved=1, because
+        // remote CPUs use the flag (Acquire) as the publication barrier
+        // for both cross-CPU dispatch (which then reads fs_base for the
+        // restore-side wrmsr) and dealloc UAF (which then frees the TCB
+        // body). See core/kernel/docs/scheduling-internals.md
+        // § Cross-CPU TCB Ownership.
+        //
+        // rdmsr clobbers rdx (which carries the save_flag pointer), so we
+        // stash it in r11 (caller-saved per System V AMD64; not part of
+        // SavedState). On x86-64 TSO, program-order stores are observed in
+        // program order by other CPUs, so the [rdi+64] store is visible
+        // before the [r11] store with no explicit fence; the scheduler-lock
+        // release at release_lock_only() happened in Rust before this asm
+        // and is independent of the publication barrier below.
+        "mov r11, rdx", // r11 = save_flag (rdx clobbered by rdmsr)
         // fs_base: read the currently-live user TLS base from IA32_FS_BASE
         // (MSR 0xc0000100). rdmsr returns high 32 bits in edx, low 32 in
-        // eax; combine into rax. Clobbers rcx/rdx/rax (all caller-saved,
-        // and rdx/save_flag is no longer needed at this point).
+        // eax; combine into rax.
         "mov ecx, 0xc0000100",
         "rdmsr",
         "shl rdx, 32",
         "or  rax, rdx",
-        "mov [rdi + 64], rax",
+        "mov [rdi + 64], rax", // saved_state.fs_base
+        // Publish context_saved = 1 only after every saved_state store is
+        // complete. The null check covers the boot path where save_flag is
+        // null (initial entry).
+        "test r11, r11",
+        "jz 1f",
+        "mov dword ptr [r11], 1", // *save_flag = 1
+        "1:",
         // ── Restore next thread ───────────────────────────────────────────
         // Restore rflags first so the restored flags take effect early.
         "mov rax, [rsi + 72]",

--- a/core/kernel/src/arch/x86_64/context.rs
+++ b/core/kernel/src/arch/x86_64/context.rs
@@ -120,21 +120,25 @@ pub fn new_state(entry: u64, stack_top: u64, arg: u64, _is_user: bool) -> SavedS
 /// thread, `next.rip` is the return address of the previous `switch` call.
 ///
 /// # Safety
-/// Both pointers must be valid, aligned `SavedState` values. The caller must
-/// hold the scheduler lock and have interrupts disabled. `save_flag` and
-/// `lock_ptr` are used on RISC-V to release the lock between save/load;
-/// on x86-64 (TSO) the lock is released inline before the call and these
-/// parameters are ignored.
+/// Both pointers must be valid, aligned `SavedState` values. The caller
+/// must hold the scheduler lock and have interrupts disabled. `save_flag`
+/// is written to `1` after every store into `*current` completes — it is
+/// the cross-CPU publication barrier for both remote dispatch (which
+/// loads `next.saved_state` after observing the flag) and
+/// `dealloc_object(Thread)` (which spins on it before `retype_free`).
+/// See `core/kernel/docs/scheduling-internals.md`
+/// § Cross-CPU TCB Ownership. `lock_ptr` is unused on x86-64; on RISC-V
+/// it carries the scheduler lock released inline between save and load.
 #[cfg(not(test))]
 #[unsafe(naked)]
 pub unsafe extern "C" fn switch(
     current: *mut SavedState,
     next: *const SavedState,
-    _save_flag: *const core::sync::atomic::AtomicU32,
+    save_flag: *const core::sync::atomic::AtomicU32,
     _lock_ptr: *const crate::sync::Spinlock,
 )
 {
-    // rdi = current, rsi = next, rdx = save_flag (unused), rcx = lock_ptr (unused)
+    // rdi = current, rsi = next, rdx = save_flag, rcx = lock_ptr (unused)
     core::arch::naked_asm!(
         // ── Save current thread ───────────────────────────────────────────
         // Pop return address into rax; the caller will "return" to it when this


### PR DESCRIPTION
## Summary
- Fixes #114: x86_64 `switch()` was publishing `context_saved = 1` before the rdmsr-derived `saved_state.fs_base` store. Remote dealloc could observe the flag and `retype_free` the TCB while this CPU still owed the fs_base write, corrupting whichever object reused the slot. Reorder to write `fs_base` first, then publish, by stashing `rdx` (save_flag pointer) in `r11` across `rdmsr`.
- Aligns with the documented `context_saved` protocol (`core/kernel/docs/scheduling-internals.md` § Cross-CPU TCB Ownership): "context_saved.store(1, Release) — AFTER switch completes." RISC-V `switch()` already followed this order; unchanged.

## Test plan
- [x] `cargo xtask clean && cargo xtask build --arch x86_64` — succeeds.
- [x] `cargo xtask clean && cargo xtask build --arch riscv64` — succeeds.
- [x] `cargo xtask run --arch x86_64` — `ALL TESTS PASSED` (148/148).
- [x] `cargo xtask run --arch riscv64` — `ALL TESTS PASSED` (148/148).
- [x] x86_64 TCG reproducer sweeps for #114 — 2× `SERAPH_ACCEL=tcg cargo xtask run-parallel --arch x86_64 --parallel 4 --runs 500 --timeout 60`:
  - Sweep 1: 487 pass / 11 ok / 0 fail / 2 hang. Of the 2 hangs: 1 stall (`#116`), 1 residual `#DE` zeroed-frame in `concurrent_ipc` (`#117`). No `err=0x11` direct-map instruction-fetch fault — the #114 surface is gone.
  - Sweep 2: 490 pass / 9 ok / 0 fail / 1 hang. The hang is again the `#116` stall. No `concurrent_ipc` fault at all in this sweep.
  - Combined: 0 occurrences of the #114 instruction-fetch fault across 1000 runs (vs the issue's documented ≈4/500 pre-fix rate).
- [x] RISC-V TCG sweep — `SERAPH_ACCEL=tcg cargo xtask run-parallel --arch riscv64 --parallel 4 --runs 500 --timeout 60`: 497 pass / 2 ok / 0 fail / 1 hang. The hang is the same `#116` stall class; cross-arch confirmation that #116 lives in arch-independent code. RISC-V `switch()` was untouched and remains correct.

## Notes
Two adjacent failure modes surfaced during verification and are tracked as separate issues so they aren't lost behind this fix:
- #116 — kernel/sched: all-CPUs-idle stall after `thread::default_affinity_bsp` (cross-arch, ≈3/1500).
- #117 — kernel/ipc: residual `stress::concurrent_ipc` `#DE` with zeroed frame (≈1/1000, distinct presentation from the #114 surface this PR closes).