### PR TITLE
ktest: cleanup pass + targeted coverage expansion

### DIFF
--- a/core/ktest/README.md
+++ b/core/ktest/README.md
@@ -12,7 +12,7 @@ On completion ktest emits the cross-harness marker
 
 ## Activating ktest
 
-Edit `rootfs/EFI/seraph/boot.conf` and change the `init` field:
+Edit `rootfs/esp/EFI/seraph/boot.conf` and change the `init` field:
 
 ```
 init=ktest
@@ -33,16 +33,19 @@ test and the most important negative paths (wrong rights, invalid arguments,
 wrong object state). Files are grouped by kernel subsystem, mirroring the
 kernel's own source layout.
 
-| File | Syscalls |
+| File | Syscalls / behaviour exercised |
 |---|---|
-| `cap.rs` | `SYS_CAP_CREATE_*`, `CAP_COPY`, `CAP_MOVE`, `CAP_INSERT`, `CAP_DERIVE`, `CAP_REVOKE`, `CAP_DELETE` |
+| `cap.rs` | `SYS_CAP_CREATE_*`, `CAP_COPY`, `CAP_MOVE`, `CAP_INSERT`, `CAP_DERIVE`, `CAP_DERIVE_TOKEN`, `CAP_REVOKE`, `CAP_DELETE` |
+| `cap_info.rs` | `SYS_CAP_INFO` (tag, rights, type-specific fields) |
+| `retype.rs` | Retype primitive: CSpace/AddressSpace augmentation, page-table walk budget, kernel PT pool consumption |
 | `mm.rs` | `SYS_MEM_MAP/UNMAP/PROTECT`, `SYS_FRAME_SPLIT`, `SYS_ASPACE_QUERY` |
-| `signal.rs` | `SYS_SIGNAL_SEND`, `SYS_SIGNAL_WAIT` |
-| `event.rs` | `SYS_EVENT_POST`, `SYS_EVENT_RECV` |
+| `signal.rs` | `SYS_SIGNAL_SEND`, `SYS_SIGNAL_WAIT` (blocking and `signal_wait_timeout`) |
+| `event.rs` | `SYS_EVENT_POST`, `SYS_EVENT_RECV` (blocking, `try_recv`, timeout) |
 | `wait_set.rs` | `SYS_WAIT_SET_ADD/REMOVE/WAIT` |
 | `ipc.rs` | `SYS_IPC_CALL`, `SYS_IPC_REPLY`, `SYS_IPC_RECV`, `SYS_IPC_BUFFER_SET` |
 | `thread.rs` | `SYS_THREAD_START/STOP/YIELD/EXIT/CONFIGURE/SET_PRIORITY/SET_AFFINITY/READ_REGS/WRITE_REGS` |
-| `hw.rs` | `SYS_MMIO_MAP`, `SYS_DMA_GRANT`, `SYS_IRQ_REGISTER/ACK`, `SYS_IOPORT_BIND`, `SYS_IOPORT_SPLIT` |
+| `fpu.rs` | FPU / SIMD / V extended-state isolation across preemption and cross-CPU migration |
+| `hw.rs` | `SYS_MMIO_MAP`, `SYS_MMIO_SPLIT`, `SYS_IRQ_REGISTER/ACK`, `SYS_IRQ_SPLIT`, `SYS_IOPORT_BIND`, `SYS_IOPORT_SPLIT`, `SYS_SBI_CALL` |
 | `sysinfo.rs` | `SYS_SYSTEM_INFO` |
 
 Adding a new syscall means adding a section in the appropriate file here.
@@ -63,6 +66,7 @@ concurrent signal and queue events.
 | `multi_caller_ipc_fifo.rs` | Three concurrent IPC callers verify FIFO send-queue ordering |
 | `cap_delegation_chain.rs` | Multi-level rights attenuation and cascaded revocation |
 | `tlb_coherency.rs` | Map/unmap cycles across CPUs to exercise TLB shootdown |
+| `retype_reclaim.rs` | Auto-reclaim invariant for every retypable kernel object |
 
 ### Tier S — `src/stress/`
 
@@ -70,15 +74,20 @@ Stress and torture tests that exercise race conditions, resource exhaustion, dee
 capability trees, and concurrent operations. **Not run by default**; enable with
 `ktest.filter=stress` (see [Command line options](#command-line-options)).
 
+Order matches `stress/mod.rs` dispatch order.
+
 | File | Scenario |
 |---|---|
 | `cap_tree_deep.rs` | 8-level derivation chain with cascading revocation |
 | `event_queue_fill_drain.rs` | Fill/drain cycles on a capacity-8 queue (ring buffer wrap-around) |
+| `idle_wake_race.rs` | Race wake of an idle CPU with concurrent ready-queue entry under affinity migration |
 | `thread_churn.rs` | 20 rapid thread create/destroy cycles (TCB and CSpace cleanup) |
+| `cap_delete_running.rs` | Delete capabilities while child threads actively use them |
 | `concurrent_signal.rs` | 4 threads sending distinct bits to one signal simultaneously |
 | `concurrent_ipc.rs` | 4 callers racing on one endpoint, 10 cycles (send-queue safety) |
 | `cap_revoke_under_use.rs` | Revoke root while 4 threads actively send on derived caps |
 | `concurrent_map_unmap.rs` | 4 threads mapping/unmapping distinct VAs in the same address space |
+| `retype_concurrent.rs` | Concurrent retype operations sharing one Frame-backed allocator |
 
 ### Tier 3 — `src/bench/`
 

--- a/core/ktest/README.md
+++ b/core/ktest/README.md
@@ -81,23 +81,25 @@ capability trees, and concurrent operations. **Not run by default**; enable with
 
 Order matches `stress/mod.rs` dispatch order.
 
-Concurrency knobs default to high values that exercise contention reliably on
-each boot (`MAX_STRESS_THREADS = 64`; tests with one bit per worker
-saturate the `u64` signal bitmask). See each test for its
-`NUM_*`/`CYCLES`/`ITERATIONS` constants.
+Concurrency knobs are currently held at their pre-`v0.1.0` baselines.
+An earlier in-tree experiment ramped these knobs to NUM=64 (per-test
+worker counts) and 5-10× iteration counts; two kernel-side scaling
+issues block taking the ramp further at this time. Once those are
+fixed, the per-test `NUM_*`/`CYCLES`/`ITERATIONS` constants should be
+revisited.
 
 | File | Scenario |
 |---|---|
-| `cap_tree_deep.rs` | 8-level derivation chain with cascading revocation, 500 passes |
-| `event_queue_fill_drain.rs` | Fill/drain cycles on a capacity-8 queue (ring buffer wrap-around), 2000 cycles |
-| `idle_wake_race.rs` | Race wake of an idle CPU with concurrent ready-queue entry under affinity migration, 50000 iterations |
-| `thread_churn.rs` | 1000 rapid thread create/destroy cycles (TCB and CSpace cleanup) |
-| `cap_delete_running.rs` | Delete capabilities while child threads actively spin (`NUM_CHILDREN`) |
-| `concurrent_signal.rs` | 64 threads sending distinct bits to one signal simultaneously |
-| `concurrent_ipc.rs` | 64 callers racing on one endpoint, 200 cycles (send-queue safety) |
-| `cap_revoke_under_use.rs` | Revoke root while 64 threads actively send on derived caps |
-| `concurrent_map_unmap.rs` | 16 threads mapping/unmapping distinct VAs in the same address space, 1000 iters each |
-| `retype_concurrent.rs` | 64 workers retyping concurrently against one Frame-backed allocator, 1000 iters each |
+| `cap_tree_deep.rs` | 8-level derivation chain with cascading revocation |
+| `event_queue_fill_drain.rs` | Fill/drain cycles on a capacity-8 queue (ring buffer wrap-around) |
+| `idle_wake_race.rs` | Race wake of an idle CPU with concurrent ready-queue entry under affinity migration |
+| `thread_churn.rs` | Rapid thread create/destroy cycles (TCB and CSpace cleanup) |
+| `cap_delete_running.rs` | Delete capabilities while child threads actively spin |
+| `concurrent_signal.rs` | Multiple threads sending distinct bits to one signal simultaneously |
+| `concurrent_ipc.rs` | Multiple callers racing on one endpoint (send-queue safety) |
+| `cap_revoke_under_use.rs` | Revoke root while child threads actively send on derived caps |
+| `concurrent_map_unmap.rs` | Multiple threads mapping/unmapping distinct VAs in the same address space |
+| `retype_concurrent.rs` | Multiple workers retyping concurrently against one Frame-backed allocator |
 | `fpu_migration_churn.rs` | 100 cycles of FPU-owner thread migration across CPUs; validates eager save / lazy restore under churn |
 | `concurrent_event_producers.rs` | Multiple producers post concurrently to one event queue; consumer verifies every producer's full sequence |
 

--- a/core/ktest/README.md
+++ b/core/ktest/README.md
@@ -23,8 +23,10 @@ Then rebuild (`cargo xtask build`) and run (`cargo xtask run`). Restore
 
 ## Test structure
 
-Tests are organised across three tiers. Each tier lives in its own source
-directory.
+Tests are organised across four tiers (three plus the opt-in stress
+tier). Each tier lives in its own source directory; each directory
+codifies a "one file per surface/scenario/race" rule at the top of its
+`mod.rs`.
 
 ### Tier 1 — `src/unit/`
 
@@ -43,7 +45,7 @@ kernel's own source layout.
 | `event.rs` | `SYS_EVENT_POST`, `SYS_EVENT_RECV` (blocking, `try_recv`, timeout) |
 | `wait_set.rs` | `SYS_WAIT_SET_ADD/REMOVE/WAIT` |
 | `ipc.rs` | `SYS_IPC_CALL`, `SYS_IPC_REPLY`, `SYS_IPC_RECV`, `SYS_IPC_BUFFER_SET` |
-| `thread.rs` | `SYS_THREAD_START/STOP/YIELD/EXIT/CONFIGURE/SET_PRIORITY/SET_AFFINITY/READ_REGS/WRITE_REGS` |
+| `thread.rs` | `SYS_THREAD_START/STOP/YIELD/EXIT/CONFIGURE/SET_PRIORITY/SET_AFFINITY/READ_REGS/WRITE_REGS/SLEEP/BIND_NOTIFICATION` |
 | `fpu.rs` | FPU / SIMD / V extended-state isolation across preemption and cross-CPU migration |
 | `hw.rs` | `SYS_MMIO_MAP`, `SYS_MMIO_SPLIT`, `SYS_IRQ_REGISTER/ACK`, `SYS_IRQ_SPLIT`, `SYS_IOPORT_BIND`, `SYS_IOPORT_SPLIT`, `SYS_SBI_CALL` |
 | `sysinfo.rs` | `SYS_SYSTEM_INFO` |
@@ -67,6 +69,9 @@ concurrent signal and queue events.
 | `cap_delegation_chain.rs` | Multi-level rights attenuation and cascaded revocation |
 | `tlb_coherency.rs` | Map/unmap cycles across CPUs to exercise TLB shootdown |
 | `retype_reclaim.rs` | Auto-reclaim invariant for every retypable kernel object |
+| `priority_preemption.rs` | Higher-priority runnable thread preempts a CPU-bound lower-priority spinner within a wall-clock budget |
+| `shared_frame_two_aspaces.rs` | One frame mapped into two `AddressSpace` caps; `aspace_query` returns identical phys backing in both |
+| `cap_move_into_fresh_cspace_then_ipc.rs` | `cap_move` an endpoint into a child cspace; the child IPC-calls through its local slot; parent receives via a sibling cap |
 
 ### Tier S — `src/stress/`
 
@@ -76,34 +81,47 @@ capability trees, and concurrent operations. **Not run by default**; enable with
 
 Order matches `stress/mod.rs` dispatch order.
 
+Concurrency knobs default to high values that exercise contention reliably on
+each boot (`MAX_STRESS_THREADS = 64`; tests with one bit per worker
+saturate the `u64` signal bitmask). See each test for its
+`NUM_*`/`CYCLES`/`ITERATIONS` constants.
+
 | File | Scenario |
 |---|---|
-| `cap_tree_deep.rs` | 8-level derivation chain with cascading revocation |
-| `event_queue_fill_drain.rs` | Fill/drain cycles on a capacity-8 queue (ring buffer wrap-around) |
-| `idle_wake_race.rs` | Race wake of an idle CPU with concurrent ready-queue entry under affinity migration |
-| `thread_churn.rs` | 20 rapid thread create/destroy cycles (TCB and CSpace cleanup) |
-| `cap_delete_running.rs` | Delete capabilities while child threads actively use them |
-| `concurrent_signal.rs` | 4 threads sending distinct bits to one signal simultaneously |
-| `concurrent_ipc.rs` | 4 callers racing on one endpoint, 10 cycles (send-queue safety) |
-| `cap_revoke_under_use.rs` | Revoke root while 4 threads actively send on derived caps |
-| `concurrent_map_unmap.rs` | 4 threads mapping/unmapping distinct VAs in the same address space |
-| `retype_concurrent.rs` | Concurrent retype operations sharing one Frame-backed allocator |
+| `cap_tree_deep.rs` | 8-level derivation chain with cascading revocation, 500 passes |
+| `event_queue_fill_drain.rs` | Fill/drain cycles on a capacity-8 queue (ring buffer wrap-around), 2000 cycles |
+| `idle_wake_race.rs` | Race wake of an idle CPU with concurrent ready-queue entry under affinity migration, 50000 iterations |
+| `thread_churn.rs` | 1000 rapid thread create/destroy cycles (TCB and CSpace cleanup) |
+| `cap_delete_running.rs` | Delete capabilities while child threads actively spin (`NUM_CHILDREN`) |
+| `concurrent_signal.rs` | 64 threads sending distinct bits to one signal simultaneously |
+| `concurrent_ipc.rs` | 64 callers racing on one endpoint, 200 cycles (send-queue safety) |
+| `cap_revoke_under_use.rs` | Revoke root while 64 threads actively send on derived caps |
+| `concurrent_map_unmap.rs` | 16 threads mapping/unmapping distinct VAs in the same address space, 1000 iters each |
+| `retype_concurrent.rs` | 64 workers retyping concurrently against one Frame-backed allocator, 1000 iters each |
+| `fpu_migration_churn.rs` | 100 cycles of FPU-owner thread migration across CPUs; validates eager save / lazy restore under churn |
+| `concurrent_event_producers.rs` | Multiple producers post concurrently to one event queue; consumer verifies every producer's full sequence |
 
 ### Tier 3 — `src/bench/`
 
 Cycle-accurate benchmarks using `rdtsc` (x86-64) or `csrr cycle` (RISC-V).
-Each benchmark logs min/mean/max cycle counts; no PASS/FAIL verdict.
+Each benchmark lives in its own file under `bench/`, mirroring
+`unit/`'s one-file-per-surface rule (`bench/{null,ipc,signal,cap,mm,
+thread,event,wait_set,tlb}.rs`). Each benchmark logs min/mean/max
+cycle counts; no PASS/FAIL verdict.
 
 | Benchmark | What it measures |
 |---|---|
 | `null_syscall_roundtrip` | Kernel entry/exit baseline (`SYS_SYSTEM_INFO`) |
-| `ipc_round_trip` | Synchronous IPC call + reply |
-| `signal_roundtrip` | Signal ping-pong between two threads |
+| `ipc_round_trip` | Synchronous IPC call + reply, per-iteration |
+| `signal_roundtrip` | Signal ping-pong between two threads, per-iteration |
 | `cap_create_delete` | `cap_create_signal` + `cap_delete` cycle |
 | `mem_map_unmap` | `mem_map` + `mem_unmap` cycle |
+| `mem_protect_pair` | `mem_protect(READONLY)` + `mem_protect(WRITABLE)` round trip |
 | `thread_lifecycle` | Full thread create → start → exit → cleanup |
+| `context_switch` | Parent/child `thread_yield` ping-pong on one CPU; reports cycles per switch |
 | `event_post_recv` | `event_post` + `event_recv` on a pre-created queue |
 | `wait_set_cycle` | Wait set create → add → wait → remove → delete |
+| `tlb_shootdown_unmap` | `mem_unmap` cost when ktest's aspace is `current` on every CPU (spinners pinned per CPU); logs `cpus=N` |
 
 ## Test infrastructure
 
@@ -112,13 +130,19 @@ Defined in `src/main.rs`:
 - `TestResult` — `Result<(), &'static str>` — no heap, no allocation.
 - `run_test!(name, body)` — macro that logs the test name, runs `body`,
   records PASS or FAIL (with reason), and never panics.
-- `TestContext` — thin struct carrying `aspace_cap`, `cspace_cap`, and the
-  IPC buffer pointer, passed by reference to every test function. `cspace_cap`
-  is queried via `cap_info(_, CAP_INFO_CSPACE_CAPACITY)` by hardware tests
-  whose scans must cover slots populated after `aspace_cap` (e.g. narrow
+- `TestContext` — thin struct carrying `aspace_cap`, `cspace_cap`, the
+  IPC buffer pointer, `memory_frame_base` (first RAM Frame cap), and
+  `sbi_control_cap` (zero on x86-64). Passed by reference to every
+  test function. `cspace_cap` is queried via
+  `cap_info(_, CAP_INFO_CSPACE_CAPACITY)` by hardware tests whose
+  scans must cover slots populated after `aspace_cap` (e.g. narrow
   `IoPortRange` caps carved by `ioport::bind_port_range` on `x86_64`).
 - `PASS_COUNT` / `FAIL_COUNT` — atomic counters updated by `run_test!`.
 - `log(msg)` / `log_u64(prefix, value)` — heap-free logging utilities.
+- `spawn::new_child(ctx)` / `configure_and_start(child, …)` /
+  `configure_and_start_pinned(child, …)` — child-thread spawn helper
+  wrapping the cspace + thread + configure + start sequence that ~30
+  sites duplicated.
 
 ## Command line options
 

--- a/core/ktest/src/bench/cap.rs
+++ b/core/ktest/src/bench/cap.rs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+//! Capability operation benchmarks.
+
+use syscall::{cap_create_signal, cap_delete};
+
+use super::{cycles_now, log_bench_header};
+
+pub(super) fn bench_cap_create_delete(ctx: &crate::TestContext, iters: u32)
+{
+    let n = u64::from(iters);
+    let mut min = u64::MAX;
+    let mut max = 0u64;
+    let mut total = 0u64;
+
+    for _ in 0..n
+    {
+        let t0 = cycles_now();
+        let Ok(sig) = cap_create_signal(ctx.memory_frame_base)
+        else
+        {
+            break;
+        };
+        cap_delete(sig).ok();
+        let t1 = cycles_now();
+        let delta = t1.saturating_sub(t0);
+        if delta < min
+        {
+            min = delta;
+        }
+        if delta > max
+        {
+            max = delta;
+        }
+        total = total.saturating_add(delta);
+    }
+
+    log_bench_header("cap_create_delete", iters);
+    if let Some(mean) = total.checked_div(n)
+    {
+        crate::log_u64("ktest: bench  cycles_min=", min);
+        crate::log_u64("ktest: bench  cycles_mean=", mean);
+        crate::log_u64("ktest: bench  cycles_max=", max);
+    }
+}

--- a/core/ktest/src/bench/event.rs
+++ b/core/ktest/src/bench/event.rs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+//! Event-queue post/recv benchmark.
+
+use syscall::{cap_delete, event_post, event_queue_create, event_recv};
+
+use super::{cycles_now, log_bench_header};
+
+pub(super) fn bench_event_post_recv(ctx: &crate::TestContext, iters: u32)
+{
+    let n = u64::from(iters);
+
+    let Ok(eq) = event_queue_create(ctx.memory_frame_base, 4)
+    else
+    {
+        return;
+    };
+
+    let mut min = u64::MAX;
+    let mut max = 0u64;
+    let mut total = 0u64;
+
+    for i in 0..n
+    {
+        let t0 = cycles_now();
+        if event_post(eq, i).is_err()
+        {
+            break;
+        }
+        if event_recv(eq).is_err()
+        {
+            break;
+        }
+        let t1 = cycles_now();
+        let delta = t1.saturating_sub(t0);
+        if delta < min
+        {
+            min = delta;
+        }
+        if delta > max
+        {
+            max = delta;
+        }
+        total = total.saturating_add(delta);
+    }
+
+    cap_delete(eq).ok();
+
+    log_bench_header("event_post_recv", iters);
+    if let Some(mean) = total.checked_div(n)
+    {
+        crate::log_u64("ktest: bench  cycles_min=", min);
+        crate::log_u64("ktest: bench  cycles_mean=", mean);
+        crate::log_u64("ktest: bench  cycles_max=", max);
+    }
+}

--- a/core/ktest/src/bench/ipc.rs
+++ b/core/ktest/src/bench/ipc.rs
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+//! Synchronous IPC round-trip benchmark.
+//!
+//! Spawns one child caller that loops `ipc_call`; parent loops
+//! `ipc_recv` / `ipc_reply`. Per-iteration bracketing on the parent
+//! side so min/max/mean are meaningful.
+
+use ipc::IpcMessage;
+use syscall::{
+    cap_copy, cap_create_cspace, cap_create_endpoint, cap_create_signal, cap_create_thread,
+    cap_delete, signal_send, signal_wait, thread_configure, thread_exit, thread_start,
+};
+
+use super::{cycles_now, log_bench_header};
+use crate::ChildStack;
+
+static mut BENCH_IPC_STACK: ChildStack = ChildStack::ZERO;
+
+fn ipc_caller_entry(arg: u64) -> !
+{
+    let ep_slot = (arg & 0xFFFF) as u32;
+    let done_slot = ((arg >> 16) & 0xFFFF) as u32;
+    let n = arg >> 32;
+
+    // Register the shared IPC buffer for this child thread.
+    let buf_addr = core::ptr::addr_of_mut!(crate::IPC_BUF) as u64;
+    if syscall::ipc_buffer_set(buf_addr).is_err()
+    {
+        signal_send(done_slot, 1).ok();
+        thread_exit()
+    }
+    let ipc_buf = buf_addr as *mut u64;
+    let msg = IpcMessage::new(0);
+
+    for _ in 0..n
+    {
+        // SAFETY: buf_addr was registered as this thread's IPC buffer above.
+        if unsafe { ipc::ipc_call(ep_slot, &msg, ipc_buf) }.is_err()
+        {
+            break;
+        }
+    }
+    signal_send(done_slot, 1).ok();
+    thread_exit()
+}
+
+pub(super) fn bench_ipc_round_trip(ctx: &crate::TestContext, iters: u32)
+{
+    const RIGHTS_SEND_GRANT: u64 = (1 << 4) | (1 << 6);
+    let n = u64::from(iters);
+
+    let Ok(ep) = cap_create_endpoint(ctx.memory_frame_base)
+    else
+    {
+        return;
+    };
+    let Ok(done) = cap_create_signal(ctx.memory_frame_base)
+    else
+    {
+        return;
+    };
+
+    let Ok(cs) = cap_create_cspace(ctx.memory_frame_base, 0, 4, 16)
+    else
+    {
+        return;
+    };
+    let Ok(child_ep) = cap_copy(ep, cs, RIGHTS_SEND_GRANT)
+    else
+    {
+        return;
+    };
+    let Ok(child_done) = cap_copy(done, cs, 1 << 7)
+    else
+    {
+        return;
+    };
+
+    let arg = u64::from(child_ep) | (u64::from(child_done) << 16) | (n << 32);
+    let Ok(th) = cap_create_thread(ctx.memory_frame_base, ctx.aspace_cap, cs)
+    else
+    {
+        return;
+    };
+    let stack_top = ChildStack::top(core::ptr::addr_of!(BENCH_IPC_STACK));
+
+    if thread_configure(th, ipc_caller_entry as *const () as u64, stack_top, arg).is_err()
+        || thread_start(th).is_err()
+    {
+        return;
+    }
+
+    let reply = IpcMessage::new(0);
+    let mut min = u64::MAX;
+    let mut max = 0u64;
+    let mut total = 0u64;
+    let mut completed: u64 = 0;
+    for _ in 0..n
+    {
+        let t0 = cycles_now();
+        // SAFETY: ctx.ipc_buf is the registered per-thread IPC buffer.
+        if unsafe { ipc::ipc_recv(ep, ctx.ipc_buf) }.is_err()
+        {
+            break;
+        }
+        // SAFETY: ctx.ipc_buf is the registered per-thread IPC buffer.
+        if unsafe { ipc::ipc_reply(&reply, ctx.ipc_buf) }.is_err()
+        {
+            break;
+        }
+        let t1 = cycles_now();
+        let delta = t1.saturating_sub(t0);
+        if delta < min
+        {
+            min = delta;
+        }
+        if delta > max
+        {
+            max = delta;
+        }
+        total = total.saturating_add(delta);
+        completed += 1;
+    }
+
+    signal_wait(done).ok();
+
+    log_bench_header("ipc_round_trip", iters);
+    if let Some(mean) = total.checked_div(completed)
+    {
+        crate::log_u64("ktest: bench  cycles_min=", min);
+        crate::log_u64("ktest: bench  cycles_mean=", mean);
+        crate::log_u64("ktest: bench  cycles_max=", max);
+    }
+
+    cap_delete(th).ok();
+    cap_delete(ep).ok();
+    cap_delete(done).ok();
+    cap_delete(cs).ok();
+}

--- a/core/ktest/src/bench/ipc.rs
+++ b/core/ktest/src/bench/ipc.rs
@@ -9,12 +9,12 @@
 
 use ipc::IpcMessage;
 use syscall::{
-    cap_copy, cap_create_cspace, cap_create_endpoint, cap_create_signal, cap_create_thread,
-    cap_delete, signal_send, signal_wait, thread_configure, thread_exit, thread_start,
+    cap_copy, cap_create_endpoint, cap_create_signal, cap_delete, signal_send, signal_wait,
+    thread_exit,
 };
 
 use super::{cycles_now, log_bench_header};
-use crate::ChildStack;
+use crate::{ChildStack, spawn};
 
 static mut BENCH_IPC_STACK: ChildStack = ChildStack::ZERO;
 
@@ -62,32 +62,26 @@ pub(super) fn bench_ipc_round_trip(ctx: &crate::TestContext, iters: u32)
         return;
     };
 
-    let Ok(cs) = cap_create_cspace(ctx.memory_frame_base, 0, 4, 16)
+    let Ok(child) = spawn::new_child(ctx)
     else
     {
         return;
     };
-    let Ok(child_ep) = cap_copy(ep, cs, RIGHTS_SEND_GRANT)
+    let Ok(child_ep) = cap_copy(ep, child.cs, RIGHTS_SEND_GRANT)
     else
     {
         return;
     };
-    let Ok(child_done) = cap_copy(done, cs, 1 << 7)
+    let Ok(child_done) = cap_copy(done, child.cs, 1 << 7)
     else
     {
         return;
     };
 
     let arg = u64::from(child_ep) | (u64::from(child_done) << 16) | (n << 32);
-    let Ok(th) = cap_create_thread(ctx.memory_frame_base, ctx.aspace_cap, cs)
-    else
-    {
-        return;
-    };
     let stack_top = ChildStack::top(core::ptr::addr_of!(BENCH_IPC_STACK));
 
-    if thread_configure(th, ipc_caller_entry as *const () as u64, stack_top, arg).is_err()
-        || thread_start(th).is_err()
+    if spawn::configure_and_start(&child, ipc_caller_entry, stack_top, arg).is_err()
     {
         return;
     }
@@ -134,8 +128,8 @@ pub(super) fn bench_ipc_round_trip(ctx: &crate::TestContext, iters: u32)
         crate::log_u64("ktest: bench  cycles_max=", max);
     }
 
-    cap_delete(th).ok();
+    cap_delete(child.th).ok();
     cap_delete(ep).ok();
     cap_delete(done).ok();
-    cap_delete(cs).ok();
+    cap_delete(child.cs).ok();
 }

--- a/core/ktest/src/bench/mm.rs
+++ b/core/ktest/src/bench/mm.rs
@@ -52,3 +52,65 @@ pub(super) fn bench_mem_map_unmap(ctx: &crate::TestContext, iters: u32)
         crate::log_u64("ktest: bench  cycles_max=", max);
     }
 }
+
+/// Benchmark: alternate `mem_protect(READ)` and `mem_protect(READ|WRITE)`
+/// on a pre-mapped page. Measures the cost of one round-trip permission
+/// flip — relevant for any future mmap-like userspace API.
+pub(super) fn bench_mem_protect(ctx: &crate::TestContext, iters: u32)
+{
+    const BENCH_VA: u64 = 0x6100_0000;
+
+    let n = u64::from(iters);
+    let Some(frame) = crate::frame_pool::alloc()
+    else
+    {
+        return;
+    };
+
+    if syscall::mem_map(frame, ctx.aspace_cap, BENCH_VA, 0, 1, syscall::MAP_WRITABLE).is_err()
+    {
+        // SAFETY: frame is from pool and was not mapped (mem_map failed).
+        unsafe { crate::frame_pool::free(frame) };
+        return;
+    }
+
+    let mut min = u64::MAX;
+    let mut max = 0u64;
+    let mut total = 0u64;
+
+    for _ in 0..n
+    {
+        let t0 = cycles_now();
+        if syscall::mem_protect(frame, ctx.aspace_cap, BENCH_VA, 1, syscall::MAP_READONLY).is_err()
+        {
+            break;
+        }
+        if syscall::mem_protect(frame, ctx.aspace_cap, BENCH_VA, 1, syscall::MAP_WRITABLE).is_err()
+        {
+            break;
+        }
+        let t1 = cycles_now();
+        let delta = t1.saturating_sub(t0);
+        if delta < min
+        {
+            min = delta;
+        }
+        if delta > max
+        {
+            max = delta;
+        }
+        total = total.saturating_add(delta);
+    }
+
+    let _ = syscall::mem_unmap(ctx.aspace_cap, BENCH_VA, 1);
+    // SAFETY: frame is from pool and now unmapped.
+    unsafe { crate::frame_pool::free(frame) };
+
+    log_bench_header("mem_protect_pair", iters);
+    if let Some(mean) = total.checked_div(n)
+    {
+        crate::log_u64("ktest: bench  cycles_min=", min);
+        crate::log_u64("ktest: bench  cycles_mean=", mean);
+        crate::log_u64("ktest: bench  cycles_max=", max);
+    }
+}

--- a/core/ktest/src/bench/mm.rs
+++ b/core/ktest/src/bench/mm.rs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+//! Memory-management benchmarks: map/unmap, protect.
+
+use super::{cycles_now, log_bench_header};
+
+pub(super) fn bench_mem_map_unmap(ctx: &crate::TestContext, iters: u32)
+{
+    const BENCH_VA: u64 = 0x6000_0000;
+
+    let n = u64::from(iters);
+    let Some(frame) = crate::frame_pool::alloc()
+    else
+    {
+        return;
+    };
+
+    let mut min = u64::MAX;
+    let mut max = 0u64;
+    let mut total = 0u64;
+
+    for _ in 0..n
+    {
+        let t0 = cycles_now();
+        if syscall::mem_map(frame, ctx.aspace_cap, BENCH_VA, 0, 1, syscall::MAP_WRITABLE).is_err()
+        {
+            break;
+        }
+        let _ = syscall::mem_unmap(ctx.aspace_cap, BENCH_VA, 1);
+        let t1 = cycles_now();
+        let delta = t1.saturating_sub(t0);
+        if delta < min
+        {
+            min = delta;
+        }
+        if delta > max
+        {
+            max = delta;
+        }
+        total = total.saturating_add(delta);
+    }
+
+    // SAFETY: frame is from pool and now unmapped.
+    unsafe { crate::frame_pool::free(frame) };
+
+    log_bench_header("mem_map_unmap", iters);
+    if let Some(mean) = total.checked_div(n)
+    {
+        crate::log_u64("ktest: bench  cycles_min=", min);
+        crate::log_u64("ktest: bench  cycles_mean=", mean);
+        crate::log_u64("ktest: bench  cycles_max=", max);
+    }
+}

--- a/core/ktest/src/bench/mod.rs
+++ b/core/ktest/src/bench/mod.rs
@@ -38,6 +38,7 @@ mod mm;
 mod null;
 mod signal;
 mod thread;
+mod tlb;
 mod wait_set;
 
 // ── Cycle counter ─────────────────────────────────────────────────────────────
@@ -150,7 +151,10 @@ pub fn run_all(ctx: &crate::TestContext, iters: u32)
     signal::bench_signal_roundtrip(ctx, iters);
     cap::bench_cap_create_delete(ctx, iters);
     mm::bench_mem_map_unmap(ctx, iters);
+    mm::bench_mem_protect(ctx, iters);
     thread::bench_thread_lifecycle(ctx, iters);
+    thread::bench_context_switch(ctx, iters);
     event::bench_event_post_recv(ctx, iters);
     wait_set::bench_wait_set(ctx, iters);
+    tlb::bench_tlb_shootdown(ctx, iters);
 }

--- a/core/ktest/src/bench/mod.rs
+++ b/core/ktest/src/bench/mod.rs
@@ -245,9 +245,13 @@ fn bench_ipc_round_trip(ctx: &crate::TestContext, iters: u32)
     }
 
     let reply = IpcMessage::new(0);
-    let t0 = cycles_now();
+    let mut min = u64::MAX;
+    let mut max = 0u64;
+    let mut total = 0u64;
+    let mut completed: u64 = 0;
     for _ in 0..n
     {
+        let t0 = cycles_now();
         // SAFETY: ctx.ipc_buf is the registered per-thread IPC buffer.
         if unsafe { ipc::ipc_recv(ep, ctx.ipc_buf) }.is_err()
         {
@@ -258,14 +262,29 @@ fn bench_ipc_round_trip(ctx: &crate::TestContext, iters: u32)
         {
             break;
         }
+        let t1 = cycles_now();
+        let delta = t1.saturating_sub(t0);
+        if delta < min
+        {
+            min = delta;
+        }
+        if delta > max
+        {
+            max = delta;
+        }
+        total = total.saturating_add(delta);
+        completed += 1;
     }
-    let t1 = cycles_now();
 
     signal_wait(done).ok();
 
-    let total = t1.saturating_sub(t0);
-    log_bench_header("ipc_round_trip_wrapped", iters);
-    crate::log_u64("ktest: bench  cycles_mean=", total / n);
+    log_bench_header("ipc_round_trip", iters);
+    if let Some(mean) = total.checked_div(completed)
+    {
+        crate::log_u64("ktest: bench  cycles_min=", min);
+        crate::log_u64("ktest: bench  cycles_mean=", mean);
+        crate::log_u64("ktest: bench  cycles_max=", max);
+    }
 
     cap_delete(th).ok();
     cap_delete(ep).ok();
@@ -361,9 +380,13 @@ fn bench_signal_roundtrip(ctx: &crate::TestContext, iters: u32)
         return;
     }
 
-    let t0 = cycles_now();
+    let mut min = u64::MAX;
+    let mut max = 0u64;
+    let mut total = 0u64;
+    let mut completed: u64 = 0;
     for _ in 0..n
     {
+        let t0 = cycles_now();
         if signal_send(ping, 1).is_err()
         {
             break;
@@ -372,14 +395,28 @@ fn bench_signal_roundtrip(ctx: &crate::TestContext, iters: u32)
         {
             break;
         }
+        let t1 = cycles_now();
+        let delta = t1.saturating_sub(t0);
+        if delta < min
+        {
+            min = delta;
+        }
+        if delta > max
+        {
+            max = delta;
+        }
+        total = total.saturating_add(delta);
+        completed += 1;
     }
-    let t1 = cycles_now();
-
-    let total = t1.saturating_sub(t0);
     signal_wait(done).ok();
 
     log_bench_header("signal_roundtrip", iters);
-    crate::log_u64("ktest: bench  cycles_mean=", total / n);
+    if let Some(mean) = total.checked_div(completed)
+    {
+        crate::log_u64("ktest: bench  cycles_min=", min);
+        crate::log_u64("ktest: bench  cycles_mean=", mean);
+        crate::log_u64("ktest: bench  cycles_max=", max);
+    }
 
     cap_delete(th).ok();
     cap_delete(ping).ok();

--- a/core/ktest/src/bench/mod.rs
+++ b/core/ktest/src/bench/mod.rs
@@ -5,6 +5,10 @@
 
 //! Tier 3 — Benchmarks / profiling.
 //!
+//! Rule (durable, mirrors `unit/mod.rs`):
+//!
+//! > **One file per kernel surface measured. New surface ⇒ new file.**
+//!
 //! Each benchmark runs an operation N times and logs min/mean/max cycle counts
 //! to the kernel serial console. No PASS/FAIL verdict is produced; the numbers
 //! are for human inspection and regression tracking.
@@ -21,20 +25,20 @@
 //!
 //! # Adding a new benchmark
 //!
-//! 1. Write a `fn bench_<name>(ctx: &crate::TestContext, iters: u32)` function below.
-//! 2. Call it from `run_all`.
-//! 3. Use `cycles_now()` to bracket the measured operation.
-//! 4. Log results with `crate::log_u64` (no heap required).
+//! 1. If the surface already has a file (e.g. `mm.rs`), add a `fn bench_<name>`
+//!    to that file. Otherwise create a sibling file under `bench/`.
+//! 2. Use `super::cycles_now()` to bracket the measured operation
+//!    per-iteration; track min/mean/max via `super::log_bench_header()`.
+//! 3. Call it from `run_all` below.
 
-use ipc::IpcMessage;
-use syscall::{
-    cap_copy, cap_create_cspace, cap_create_endpoint, cap_create_signal, cap_create_thread,
-    cap_delete, event_post, event_queue_create, event_recv, signal_send, signal_wait,
-    thread_configure, thread_exit, thread_start, wait_set_add, wait_set_remove, wait_set_wait,
-};
-use syscall_abi::SystemInfoType;
-
-use crate::ChildStack;
+mod cap;
+mod event;
+mod ipc;
+mod mm;
+mod null;
+mod signal;
+mod thread;
+mod wait_set;
 
 // ── Cycle counter ─────────────────────────────────────────────────────────────
 
@@ -47,7 +51,7 @@ use crate::ChildStack;
 // inline_always: RDTSC must be inlined to avoid call overhead in cycle benchmarks.
 #[allow(clippy::inline_always)]
 #[inline(always)]
-fn cycles_now() -> u64
+pub(super) fn cycles_now() -> u64
 {
     #[cfg(target_arch = "x86_64")]
     {
@@ -83,7 +87,7 @@ fn cycles_now() -> u64
 }
 
 /// Log benchmark results with configurable N.
-fn log_bench_header(name: &str, n: u32)
+pub(super) fn log_bench_header(name: &str, n: u32)
 {
     // Build "ktest: bench  <name>  N=<n>" string.
     let mut buf = [0u8; 128];
@@ -133,582 +137,6 @@ fn log_bench_header(name: &str, n: u32)
     }
 }
 
-// ── Benchmarks ────────────────────────────────────────────────────────────────
-
-/// Benchmark: null syscall round-trip (kernel entry + exit cost baseline).
-fn bench_null_syscall(_ctx: &crate::TestContext, iters: u32)
-{
-    let n = u64::from(iters);
-    let mut min = u64::MAX;
-    let mut max = 0u64;
-    let mut total = 0u64;
-
-    for _ in 0..n
-    {
-        let t0 = cycles_now();
-        let _ = syscall::system_info(SystemInfoType::KernelVersion as u64);
-        let t1 = cycles_now();
-        let delta = t1.saturating_sub(t0);
-        if delta < min
-        {
-            min = delta;
-        }
-        if delta > max
-        {
-            max = delta;
-        }
-        total = total.saturating_add(delta);
-    }
-
-    log_bench_header("null_syscall_roundtrip", iters);
-    crate::log_u64("ktest: bench  cycles_min=", min);
-    crate::log_u64("ktest: bench  cycles_mean=", total / n);
-    crate::log_u64("ktest: bench  cycles_max=", max);
-}
-
-// ── IPC round-trip benchmark ──────────────────────────────────────────────────
-
-static mut BENCH_IPC_STACK: ChildStack = ChildStack::ZERO;
-
-fn ipc_caller_entry(arg: u64) -> !
-{
-    let ep_slot = (arg & 0xFFFF) as u32;
-    let done_slot = ((arg >> 16) & 0xFFFF) as u32;
-    let n = arg >> 32;
-
-    // Register the shared IPC buffer for this child thread.
-    let buf_addr = core::ptr::addr_of_mut!(crate::IPC_BUF) as u64;
-    if syscall::ipc_buffer_set(buf_addr).is_err()
-    {
-        signal_send(done_slot, 1).ok();
-        thread_exit()
-    }
-    let ipc_buf = buf_addr as *mut u64;
-    let msg = IpcMessage::new(0);
-
-    for _ in 0..n
-    {
-        // SAFETY: buf_addr was registered as this thread's IPC buffer above.
-        if unsafe { ipc::ipc_call(ep_slot, &msg, ipc_buf) }.is_err()
-        {
-            break;
-        }
-    }
-    signal_send(done_slot, 1).ok();
-    thread_exit()
-}
-
-fn bench_ipc_round_trip(ctx: &crate::TestContext, iters: u32)
-{
-    const RIGHTS_SEND_GRANT: u64 = (1 << 4) | (1 << 6);
-    let n = u64::from(iters);
-
-    let Ok(ep) = cap_create_endpoint(ctx.memory_frame_base)
-    else
-    {
-        return;
-    };
-    let Ok(done) = cap_create_signal(ctx.memory_frame_base)
-    else
-    {
-        return;
-    };
-
-    let Ok(cs) = cap_create_cspace(ctx.memory_frame_base, 0, 4, 16)
-    else
-    {
-        return;
-    };
-    let Ok(child_ep) = cap_copy(ep, cs, RIGHTS_SEND_GRANT)
-    else
-    {
-        return;
-    };
-    let Ok(child_done) = cap_copy(done, cs, 1 << 7)
-    else
-    {
-        return;
-    };
-
-    let arg = u64::from(child_ep) | (u64::from(child_done) << 16) | (n << 32);
-    let Ok(th) = cap_create_thread(ctx.memory_frame_base, ctx.aspace_cap, cs)
-    else
-    {
-        return;
-    };
-    let stack_top = ChildStack::top(core::ptr::addr_of!(BENCH_IPC_STACK));
-
-    if thread_configure(th, ipc_caller_entry as *const () as u64, stack_top, arg).is_err()
-        || thread_start(th).is_err()
-    {
-        return;
-    }
-
-    let reply = IpcMessage::new(0);
-    let mut min = u64::MAX;
-    let mut max = 0u64;
-    let mut total = 0u64;
-    let mut completed: u64 = 0;
-    for _ in 0..n
-    {
-        let t0 = cycles_now();
-        // SAFETY: ctx.ipc_buf is the registered per-thread IPC buffer.
-        if unsafe { ipc::ipc_recv(ep, ctx.ipc_buf) }.is_err()
-        {
-            break;
-        }
-        // SAFETY: ctx.ipc_buf is the registered per-thread IPC buffer.
-        if unsafe { ipc::ipc_reply(&reply, ctx.ipc_buf) }.is_err()
-        {
-            break;
-        }
-        let t1 = cycles_now();
-        let delta = t1.saturating_sub(t0);
-        if delta < min
-        {
-            min = delta;
-        }
-        if delta > max
-        {
-            max = delta;
-        }
-        total = total.saturating_add(delta);
-        completed += 1;
-    }
-
-    signal_wait(done).ok();
-
-    log_bench_header("ipc_round_trip", iters);
-    if let Some(mean) = total.checked_div(completed)
-    {
-        crate::log_u64("ktest: bench  cycles_min=", min);
-        crate::log_u64("ktest: bench  cycles_mean=", mean);
-        crate::log_u64("ktest: bench  cycles_max=", max);
-    }
-
-    cap_delete(th).ok();
-    cap_delete(ep).ok();
-    cap_delete(done).ok();
-    cap_delete(cs).ok();
-}
-
-// ── Signal round-trip benchmark ───────────────────────────────────────────────
-
-static mut BENCH_SIGNAL_STACK: ChildStack = ChildStack::ZERO;
-
-fn signal_pong_entry(arg: u64) -> !
-{
-    let in_slot = (arg & 0xFFFF) as u32;
-    let out_slot = ((arg >> 16) & 0xFFFF) as u32;
-    let done_slot = ((arg >> 32) & 0xFFFF) as u32;
-    let n = arg >> 48;
-
-    for _ in 0..n
-    {
-        if signal_wait(in_slot).is_err()
-        {
-            break;
-        }
-        if signal_send(out_slot, 1).is_err()
-        {
-            break;
-        }
-    }
-    signal_send(done_slot, 1).ok();
-    thread_exit()
-}
-
-// similar_names: ping/pong are intentionally paired names for the two directions.
-#[allow(clippy::similar_names)]
-fn bench_signal_roundtrip(ctx: &crate::TestContext, iters: u32)
-{
-    const RIGHTS_SIGNAL: u64 = 1 << 7;
-    const RIGHTS_WAIT: u64 = 1 << 8;
-    let n = u64::from(iters);
-
-    let Ok(ping) = cap_create_signal(ctx.memory_frame_base)
-    else
-    {
-        return;
-    };
-    let Ok(pong) = cap_create_signal(ctx.memory_frame_base)
-    else
-    {
-        return;
-    };
-    let Ok(done) = cap_create_signal(ctx.memory_frame_base)
-    else
-    {
-        return;
-    };
-
-    let Ok(cs) = cap_create_cspace(ctx.memory_frame_base, 0, 4, 16)
-    else
-    {
-        return;
-    };
-    let Ok(child_ping) = cap_copy(ping, cs, RIGHTS_WAIT)
-    else
-    {
-        return;
-    };
-    let Ok(child_pong) = cap_copy(pong, cs, RIGHTS_SIGNAL)
-    else
-    {
-        return;
-    };
-    let Ok(child_done) = cap_copy(done, cs, RIGHTS_SIGNAL)
-    else
-    {
-        return;
-    };
-
-    let arg = u64::from(child_ping)
-        | (u64::from(child_pong) << 16)
-        | (u64::from(child_done) << 32)
-        | (n << 48);
-    let Ok(th) = cap_create_thread(ctx.memory_frame_base, ctx.aspace_cap, cs)
-    else
-    {
-        return;
-    };
-    let stack_top = ChildStack::top(core::ptr::addr_of!(BENCH_SIGNAL_STACK));
-
-    if thread_configure(th, signal_pong_entry as *const () as u64, stack_top, arg).is_err()
-        || thread_start(th).is_err()
-    {
-        return;
-    }
-
-    let mut min = u64::MAX;
-    let mut max = 0u64;
-    let mut total = 0u64;
-    let mut completed: u64 = 0;
-    for _ in 0..n
-    {
-        let t0 = cycles_now();
-        if signal_send(ping, 1).is_err()
-        {
-            break;
-        }
-        if signal_wait(pong).is_err()
-        {
-            break;
-        }
-        let t1 = cycles_now();
-        let delta = t1.saturating_sub(t0);
-        if delta < min
-        {
-            min = delta;
-        }
-        if delta > max
-        {
-            max = delta;
-        }
-        total = total.saturating_add(delta);
-        completed += 1;
-    }
-    signal_wait(done).ok();
-
-    log_bench_header("signal_roundtrip", iters);
-    if let Some(mean) = total.checked_div(completed)
-    {
-        crate::log_u64("ktest: bench  cycles_min=", min);
-        crate::log_u64("ktest: bench  cycles_mean=", mean);
-        crate::log_u64("ktest: bench  cycles_max=", max);
-    }
-
-    cap_delete(th).ok();
-    cap_delete(ping).ok();
-    cap_delete(pong).ok();
-    cap_delete(done).ok();
-    cap_delete(cs).ok();
-}
-
-// ── New benchmarks ───────────────────────────────────────────────────────────
-
-/// Benchmark: cap create + delete cycle.
-fn bench_cap_create_delete(ctx: &crate::TestContext, iters: u32)
-{
-    let n = u64::from(iters);
-    let mut min = u64::MAX;
-    let mut max = 0u64;
-    let mut total = 0u64;
-
-    for _ in 0..n
-    {
-        let t0 = cycles_now();
-        let Ok(sig) = cap_create_signal(ctx.memory_frame_base)
-        else
-        {
-            break;
-        };
-        cap_delete(sig).ok();
-        let t1 = cycles_now();
-        let delta = t1.saturating_sub(t0);
-        if delta < min
-        {
-            min = delta;
-        }
-        if delta > max
-        {
-            max = delta;
-        }
-        total = total.saturating_add(delta);
-    }
-
-    log_bench_header("cap_create_delete", iters);
-    crate::log_u64("ktest: bench  cycles_min=", min);
-    crate::log_u64("ktest: bench  cycles_mean=", total / n);
-    crate::log_u64("ktest: bench  cycles_max=", max);
-}
-
-/// Benchmark: memory map + unmap cycle.
-fn bench_mem_map_unmap(ctx: &crate::TestContext, iters: u32)
-{
-    const BENCH_VA: u64 = 0x6000_0000;
-
-    let n = u64::from(iters);
-    let Some(frame) = crate::frame_pool::alloc()
-    else
-    {
-        return;
-    };
-
-    let mut min = u64::MAX;
-    let mut max = 0u64;
-    let mut total = 0u64;
-
-    for _ in 0..n
-    {
-        let t0 = cycles_now();
-        if syscall::mem_map(frame, ctx.aspace_cap, BENCH_VA, 0, 1, syscall::MAP_WRITABLE).is_err()
-        {
-            break;
-        }
-        let _ = syscall::mem_unmap(ctx.aspace_cap, BENCH_VA, 1);
-        let t1 = cycles_now();
-        let delta = t1.saturating_sub(t0);
-        if delta < min
-        {
-            min = delta;
-        }
-        if delta > max
-        {
-            max = delta;
-        }
-        total = total.saturating_add(delta);
-    }
-
-    // SAFETY: frame is from pool and now unmapped.
-    unsafe { crate::frame_pool::free(frame) };
-
-    log_bench_header("mem_map_unmap", iters);
-    crate::log_u64("ktest: bench  cycles_min=", min);
-    crate::log_u64("ktest: bench  cycles_mean=", total / n);
-    crate::log_u64("ktest: bench  cycles_max=", max);
-}
-
-/// Benchmark: thread create + start + exit + cleanup lifecycle.
-static mut BENCH_LIFECYCLE_STACK: ChildStack = ChildStack::ZERO;
-
-fn lifecycle_entry(done_slot: u64) -> !
-{
-    // cast_possible_truncation: done_slot is a kernel cap slot index < 2^32.
-    #[allow(clippy::cast_possible_truncation)]
-    signal_send(done_slot as u32, 0x1).ok();
-    thread_exit()
-}
-
-fn bench_thread_lifecycle(ctx: &crate::TestContext, iters: u32)
-{
-    // Use fewer iterations for this heavier benchmark.
-    let n = iters.min(100);
-    let n64 = u64::from(n);
-
-    let Ok(done) = cap_create_signal(ctx.memory_frame_base)
-    else
-    {
-        return;
-    };
-    let stack_top = ChildStack::top(core::ptr::addr_of!(BENCH_LIFECYCLE_STACK));
-
-    let mut min = u64::MAX;
-    let mut max = 0u64;
-    let mut total = 0u64;
-
-    for _ in 0..n
-    {
-        let t0 = cycles_now();
-
-        let Ok(cs) = cap_create_cspace(ctx.memory_frame_base, 0, 4, 16)
-        else
-        {
-            break;
-        };
-        let Ok(child_done) = cap_copy(done, cs, 1 << 7)
-        else
-        {
-            break;
-        };
-        let Ok(th) = cap_create_thread(ctx.memory_frame_base, ctx.aspace_cap, cs)
-        else
-        {
-            break;
-        };
-        if thread_configure(
-            th,
-            lifecycle_entry as *const () as u64,
-            stack_top,
-            u64::from(child_done),
-        )
-        .is_err()
-            || thread_start(th).is_err()
-        {
-            break;
-        }
-        signal_wait(done).ok();
-        cap_delete(th).ok();
-        cap_delete(cs).ok();
-
-        let t1 = cycles_now();
-        let delta = t1.saturating_sub(t0);
-        if delta < min
-        {
-            min = delta;
-        }
-        if delta > max
-        {
-            max = delta;
-        }
-        total = total.saturating_add(delta);
-    }
-
-    cap_delete(done).ok();
-
-    log_bench_header("thread_lifecycle", n);
-    crate::log_u64("ktest: bench  cycles_min=", min);
-    crate::log_u64("ktest: bench  cycles_mean=", total / n64);
-    crate::log_u64("ktest: bench  cycles_max=", max);
-}
-
-/// Benchmark: event queue post + recv cycle.
-fn bench_event_post_recv(ctx: &crate::TestContext, iters: u32)
-{
-    let n = u64::from(iters);
-
-    let Ok(eq) = event_queue_create(ctx.memory_frame_base, 4)
-    else
-    {
-        return;
-    };
-
-    let mut min = u64::MAX;
-    let mut max = 0u64;
-    let mut total = 0u64;
-
-    for i in 0..n
-    {
-        let t0 = cycles_now();
-        if event_post(eq, i).is_err()
-        {
-            break;
-        }
-        if event_recv(eq).is_err()
-        {
-            break;
-        }
-        let t1 = cycles_now();
-        let delta = t1.saturating_sub(t0);
-        if delta < min
-        {
-            min = delta;
-        }
-        if delta > max
-        {
-            max = delta;
-        }
-        total = total.saturating_add(delta);
-    }
-
-    cap_delete(eq).ok();
-
-    log_bench_header("event_post_recv", iters);
-    crate::log_u64("ktest: bench  cycles_min=", min);
-    crate::log_u64("ktest: bench  cycles_mean=", total / n);
-    crate::log_u64("ktest: bench  cycles_max=", max);
-}
-
-/// Benchmark: wait set create + add + wait + remove + delete cycle.
-fn bench_wait_set(ctx: &crate::TestContext, iters: u32)
-{
-    // Cap this benchmark at 100 iterations; wait set create/delete involves
-    // heap allocations that fragment under high churn.
-    let n = u64::from(iters.min(100));
-
-    let Ok(sig) = cap_create_signal(ctx.memory_frame_base)
-    else
-    {
-        return;
-    };
-
-    let mut min = u64::MAX;
-    let mut max = 0u64;
-    let mut total = 0u64;
-
-    for _ in 0..n
-    {
-        // Pre-arm the signal so wait_set_wait returns immediately.
-        signal_send(sig, 0x1).ok();
-
-        let t0 = cycles_now();
-        let Ok(ws) = cap_create_wait_set(ctx.memory_frame_base)
-        else
-        {
-            break;
-        };
-        if wait_set_add(ws, sig, 42).is_err()
-        {
-            cap_delete(ws).ok();
-            break;
-        }
-        let _ = wait_set_wait(ws);
-        let _ = wait_set_remove(ws, sig);
-        cap_delete(ws).ok();
-        let t1 = cycles_now();
-
-        // Drain bits left by signal_send.
-        signal_wait(sig).ok();
-
-        let delta = t1.saturating_sub(t0);
-        if delta < min
-        {
-            min = delta;
-        }
-        if delta > max
-        {
-            max = delta;
-        }
-        total = total.saturating_add(delta);
-    }
-
-    cap_delete(sig).ok();
-
-    // cast_possible_truncation: n is capped at 100; fits in u32.
-    #[allow(clippy::cast_possible_truncation)]
-    let actual_n = n as u32;
-    log_bench_header("wait_set_cycle", actual_n);
-    crate::log_u64("ktest: bench  cycles_min=", min);
-    crate::log_u64("ktest: bench  cycles_mean=", total / n);
-    crate::log_u64("ktest: bench  cycles_max=", max);
-}
-
-// Thin wrapper — same as in unit/cap.rs.
-fn cap_create_wait_set(frame_cap: u32) -> Result<u32, i64>
-{
-    syscall::wait_set_create(frame_cap)
-}
-
 // ── Entry point ───────────────────────────────────────────────────────────────
 
 /// Run all Tier 3 benchmarks.
@@ -717,12 +145,12 @@ fn cap_create_wait_set(frame_cap: u32) -> Result<u32, i64>
 /// directly via `log`/`log_u64`; no PASS/FAIL counters are updated.
 pub fn run_all(ctx: &crate::TestContext, iters: u32)
 {
-    bench_null_syscall(ctx, iters);
-    bench_ipc_round_trip(ctx, iters);
-    bench_signal_roundtrip(ctx, iters);
-    bench_cap_create_delete(ctx, iters);
-    bench_mem_map_unmap(ctx, iters);
-    bench_thread_lifecycle(ctx, iters);
-    bench_event_post_recv(ctx, iters);
-    bench_wait_set(ctx, iters);
+    null::bench_null_syscall(ctx, iters);
+    ipc::bench_ipc_round_trip(ctx, iters);
+    signal::bench_signal_roundtrip(ctx, iters);
+    cap::bench_cap_create_delete(ctx, iters);
+    mm::bench_mem_map_unmap(ctx, iters);
+    thread::bench_thread_lifecycle(ctx, iters);
+    event::bench_event_post_recv(ctx, iters);
+    wait_set::bench_wait_set(ctx, iters);
 }

--- a/core/ktest/src/bench/null.rs
+++ b/core/ktest/src/bench/null.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+//! Null-syscall round-trip benchmark.
+//!
+//! Measures the cost of a minimal kernel entry + exit. Uses
+//! `SYS_SYSTEM_INFO(KernelVersion)` because it dispatches to a handler that
+//! does effectively no work after the trap-frame decode.
+
+use syscall_abi::SystemInfoType;
+
+use super::{cycles_now, log_bench_header};
+
+pub(super) fn bench_null_syscall(_ctx: &crate::TestContext, iters: u32)
+{
+    let n = u64::from(iters);
+    let mut min = u64::MAX;
+    let mut max = 0u64;
+    let mut total = 0u64;
+
+    for _ in 0..n
+    {
+        let t0 = cycles_now();
+        let _ = syscall::system_info(SystemInfoType::KernelVersion as u64);
+        let t1 = cycles_now();
+        let delta = t1.saturating_sub(t0);
+        if delta < min
+        {
+            min = delta;
+        }
+        if delta > max
+        {
+            max = delta;
+        }
+        total = total.saturating_add(delta);
+    }
+
+    log_bench_header("null_syscall_roundtrip", iters);
+    if let Some(mean) = total.checked_div(n)
+    {
+        crate::log_u64("ktest: bench  cycles_min=", min);
+        crate::log_u64("ktest: bench  cycles_mean=", mean);
+        crate::log_u64("ktest: bench  cycles_max=", max);
+    }
+}

--- a/core/ktest/src/bench/signal.rs
+++ b/core/ktest/src/bench/signal.rs
@@ -6,13 +6,10 @@
 //! Parent and child ping-pong via two signals. Per-iteration bracketing
 //! on the parent side.
 
-use syscall::{
-    cap_copy, cap_create_cspace, cap_create_signal, cap_create_thread, cap_delete, signal_send,
-    signal_wait, thread_configure, thread_exit, thread_start,
-};
+use syscall::{cap_copy, cap_create_signal, cap_delete, signal_send, signal_wait, thread_exit};
 
 use super::{cycles_now, log_bench_header};
-use crate::ChildStack;
+use crate::{ChildStack, spawn};
 
 static mut BENCH_SIGNAL_STACK: ChildStack = ChildStack::ZERO;
 
@@ -62,22 +59,22 @@ pub(super) fn bench_signal_roundtrip(ctx: &crate::TestContext, iters: u32)
         return;
     };
 
-    let Ok(cs) = cap_create_cspace(ctx.memory_frame_base, 0, 4, 16)
+    let Ok(child) = spawn::new_child(ctx)
     else
     {
         return;
     };
-    let Ok(child_ping) = cap_copy(ping, cs, RIGHTS_WAIT)
+    let Ok(child_ping) = cap_copy(ping, child.cs, RIGHTS_WAIT)
     else
     {
         return;
     };
-    let Ok(child_pong) = cap_copy(pong, cs, RIGHTS_SIGNAL)
+    let Ok(child_pong) = cap_copy(pong, child.cs, RIGHTS_SIGNAL)
     else
     {
         return;
     };
-    let Ok(child_done) = cap_copy(done, cs, RIGHTS_SIGNAL)
+    let Ok(child_done) = cap_copy(done, child.cs, RIGHTS_SIGNAL)
     else
     {
         return;
@@ -87,15 +84,9 @@ pub(super) fn bench_signal_roundtrip(ctx: &crate::TestContext, iters: u32)
         | (u64::from(child_pong) << 16)
         | (u64::from(child_done) << 32)
         | (n << 48);
-    let Ok(th) = cap_create_thread(ctx.memory_frame_base, ctx.aspace_cap, cs)
-    else
-    {
-        return;
-    };
     let stack_top = ChildStack::top(core::ptr::addr_of!(BENCH_SIGNAL_STACK));
 
-    if thread_configure(th, signal_pong_entry as *const () as u64, stack_top, arg).is_err()
-        || thread_start(th).is_err()
+    if spawn::configure_and_start(&child, signal_pong_entry, stack_top, arg).is_err()
     {
         return;
     }
@@ -138,9 +129,9 @@ pub(super) fn bench_signal_roundtrip(ctx: &crate::TestContext, iters: u32)
         crate::log_u64("ktest: bench  cycles_max=", max);
     }
 
-    cap_delete(th).ok();
+    cap_delete(child.th).ok();
     cap_delete(ping).ok();
     cap_delete(pong).ok();
     cap_delete(done).ok();
-    cap_delete(cs).ok();
+    cap_delete(child.cs).ok();
 }

--- a/core/ktest/src/bench/signal.rs
+++ b/core/ktest/src/bench/signal.rs
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+//! Signal ping-pong round-trip benchmark.
+//!
+//! Parent and child ping-pong via two signals. Per-iteration bracketing
+//! on the parent side.
+
+use syscall::{
+    cap_copy, cap_create_cspace, cap_create_signal, cap_create_thread, cap_delete, signal_send,
+    signal_wait, thread_configure, thread_exit, thread_start,
+};
+
+use super::{cycles_now, log_bench_header};
+use crate::ChildStack;
+
+static mut BENCH_SIGNAL_STACK: ChildStack = ChildStack::ZERO;
+
+fn signal_pong_entry(arg: u64) -> !
+{
+    let in_slot = (arg & 0xFFFF) as u32;
+    let out_slot = ((arg >> 16) & 0xFFFF) as u32;
+    let done_slot = ((arg >> 32) & 0xFFFF) as u32;
+    let n = arg >> 48;
+
+    for _ in 0..n
+    {
+        if signal_wait(in_slot).is_err()
+        {
+            break;
+        }
+        if signal_send(out_slot, 1).is_err()
+        {
+            break;
+        }
+    }
+    signal_send(done_slot, 1).ok();
+    thread_exit()
+}
+
+// similar_names: ping/pong are intentionally paired names for the two directions.
+#[allow(clippy::similar_names)]
+pub(super) fn bench_signal_roundtrip(ctx: &crate::TestContext, iters: u32)
+{
+    const RIGHTS_SIGNAL: u64 = 1 << 7;
+    const RIGHTS_WAIT: u64 = 1 << 8;
+    let n = u64::from(iters);
+
+    let Ok(ping) = cap_create_signal(ctx.memory_frame_base)
+    else
+    {
+        return;
+    };
+    let Ok(pong) = cap_create_signal(ctx.memory_frame_base)
+    else
+    {
+        return;
+    };
+    let Ok(done) = cap_create_signal(ctx.memory_frame_base)
+    else
+    {
+        return;
+    };
+
+    let Ok(cs) = cap_create_cspace(ctx.memory_frame_base, 0, 4, 16)
+    else
+    {
+        return;
+    };
+    let Ok(child_ping) = cap_copy(ping, cs, RIGHTS_WAIT)
+    else
+    {
+        return;
+    };
+    let Ok(child_pong) = cap_copy(pong, cs, RIGHTS_SIGNAL)
+    else
+    {
+        return;
+    };
+    let Ok(child_done) = cap_copy(done, cs, RIGHTS_SIGNAL)
+    else
+    {
+        return;
+    };
+
+    let arg = u64::from(child_ping)
+        | (u64::from(child_pong) << 16)
+        | (u64::from(child_done) << 32)
+        | (n << 48);
+    let Ok(th) = cap_create_thread(ctx.memory_frame_base, ctx.aspace_cap, cs)
+    else
+    {
+        return;
+    };
+    let stack_top = ChildStack::top(core::ptr::addr_of!(BENCH_SIGNAL_STACK));
+
+    if thread_configure(th, signal_pong_entry as *const () as u64, stack_top, arg).is_err()
+        || thread_start(th).is_err()
+    {
+        return;
+    }
+
+    let mut min = u64::MAX;
+    let mut max = 0u64;
+    let mut total = 0u64;
+    let mut completed: u64 = 0;
+    for _ in 0..n
+    {
+        let t0 = cycles_now();
+        if signal_send(ping, 1).is_err()
+        {
+            break;
+        }
+        if signal_wait(pong).is_err()
+        {
+            break;
+        }
+        let t1 = cycles_now();
+        let delta = t1.saturating_sub(t0);
+        if delta < min
+        {
+            min = delta;
+        }
+        if delta > max
+        {
+            max = delta;
+        }
+        total = total.saturating_add(delta);
+        completed += 1;
+    }
+    signal_wait(done).ok();
+
+    log_bench_header("signal_roundtrip", iters);
+    if let Some(mean) = total.checked_div(completed)
+    {
+        crate::log_u64("ktest: bench  cycles_min=", min);
+        crate::log_u64("ktest: bench  cycles_mean=", mean);
+        crate::log_u64("ktest: bench  cycles_max=", max);
+    }
+
+    cap_delete(th).ok();
+    cap_delete(ping).ok();
+    cap_delete(pong).ok();
+    cap_delete(done).ok();
+    cap_delete(cs).ok();
+}

--- a/core/ktest/src/bench/thread.rs
+++ b/core/ktest/src/bench/thread.rs
@@ -34,6 +34,7 @@ pub(super) fn bench_thread_lifecycle(ctx: &crate::TestContext, iters: u32)
     let mut min = u64::MAX;
     let mut max = 0u64;
     let mut total = 0u64;
+    let mut completed: u64 = 0;
 
     for _ in 0..n
     {
@@ -69,12 +70,15 @@ pub(super) fn bench_thread_lifecycle(ctx: &crate::TestContext, iters: u32)
             max = delta;
         }
         total = total.saturating_add(delta);
+        completed += 1;
     }
 
     cap_delete(done).ok();
 
     log_bench_header("thread_lifecycle", n);
-    if let Some(mean) = total.checked_div(n64)
+    // Guard against no successful iteration so we don't log u64::MAX min.
+    let _ = n64;
+    if let Some(mean) = total.checked_div(completed)
     {
         crate::log_u64("ktest: bench  cycles_min=", min);
         crate::log_u64("ktest: bench  cycles_mean=", mean);

--- a/core/ktest/src/bench/thread.rs
+++ b/core/ktest/src/bench/thread.rs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+//! Thread lifecycle benchmark: create → start → exit → cleanup.
+
+use syscall::{
+    cap_copy, cap_create_cspace, cap_create_signal, cap_create_thread, cap_delete, signal_send,
+    signal_wait, thread_configure, thread_exit, thread_start,
+};
+
+use super::{cycles_now, log_bench_header};
+use crate::ChildStack;
+
+static mut BENCH_LIFECYCLE_STACK: ChildStack = ChildStack::ZERO;
+
+fn lifecycle_entry(done_slot: u64) -> !
+{
+    // cast_possible_truncation: done_slot is a kernel cap slot index < 2^32.
+    #[allow(clippy::cast_possible_truncation)]
+    signal_send(done_slot as u32, 0x1).ok();
+    thread_exit()
+}
+
+pub(super) fn bench_thread_lifecycle(ctx: &crate::TestContext, iters: u32)
+{
+    // Use fewer iterations for this heavier benchmark.
+    let n = iters.min(100);
+    let n64 = u64::from(n);
+
+    let Ok(done) = cap_create_signal(ctx.memory_frame_base)
+    else
+    {
+        return;
+    };
+    let stack_top = ChildStack::top(core::ptr::addr_of!(BENCH_LIFECYCLE_STACK));
+
+    let mut min = u64::MAX;
+    let mut max = 0u64;
+    let mut total = 0u64;
+
+    for _ in 0..n
+    {
+        let t0 = cycles_now();
+
+        let Ok(cs) = cap_create_cspace(ctx.memory_frame_base, 0, 4, 16)
+        else
+        {
+            break;
+        };
+        let Ok(child_done) = cap_copy(done, cs, 1 << 7)
+        else
+        {
+            break;
+        };
+        let Ok(th) = cap_create_thread(ctx.memory_frame_base, ctx.aspace_cap, cs)
+        else
+        {
+            break;
+        };
+        if thread_configure(
+            th,
+            lifecycle_entry as *const () as u64,
+            stack_top,
+            u64::from(child_done),
+        )
+        .is_err()
+            || thread_start(th).is_err()
+        {
+            break;
+        }
+        signal_wait(done).ok();
+        cap_delete(th).ok();
+        cap_delete(cs).ok();
+
+        let t1 = cycles_now();
+        let delta = t1.saturating_sub(t0);
+        if delta < min
+        {
+            min = delta;
+        }
+        if delta > max
+        {
+            max = delta;
+        }
+        total = total.saturating_add(delta);
+    }
+
+    cap_delete(done).ok();
+
+    log_bench_header("thread_lifecycle", n);
+    if let Some(mean) = total.checked_div(n64)
+    {
+        crate::log_u64("ktest: bench  cycles_min=", min);
+        crate::log_u64("ktest: bench  cycles_mean=", mean);
+        crate::log_u64("ktest: bench  cycles_max=", max);
+    }
+}

--- a/core/ktest/src/bench/thread.rs
+++ b/core/ktest/src/bench/thread.rs
@@ -3,13 +3,10 @@
 
 //! Thread lifecycle benchmark: create → start → exit → cleanup.
 
-use syscall::{
-    cap_copy, cap_create_cspace, cap_create_signal, cap_create_thread, cap_delete, signal_send,
-    signal_wait, thread_configure, thread_exit, thread_start,
-};
+use syscall::{cap_copy, cap_create_signal, cap_delete, signal_send, signal_wait, thread_exit};
 
 use super::{cycles_now, log_bench_header};
-use crate::ChildStack;
+use crate::{ChildStack, spawn};
 
 static mut BENCH_LIFECYCLE_STACK: ChildStack = ChildStack::ZERO;
 
@@ -42,35 +39,24 @@ pub(super) fn bench_thread_lifecycle(ctx: &crate::TestContext, iters: u32)
     {
         let t0 = cycles_now();
 
-        let Ok(cs) = cap_create_cspace(ctx.memory_frame_base, 0, 4, 16)
+        let Ok(child) = spawn::new_child(ctx)
         else
         {
             break;
         };
-        let Ok(child_done) = cap_copy(done, cs, 1 << 7)
+        let Ok(child_done) = cap_copy(done, child.cs, 1 << 7)
         else
         {
             break;
         };
-        let Ok(th) = cap_create_thread(ctx.memory_frame_base, ctx.aspace_cap, cs)
-        else
-        {
-            break;
-        };
-        if thread_configure(
-            th,
-            lifecycle_entry as *const () as u64,
-            stack_top,
-            u64::from(child_done),
-        )
-        .is_err()
-            || thread_start(th).is_err()
+        if spawn::configure_and_start(&child, lifecycle_entry, stack_top, u64::from(child_done))
+            .is_err()
         {
             break;
         }
         signal_wait(done).ok();
-        cap_delete(th).ok();
-        cap_delete(cs).ok();
+        cap_delete(child.th).ok();
+        cap_delete(child.cs).ok();
 
         let t1 = cycles_now();
         let delta = t1.saturating_sub(t0);

--- a/core/ktest/src/bench/thread.rs
+++ b/core/ktest/src/bench/thread.rs
@@ -81,3 +81,92 @@ pub(super) fn bench_thread_lifecycle(ctx: &crate::TestContext, iters: u32)
         crate::log_u64("ktest: bench  cycles_max=", max);
     }
 }
+
+// ── Context-switch latency ────────────────────────────────────────────────────
+
+static mut BENCH_CTXSWITCH_STACK: ChildStack = ChildStack::ZERO;
+/// Iterations counter for the ping-pong loop, set by the parent before
+/// starting the child. Read by the child to drive its yield count.
+static BENCH_CTXSWITCH_ITERS: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
+
+/// Child entry: ping-pong via `thread_yield` for `BENCH_CTXSWITCH_ITERS`
+/// iterations, then signal `done_slot` and exit.
+fn ctxswitch_child_entry(done_slot: u64) -> !
+{
+    let n = BENCH_CTXSWITCH_ITERS.load(core::sync::atomic::Ordering::Acquire);
+    for _ in 0..n
+    {
+        let _ = syscall::thread_yield();
+    }
+    // cast_possible_truncation: done_slot is a kernel cap slot index < 2^32.
+    #[allow(clippy::cast_possible_truncation)]
+    signal_send(done_slot as u32, 0x1).ok();
+    thread_exit()
+}
+
+/// Benchmark: context-switch latency via parent/child `thread_yield`
+/// ping-pong, both threads pinned to CPU 0 so the test measures real
+/// context-switch cost (not just yield-and-return-to-same-thread).
+///
+/// Cost-per-switch = total wall cycles / (2 * N) — each iteration is two
+/// switches (parent → child, child → parent).
+pub(super) fn bench_context_switch(ctx: &crate::TestContext, iters: u32)
+{
+    use crate::spawn;
+
+    let n = u64::from(iters);
+    BENCH_CTXSWITCH_ITERS.store(n, core::sync::atomic::Ordering::Release);
+
+    let Ok(done) = cap_create_signal(ctx.memory_frame_base)
+    else
+    {
+        return;
+    };
+    let Ok(child) = spawn::new_child(ctx)
+    else
+    {
+        return;
+    };
+    let Ok(child_done) = cap_copy(done, child.cs, 1 << 7)
+    else
+    {
+        return;
+    };
+    let stack_top = ChildStack::top(core::ptr::addr_of!(BENCH_CTXSWITCH_STACK));
+    if spawn::configure_and_start_pinned(
+        &child,
+        ctxswitch_child_entry,
+        stack_top,
+        u64::from(child_done),
+        0,
+    )
+    .is_err()
+    {
+        cap_delete(child.th).ok();
+        cap_delete(child.cs).ok();
+        cap_delete(done).ok();
+        return;
+    }
+
+    let t0 = cycles_now();
+    for _ in 0..n
+    {
+        let _ = syscall::thread_yield();
+    }
+    let t1 = cycles_now();
+
+    signal_wait(done).ok();
+    cap_delete(child.th).ok();
+    cap_delete(child.cs).ok();
+    cap_delete(done).ok();
+
+    let total = t1.saturating_sub(t0);
+    // Two switches per iteration: parent → child and child → parent.
+    let per_switch = total.checked_div(n.saturating_mul(2));
+
+    log_bench_header("context_switch", iters);
+    if let Some(per) = per_switch
+    {
+        crate::log_u64("ktest: bench  cycles_per_switch=", per);
+    }
+}

--- a/core/ktest/src/bench/tlb.rs
+++ b/core/ktest/src/bench/tlb.rs
@@ -11,7 +11,7 @@
 //!
 //! Logs `cpus=N` alongside the result so SMP and UP runs aren't conflated.
 
-use syscall::{cap_create_signal, cap_delete, signal_send, signal_wait, system_info};
+use syscall::{cap_create_signal, cap_delete, signal_send, signal_wait, system_info, thread_yield};
 use syscall_abi::SystemInfoType;
 
 use super::{cycles_now, log_bench_header};
@@ -20,8 +20,24 @@ use crate::{ChildStack, spawn};
 const MAX_PINNED: usize = 7; // CPU 0 is ktest's own; pin children to 1..=7.
 static mut SHOOTDOWN_STACKS: [ChildStack; MAX_PINNED] = [const { ChildStack::ZERO }; MAX_PINNED];
 
-/// Child entry: signal "ready" and spin until `cap_delete` of the thread
-/// cap tears it down. Pure userspace spin — no syscalls back.
+/// Child entry: signal "ready", then loop on `thread_yield` until
+/// `cap_delete` of the thread cap tears it down.
+///
+/// `thread_yield` is the preemption point: the kernel's
+/// thread-cap-delete path marks the thread Exited under the scheduler
+/// lock; on the next reschedule (which a yield triggers immediately)
+/// the kernel observes Exited and reaps the TCB without having to
+/// race the timer tick. A pure-userspace `spin_loop` body — the
+/// previous shape — has no kernel entry point, so a CPU pinned to a
+/// single yield-free spinner can only be preempted on a timer
+/// boundary, which under release-mode CI is too unreliable: the
+/// follow-on `cap_delete` in the bench teardown hangs the harness.
+///
+/// We still keep ktest's aspace `current` on the pinned CPU between
+/// yields (each yield returns to the same spinner because no other
+/// thread is ready on that CPU), so the bench's premise — the parent's
+/// `mem_unmap` issues a TLB-shootdown IPI to every CPU with the aspace
+/// live — still holds.
 // cast_possible_truncation: ready_slot is a kernel cap slot index < 2^32.
 #[allow(clippy::cast_possible_truncation)]
 fn shootdown_spinner_entry(ready_slot: u64) -> !
@@ -29,7 +45,7 @@ fn shootdown_spinner_entry(ready_slot: u64) -> !
     signal_send(ready_slot as u32, 0x1).ok();
     loop
     {
-        core::hint::spin_loop();
+        let _ = thread_yield();
     }
 }
 

--- a/core/ktest/src/bench/tlb.rs
+++ b/core/ktest/src/bench/tlb.rs
@@ -36,7 +36,11 @@ use syscall_abi::SystemInfoType;
 use super::{cycles_now, log_bench_header};
 use crate::{ChildStack, spawn};
 
-const MAX_PINNED: usize = 7; // CPU 0 is ktest's own; pin children to 1..=7.
+/// Ceiling on the worker count. CPU 0 is ktest's own; pin children to
+/// 1..=`MAX_PINNED`. 7 covers an 8-vCPU QEMU configuration (the
+/// largest topology in the project's CI matrix today) and keeps
+/// `SHOOTDOWN_STACKS` BSS at 7 × 16 KiB = 112 KiB.
+const MAX_PINNED: usize = 7;
 static mut SHOOTDOWN_STACKS: [ChildStack; MAX_PINNED] = [const { ChildStack::ZERO }; MAX_PINNED];
 
 /// Set by the parent before its `cap_delete` cleanup. Workers poll this

--- a/core/ktest/src/bench/tlb.rs
+++ b/core/ktest/src/bench/tlb.rs
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+//! TLB-shootdown latency benchmark.
+//!
+//! Pre-spawns one pinned thread per available CPU (besides ktest's own
+//! CPU 0), all sharing ktest's address space — so the aspace is
+//! `current` on every CPU. The benchmark loop then `mem_map`s + `mem_unmap`s
+//! a single page; per-iteration bracketing isolates the `mem_unmap` call
+//! (which triggers an IPI shootdown on every CPU with the aspace `current`).
+//!
+//! Logs `cpus=N` alongside the result so SMP and UP runs aren't conflated.
+
+use syscall::{cap_create_signal, cap_delete, signal_send, signal_wait, system_info};
+use syscall_abi::SystemInfoType;
+
+use super::{cycles_now, log_bench_header};
+use crate::{ChildStack, spawn};
+
+const MAX_PINNED: usize = 7; // CPU 0 is ktest's own; pin children to 1..=7.
+static mut SHOOTDOWN_STACKS: [ChildStack; MAX_PINNED] = [const { ChildStack::ZERO }; MAX_PINNED];
+
+/// Child entry: signal "ready" and spin until `cap_delete` of the thread
+/// cap tears it down. Pure userspace spin — no syscalls back.
+// cast_possible_truncation: ready_slot is a kernel cap slot index < 2^32.
+#[allow(clippy::cast_possible_truncation)]
+fn shootdown_spinner_entry(ready_slot: u64) -> !
+{
+    signal_send(ready_slot as u32, 0x1).ok();
+    loop
+    {
+        core::hint::spin_loop();
+    }
+}
+
+#[allow(clippy::too_many_lines)] // spinner spawn + measure loop + cleanup.
+pub(super) fn bench_tlb_shootdown(ctx: &crate::TestContext, iters: u32)
+{
+    const BENCH_VA: u64 = 0x6200_0000;
+
+    let cpus = system_info(SystemInfoType::CpuCount as u64).unwrap_or(1);
+    // cast_possible_truncation: cpus is < 256 on every supported platform.
+    #[allow(clippy::cast_possible_truncation)]
+    let pin_count = (cpus.saturating_sub(1) as usize).min(MAX_PINNED);
+
+    let Ok(ready) = cap_create_signal(ctx.memory_frame_base)
+    else
+    {
+        return;
+    };
+
+    let mut threads = [0u32; MAX_PINNED];
+    let mut cspaces = [0u32; MAX_PINNED];
+    let mut spawned: usize = 0;
+
+    // Spawn one pinned spinner per non-ktest CPU.
+    for i in 0..pin_count
+    {
+        let Ok(child) = spawn::new_child(ctx)
+        else
+        {
+            break;
+        };
+        let Ok(child_ready) = syscall::cap_copy(ready, child.cs, 1 << 7)
+        else
+        {
+            cap_delete(child.th).ok();
+            cap_delete(child.cs).ok();
+            break;
+        };
+        // SAFETY: bench tier runs sequentially; this is the only use of
+        // SHOOTDOWN_STACKS[i].
+        let stack_top = ChildStack::top(unsafe { core::ptr::addr_of!(SHOOTDOWN_STACKS[i]) });
+        // i runs 0..pin_count ≤ MAX_PINNED ≤ 7; fits in u32.
+        #[allow(clippy::cast_possible_truncation)]
+        let cpu = (i + 1) as u32;
+        if spawn::configure_and_start_pinned(
+            &child,
+            shootdown_spinner_entry,
+            stack_top,
+            u64::from(child_ready),
+            cpu,
+        )
+        .is_err()
+        {
+            cap_delete(child.th).ok();
+            cap_delete(child.cs).ok();
+            break;
+        }
+        threads[i] = child.th;
+        cspaces[i] = child.cs;
+        spawned += 1;
+    }
+
+    // Wait for each spawned child to confirm it's running (ensures the
+    // aspace is loaded on each pinned CPU before we measure shootdowns).
+    for _ in 0..spawned
+    {
+        let _ = signal_wait(ready);
+    }
+
+    let Some(frame) = crate::frame_pool::alloc()
+    else
+    {
+        // Tear down children before returning.
+        for i in 0..spawned
+        {
+            cap_delete(threads[i]).ok();
+            cap_delete(cspaces[i]).ok();
+        }
+        cap_delete(ready).ok();
+        return;
+    };
+
+    let n = u64::from(iters);
+    let mut min = u64::MAX;
+    let mut max = 0u64;
+    let mut total = 0u64;
+
+    for _ in 0..n
+    {
+        if syscall::mem_map(frame, ctx.aspace_cap, BENCH_VA, 0, 1, syscall::MAP_WRITABLE).is_err()
+        {
+            break;
+        }
+        // Measure the unmap — that's the path that issues the shootdown IPI.
+        let t0 = cycles_now();
+        let _ = syscall::mem_unmap(ctx.aspace_cap, BENCH_VA, 1);
+        let t1 = cycles_now();
+        let delta = t1.saturating_sub(t0);
+        if delta < min
+        {
+            min = delta;
+        }
+        if delta > max
+        {
+            max = delta;
+        }
+        total = total.saturating_add(delta);
+    }
+
+    // SAFETY: frame is from pool and now unmapped.
+    unsafe { crate::frame_pool::free(frame) };
+
+    // Tear down spinners. Deleting the Thread cap kicks the spinner off the
+    // CPU (kernel waits for the running thread to context-switch out, then
+    // frees the TCB).
+    for i in 0..spawned
+    {
+        cap_delete(threads[i]).ok();
+        cap_delete(cspaces[i]).ok();
+    }
+    cap_delete(ready).ok();
+
+    log_bench_header("tlb_shootdown_unmap", iters);
+    crate::log_u64("ktest: bench  cpus=", cpus);
+    crate::log_u64("ktest: bench  pinned_workers=", spawned as u64);
+    if let Some(mean) = total.checked_div(n)
+    {
+        crate::log_u64("ktest: bench  cycles_min=", min);
+        crate::log_u64("ktest: bench  cycles_mean=", mean);
+        crate::log_u64("ktest: bench  cycles_max=", max);
+    }
+}

--- a/core/ktest/src/bench/tlb.rs
+++ b/core/ktest/src/bench/tlb.rs
@@ -37,9 +37,9 @@ use super::{cycles_now, log_bench_header};
 use crate::{ChildStack, spawn};
 
 /// Ceiling on the worker count. CPU 0 is ktest's own; pin children to
-/// 1..=`MAX_PINNED`. 7 covers an 8-vCPU QEMU configuration (the
-/// largest topology in the project's CI matrix today) and keeps
-/// `SHOOTDOWN_STACKS` BSS at 7 × 16 KiB = 112 KiB.
+/// 1..=`MAX_PINNED`. 7 covers up to an 8-vCPU host with headroom over
+/// the 4-vCPU QEMU configuration ktest currently boots under, and
+/// keeps `SHOOTDOWN_STACKS` BSS at 7 × 16 KiB = 112 KiB.
 const MAX_PINNED: usize = 7;
 static mut SHOOTDOWN_STACKS: [ChildStack; MAX_PINNED] = [const { ChildStack::ZERO }; MAX_PINNED];
 

--- a/core/ktest/src/bench/tlb.rs
+++ b/core/ktest/src/bench/tlb.rs
@@ -3,15 +3,34 @@
 
 //! TLB-shootdown latency benchmark.
 //!
-//! Pre-spawns one pinned thread per available CPU (besides ktest's own
-//! CPU 0), all sharing ktest's address space — so the aspace is
-//! `current` on every CPU. The benchmark loop then `mem_map`s + `mem_unmap`s
-//! a single page; per-iteration bracketing isolates the `mem_unmap` call
-//! (which triggers an IPI shootdown on every CPU with the aspace `current`).
+//! Pre-spawns one worker thread per available CPU (besides ktest's
+//! own CPU 0), each pinned to a distinct CPU and running in ktest's
+//! address space — so the aspace is `current` on every CPU during
+//! the measure loop. The benchmark loop then `mem_map`s + `mem_unmap`s
+//! a single page; per-iteration bracketing isolates the `mem_unmap`
+//! call (which triggers an IPI shootdown on every CPU with the aspace
+//! `current`).
 //!
-//! Logs `cpus=N` alongside the result so SMP and UP runs aren't conflated.
+//! Logs `cpus=N` alongside the result so SMP and UP runs aren't
+//! conflated.
+//!
+//! ## Worker shutdown contract
+//!
+//! The workers must terminate cleanly before the bench's `cap_delete`
+//! cleanup, otherwise `cap_delete` of a still-running pinned thread
+//! on a CPU with no other ready threads races a kernel preemption
+//! point — observed to hang the harness past the CI per-run watchdog
+//! on both `x86_64` and `riscv64` in release mode.
+//!
+//! The fix here is cooperative: workers check `EXIT_REQUESTED` between
+//! yields and call `thread_exit` themselves. By the time the parent
+//! calls `cap_delete`, every worker is already Exited.
 
-use syscall::{cap_create_signal, cap_delete, signal_send, signal_wait, system_info, thread_yield};
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use syscall::{
+    cap_create_signal, cap_delete, signal_send, signal_wait, system_info, thread_exit, thread_yield,
+};
 use syscall_abi::SystemInfoType;
 
 use super::{cycles_now, log_bench_header};
@@ -20,48 +39,70 @@ use crate::{ChildStack, spawn};
 const MAX_PINNED: usize = 7; // CPU 0 is ktest's own; pin children to 1..=7.
 static mut SHOOTDOWN_STACKS: [ChildStack; MAX_PINNED] = [const { ChildStack::ZERO }; MAX_PINNED];
 
-/// Child entry: signal "ready", then loop on `thread_yield` until
-/// `cap_delete` of the thread cap tears it down.
+/// Set by the parent before its `cap_delete` cleanup. Workers poll this
+/// between yields and exit cleanly when set; the parent then `signal_wait`s
+/// on the per-worker exited-bits before deleting any Thread cap, so
+/// `cap_delete` never has to reap a running thread.
+static EXIT_REQUESTED: AtomicBool = AtomicBool::new(false);
+
+/// Worker entry: signal "ready" with this worker's unique bit, then
+/// loop yielding until the parent sets `EXIT_REQUESTED`. On exit,
+/// signal the parent's `done_slot` with the same unique bit so the
+/// parent knows it's safe to `cap_delete`.
 ///
-/// `thread_yield` is the preemption point: the kernel's
-/// thread-cap-delete path marks the thread Exited under the scheduler
-/// lock; on the next reschedule (which a yield triggers immediately)
-/// the kernel observes Exited and reaps the TCB without having to
-/// race the timer tick. A pure-userspace `spin_loop` body — the
-/// previous shape — has no kernel entry point, so a CPU pinned to a
-/// single yield-free spinner can only be preempted on a timer
-/// boundary, which under release-mode CI is too unreliable: the
-/// follow-on `cap_delete` in the bench teardown hangs the harness.
-///
-/// We still keep ktest's aspace `current` on the pinned CPU between
-/// yields (each yield returns to the same spinner because no other
-/// thread is ready on that CPU), so the bench's premise — the parent's
-/// `mem_unmap` issues a TLB-shootdown IPI to every CPU with the aspace
-/// live — still holds.
-// cast_possible_truncation: ready_slot is a kernel cap slot index < 2^32.
+/// `arg` packs `ready_slot[15:0] | done_slot[31:16] | bit_index[39:32]`.
+/// Unique bits matter: the kernel's signal cap is a 64-bit OR-accumulator,
+/// so if all workers sent the same bit (`0x1`), N concurrent
+/// `signal_send`s collapse to one wakeup and the parent's `signal_wait`
+/// loop hangs on the second iteration.
+// cast_possible_truncation: slot indices and bit index fit in their packed widths.
 #[allow(clippy::cast_possible_truncation)]
-fn shootdown_spinner_entry(ready_slot: u64) -> !
+fn shootdown_spinner_entry(arg: u64) -> !
 {
-    signal_send(ready_slot as u32, 0x1).ok();
-    loop
+    let ready_slot = (arg & 0xFFFF) as u32;
+    let done_slot = ((arg >> 16) & 0xFFFF) as u32;
+    let bit_index = ((arg >> 32) & 0xFF) as u32;
+    let bit = 1u64 << bit_index;
+
+    signal_send(ready_slot, bit).ok();
+    while !EXIT_REQUESTED.load(Ordering::Acquire)
     {
         let _ = thread_yield();
     }
+    signal_send(done_slot, bit).ok();
+    thread_exit()
 }
 
-#[allow(clippy::too_many_lines)] // spinner spawn + measure loop + cleanup.
+#[allow(clippy::too_many_lines)] // setup + measure loop + cooperative teardown.
 pub(super) fn bench_tlb_shootdown(ctx: &crate::TestContext, iters: u32)
 {
     const BENCH_VA: u64 = 0x6200_0000;
 
+    // Print the header up front so failures in the spawn / signal_wait /
+    // measure loop are bisectable on the boot log instead of looking
+    // like the bench never ran. Min/mean/max are logged after teardown
+    // if the measure loop made progress.
+    log_bench_header("tlb_shootdown_unmap", iters);
+
     let cpus = system_info(SystemInfoType::CpuCount as u64).unwrap_or(1);
+    crate::log_u64("ktest: bench  cpus=", cpus);
     // cast_possible_truncation: cpus is < 256 on every supported platform.
     #[allow(clippy::cast_possible_truncation)]
     let pin_count = (cpus.saturating_sub(1) as usize).min(MAX_PINNED);
 
+    // Reset the cross-bench flag so a re-run sees the worker shutdown
+    // contract from a clean state.
+    EXIT_REQUESTED.store(false, Ordering::Release);
+
     let Ok(ready) = cap_create_signal(ctx.memory_frame_base)
     else
     {
+        return;
+    };
+    let Ok(done) = cap_create_signal(ctx.memory_frame_base)
+    else
+    {
+        cap_delete(ready).ok();
         return;
     };
 
@@ -84,20 +125,23 @@ pub(super) fn bench_tlb_shootdown(ctx: &crate::TestContext, iters: u32)
             cap_delete(child.cs).ok();
             break;
         };
+        let Ok(child_done) = syscall::cap_copy(done, child.cs, 1 << 7)
+        else
+        {
+            cap_delete(child.th).ok();
+            cap_delete(child.cs).ok();
+            break;
+        };
         // SAFETY: bench tier runs sequentially; this is the only use of
         // SHOOTDOWN_STACKS[i].
         let stack_top = ChildStack::top(unsafe { core::ptr::addr_of!(SHOOTDOWN_STACKS[i]) });
         // i runs 0..pin_count ≤ MAX_PINNED ≤ 7; fits in u32.
         #[allow(clippy::cast_possible_truncation)]
         let cpu = (i + 1) as u32;
-        if spawn::configure_and_start_pinned(
-            &child,
-            shootdown_spinner_entry,
-            stack_top,
-            u64::from(child_ready),
-            cpu,
-        )
-        .is_err()
+        // Pack: ready[15:0], done[31:16], done_bit_index[39:32].
+        let arg = u64::from(child_ready) | (u64::from(child_done) << 16) | ((i as u64) << 32);
+        if spawn::configure_and_start_pinned(&child, shootdown_spinner_entry, stack_top, arg, cpu)
+            .is_err()
         {
             cap_delete(child.th).ok();
             cap_delete(child.cs).ok();
@@ -108,23 +152,28 @@ pub(super) fn bench_tlb_shootdown(ctx: &crate::TestContext, iters: u32)
         spawned += 1;
     }
 
-    // Wait for each spawned child to confirm it's running (ensures the
-    // aspace is loaded on each pinned CPU before we measure shootdowns).
-    for _ in 0..spawned
+    crate::log_u64("ktest: bench  pinned_workers=", spawned as u64);
+
+    // Wait for every spawned child's unique ready-bit (saturate then drop
+    // the loop). Single-shot signal_wait would race when N workers post
+    // identical bits concurrently — the kernel OR-accumulates and only
+    // wakes the parent once. Each worker sends `1 << i` instead.
+    if spawned > 0
     {
-        let _ = signal_wait(ready);
+        let all_ready = (1u64 << spawned) - 1;
+        let mut ready_bits: u64 = 0;
+        while ready_bits & all_ready != all_ready
+        {
+            ready_bits |= signal_wait(ready).unwrap_or(0);
+        }
     }
 
     let Some(frame) = crate::frame_pool::alloc()
     else
     {
-        // Tear down children before returning.
-        for i in 0..spawned
-        {
-            cap_delete(threads[i]).ok();
-            cap_delete(cspaces[i]).ok();
-        }
-        cap_delete(ready).ok();
+        // Cooperative teardown even on the early-return path.
+        EXIT_REQUESTED.store(true, Ordering::Release);
+        teardown(&threads, &cspaces, spawned, ready, done);
         return;
     };
 
@@ -158,23 +207,48 @@ pub(super) fn bench_tlb_shootdown(ctx: &crate::TestContext, iters: u32)
     // SAFETY: frame is from pool and now unmapped.
     unsafe { crate::frame_pool::free(frame) };
 
-    // Tear down spinners. Deleting the Thread cap kicks the spinner off the
-    // CPU (kernel waits for the running thread to context-switch out, then
-    // frees the TCB).
-    for i in 0..spawned
-    {
-        cap_delete(threads[i]).ok();
-        cap_delete(cspaces[i]).ok();
-    }
-    cap_delete(ready).ok();
+    // Cooperative teardown: flip the flag, wait for every worker's
+    // exit-bit on `done`, then cap_delete (each Thread is already Exited).
+    EXIT_REQUESTED.store(true, Ordering::Release);
+    teardown(&threads, &cspaces, spawned, ready, done);
 
-    log_bench_header("tlb_shootdown_unmap", iters);
-    crate::log_u64("ktest: bench  cpus=", cpus);
-    crate::log_u64("ktest: bench  pinned_workers=", spawned as u64);
     if let Some(mean) = total.checked_div(n)
     {
         crate::log_u64("ktest: bench  cycles_min=", min);
         crate::log_u64("ktest: bench  cycles_mean=", mean);
         crate::log_u64("ktest: bench  cycles_max=", max);
     }
+}
+
+/// Wait for every spawned worker's `done` bit, then `cap_delete` all
+/// thread + cspace caps. Each worker `signal_send`s its `1 << i` bit on
+/// `done` right before `thread_exit`; the parent accumulates all bits
+/// before issuing any `cap_delete`, so every Thread cap deleted is in
+/// the Exited state.
+fn teardown(
+    threads: &[u32; MAX_PINNED],
+    cspaces: &[u32; MAX_PINNED],
+    spawned: usize,
+    ready: u32,
+    done: u32,
+)
+{
+    if spawned > 0
+    {
+        // Saturate the expected bitmask; `1u64 << spawned` would overflow
+        // at `spawned == 64`, but MAX_PINNED caps us well below that.
+        let all_done = (1u64 << spawned) - 1;
+        let mut done_bits: u64 = 0;
+        while done_bits & all_done != all_done
+        {
+            done_bits |= signal_wait(done).unwrap_or(0);
+        }
+    }
+    for i in 0..spawned
+    {
+        cap_delete(threads[i]).ok();
+        cap_delete(cspaces[i]).ok();
+    }
+    cap_delete(ready).ok();
+    cap_delete(done).ok();
 }

--- a/core/ktest/src/bench/wait_set.rs
+++ b/core/ktest/src/bench/wait_set.rs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+//! Wait-set create → add → wait → remove → delete cycle benchmark.
+
+use syscall::{
+    cap_create_signal, cap_delete, signal_send, signal_wait, wait_set_add, wait_set_remove,
+    wait_set_wait,
+};
+
+use super::{cycles_now, log_bench_header};
+
+// Thin wrapper — same as in unit/cap.rs.
+fn cap_create_wait_set(frame_cap: u32) -> Result<u32, i64>
+{
+    syscall::wait_set_create(frame_cap)
+}
+
+pub(super) fn bench_wait_set(ctx: &crate::TestContext, iters: u32)
+{
+    // Cap this benchmark at 100 iterations; wait set create/delete involves
+    // heap allocations that fragment under high churn.
+    let n = u64::from(iters.min(100));
+
+    let Ok(sig) = cap_create_signal(ctx.memory_frame_base)
+    else
+    {
+        return;
+    };
+
+    let mut min = u64::MAX;
+    let mut max = 0u64;
+    let mut total = 0u64;
+
+    for _ in 0..n
+    {
+        // Pre-arm the signal so wait_set_wait returns immediately.
+        signal_send(sig, 0x1).ok();
+
+        let t0 = cycles_now();
+        let Ok(ws) = cap_create_wait_set(ctx.memory_frame_base)
+        else
+        {
+            break;
+        };
+        if wait_set_add(ws, sig, 42).is_err()
+        {
+            cap_delete(ws).ok();
+            break;
+        }
+        let _ = wait_set_wait(ws);
+        let _ = wait_set_remove(ws, sig);
+        cap_delete(ws).ok();
+        let t1 = cycles_now();
+
+        // Drain bits left by signal_send.
+        signal_wait(sig).ok();
+
+        let delta = t1.saturating_sub(t0);
+        if delta < min
+        {
+            min = delta;
+        }
+        if delta > max
+        {
+            max = delta;
+        }
+        total = total.saturating_add(delta);
+    }
+
+    cap_delete(sig).ok();
+
+    // cast_possible_truncation: n is capped at 100; fits in u32.
+    #[allow(clippy::cast_possible_truncation)]
+    let actual_n = n as u32;
+    log_bench_header("wait_set_cycle", actual_n);
+    if let Some(mean) = total.checked_div(n)
+    {
+        crate::log_u64("ktest: bench  cycles_min=", min);
+        crate::log_u64("ktest: bench  cycles_mean=", mean);
+        crate::log_u64("ktest: bench  cycles_max=", max);
+    }
+}

--- a/core/ktest/src/integration/cap_move_into_fresh_cspace_then_ipc.rs
+++ b/core/ktest/src/integration/cap_move_into_fresh_cspace_then_ipc.rs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+//! Integration: `cap_move` an endpoint into a fresh `CSpace`, then IPC across it.
+//!
+//! Validates that `cap_move` correctly relocates an IPC-bearing cap into a
+//! foreign cspace while preserving IPC routing. The source slot in the
+//! parent's cspace becomes null after the move; the child uses its local
+//! slot index in the moved cspace to issue `ipc_call`. The parent keeps a
+//! sibling copy of the endpoint cap in its own cspace and uses it to
+//! `ipc_recv` the child's call.
+
+use ipc::IpcMessage;
+use syscall::{cap_copy, cap_create_endpoint, cap_create_signal, cap_delete, signal_wait};
+
+use crate::{ChildStack, TestContext, TestResult};
+
+/// SEND + GRANT rights — the child needs both to issue an `ipc_call`.
+const RIGHTS_SEND_GRANT: u64 = (1 << 4) | (1 << 6);
+
+static mut CHILD_STACK: ChildStack = ChildStack::ZERO;
+
+/// Child entry: issue one `ipc_call` via the slot whose index is packed
+/// in the low 32 bits of `arg`. Signal `done_slot` (high 32 bits) and exit.
+// cast_possible_truncation: slot indices are < 2^32.
+#[allow(clippy::cast_possible_truncation)]
+fn caller_entry(arg: u64) -> !
+{
+    let ep_slot = (arg & 0xFFFF_FFFF) as u32;
+    let done_slot = (arg >> 32) as u32;
+
+    // Register the shared IPC buffer for this child thread.
+    let buf_addr = core::ptr::addr_of_mut!(crate::IPC_BUF) as u64;
+    if syscall::ipc_buffer_set(buf_addr).is_err()
+    {
+        syscall::signal_send(done_slot, 1).ok();
+        syscall::thread_exit();
+    }
+    let msg = IpcMessage::new(0xABC);
+    // SAFETY: buf_addr was registered as this thread's IPC buffer above.
+    let _ = unsafe { ipc::ipc_call(ep_slot, &msg, buf_addr as *mut u64) };
+    syscall::signal_send(done_slot, 1).ok();
+    syscall::thread_exit();
+}
+
+pub fn run(ctx: &TestContext) -> TestResult
+{
+    crate::log("cap_move_into_fresh_cspace_then_ipc: starting");
+
+    // Mint two siblings of the same underlying endpoint object: the parent
+    // keeps one (in its own cspace) and the other is the cap that will be
+    // moved into the child cspace.
+    let ep_parent = cap_create_endpoint(ctx.memory_frame_base)
+        .map_err(|_| "cap_move_into_fresh_cspace_then_ipc: cap_create_endpoint (parent) failed")?;
+    let ep_donor = cap_copy(ep_parent, ctx.cspace_cap, RIGHTS_SEND_GRANT)
+        .map_err(|_| "cap_move_into_fresh_cspace_then_ipc: sibling cap_copy (donor) failed")?;
+
+    let done = cap_create_signal(ctx.memory_frame_base)
+        .map_err(|_| "cap_move_into_fresh_cspace_then_ipc: cap_create_signal (done) failed")?;
+
+    let child = crate::spawn::new_child(ctx)
+        .map_err(|_| "cap_move_into_fresh_cspace_then_ipc: spawn::new_child failed")?;
+
+    let child_done = cap_copy(done, child.cs, 1 << 7)
+        .map_err(|_| "cap_move_into_fresh_cspace_then_ipc: cap_copy (child_done) failed")?;
+
+    // Move (not copy) the donor sibling into the child's cspace. After
+    // this, ep_donor in the parent's cspace becomes null; the cap lives
+    // only in the child's cspace.
+    let child_ep = syscall::cap_move(ep_donor, child.cs, 0)
+        .map_err(|_| "cap_move_into_fresh_cspace_then_ipc: cap_move failed")?;
+
+    // Verify: the parent's ep_donor slot must be null now (any operation
+    // returns an error).
+    if syscall::signal_send(ep_donor, 0).is_ok()
+    {
+        return Err("cap_move_into_fresh_cspace_then_ipc: source slot still usable after cap_move");
+    }
+
+    let arg = u64::from(child_ep) | (u64::from(child_done) << 32);
+    let stack_top = ChildStack::top(core::ptr::addr_of!(CHILD_STACK));
+    crate::spawn::configure_and_start(&child, caller_entry, stack_top, arg)
+        .map_err(|_| "cap_move_into_fresh_cspace_then_ipc: configure_and_start failed")?;
+
+    // Server side: recv the call through the parent's sibling cap, reply,
+    // then verify the call was actually the child's.
+    // SAFETY: ctx.ipc_buf is the registered per-thread IPC buffer.
+    let msg = unsafe { ipc::ipc_recv(ep_parent, ctx.ipc_buf) }
+        .map_err(|_| "cap_move_into_fresh_cspace_then_ipc: ipc_recv failed")?;
+    if msg.label != 0xABC
+    {
+        return Err("cap_move_into_fresh_cspace_then_ipc: wrong label on received message");
+    }
+    let reply = IpcMessage::new(0);
+    // SAFETY: ctx.ipc_buf is the registered per-thread IPC buffer.
+    unsafe { ipc::ipc_reply(&reply, ctx.ipc_buf) }
+        .map_err(|_| "cap_move_into_fresh_cspace_then_ipc: ipc_reply failed")?;
+
+    // Wait for the child to exit cleanly.
+    signal_wait(done).ok();
+
+    cap_delete(child.th).ok();
+    cap_delete(child.cs).ok();
+    cap_delete(ep_parent).ok();
+    cap_delete(done).ok();
+    Ok(())
+}

--- a/core/ktest/src/integration/mod.rs
+++ b/core/ktest/src/integration/mod.rs
@@ -24,7 +24,11 @@
 //! - `memory_lifecycle.rs`       — frame split → map → protect → unmap with state checks
 //! - `multi_caller_ipc_fifo.rs`  — endpoint send-queue FIFO ordering with three concurrent callers
 //! - `cap_delegation_chain.rs`   — multi-level rights attenuation and cascaded revocation
+//! - `tlb_coherency.rs`          — map/unmap cycles across CPUs exercising TLB shootdown
 //! - `retype_reclaim.rs`         — auto-reclaim invariant for every retypable kernel object
+//! - `priority_preemption.rs`    — higher-priority runnable thread preempts a busy lower-priority one
+//! - `shared_frame_two_aspaces.rs` — one frame mapped into two `AddressSpace` caps; phys round-trip
+//! - `cap_move_into_fresh_cspace_then_ipc.rs` — `cap_move` an endpoint into a child cspace; child IPC-calls through it
 
 pub mod cap_delegation_chain;
 pub mod cap_move_into_fresh_cspace_then_ipc;

--- a/core/ktest/src/integration/mod.rs
+++ b/core/ktest/src/integration/mod.rs
@@ -5,11 +5,17 @@
 
 //! Tier 2 — cross-subsystem integration tests.
 //!
+//! Rule (durable):
+//!
+//! > **One file per cross-subsystem scenario. New scenario ⇒ new file.**
+//!
 //! Each file exercises a realistic multi-syscall scenario that spans more than
 //! one kernel subsystem. These tests catch emergent bugs that isolated syscall
 //! tests miss — for example, capability rights surviving an IPC transfer, thread
 //! register state being correct after stop+write+resume, or wait set ordering
-//! when multiple sources fire concurrently.
+//! when multiple sources fire concurrently. Don't extend an existing
+//! scenario file to bolt on a tangential second scenario; add a sibling
+//! file.
 //!
 //! Files:
 //! - `thread_lifecycle.rs`       — full thread lifecycle end-to-end

--- a/core/ktest/src/integration/mod.rs
+++ b/core/ktest/src/integration/mod.rs
@@ -27,10 +27,13 @@
 //! - `retype_reclaim.rs`         — auto-reclaim invariant for every retypable kernel object
 
 pub mod cap_delegation_chain;
+pub mod cap_move_into_fresh_cspace_then_ipc;
 pub mod cap_transfer;
 pub mod memory_lifecycle;
 pub mod multi_caller_ipc_fifo;
+pub mod priority_preemption;
 pub mod retype_reclaim;
+pub mod shared_frame_two_aspaces;
 pub mod thread_lifecycle;
 pub mod tlb_coherency;
 pub mod wait_concurrency;
@@ -58,4 +61,16 @@ pub fn run_all(ctx: &TestContext)
     );
     run_integration_test!("integration::tlb_coherency", tlb_coherency::run(ctx));
     run_integration_test!("integration::retype_reclaim", retype_reclaim::run(ctx));
+    run_integration_test!(
+        "integration::priority_preemption",
+        priority_preemption::run(ctx)
+    );
+    run_integration_test!(
+        "integration::shared_frame_two_aspaces",
+        shared_frame_two_aspaces::run(ctx)
+    );
+    run_integration_test!(
+        "integration::cap_move_into_fresh_cspace_then_ipc",
+        cap_move_into_fresh_cspace_then_ipc::run(ctx)
+    );
 }

--- a/core/ktest/src/integration/multi_caller_ipc_fifo.rs
+++ b/core/ktest/src/integration/multi_caller_ipc_fifo.rs
@@ -20,12 +20,11 @@
 
 use ipc::IpcMessage;
 use syscall::{
-    cap_copy, cap_create_cspace, cap_create_endpoint, cap_create_signal, cap_create_thread,
-    cap_delete, signal_send, signal_wait, thread_configure, thread_exit, thread_set_affinity,
-    thread_start, thread_yield,
+    cap_copy, cap_create_endpoint, cap_create_signal, cap_delete, signal_send, signal_wait,
+    thread_exit, thread_yield,
 };
 
-use crate::{ChildStack, TestContext, TestResult};
+use crate::{ChildStack, TestContext, TestResult, spawn};
 
 // SEND | GRANT rights (bits 4 and 6).
 const RIGHTS_SEND_GRANT: u64 = (1 << 4) | (1 << 6);
@@ -45,59 +44,42 @@ pub fn run(ctx: &TestContext) -> TestResult
         .map_err(|_| "multi_caller_ipc_fifo: cap_create_signal failed")?;
 
     // ── Build and start caller A ──────────────────────────────────────────────
-    let cs_a = cap_create_cspace(ctx.memory_frame_base, 0, 4, 16)
-        .map_err(|_| "multi_caller_ipc_fifo: cs_a failed")?;
-    let ep_a =
-        cap_copy(ep, cs_a, RIGHTS_SEND_GRANT).map_err(|_| "multi_caller_ipc_fifo: ep_a failed")?;
+    let child_a = spawn::new_child(ctx).map_err(|_| "multi_caller_ipc_fifo: new_child A failed")?;
+    let ep_a = cap_copy(ep, child_a.cs, RIGHTS_SEND_GRANT)
+        .map_err(|_| "multi_caller_ipc_fifo: ep_a failed")?;
     let done_a =
-        cap_copy(done, cs_a, 1 << 7).map_err(|_| "multi_caller_ipc_fifo: done_a failed")?;
+        cap_copy(done, child_a.cs, 1 << 7).map_err(|_| "multi_caller_ipc_fifo: done_a failed")?;
     // arg: ep_slot | (done_slot << 16) | (label << 32)
     let arg_a = u64::from(ep_a) | (u64::from(done_a) << 16) | (1u64 << 32);
-    let th_a = cap_create_thread(ctx.memory_frame_base, ctx.aspace_cap, cs_a)
-        .map_err(|_| "multi_caller_ipc_fifo: th_a failed")?;
     let stack_a = ChildStack::top(core::ptr::addr_of!(STACK_A));
-    thread_configure(th_a, caller_entry as *const () as u64, stack_a, arg_a)
-        .map_err(|_| "multi_caller_ipc_fifo: configure th_a failed")?;
     // Pin to CPU 0 so yield-based FIFO ordering is reliable under SMP.
-    thread_set_affinity(th_a, 0).map_err(|_| "multi_caller_ipc_fifo: set_affinity th_a failed")?;
-    thread_start(th_a).map_err(|_| "multi_caller_ipc_fifo: start th_a failed")?;
+    spawn::configure_and_start_pinned(&child_a, caller_entry, stack_a, arg_a, 0)
+        .map_err(|_| "multi_caller_ipc_fifo: start A failed")?;
     // Yield so A runs and blocks on ipc_call before B is started.
     thread_yield().map_err(|_| "multi_caller_ipc_fifo: yield after A failed")?;
 
     // ── Build and start caller B ──────────────────────────────────────────────
-    let cs_b = cap_create_cspace(ctx.memory_frame_base, 0, 4, 16)
-        .map_err(|_| "multi_caller_ipc_fifo: cs_b failed")?;
-    let ep_b =
-        cap_copy(ep, cs_b, RIGHTS_SEND_GRANT).map_err(|_| "multi_caller_ipc_fifo: ep_b failed")?;
+    let child_b = spawn::new_child(ctx).map_err(|_| "multi_caller_ipc_fifo: new_child B failed")?;
+    let ep_b = cap_copy(ep, child_b.cs, RIGHTS_SEND_GRANT)
+        .map_err(|_| "multi_caller_ipc_fifo: ep_b failed")?;
     let done_b =
-        cap_copy(done, cs_b, 1 << 7).map_err(|_| "multi_caller_ipc_fifo: done_b failed")?;
+        cap_copy(done, child_b.cs, 1 << 7).map_err(|_| "multi_caller_ipc_fifo: done_b failed")?;
     let arg_b = u64::from(ep_b) | (u64::from(done_b) << 16) | (2u64 << 32);
-    let th_b = cap_create_thread(ctx.memory_frame_base, ctx.aspace_cap, cs_b)
-        .map_err(|_| "multi_caller_ipc_fifo: th_b failed")?;
     let stack_b = ChildStack::top(core::ptr::addr_of!(STACK_B));
-    thread_configure(th_b, caller_entry as *const () as u64, stack_b, arg_b)
-        .map_err(|_| "multi_caller_ipc_fifo: configure th_b failed")?;
-    // Pin to CPU 0 so yield-based FIFO ordering is reliable under SMP.
-    thread_set_affinity(th_b, 0).map_err(|_| "multi_caller_ipc_fifo: set_affinity th_b failed")?;
-    thread_start(th_b).map_err(|_| "multi_caller_ipc_fifo: start th_b failed")?;
+    spawn::configure_and_start_pinned(&child_b, caller_entry, stack_b, arg_b, 0)
+        .map_err(|_| "multi_caller_ipc_fifo: start B failed")?;
     thread_yield().map_err(|_| "multi_caller_ipc_fifo: yield after B failed")?;
 
     // ── Build and start caller C ──────────────────────────────────────────────
-    let cs_c = cap_create_cspace(ctx.memory_frame_base, 0, 4, 16)
-        .map_err(|_| "multi_caller_ipc_fifo: cs_c failed")?;
-    let ep_c =
-        cap_copy(ep, cs_c, RIGHTS_SEND_GRANT).map_err(|_| "multi_caller_ipc_fifo: ep_c failed")?;
+    let child_c = spawn::new_child(ctx).map_err(|_| "multi_caller_ipc_fifo: new_child C failed")?;
+    let ep_c = cap_copy(ep, child_c.cs, RIGHTS_SEND_GRANT)
+        .map_err(|_| "multi_caller_ipc_fifo: ep_c failed")?;
     let done_c =
-        cap_copy(done, cs_c, 1 << 7).map_err(|_| "multi_caller_ipc_fifo: done_c failed")?;
+        cap_copy(done, child_c.cs, 1 << 7).map_err(|_| "multi_caller_ipc_fifo: done_c failed")?;
     let arg_c = u64::from(ep_c) | (u64::from(done_c) << 16) | (3u64 << 32);
-    let th_c = cap_create_thread(ctx.memory_frame_base, ctx.aspace_cap, cs_c)
-        .map_err(|_| "multi_caller_ipc_fifo: th_c failed")?;
     let stack_c = ChildStack::top(core::ptr::addr_of!(STACK_C));
-    thread_configure(th_c, caller_entry as *const () as u64, stack_c, arg_c)
-        .map_err(|_| "multi_caller_ipc_fifo: configure th_c failed")?;
-    // Pin to CPU 0 so yield-based FIFO ordering is reliable under SMP.
-    thread_set_affinity(th_c, 0).map_err(|_| "multi_caller_ipc_fifo: set_affinity th_c failed")?;
-    thread_start(th_c).map_err(|_| "multi_caller_ipc_fifo: start th_c failed")?;
+    spawn::configure_and_start_pinned(&child_c, caller_entry, stack_c, arg_c, 0)
+        .map_err(|_| "multi_caller_ipc_fifo: start C failed")?;
     thread_yield().map_err(|_| "multi_caller_ipc_fifo: yield after C failed")?;
 
     // ── Drain send queue in FIFO order ────────────────────────────────────────
@@ -150,12 +132,12 @@ pub fn run(ctx: &TestContext) -> TestResult
         all_done |= bits;
     }
 
-    cap_delete(th_a).ok();
-    cap_delete(cs_a).ok();
-    cap_delete(th_b).ok();
-    cap_delete(cs_b).ok();
-    cap_delete(th_c).ok();
-    cap_delete(cs_c).ok();
+    cap_delete(child_a.th).ok();
+    cap_delete(child_a.cs).ok();
+    cap_delete(child_b.th).ok();
+    cap_delete(child_b.cs).ok();
+    cap_delete(child_c.th).ok();
+    cap_delete(child_c.cs).ok();
     cap_delete(ep).ok();
     cap_delete(done).ok();
 

--- a/core/ktest/src/integration/priority_preemption.rs
+++ b/core/ktest/src/integration/priority_preemption.rs
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+//! Integration: a higher-priority runnable thread preempts a CPU-bound lower
+//! priority one within a small time budget.
+//!
+//! Setup:
+//!
+//! - Both children pinned to CPU 0 so the test measures preemption, not
+//!   parallelism.
+//! - Child A (normal priority): tight spin loop, posts a "finished" bit only
+//!   at the end.
+//! - Child B (elevated priority): signals "ran" immediately and exits.
+//!
+//! Verification: the parent unblocks on B's "ran" signal well before A's
+//! spinner finishes. Slack: B should arrive within ~5 timer ticks worth
+//! of wall time of being made runnable. Skipped if no `SchedControl` cap
+//! exists in the initial cap set (no elevation path).
+
+use core::sync::atomic::{AtomicU64, Ordering};
+
+use syscall::{
+    cap_copy, cap_create_signal, cap_delete, signal_send, signal_wait_timeout, system_info,
+    thread_exit, thread_set_priority, thread_yield,
+};
+use syscall_abi::SystemInfoType;
+
+use crate::{ChildStack, TestContext, TestResult};
+
+/// SIGNAL right (send) only.
+const RIGHTS_SIGNAL: u64 = 1 << 7;
+
+/// Spin iterations for the low-priority hog. Large enough that, absent
+/// preemption, the hog dominates the CPU for tens of ms.
+const SPIN_ITERS: u64 = 50_000_000;
+
+/// Wall-time budget the elevated child has to arrive (µs).
+const PREEMPT_BUDGET_US: u64 = 100_000;
+
+static mut HOG_STACK: ChildStack = ChildStack::ZERO;
+static mut ELEVATED_STACK: ChildStack = ChildStack::ZERO;
+
+/// Stored count of iterations the hog completed before being killed,
+/// for diagnostics on failure.
+static HOG_REMAINING: AtomicU64 = AtomicU64::new(0);
+
+/// Hog: spin `SPIN_ITERS` times and post `done_bit` (low 32 bits) on
+/// `done_slot` (high 32 bits).
+// cast_possible_truncation: slot indices are < 2^32.
+#[allow(clippy::cast_possible_truncation)]
+fn hog_entry(arg: u64) -> !
+{
+    let done_slot = (arg & 0xFFFF_FFFF) as u32;
+    let done_bit = arg >> 32;
+    let mut n = SPIN_ITERS;
+    while n != 0
+    {
+        core::hint::spin_loop();
+        n -= 1;
+    }
+    HOG_REMAINING.store(n, Ordering::Release);
+    signal_send(done_slot, done_bit).ok();
+    thread_exit();
+}
+
+/// Elevated: immediately post `done_bit` (low 32 bits) on `done_slot`
+/// (high 32 bits) and exit.
+// cast_possible_truncation: slot indices are < 2^32.
+#[allow(clippy::cast_possible_truncation)]
+fn elevated_entry(arg: u64) -> !
+{
+    let done_slot = (arg & 0xFFFF_FFFF) as u32;
+    let done_bit = arg >> 32;
+    signal_send(done_slot, done_bit).ok();
+    thread_exit();
+}
+
+/// Scan ktest's initial cap set for the first slot accepting an elevated
+/// priority — that's the `SchedControl` cap. Mirrors the discovery in
+/// `unit/thread::set_priority_elevated_with_cap`.
+fn find_sched_control(probe_thread: u32, max_slot: u32) -> Option<u32>
+{
+    for slot in 1..max_slot
+    {
+        if thread_set_priority(probe_thread, 25, slot).is_ok()
+        {
+            // Reset probe back to normal priority.
+            let _ = thread_set_priority(probe_thread, 10, slot);
+            return Some(slot);
+        }
+    }
+    None
+}
+
+pub fn run(ctx: &TestContext) -> TestResult
+{
+    crate::log("priority_preemption: starting");
+
+    // Discover SchedControl by probing on a throwaway thread.
+    let probe = crate::spawn::new_child(ctx)
+        .map_err(|_| "priority_preemption: spawn::new_child (probe) failed")?;
+    let sched_cap = find_sched_control(probe.th, ctx.aspace_cap + 20);
+    cap_delete(probe.th).ok();
+    cap_delete(probe.cs).ok();
+
+    let Some(sched_cap) = sched_cap
+    else
+    {
+        crate::log("ktest: priority_preemption SKIP (no SchedControl cap in initial cap set)");
+        return Ok(());
+    };
+
+    let done = cap_create_signal(ctx.memory_frame_base)
+        .map_err(|_| "priority_preemption: cap_create_signal (done) failed")?;
+
+    // ── Hog: spawn, pin to CPU 0, default priority. ──────────────────────────
+    let hog = crate::spawn::new_child(ctx)
+        .map_err(|_| "priority_preemption: spawn::new_child (hog) failed")?;
+    let hog_done = cap_copy(done, hog.cs, RIGHTS_SIGNAL)
+        .map_err(|_| "priority_preemption: cap_copy hog_done failed")?;
+    let hog_arg = u64::from(hog_done) | (0x1u64 << 32);
+    let hog_stack = ChildStack::top(core::ptr::addr_of!(HOG_STACK));
+    crate::spawn::configure_and_start_pinned(&hog, hog_entry, hog_stack, hog_arg, 0)
+        .map_err(|_| "priority_preemption: hog configure_and_start_pinned failed")?;
+
+    // Yield so the hog gets on CPU 0 and starts spinning.
+    thread_yield().map_err(|_| "priority_preemption: yield after hog failed")?;
+
+    // ── Elevated: spawn, pin to CPU 0, elevated priority. ────────────────────
+    let elevated = crate::spawn::new_child(ctx)
+        .map_err(|_| "priority_preemption: spawn::new_child (elevated) failed")?;
+    let elevated_done = cap_copy(done, elevated.cs, RIGHTS_SIGNAL)
+        .map_err(|_| "priority_preemption: cap_copy elevated_done failed")?;
+    thread_set_priority(elevated.th, 20, sched_cap)
+        .map_err(|_| "priority_preemption: thread_set_priority (elevated) failed")?;
+    let elevated_arg = u64::from(elevated_done) | (0x2u64 << 32);
+    let elevated_stack = ChildStack::top(core::ptr::addr_of!(ELEVATED_STACK));
+
+    let t_made_runnable = system_info(SystemInfoType::ElapsedUs as u64)
+        .map_err(|_| "priority_preemption: system_info before configure failed")?;
+    crate::spawn::configure_and_start_pinned(
+        &elevated,
+        elevated_entry,
+        elevated_stack,
+        elevated_arg,
+        0,
+    )
+    .map_err(|_| "priority_preemption: elevated configure_and_start_pinned failed")?;
+
+    // Wait for either signal: elevated bit 0x2 means preemption succeeded,
+    // hog bit 0x1 means the hog finished before being preempted (failure).
+    let bits = signal_wait_timeout(done, PREEMPT_BUDGET_US / 1000)
+        .map_err(|_| "priority_preemption: signal_wait_timeout failed")?;
+
+    let t_observed = system_info(SystemInfoType::ElapsedUs as u64)
+        .map_err(|_| "priority_preemption: system_info after wait failed")?;
+    let elapsed_us = t_observed.wrapping_sub(t_made_runnable);
+
+    if bits & 0x2 == 0
+    {
+        crate::log_u64("priority_preemption: bits=", bits);
+        crate::log_u64("priority_preemption: elapsed_us=", elapsed_us);
+        return Err("priority_preemption: elevated child did not signal within preemption budget");
+    }
+
+    if elapsed_us > PREEMPT_BUDGET_US
+    {
+        crate::log_u64("priority_preemption: elapsed_us=", elapsed_us);
+        return Err("priority_preemption: elevated signal arrived but exceeded preemption budget");
+    }
+
+    // Drain the hog's done bit (it will finish eventually).
+    loop
+    {
+        let bits = signal_wait_timeout(done, 5_000).unwrap_or(0);
+        if bits & 0x1 != 0
+        {
+            break;
+        }
+        // The hog may take ~1 s to complete; keep waiting in small windows
+        // rather than blocking forever.
+    }
+
+    cap_delete(hog.th).ok();
+    cap_delete(hog.cs).ok();
+    cap_delete(elevated.th).ok();
+    cap_delete(elevated.cs).ok();
+    cap_delete(done).ok();
+    Ok(())
+}

--- a/core/ktest/src/integration/priority_preemption.rs
+++ b/core/ktest/src/integration/priority_preemption.rs
@@ -17,8 +17,6 @@
 //! of wall time of being made runnable. Skipped if no `SchedControl` cap
 //! exists in the initial cap set (no elevation path).
 
-use core::sync::atomic::{AtomicU64, Ordering};
-
 use syscall::{
     cap_copy, cap_create_signal, cap_delete, signal_send, signal_wait_timeout, system_info,
     thread_exit, thread_set_priority, thread_yield,
@@ -40,10 +38,6 @@ const PREEMPT_BUDGET_US: u64 = 100_000;
 static mut HOG_STACK: ChildStack = ChildStack::ZERO;
 static mut ELEVATED_STACK: ChildStack = ChildStack::ZERO;
 
-/// Stored count of iterations the hog completed before being killed,
-/// for diagnostics on failure.
-static HOG_REMAINING: AtomicU64 = AtomicU64::new(0);
-
 /// Hog: spin `SPIN_ITERS` times and post `done_bit` (low 32 bits) on
 /// `done_slot` (high 32 bits).
 // cast_possible_truncation: slot indices are < 2^32.
@@ -56,9 +50,14 @@ fn hog_entry(arg: u64) -> !
     while n != 0
     {
         core::hint::spin_loop();
+        // black_box prevents LLVM from collapsing the spin to a single
+        // sub-and-branch loop or a noop in release mode; the test
+        // premise — "hog dominates a CPU long enough that we can
+        // observe whether preemption fires" — depends on the loop
+        // body actually consuming wall-clock time.
+        core::hint::black_box(n);
         n -= 1;
     }
-    HOG_REMAINING.store(n, Ordering::Release);
     signal_send(done_slot, done_bit).ok();
     thread_exit();
 }

--- a/core/ktest/src/integration/shared_frame_two_aspaces.rs
+++ b/core/ktest/src/integration/shared_frame_two_aspaces.rs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+//! Integration: a single frame is mappable into two distinct address spaces
+//! and the kernel reports the same physical backing in both.
+//!
+//! Mints a fresh `AddressSpace` cap, then maps one frame from the pool both
+//! into ktest's own aspace at one VA and into the new aspace at a different
+//! VA. `aspace_query` on each VA returns the underlying physical address;
+//! the two phys addresses must be equal — that's the kernel-side invariant
+//! that proves the frame is shared.
+//!
+//! Not validated here (would require running user code in the secondary
+//! aspace): writes via VA-A become observable through VA-B. That requires
+//! the secondary aspace to also map ktest's code/data/stack, which is a
+//! bigger setup than this integration test covers. The phys-equality check
+//! is the kernel-level invariant the test cares about.
+
+use syscall::{MAP_WRITABLE, aspace_query, cap_create_aspace, cap_delete, mem_map, mem_unmap};
+
+use crate::{TestContext, TestResult};
+
+/// Distinct VAs so the mappings don't alias each other within the same
+/// aspace (we map at `VA_A` in ktest's aspace and `VA_B` in the second aspace).
+const VA_A: u64 = 0x5800_0000;
+const VA_B: u64 = 0x5900_0000;
+
+pub fn run(ctx: &TestContext) -> TestResult
+{
+    crate::log("shared_frame_two_aspaces: starting");
+
+    // Mint a fresh address space.
+    let aspace_b = cap_create_aspace(ctx.memory_frame_base, 0, 8)
+        .map_err(|_| "shared_frame_two_aspaces: cap_create_aspace failed")?;
+
+    // Pull one frame from the pool — backed by ktest's own RAM cap.
+    let frame = crate::frame_pool::alloc()
+        .ok_or("shared_frame_two_aspaces: frame_pool::alloc returned None")?;
+
+    // Map into ktest's aspace.
+    mem_map(frame, ctx.aspace_cap, VA_A, 0, 1, MAP_WRITABLE)
+        .map_err(|_| "shared_frame_two_aspaces: mem_map (aspace A) failed")?;
+
+    // Map the same frame into the new aspace at a different VA.
+    mem_map(frame, aspace_b, VA_B, 0, 1, MAP_WRITABLE)
+        .map_err(|_| "shared_frame_two_aspaces: mem_map (aspace B) failed")?;
+
+    // Both queries must return the same physical address — the kernel-side
+    // proof that the frame backs both mappings.
+    let phys_a = aspace_query(ctx.aspace_cap, VA_A)
+        .map_err(|_| "shared_frame_two_aspaces: aspace_query (A) failed")?;
+    let phys_b = aspace_query(aspace_b, VA_B)
+        .map_err(|_| "shared_frame_two_aspaces: aspace_query (B) failed")?;
+    if phys_a != phys_b
+    {
+        crate::log_u64("shared_frame_two_aspaces: phys_a=", phys_a);
+        crate::log_u64("shared_frame_two_aspaces: phys_b=", phys_b);
+        return Err(
+            "shared_frame_two_aspaces: same frame mapped in two aspaces has different phys",
+        );
+    }
+
+    // Cleanup: unmap from both aspaces before returning the frame to the pool.
+    mem_unmap(ctx.aspace_cap, VA_A, 1)
+        .map_err(|_| "shared_frame_two_aspaces: mem_unmap (A) failed")?;
+    mem_unmap(aspace_b, VA_B, 1).map_err(|_| "shared_frame_two_aspaces: mem_unmap (B) failed")?;
+
+    // SAFETY: frame is from pool and now unmapped from both aspaces.
+    unsafe { crate::frame_pool::free(frame) };
+    cap_delete(aspace_b).ok();
+    Ok(())
+}

--- a/core/ktest/src/integration/thread_lifecycle.rs
+++ b/core/ktest/src/integration/thread_lifecycle.rs
@@ -26,8 +26,8 @@ use core::sync::atomic::{AtomicU32, Ordering};
 
 use syscall::{
     cap_copy, cap_create_cspace, cap_create_signal, cap_create_thread, cap_delete, signal_send,
-    signal_wait, thread_configure, thread_exit, thread_read_regs, thread_set_affinity,
-    thread_set_priority, thread_start, thread_stop, thread_write_regs,
+    signal_wait, thread_exit, thread_read_regs, thread_set_affinity, thread_set_priority,
+    thread_start, thread_stop, thread_write_regs,
 };
 
 use crate::{ChildStack, TestContext, TestResult};
@@ -55,27 +55,19 @@ pub fn run(ctx: &TestContext) -> TestResult
         .map_err(|_| "integration::thread_lifecycle: cap_create_signal (ready) failed")?;
     let block = cap_create_signal(ctx.memory_frame_base)
         .map_err(|_| "integration::thread_lifecycle: cap_create_signal (block) failed")?;
-    let cs = cap_create_cspace(ctx.memory_frame_base, 0, 4, 16)
-        .map_err(|_| "integration::thread_lifecycle: cap_create_cspace failed")?;
-    let child_ready = cap_copy(ready, cs, RIGHTS_SIGNAL)
+    let child = crate::spawn::new_child(ctx)
+        .map_err(|_| "integration::thread_lifecycle: spawn::new_child failed")?;
+    let child_ready = cap_copy(ready, child.cs, RIGHTS_SIGNAL)
         .map_err(|_| "integration::thread_lifecycle: cap_copy (ready→child) failed")?;
-    let child_block = cap_copy(block, cs, RIGHTS_WAIT)
+    let child_block = cap_copy(block, child.cs, RIGHTS_WAIT)
         .map_err(|_| "integration::thread_lifecycle: cap_copy (block→child) failed")?;
-    let th = cap_create_thread(ctx.memory_frame_base, ctx.aspace_cap, cs)
-        .map_err(|_| "integration::thread_lifecycle: cap_create_thread failed")?;
 
     let stack_top = ChildStack::top(core::ptr::addr_of!(CHILD_STACK));
     let blocker_arg = (u64::from(child_ready) << 32) | u64::from(child_block);
-    thread_configure(
-        th,
-        blocker_entry as *const () as u64,
-        stack_top,
-        blocker_arg,
-    )
-    .map_err(|_| "integration::thread_lifecycle: thread_configure failed")?;
 
     // ── Step 3: Start — child signals readiness. ──────────────────────────────
-    thread_start(th).map_err(|_| "integration::thread_lifecycle: thread_start failed")?;
+    crate::spawn::configure_and_start(&child, blocker_entry, stack_top, blocker_arg)
+        .map_err(|_| "integration::thread_lifecycle: configure_and_start failed")?;
     let ready_bits = signal_wait(ready)
         .map_err(|_| "integration::thread_lifecycle: signal_wait (readiness) failed")?;
     if ready_bits != 0x1
@@ -84,11 +76,11 @@ pub fn run(ctx: &TestContext) -> TestResult
     }
 
     // ── Step 4: Stop while child is blocked. ──────────────────────────────────
-    thread_stop(th).map_err(|_| "integration::thread_lifecycle: thread_stop failed")?;
+    thread_stop(child.th).map_err(|_| "integration::thread_lifecycle: thread_stop failed")?;
 
     // ── Step 5: Read registers — verify IP is non-zero. ───────────────────────
     let mut reg_buf = [0u8; BUF];
-    thread_read_regs(th, reg_buf.as_mut_ptr(), BUF)
+    thread_read_regs(child.th, reg_buf.as_mut_ptr(), BUF)
         .map_err(|_| "integration::thread_lifecycle: thread_read_regs failed")?;
 
     let ip = u64::from_le_bytes(
@@ -107,11 +99,12 @@ pub fn run(ctx: &TestContext) -> TestResult
     PHASE2_SIG.store(child_ready, Ordering::Release);
     let phase2_ptr = phase2_entry as *const () as u64;
     reg_buf[IP_OFFSET..IP_OFFSET + 8].copy_from_slice(&phase2_ptr.to_le_bytes());
-    thread_write_regs(th, reg_buf.as_ptr(), BUF)
+    thread_write_regs(child.th, reg_buf.as_ptr(), BUF)
         .map_err(|_| "integration::thread_lifecycle: thread_write_regs failed")?;
 
     // ── Step 7: Resume — child lands in phase2_entry and sends 0x2. ──────────
-    thread_start(th).map_err(|_| "integration::thread_lifecycle: thread_start (resume) failed")?;
+    thread_start(child.th)
+        .map_err(|_| "integration::thread_lifecycle: thread_start (resume) failed")?;
     let phase2_bits = signal_wait(ready)
         .map_err(|_| "integration::thread_lifecycle: signal_wait (phase2) failed")?;
     if phase2_bits != 0x2
@@ -136,10 +129,10 @@ pub fn run(ctx: &TestContext) -> TestResult
 
     cap_delete(th2).ok();
     cap_delete(cs2).ok();
-    cap_delete(th).ok();
+    cap_delete(child.th).ok();
     cap_delete(ready).ok();
     cap_delete(block).ok();
-    cap_delete(cs).ok();
+    cap_delete(child.cs).ok();
     Ok(())
 }
 

--- a/core/ktest/src/integration/tlb_coherency.rs
+++ b/core/ktest/src/integration/tlb_coherency.rs
@@ -20,8 +20,8 @@
 //! confirming the protocol operates correctly under concurrent access.
 
 use syscall::{
-    cap_copy, cap_create_cspace, cap_create_signal, cap_create_thread, cap_delete, mem_map,
-    mem_unmap, signal_send, signal_wait, system_info, thread_configure, thread_exit, thread_start,
+    cap_copy, cap_create_signal, cap_delete, mem_map, mem_unmap, signal_send, signal_wait,
+    system_info, thread_exit,
 };
 use syscall_abi::SystemInfoType;
 
@@ -60,37 +60,29 @@ pub fn run(ctx: &TestContext) -> TestResult
     let c2p = cap_create_signal(ctx.memory_frame_base)
         .map_err(|_| "integration::tlb_coherency: cap_create_signal (c2p) failed")?;
 
-    let cs = cap_create_cspace(ctx.memory_frame_base, 0, 4, 16)
-        .map_err(|_| "integration::tlb_coherency: cap_create_cspace failed")?;
+    let child = crate::spawn::new_child(ctx)
+        .map_err(|_| "integration::tlb_coherency: spawn::new_child failed")?;
 
     // Copy both signals into child's cspace.
-    let child_p2c = cap_copy(p2c, cs, RIGHTS_SIGNAL_WAIT)
+    let child_p2c = cap_copy(p2c, child.cs, RIGHTS_SIGNAL_WAIT)
         .map_err(|_| "integration::tlb_coherency: cap_copy (p2c) failed")?;
-    let child_c2p = cap_copy(c2p, cs, RIGHTS_SIGNAL_WAIT)
+    let child_c2p = cap_copy(c2p, child.cs, RIGHTS_SIGNAL_WAIT)
         .map_err(|_| "integration::tlb_coherency: cap_copy (c2p) failed")?;
 
     // Pass child's c2p slot via static (thread_configure only has one arg).
     // SAFETY: single-threaded at this point; child not started yet.
     unsafe { CHILD_C2P_SLOT = child_c2p };
 
-    // ── 3. Create a child thread pinned to CPU 1. ────────────────────────────
-    let th = cap_create_thread(ctx.memory_frame_base, ctx.aspace_cap, cs)
-        .map_err(|_| "integration::tlb_coherency: cap_create_thread failed")?;
-
+    // ── 3. Configure + pin child to CPU 1, then start. ──────────────────────
     let stack_top = ChildStack::top(core::ptr::addr_of!(CHILD_STACK));
-    thread_configure(
-        th,
-        tlb_worker_thread as *const () as u64,
+    crate::spawn::configure_and_start_pinned(
+        &child,
+        tlb_worker_thread,
         stack_top,
         u64::from(child_p2c), // arg = p2c slot; c2p slot read from static
+        1,
     )
-    .map_err(|_| "integration::tlb_coherency: thread_configure failed")?;
-
-    // Pin child to CPU 1 (parent runs on CPU 0 by default).
-    syscall::thread_set_affinity(th, 1)
-        .map_err(|_| "integration::tlb_coherency: thread_set_affinity failed")?;
-
-    thread_start(th).map_err(|_| "integration::tlb_coherency: thread_start failed")?;
+    .map_err(|_| "integration::tlb_coherency: configure_and_start_pinned failed")?;
 
     // Wait for child to signal readiness on c2p.
     let ready = signal_wait(c2p)
@@ -150,8 +142,8 @@ pub fn run(ctx: &TestContext) -> TestResult
     signal_send(p2c, 0x80).map_err(|_| "integration::tlb_coherency: signal_send (exit) failed")?;
 
     // ── 6. Clean up. ─────────────────────────────────────────────────────────
-    cap_delete(th).map_err(|_| "integration::tlb_coherency: cap_delete (th) failed")?;
-    cap_delete(cs).map_err(|_| "integration::tlb_coherency: cap_delete (cs) failed")?;
+    cap_delete(child.th).map_err(|_| "integration::tlb_coherency: cap_delete (th) failed")?;
+    cap_delete(child.cs).map_err(|_| "integration::tlb_coherency: cap_delete (cs) failed")?;
     cap_delete(p2c).map_err(|_| "integration::tlb_coherency: cap_delete (p2c) failed")?;
     cap_delete(c2p).map_err(|_| "integration::tlb_coherency: cap_delete (c2p) failed")?;
 

--- a/core/ktest/src/integration/tlb_coherency.rs
+++ b/core/ktest/src/integration/tlb_coherency.rs
@@ -29,7 +29,7 @@ use crate::{ChildStack, TestContext, TestResult};
 
 const TEST_VA: u64 = 0x5000_0000; // 1.25 GiB — distinct from other integration tests.
 const RIGHTS_SIGNAL_WAIT: u64 = (1 << 7) | (1 << 8);
-const CYCLES: usize = 20;
+const CYCLES: usize = 100;
 
 static mut CHILD_STACK: ChildStack = ChildStack::ZERO;
 

--- a/core/ktest/src/integration/tlb_coherency.rs
+++ b/core/ktest/src/integration/tlb_coherency.rs
@@ -29,7 +29,7 @@ use crate::{ChildStack, TestContext, TestResult};
 
 const TEST_VA: u64 = 0x5000_0000; // 1.25 GiB — distinct from other integration tests.
 const RIGHTS_SIGNAL_WAIT: u64 = (1 << 7) | (1 << 8);
-const CYCLES: usize = 100;
+const CYCLES: usize = 20;
 
 static mut CHILD_STACK: ChildStack = ChildStack::ZERO;
 

--- a/core/ktest/src/integration/wait_concurrency.rs
+++ b/core/ktest/src/integration/wait_concurrency.rs
@@ -19,9 +19,9 @@
 //!   - `wait_set_remove` prevents the removed source from waking the set.
 
 use syscall::{
-    cap_copy, cap_create_cspace, cap_create_signal, cap_create_thread, cap_delete, event_post,
-    event_queue_create, event_recv, signal_send, signal_wait, thread_configure, thread_exit,
-    thread_start, wait_set_add, wait_set_create, wait_set_remove, wait_set_wait,
+    cap_copy, cap_create_signal, cap_delete, event_post, event_queue_create, event_recv,
+    signal_send, signal_wait, thread_exit, wait_set_add, wait_set_create, wait_set_remove,
+    wait_set_wait,
 };
 
 use crate::{ChildStack, TestContext, TestResult};
@@ -60,22 +60,14 @@ pub fn run(ctx: &TestContext) -> TestResult
         .map_err(|_| "integration::wait_concurrency: event_recv (drain part A) failed")?;
 
     // ── Part B: Child fires signal — blocking wake. ───────────────────────────
-    let cs = cap_create_cspace(ctx.memory_frame_base, 0, 4, 16)
-        .map_err(|_| "integration::wait_concurrency: cap_create_cspace failed")?;
-    let child_sig = cap_copy(sig, cs, RIGHTS_SIGNAL)
+    let child = crate::spawn::new_child(ctx)
+        .map_err(|_| "integration::wait_concurrency: spawn::new_child failed")?;
+    let child_sig = cap_copy(sig, child.cs, RIGHTS_SIGNAL)
         .map_err(|_| "integration::wait_concurrency: cap_copy sig failed")?;
-    let th = cap_create_thread(ctx.memory_frame_base, ctx.aspace_cap, cs)
-        .map_err(|_| "integration::wait_concurrency: cap_create_thread failed")?;
 
     let stack_top = ChildStack::top(core::ptr::addr_of!(CHILD_STACK));
-    thread_configure(
-        th,
-        sender_entry as *const () as u64,
-        stack_top,
-        u64::from(child_sig),
-    )
-    .map_err(|_| "integration::wait_concurrency: thread_configure failed")?;
-    thread_start(th).map_err(|_| "integration::wait_concurrency: thread_start failed")?;
+    crate::spawn::configure_and_start(&child, sender_entry, stack_top, u64::from(child_sig))
+        .map_err(|_| "integration::wait_concurrency: configure_and_start failed")?;
 
     // Block until the child fires the signal.
     let tok_b = wait_set_wait(ws)
@@ -116,7 +108,8 @@ pub fn run(ctx: &TestContext) -> TestResult
     cap_delete(eq).ok();
     cap_delete(sig).ok();
     cap_delete(ws).ok();
-    cap_delete(cs).ok();
+    cap_delete(child.th).ok();
+    cap_delete(child.cs).ok();
     Ok(())
 }
 

--- a/core/ktest/src/main.rs
+++ b/core/ktest/src/main.rs
@@ -29,6 +29,7 @@ mod frame_pool;
 mod framebuffer;
 mod integration;
 mod serial;
+mod spawn;
 mod stress;
 mod unit;
 

--- a/core/ktest/src/main.rs
+++ b/core/ktest/src/main.rs
@@ -154,6 +154,11 @@ pub struct TestContext
     /// `frame_pool` slots elsewhere are derived from a segment cap and
     /// therefore lack the RETYPE right.
     pub memory_frame_base: u32,
+
+    /// RISC-V SBI control cap (slot index), kernel-minted in init's
+    /// initial cap set. Zero on x86-64, where SBI is unavailable.
+    /// Tests of `SYS_SBI_CALL` use this cap.
+    pub sbi_control_cap: u32,
 }
 
 /// 16 KiB stack for a child thread, aligned per the System V ABI.
@@ -265,6 +270,7 @@ fn run(info_ptr: u64) -> !
         cspace_cap: info.cspace_cap,
         ipc_buf: ipc_buf_ptr,
         memory_frame_base: info.memory_frame_base,
+        sbi_control_cap: info.sbi_control_cap,
     };
 
     // Parse config early so we can gate tier execution and pass bench_iters.

--- a/core/ktest/src/main.rs
+++ b/core/ktest/src/main.rs
@@ -10,7 +10,7 @@
 //!
 //! 1. **Tier 1** (`unit/`)        — exercises every kernel syscall in isolation.
 //! 2. **Tier 2** (`integration/`) — cross-subsystem scenario tests.
-//! 3. **Tier 3** (`bench/`)       — placeholder for future timing/profiling.
+//! 3. **Tier 3** (`bench/`)       — cycle-accurate benchmarks (`rdtsc` / `csrr cycle`).
 //!
 //! Results are printed directly to the serial console via hardware I/O.
 //! Each test prints `PASS` or `FAIL`. A summary follows. ktest then exits.

--- a/core/ktest/src/spawn.rs
+++ b/core/ktest/src/spawn.rs
@@ -38,9 +38,9 @@ pub struct SpawnedChild
 pub fn new_child(ctx: &TestContext) -> Result<SpawnedChild, &'static str>
 {
     // cap_create_cspace(frame, l1_idx=0, l1_depth=4, l2_size=16) — the
-    // 16-slot cspace is the default ceiling for tests that copy 1-3
-    // caps into the child plus headroom. Tests with wider cap layouts
-    // (e.g. integration/cap_transfer.rs uses a 32-slot cspace,
+    // 16-slot cspace covers tests that copy 1-3 caps into the child
+    // plus headroom. Tests with wider cap layouts (e.g.
+    // integration/cap_transfer.rs uses a 32-slot cspace,
     // stress/retype_concurrent.rs uses 64) bypass this helper and
     // call cap_create_cspace directly.
     let cs = cap_create_cspace(ctx.memory_frame_base, 0, 4, 16)

--- a/core/ktest/src/spawn.rs
+++ b/core/ktest/src/spawn.rs
@@ -37,6 +37,12 @@ pub struct SpawnedChild
 /// performs any required `cap_copy` into `child.cs` first.
 pub fn new_child(ctx: &TestContext) -> Result<SpawnedChild, &'static str>
 {
+    // cap_create_cspace(frame, l1_idx=0, l1_depth=4, l2_size=16) — the
+    // 16-slot cspace is the default ceiling for tests that copy 1-3
+    // caps into the child plus headroom. Tests with wider cap layouts
+    // (e.g. integration/cap_transfer.rs uses a 32-slot cspace,
+    // stress/retype_concurrent.rs uses 64) bypass this helper and
+    // call cap_create_cspace directly.
     let cs = cap_create_cspace(ctx.memory_frame_base, 0, 4, 16)
         .map_err(|_| "spawn::new_child: cap_create_cspace failed")?;
     let th = cap_create_thread(ctx.memory_frame_base, ctx.aspace_cap, cs)

--- a/core/ktest/src/spawn.rs
+++ b/core/ktest/src/spawn.rs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// ktest/src/spawn.rs
+
+//! Child-thread spawn helper.
+//!
+//! Most ktest scenarios spawn a child thread in a fresh `CSpace`, copy one
+//! or two caps into that `CSpace`, then configure-and-start the thread. The
+//! `cap_create_cspace + cap_create_thread + thread_configure + thread_start`
+//! plumbing is mechanical and identical across ~25 sites. This module
+//! wraps it so each test reads as scenario, not boilerplate.
+//!
+//! Use [`new_child`] to mint the (`CSpace`, Thread) pair, do any `cap_copy`
+//! calls into `child.cs`, then call [`configure_and_start`] (or
+//! [`configure_and_start_pinned`] for an affinity-bound child) to launch.
+
+use syscall::{
+    cap_create_cspace, cap_create_thread, thread_configure, thread_set_affinity, thread_start,
+};
+
+use crate::TestContext;
+
+/// Child-thread handle returned by [`new_child`].
+///
+/// Caller is responsible for deleting both caps when the child has exited
+/// (typically via `signal_wait`-based handshake). Order: `th` first,
+/// then `cs`.
+pub struct SpawnedChild
+{
+    pub th: u32,
+    pub cs: u32,
+}
+
+/// Mint a new (`CSpace`, Thread) pair both bound to the test's address
+/// space. The thread is not configured or started yet — the caller
+/// performs any required `cap_copy` into `child.cs` first.
+pub fn new_child(ctx: &TestContext) -> Result<SpawnedChild, &'static str>
+{
+    let cs = cap_create_cspace(ctx.memory_frame_base, 0, 4, 16)
+        .map_err(|_| "spawn::new_child: cap_create_cspace failed")?;
+    let th = cap_create_thread(ctx.memory_frame_base, ctx.aspace_cap, cs)
+        .map_err(|_| "spawn::new_child: cap_create_thread failed")?;
+    Ok(SpawnedChild { th, cs })
+}
+
+/// Configure `child` to enter `entry(arg)` on `stack_top` and start it.
+///
+/// `entry` is the typical `extern "C" fn(u64) -> !` shape used by all
+/// existing ktest children.
+pub fn configure_and_start(
+    child: &SpawnedChild,
+    entry: fn(u64) -> !,
+    stack_top: u64,
+    arg: u64,
+) -> Result<(), &'static str>
+{
+    thread_configure(child.th, entry as *const () as u64, stack_top, arg)
+        .map_err(|_| "spawn::configure_and_start: thread_configure failed")?;
+    thread_start(child.th).map_err(|_| "spawn::configure_and_start: thread_start failed")?;
+    Ok(())
+}
+
+/// Like [`configure_and_start`] but pins the child to `cpu` via
+/// `thread_set_affinity` before starting it.
+pub fn configure_and_start_pinned(
+    child: &SpawnedChild,
+    entry: fn(u64) -> !,
+    stack_top: u64,
+    arg: u64,
+    cpu: u32,
+) -> Result<(), &'static str>
+{
+    thread_configure(child.th, entry as *const () as u64, stack_top, arg)
+        .map_err(|_| "spawn::configure_and_start_pinned: thread_configure failed")?;
+    thread_set_affinity(child.th, cpu)
+        .map_err(|_| "spawn::configure_and_start_pinned: thread_set_affinity failed")?;
+    thread_start(child.th).map_err(|_| "spawn::configure_and_start_pinned: thread_start failed")?;
+    Ok(())
+}

--- a/core/ktest/src/stress/cap_delete_running.rs
+++ b/core/ktest/src/stress/cap_delete_running.rs
@@ -17,11 +17,9 @@
 //! Without that handling the TCB would be freed while a CPU still held it
 //! in `sched.current`, causing a use-after-free on the next context switch.
 
-use syscall::{
-    cap_create_cspace, cap_create_thread, cap_delete, thread_configure, thread_start, thread_yield,
-};
+use syscall::{cap_delete, thread_yield};
 
-use crate::{ChildStack, TestContext, TestResult};
+use crate::{ChildStack, TestContext, TestResult, spawn};
 
 const NUM_CHILDREN: usize = 4;
 
@@ -32,20 +30,16 @@ pub fn run(ctx: &TestContext) -> TestResult
 
     for i in 0..NUM_CHILDREN
     {
-        let cs = cap_create_cspace(ctx.memory_frame_base, 0, 4, 8)
-            .map_err(|_| "cap_delete_running: create_cspace failed")?;
-        let th = cap_create_thread(ctx.memory_frame_base, ctx.aspace_cap, cs)
-            .map_err(|_| "cap_delete_running: create_thread failed")?;
-
+        let child =
+            spawn::new_child(ctx).map_err(|_| "cap_delete_running: spawn::new_child failed")?;
         // SAFETY: stress tests run sequentially; only this test uses these
         // STRESS_STACKS slots.
         let stack_top = ChildStack::top(unsafe { core::ptr::addr_of!(super::STRESS_STACKS[i]) });
-        thread_configure(th, spinner_entry as *const () as u64, stack_top, 0)
-            .map_err(|_| "cap_delete_running: thread_configure failed")?;
-        thread_start(th).map_err(|_| "cap_delete_running: thread_start failed")?;
+        spawn::configure_and_start(&child, spinner_entry, stack_top, 0)
+            .map_err(|_| "cap_delete_running: configure_and_start failed")?;
 
-        threads[i] = th;
-        cspaces[i] = cs;
+        threads[i] = child.th;
+        cspaces[i] = child.cs;
     }
 
     // Yield a few times so the children actually get on a CPU before we

--- a/core/ktest/src/stress/cap_delete_running.rs
+++ b/core/ktest/src/stress/cap_delete_running.rs
@@ -21,7 +21,12 @@ use syscall::{cap_delete, thread_yield};
 
 use crate::{ChildStack, TestContext, TestResult, spawn};
 
-const NUM_CHILDREN: usize = 16;
+/// 4 — pre-ramp baseline. See `concurrent_signal.rs::NUM_SENDERS` for
+/// the kernel-side scaling pathologies. The follow-on hang in
+/// `cap_revoke_under_use` was observed even after this test ran to PASS
+/// at NUM=16, so kernel state appears to accumulate; keeping per-test
+/// concurrency at the pre-ramp baseline avoids cross-test interference.
+const NUM_CHILDREN: usize = 4;
 
 pub fn run(ctx: &TestContext) -> TestResult
 {

--- a/core/ktest/src/stress/cap_delete_running.rs
+++ b/core/ktest/src/stress/cap_delete_running.rs
@@ -21,7 +21,7 @@ use syscall::{cap_delete, thread_yield};
 
 use crate::{ChildStack, TestContext, TestResult, spawn};
 
-const NUM_CHILDREN: usize = 4;
+const NUM_CHILDREN: usize = 16;
 
 pub fn run(ctx: &TestContext) -> TestResult
 {

--- a/core/ktest/src/stress/cap_revoke_under_use.rs
+++ b/core/ktest/src/stress/cap_revoke_under_use.rs
@@ -14,7 +14,11 @@ use syscall::{
 
 use crate::{ChildStack, TestContext, TestResult, spawn};
 
-const NUM_CHILDREN: usize = 64;
+/// 16 — pre-ramp baseline. See the kernel-side notes on `NUM_SENDERS`
+/// in `concurrent_signal.rs` for the two scaling pathologies that block
+/// ramping this further; the `cap_revoke`-under-spinner-flood case is
+/// the one this test would normally surface.
+const NUM_CHILDREN: usize = 16;
 const RIGHTS_SIGNAL: u64 = 1 << 7;
 
 pub fn run(ctx: &TestContext) -> TestResult

--- a/core/ktest/src/stress/cap_revoke_under_use.rs
+++ b/core/ktest/src/stress/cap_revoke_under_use.rs
@@ -14,7 +14,7 @@ use syscall::{
 
 use crate::{ChildStack, TestContext, TestResult, spawn};
 
-const NUM_CHILDREN: usize = 16;
+const NUM_CHILDREN: usize = 64;
 const RIGHTS_SIGNAL: u64 = 1 << 7;
 
 pub fn run(ctx: &TestContext) -> TestResult
@@ -44,8 +44,10 @@ pub fn run(ctx: &TestContext) -> TestResult
         let child_done = cap_copy(done, child.cs, 1 << 7)
             .map_err(|_| "cap_revoke_under_use: cap_copy done failed")?;
 
-        let done_bit = 1u64 << i;
-        let arg = u64::from(child_sig) | (u64::from(child_done) << 16) | (done_bit << 32);
+        // Pack: sig_slot[15:0], done_slot[31:16], bit_index[47:32]. Encode
+        // the bit index (not bit value) so it fits in 16 bits even for
+        // NUM_CHILDREN up to 64.
+        let arg = u64::from(child_sig) | (u64::from(child_done) << 16) | ((i as u64) << 32);
         // SAFETY: Each child uses a distinct stack index.
         let stack_top = ChildStack::top(unsafe { core::ptr::addr_of!(super::STRESS_STACKS[i]) });
         spawn::configure_and_start(&child, sender_loop_entry, stack_top, arg)
@@ -66,7 +68,15 @@ pub fn run(ctx: &TestContext) -> TestResult
     cap_revoke(root).map_err(|_| "cap_revoke_under_use: cap_revoke failed")?;
 
     // Wait for all children to report done. Each child sends a unique bit.
-    let all_done = (1u64 << NUM_CHILDREN) - 1;
+    // At NUM_CHILDREN=64 the bitmask saturates the u64.
+    let all_done: u64 = if NUM_CHILDREN >= 64
+    {
+        u64::MAX
+    }
+    else
+    {
+        (1u64 << NUM_CHILDREN) - 1
+    };
     let mut done_bits: u64 = 0;
     while done_bits != all_done
     {
@@ -94,7 +104,8 @@ fn sender_loop_entry(arg: u64) -> !
 {
     let sig_slot = (arg & 0xFFFF) as u32;
     let done_slot = ((arg >> 16) & 0xFFFF) as u32;
-    let done_bit = (arg >> 32) & 0xFFFF;
+    let bit_index = (arg >> 32) & 0xFFFF;
+    let done_bit = 1u64 << bit_index;
 
     // Send in a tight loop until the cap is revoked.
     loop

--- a/core/ktest/src/stress/cap_revoke_under_use.rs
+++ b/core/ktest/src/stress/cap_revoke_under_use.rs
@@ -8,12 +8,11 @@
 //! kernel panic or use-after-free occurs.
 
 use syscall::{
-    cap_copy, cap_create_cspace, cap_create_signal, cap_create_thread, cap_delete, cap_derive,
-    cap_revoke, signal_send, signal_wait, thread_configure, thread_exit, thread_start,
-    thread_yield,
+    cap_copy, cap_create_signal, cap_delete, cap_derive, cap_revoke, signal_send, signal_wait,
+    thread_exit, thread_yield,
 };
 
-use crate::{ChildStack, TestContext, TestResult};
+use crate::{ChildStack, TestContext, TestResult, spawn};
 
 const NUM_CHILDREN: usize = 16;
 const RIGHTS_SIGNAL: u64 = 1 << 7;
@@ -38,26 +37,22 @@ pub fn run(ctx: &TestContext) -> TestResult
     let mut cspaces = [0u32; NUM_CHILDREN];
     for i in 0..NUM_CHILDREN
     {
-        let cs = cap_create_cspace(ctx.memory_frame_base, 0, 4, 16)
-            .map_err(|_| "cap_revoke_under_use: create_cspace failed")?;
-        let child_sig = cap_copy(derived[i], cs, RIGHTS_SIGNAL)
+        let child =
+            spawn::new_child(ctx).map_err(|_| "cap_revoke_under_use: spawn::new_child failed")?;
+        let child_sig = cap_copy(derived[i], child.cs, RIGHTS_SIGNAL)
             .map_err(|_| "cap_revoke_under_use: cap_copy sig failed")?;
-        let child_done =
-            cap_copy(done, cs, 1 << 7).map_err(|_| "cap_revoke_under_use: cap_copy done failed")?;
-
-        let th = cap_create_thread(ctx.memory_frame_base, ctx.aspace_cap, cs)
-            .map_err(|_| "cap_revoke_under_use: create_thread failed")?;
+        let child_done = cap_copy(done, child.cs, 1 << 7)
+            .map_err(|_| "cap_revoke_under_use: cap_copy done failed")?;
 
         let done_bit = 1u64 << i;
         let arg = u64::from(child_sig) | (u64::from(child_done) << 16) | (done_bit << 32);
         // SAFETY: Each child uses a distinct stack index.
         let stack_top = ChildStack::top(unsafe { core::ptr::addr_of!(super::STRESS_STACKS[i]) });
-        thread_configure(th, sender_loop_entry as *const () as u64, stack_top, arg)
-            .map_err(|_| "cap_revoke_under_use: thread_configure failed")?;
-        thread_start(th).map_err(|_| "cap_revoke_under_use: thread_start failed")?;
+        spawn::configure_and_start(&child, sender_loop_entry, stack_top, arg)
+            .map_err(|_| "cap_revoke_under_use: configure_and_start failed")?;
 
-        threads[i] = th;
-        cspaces[i] = cs;
+        threads[i] = child.th;
+        cspaces[i] = child.cs;
     }
 
     // Let children run for a while before revoking.

--- a/core/ktest/src/stress/cap_tree_deep.rs
+++ b/core/ktest/src/stress/cap_tree_deep.rs
@@ -11,7 +11,7 @@ use syscall::{cap_create_signal, cap_delete, cap_derive, cap_revoke, signal_send
 use crate::{TestContext, TestResult};
 
 const CHAIN_DEPTH: usize = 8;
-const PASSES: usize = 50;
+const PASSES: usize = 500;
 const RIGHTS_SIGNAL: u64 = 1 << 7;
 
 pub fn run(ctx: &TestContext) -> TestResult

--- a/core/ktest/src/stress/cap_tree_deep.rs
+++ b/core/ktest/src/stress/cap_tree_deep.rs
@@ -11,7 +11,7 @@ use syscall::{cap_create_signal, cap_delete, cap_derive, cap_revoke, signal_send
 use crate::{TestContext, TestResult};
 
 const CHAIN_DEPTH: usize = 8;
-const PASSES: usize = 500;
+const PASSES: usize = 50;
 const RIGHTS_SIGNAL: u64 = 1 << 7;
 
 pub fn run(ctx: &TestContext) -> TestResult

--- a/core/ktest/src/stress/concurrent_event_producers.rs
+++ b/core/ktest/src/stress/concurrent_event_producers.rs
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+//! Stress: many concurrent producers on one event queue.
+//!
+//! Existing `stress/event_queue_fill_drain.rs` is single-threaded
+//! (one fill, one drain). This test runs multiple producer threads
+//! posting concurrently to one queue; the parent (single consumer)
+//! drains all messages and verifies every producer's full sequence
+//! arrived exactly once. Exercises the event-queue post-side spinlock
+//! under contention.
+//!
+//! Payload encoding: each producer claims a distinct 4-bit "producer id"
+//! and posts an 8-bit sequence number. The parent reconstructs the per-
+//! producer set and asserts each set is `0..MESSAGES_PER_PRODUCER`.
+
+use syscall::{
+    cap_copy, cap_create_signal, cap_delete, event_post, event_queue_create, event_recv,
+    signal_send, signal_wait, thread_exit,
+};
+
+use crate::{ChildStack, TestContext, TestResult, spawn};
+
+/// One producer per stress stack — capped at `MAX_STRESS_THREADS`.
+const NUM_PRODUCERS: usize = 4;
+/// Messages per producer.
+const MESSAGES_PER_PRODUCER: u32 = 64;
+/// Total messages across all producers.
+#[allow(clippy::cast_possible_truncation)]
+const TOTAL_MESSAGES: u32 = NUM_PRODUCERS as u32 * MESSAGES_PER_PRODUCER;
+
+/// SIGNAL right (send) only.
+const RIGHTS_SIGNAL: u64 = 1 << 7;
+/// `EventQueue` POST right (bit 9 per the kernel).
+const RIGHTS_POST: u64 = 1 << 9;
+
+/// Producer: post `MESSAGES_PER_PRODUCER` messages each tagged with its
+/// producer id, then post done bit.
+///
+/// `arg`: bits[15:0] = queue slot, bits[31:16] = done slot,
+///        bits[47:32] = producer id.
+// cast_possible_truncation: slot indices are < 2^32.
+#[allow(clippy::cast_possible_truncation)]
+fn producer_entry(arg: u64) -> !
+{
+    let queue_slot = (arg & 0xFFFF) as u32;
+    let done_slot = ((arg >> 16) & 0xFFFF) as u32;
+    let producer_id = (arg >> 32) & 0xFFFF;
+
+    for seq in 0..u64::from(MESSAGES_PER_PRODUCER)
+    {
+        // Pack: bits[3:0] = producer_id, bits[11:4] = seq.
+        let payload = producer_id | (seq << 4);
+        if event_post(queue_slot, payload).is_err()
+        {
+            break;
+        }
+    }
+    signal_send(done_slot, 1u64 << producer_id).ok();
+    thread_exit()
+}
+
+pub fn run(ctx: &TestContext) -> TestResult
+{
+    let eq = event_queue_create(ctx.memory_frame_base, TOTAL_MESSAGES)
+        .map_err(|_| "concurrent_event_producers: event_queue_create failed")?;
+    let done = cap_create_signal(ctx.memory_frame_base)
+        .map_err(|_| "concurrent_event_producers: cap_create_signal failed")?;
+
+    let mut threads = [0u32; NUM_PRODUCERS];
+    let mut cspaces = [0u32; NUM_PRODUCERS];
+
+    for i in 0..NUM_PRODUCERS
+    {
+        let child = spawn::new_child(ctx)
+            .map_err(|_| "concurrent_event_producers: spawn::new_child failed")?;
+        let child_eq = cap_copy(eq, child.cs, RIGHTS_POST)
+            .map_err(|_| "concurrent_event_producers: cap_copy queue failed")?;
+        let child_done = cap_copy(done, child.cs, RIGHTS_SIGNAL)
+            .map_err(|_| "concurrent_event_producers: cap_copy done failed")?;
+        let arg = u64::from(child_eq) | (u64::from(child_done) << 16) | ((i as u64) << 32);
+
+        // SAFETY: stress tests run sequentially; each producer gets its own stack.
+        let stack_top = ChildStack::top(unsafe { core::ptr::addr_of!(super::STRESS_STACKS[i]) });
+        spawn::configure_and_start(&child, producer_entry, stack_top, arg)
+            .map_err(|_| "concurrent_event_producers: configure_and_start failed")?;
+
+        threads[i] = child.th;
+        cspaces[i] = child.cs;
+    }
+
+    // Consumer: drain TOTAL_MESSAGES messages and bucket by producer id.
+    let mut per_producer = [[false; MESSAGES_PER_PRODUCER as usize]; NUM_PRODUCERS];
+    for _ in 0..TOTAL_MESSAGES
+    {
+        let payload =
+            event_recv(eq).map_err(|_| "concurrent_event_producers: event_recv failed")?;
+        // cast_possible_truncation: low nibbles are bounded by NUM_PRODUCERS
+        // and MESSAGES_PER_PRODUCER which both fit in usize easily.
+        #[allow(clippy::cast_possible_truncation)]
+        let producer_id = (payload & 0xF) as usize;
+        #[allow(clippy::cast_possible_truncation)]
+        let seq = ((payload >> 4) & 0xFF) as usize;
+        if producer_id >= NUM_PRODUCERS
+        {
+            return Err("concurrent_event_producers: producer id out of range");
+        }
+        if seq >= MESSAGES_PER_PRODUCER as usize
+        {
+            return Err("concurrent_event_producers: seq out of range");
+        }
+        if per_producer[producer_id][seq]
+        {
+            return Err("concurrent_event_producers: duplicate (producer, seq)");
+        }
+        per_producer[producer_id][seq] = true;
+    }
+
+    // Wait for all producers to signal done.
+    let all_done = (1u64 << NUM_PRODUCERS) - 1;
+    let mut done_bits: u64 = 0;
+    while done_bits & all_done != all_done
+    {
+        done_bits |= signal_wait(done).unwrap_or(0);
+    }
+
+    // Verify every producer's full sequence arrived.
+    for (p_id, seen) in per_producer.iter().enumerate()
+    {
+        for (seq, &present) in seen.iter().enumerate()
+        {
+            if !present
+            {
+                crate::log_u64("concurrent_event_producers: missing producer=", p_id as u64);
+                crate::log_u64("concurrent_event_producers: missing seq=", seq as u64);
+                return Err("concurrent_event_producers: missing message");
+            }
+        }
+    }
+
+    for i in 0..NUM_PRODUCERS
+    {
+        cap_delete(threads[i]).ok();
+        cap_delete(cspaces[i]).ok();
+    }
+    cap_delete(eq).ok();
+    cap_delete(done).ok();
+    Ok(())
+}

--- a/core/ktest/src/stress/concurrent_ipc.rs
+++ b/core/ktest/src/stress/concurrent_ipc.rs
@@ -15,8 +15,12 @@ use syscall::{
 
 use crate::{ChildStack, TestContext, TestResult, spawn};
 
-const NUM_CALLERS: usize = 64;
-const CYCLES: usize = 200;
+/// 16 — see the kernel-side notes on `NUM_SENDERS` in
+/// `concurrent_signal.rs`. `CYCLES` is the pre-ramp baseline (in-tree
+/// experiments with `CYCLES=200` triggered the same follow-on hang in
+/// `cap_revoke_under_use`).
+const NUM_CALLERS: usize = 16;
+const CYCLES: usize = 50;
 
 // SEND + GRANT rights.
 const RIGHTS_SEND_GRANT: u64 = (1 << 4) | (1 << 6);

--- a/core/ktest/src/stress/concurrent_ipc.rs
+++ b/core/ktest/src/stress/concurrent_ipc.rs
@@ -8,11 +8,11 @@
 
 use ipc::IpcMessage;
 use syscall::{
-    cap_copy, cap_create_cspace, cap_create_endpoint, cap_create_signal, cap_create_thread,
-    cap_delete, signal_send, signal_wait, thread_configure, thread_exit, thread_start,
+    cap_copy, cap_create_endpoint, cap_create_signal, cap_delete, signal_send, signal_wait,
+    thread_exit,
 };
 
-use crate::{ChildStack, TestContext, TestResult};
+use crate::{ChildStack, TestContext, TestResult, spawn};
 
 const NUM_CALLERS: usize = 16;
 const CYCLES: usize = 50;
@@ -35,15 +35,12 @@ pub fn run(ctx: &TestContext) -> TestResult
         // Start all callers simultaneously (no yields between starts).
         for i in 0..NUM_CALLERS
         {
-            let cs = cap_create_cspace(ctx.memory_frame_base, 0, 4, 16)
-                .map_err(|_| "concurrent_ipc: create_cspace failed")?;
-            let child_ep = cap_copy(ep, cs, RIGHTS_SEND_GRANT)
+            let child =
+                spawn::new_child(ctx).map_err(|_| "concurrent_ipc: spawn::new_child failed")?;
+            let child_ep = cap_copy(ep, child.cs, RIGHTS_SEND_GRANT)
                 .map_err(|_| "concurrent_ipc: cap_copy ep failed")?;
-            let child_done =
-                cap_copy(done, cs, 1 << 7).map_err(|_| "concurrent_ipc: cap_copy done failed")?;
-
-            let th = cap_create_thread(ctx.memory_frame_base, ctx.aspace_cap, cs)
-                .map_err(|_| "concurrent_ipc: create_thread failed")?;
+            let child_done = cap_copy(done, child.cs, 1 << 7)
+                .map_err(|_| "concurrent_ipc: cap_copy done failed")?;
 
             // Pack: label = i+1 (1-based), done_bit = 1<<i (unique per child).
             let arg = u64::from(child_ep)
@@ -54,12 +51,11 @@ pub fn run(ctx: &TestContext) -> TestResult
             // SAFETY: Each caller uses a distinct stack index.
             let stack_top =
                 ChildStack::top(unsafe { core::ptr::addr_of!(super::STRESS_STACKS[i]) });
-            thread_configure(th, caller_entry as *const () as u64, stack_top, arg)
-                .map_err(|_| "concurrent_ipc: thread_configure failed")?;
-            thread_start(th).map_err(|_| "concurrent_ipc: thread_start failed")?;
+            spawn::configure_and_start(&child, caller_entry, stack_top, arg)
+                .map_err(|_| "concurrent_ipc: configure_and_start failed")?;
 
-            threads[i] = th;
-            cspaces[i] = cs;
+            threads[i] = child.th;
+            cspaces[i] = child.cs;
         }
 
         // Server: receive and reply to all callers.

--- a/core/ktest/src/stress/concurrent_ipc.rs
+++ b/core/ktest/src/stress/concurrent_ipc.rs
@@ -3,8 +3,9 @@
 
 //! Stress test: concurrent IPC endpoint races.
 //!
-//! 4 callers simultaneously block on one endpoint. The server drains all 4,
-//! verifying no callers are lost. Repeats for 10 cycles.
+//! `NUM_CALLERS` callers simultaneously block on one endpoint. The server
+//! drains all of them, verifying no caller is lost. Repeats for `CYCLES`
+//! cycles. Exercises the endpoint send-queue spinlock under contention.
 
 use ipc::IpcMessage;
 use syscall::{
@@ -14,8 +15,8 @@ use syscall::{
 
 use crate::{ChildStack, TestContext, TestResult, spawn};
 
-const NUM_CALLERS: usize = 16;
-const CYCLES: usize = 50;
+const NUM_CALLERS: usize = 64;
+const CYCLES: usize = 200;
 
 // SEND + GRANT rights.
 const RIGHTS_SEND_GRANT: u64 = (1 << 4) | (1 << 6);
@@ -42,11 +43,13 @@ pub fn run(ctx: &TestContext) -> TestResult
             let child_done = cap_copy(done, child.cs, 1 << 7)
                 .map_err(|_| "concurrent_ipc: cap_copy done failed")?;
 
-            // Pack: label = i+1 (1-based), done_bit = 1<<i (unique per child).
+            // Pack: ep_slot[15:0], done_slot[31:16], label=i+1 (1-based)[47:32],
+            // bit_index[55:48]. Encode bit index (not bit value) so it fits
+            // in 8 bits even for NUM_CALLERS up to 256.
             let arg = u64::from(child_ep)
                 | (u64::from(child_done) << 16)
                 | (((i + 1) as u64) << 32)
-                | ((1u64 << i) << 48);
+                | ((i as u64) << 48);
 
             // SAFETY: Each caller uses a distinct stack index.
             let stack_top =
@@ -59,22 +62,23 @@ pub fn run(ctx: &TestContext) -> TestResult
         }
 
         // Server: receive and reply to all callers.
-        let mut received_bitmap: u32 = 0;
+        let mut received_bitmap: u64 = 0;
         let reply = IpcMessage::new(0);
         for _ in 0..NUM_CALLERS
         {
             // SAFETY: ctx.ipc_buf is the registered per-thread IPC buffer.
             let msg = unsafe { ipc::ipc_recv(ep, ctx.ipc_buf) }
                 .map_err(|_| "concurrent_ipc: ipc_recv failed")?;
-            // Label values are 1..=NUM_CALLERS; fits in u32. Truncation is safe
-            // because we validate idx is in [1, NUM_CALLERS] immediately below.
+            let idx = msg.label;
+            // cast_possible_truncation: idx is bounded by NUM_CALLERS which
+            // fits in usize on every target ktest supports.
             #[allow(clippy::cast_possible_truncation)]
-            let idx = msg.label as u32;
-            if idx == 0 || idx as usize > NUM_CALLERS
+            let idx_us = idx as usize;
+            if idx == 0 || idx_us > NUM_CALLERS
             {
                 return Err("concurrent_ipc: received out-of-range label");
             }
-            let bit = 1u32 << (idx - 1);
+            let bit = 1u64 << (idx - 1);
             if received_bitmap & bit != 0
             {
                 return Err("concurrent_ipc: duplicate label received");
@@ -85,16 +89,24 @@ pub fn run(ctx: &TestContext) -> TestResult
                 .map_err(|_| "concurrent_ipc: ipc_reply failed")?;
         }
 
-        // Verify all callers received.
-        let expected = (1u32 << NUM_CALLERS) - 1;
+        // Verify all callers received. At NUM_CALLERS=64, this is the
+        // full u64 (`u64::MAX`); for smaller values, mask appropriately.
+        let expected: u64 = if NUM_CALLERS >= 64
+        {
+            u64::MAX
+        }
+        else
+        {
+            (1u64 << NUM_CALLERS) - 1
+        };
         if received_bitmap != expected
         {
             return Err("concurrent_ipc: not all callers received");
         }
 
         // Wait for all children to signal done. Each child sends a unique
-        // bit (1<<i), so we wait until all 4 bits are set.
-        let all_done = (1u64 << NUM_CALLERS) - 1;
+        // bit (1<<i), so we wait until every bit is set.
+        let all_done = expected;
         let mut done_bits: u64 = 0;
         while done_bits != all_done
         {
@@ -122,7 +134,8 @@ fn caller_entry(arg: u64) -> !
     let ep_slot = (arg & 0xFFFF) as u32;
     let done_slot = ((arg >> 16) & 0xFFFF) as u32;
     let label = (arg >> 32) & 0xFFFF;
-    let done_bit = arg >> 48;
+    let bit_index = (arg >> 48) & 0xFF;
+    let done_bit = 1u64 << bit_index;
 
     // Register the shared IPC buffer for this child thread.
     let buf_addr = core::ptr::addr_of_mut!(crate::IPC_BUF) as u64;

--- a/core/ktest/src/stress/concurrent_map_unmap.rs
+++ b/core/ktest/src/stress/concurrent_map_unmap.rs
@@ -14,8 +14,8 @@ use syscall::{
 
 use crate::{ChildStack, TestContext, TestResult, spawn};
 
-const NUM_CHILDREN: usize = 4;
-const MAP_ITERATIONS: usize = 200;
+const NUM_CHILDREN: usize = 16;
+const MAP_ITERATIONS: usize = 1000;
 
 /// Base VA for stress mappings, well above normal test VAs.
 const STRESS_MAP_BASE: u64 = 0x5000_0000;
@@ -79,8 +79,9 @@ pub fn run(ctx: &TestContext) -> TestResult
     {
         let bits = signal_wait(done).map_err(|_| "concurrent_map_unmap: signal_wait failed")?;
         done_bits |= bits;
-        // Bit 8 is our error indicator (not used by any done_bit since max is 1<<3).
-        if bits & (1 << 8) != 0
+        // Bit 32 is the error indicator (well clear of done_bit range for
+        // NUM_CHILDREN up to 32).
+        if bits & (1 << 32) != 0
         {
             child_failed = true;
         }
@@ -104,12 +105,11 @@ pub fn run(ctx: &TestContext) -> TestResult
 }
 
 /// Per-child VA, set by parent before starting each child.
-static VA_PER_CHILD: [core::sync::atomic::AtomicU64; NUM_CHILDREN] = [
-    core::sync::atomic::AtomicU64::new(0),
-    core::sync::atomic::AtomicU64::new(0),
-    core::sync::atomic::AtomicU64::new(0),
-    core::sync::atomic::AtomicU64::new(0),
-];
+static VA_PER_CHILD: [core::sync::atomic::AtomicU64; NUM_CHILDREN] = {
+    // const-fn loop is unstable in stable Rust; use a const block + manual
+    // population via array-init-by-fn idiom.
+    [const { core::sync::atomic::AtomicU64::new(0) }; NUM_CHILDREN]
+};
 
 // cast_possible_truncation: slot indices are kernel cap slots < 2^32.
 #[allow(clippy::cast_possible_truncation)]
@@ -128,8 +128,8 @@ fn mapper_entry(arg: u64) -> !
     {
         if mem_map(frame_cap, aspace, va, 0, 1, syscall::MAP_WRITABLE).is_err()
         {
-            // Send done_bit | error indicator (bit 8).
-            signal_send(done_slot, done_bit | (1 << 8)).ok();
+            // Send done_bit | error indicator (bit 32).
+            signal_send(done_slot, done_bit | (1 << 32)).ok();
             thread_exit();
         }
 
@@ -140,13 +140,13 @@ fn mapper_entry(arg: u64) -> !
         // ktest's own statics.
         if syscall::aspace_query(aspace, va).is_err()
         {
-            signal_send(done_slot, done_bit | (1 << 8)).ok();
+            signal_send(done_slot, done_bit | (1 << 32)).ok();
             thread_exit();
         }
 
         if mem_unmap(aspace, va, 1).is_err()
         {
-            signal_send(done_slot, done_bit | (1 << 8)).ok();
+            signal_send(done_slot, done_bit | (1 << 32)).ok();
             thread_exit();
         }
     }

--- a/core/ktest/src/stress/concurrent_map_unmap.rs
+++ b/core/ktest/src/stress/concurrent_map_unmap.rs
@@ -8,11 +8,11 @@
 //! shootdown under load.
 
 use syscall::{
-    cap_copy, cap_create_cspace, cap_create_signal, cap_create_thread, cap_delete, mem_map,
-    mem_unmap, signal_send, signal_wait, thread_configure, thread_exit, thread_start,
+    cap_copy, cap_create_signal, cap_delete, mem_map, mem_unmap, signal_send, signal_wait,
+    thread_exit,
 };
 
-use crate::{ChildStack, TestContext, TestResult};
+use crate::{ChildStack, TestContext, TestResult, spawn};
 
 const NUM_CHILDREN: usize = 4;
 const MAP_ITERATIONS: usize = 200;
@@ -40,18 +40,15 @@ pub fn run(ctx: &TestContext) -> TestResult
     let mut cspaces = [0u32; NUM_CHILDREN];
     for i in 0..NUM_CHILDREN
     {
-        let cs = cap_create_cspace(ctx.memory_frame_base, 0, 4, 16)
-            .map_err(|_| "concurrent_map_unmap: create_cspace failed")?;
-        let child_done =
-            cap_copy(done, cs, 1 << 7).map_err(|_| "concurrent_map_unmap: cap_copy done failed")?;
+        let child =
+            spawn::new_child(ctx).map_err(|_| "concurrent_map_unmap: spawn::new_child failed")?;
+        let child_done = cap_copy(done, child.cs, 1 << 7)
+            .map_err(|_| "concurrent_map_unmap: cap_copy done failed")?;
         // Copy frame and aspace caps into child's CSpace with full rights.
-        let child_frame = cap_copy(frames[i], cs, syscall::RIGHTS_ALL)
+        let child_frame = cap_copy(frames[i], child.cs, syscall::RIGHTS_ALL)
             .map_err(|_| "concurrent_map_unmap: cap_copy frame failed")?;
-        let child_aspace = cap_copy(ctx.aspace_cap, cs, syscall::RIGHTS_ALL)
+        let child_aspace = cap_copy(ctx.aspace_cap, child.cs, syscall::RIGHTS_ALL)
             .map_err(|_| "concurrent_map_unmap: cap_copy aspace failed")?;
-
-        let th = cap_create_thread(ctx.memory_frame_base, ctx.aspace_cap, cs)
-            .map_err(|_| "concurrent_map_unmap: create_thread failed")?;
 
         let done_bit = 1u64 << i;
         let va = STRESS_MAP_BASE + (i as u64) * VA_STRIDE;
@@ -61,19 +58,17 @@ pub fn run(ctx: &TestContext) -> TestResult
             | (u64::from(child_aspace) << 32)
             | (done_bit << 48);
 
-        // SAFETY: Each child uses a distinct stack index.
-        let stack_top = ChildStack::top(unsafe { core::ptr::addr_of!(super::STRESS_STACKS[i]) });
-        thread_configure(th, mapper_entry as *const () as u64, stack_top, arg)
-            .map_err(|_| "concurrent_map_unmap: thread_configure failed")?;
-
         // Set the VA for this child via a static. Children read it from
         // a shared array indexed by child_frame slot (deterministic mapping).
         VA_PER_CHILD[i].store(va, core::sync::atomic::Ordering::Release);
 
-        thread_start(th).map_err(|_| "concurrent_map_unmap: thread_start failed")?;
+        // SAFETY: Each child uses a distinct stack index.
+        let stack_top = ChildStack::top(unsafe { core::ptr::addr_of!(super::STRESS_STACKS[i]) });
+        spawn::configure_and_start(&child, mapper_entry, stack_top, arg)
+            .map_err(|_| "concurrent_map_unmap: configure_and_start failed")?;
 
-        threads[i] = th;
-        cspaces[i] = cs;
+        threads[i] = child.th;
+        cspaces[i] = child.cs;
     }
 
     // Wait for all children. Each child sends a unique bit (1<<i).

--- a/core/ktest/src/stress/concurrent_map_unmap.rs
+++ b/core/ktest/src/stress/concurrent_map_unmap.rs
@@ -14,8 +14,12 @@ use syscall::{
 
 use crate::{ChildStack, TestContext, TestResult, spawn};
 
-const NUM_CHILDREN: usize = 16;
-const MAP_ITERATIONS: usize = 1000;
+/// 4 — pre-ramp baseline. See `concurrent_signal.rs::NUM_SENDERS` for
+/// kernel-side reasons we cap per-test concurrency at the pre-ramp
+/// baseline. Iteration count is also baseline; in-tree experiments with
+/// `MAP_ITERATIONS=1000` triggered the same follow-on hang.
+const NUM_CHILDREN: usize = 4;
+const MAP_ITERATIONS: usize = 200;
 
 /// Base VA for stress mappings, well above normal test VAs.
 const STRESS_MAP_BASE: u64 = 0x5000_0000;

--- a/core/ktest/src/stress/concurrent_signal.rs
+++ b/core/ktest/src/stress/concurrent_signal.rs
@@ -11,24 +11,31 @@ use syscall::{cap_copy, cap_create_signal, cap_delete, signal_send, signal_wait,
 
 use crate::{ChildStack, TestContext, TestResult, spawn};
 
-const NUM_SENDERS: usize = 64;
-const SEND_ITERATIONS: u64 = 5000;
+/// 16 — pre-ramp baseline. Two separate kernel-side issues block
+/// ramping this further in-tree:
+///
+/// 1. Bit 63 of `SYS_SIGNAL_WAIT`'s returned bitmask aliases with the
+///    dispatcher's `cast_signed()` Err encoding, so per-bit accounting
+///    tops out at 63 distinct workers.
+/// 2. Above ~16-32 concurrently runnable spinning syscall threads on
+///    4-CPU SMP, follow-on tests (notably `cap_revoke_under_use`)
+///    observe scheduler-fairness starvation. Until the kernel is
+///    fixed, we keep this constant at the pre-ramp baseline so
+///    downstream stress tests aren't compromised.
+///
+/// Iteration count is the pre-ramp baseline; in-tree experiments showed
+/// the ramped 5000-iter variant left follow-on tests in a degraded state
+/// (notably `cap_revoke_under_use` hangs even at its own NUM=16). Filed
+/// separately; revisit once the kernel-side fairness issue is resolved.
+const NUM_SENDERS: usize = 16;
+const SEND_ITERATIONS: u64 = 2000;
 
-/// Each sender ORs its unique bit (`1 << i`) once per iteration. The
-/// signal's bit width is 64; one sender per bit saturates the bitmask.
-const fn sender_bits() -> [u64; NUM_SENDERS]
-{
-    let mut bits = [0u64; NUM_SENDERS];
-    let mut i = 0;
-    while i < NUM_SENDERS
-    {
-        bits[i] = 1u64 << i;
-        i += 1;
-    }
-    bits
-}
-const SENDER_BITS: [u64; NUM_SENDERS] = sender_bits();
-const ALL_BITS: u64 = u64::MAX;
+/// Each sender ORs its unique bit (`1 << i`) once per iteration.
+const SENDER_BITS: [u64; NUM_SENDERS] = [
+    0x1, 0x2, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80, 0x100, 0x200, 0x400, 0x800, 0x1000, 0x2000, 0x4000,
+    0x8000,
+];
+const ALL_BITS: u64 = 0xFFFF;
 
 pub fn run(ctx: &TestContext) -> TestResult
 {

--- a/core/ktest/src/stress/concurrent_signal.rs
+++ b/core/ktest/src/stress/concurrent_signal.rs
@@ -7,12 +7,9 @@
 //! The parent waits for all children to finish, then verifies all bit patterns
 //! arrived in the accumulated signal state.
 
-use syscall::{
-    cap_copy, cap_create_cspace, cap_create_signal, cap_create_thread, cap_delete, signal_send,
-    signal_wait, thread_configure, thread_exit, thread_start,
-};
+use syscall::{cap_copy, cap_create_signal, cap_delete, signal_send, signal_wait, thread_exit};
 
-use crate::{ChildStack, TestContext, TestResult};
+use crate::{ChildStack, TestContext, TestResult, spawn};
 
 const NUM_SENDERS: usize = 16;
 const SEND_ITERATIONS: u64 = 2000;
@@ -37,28 +34,24 @@ pub fn run(ctx: &TestContext) -> TestResult
 
     for i in 0..NUM_SENDERS
     {
-        let cs = cap_create_cspace(ctx.memory_frame_base, 0, 4, 16)
-            .map_err(|_| "concurrent_signal: create_cspace failed")?;
+        let child =
+            spawn::new_child(ctx).map_err(|_| "concurrent_signal: spawn::new_child failed")?;
         // Child needs SIGNAL right on target and done.
-        let child_target = cap_copy(target, cs, 1 << 7)
+        let child_target = cap_copy(target, child.cs, 1 << 7)
             .map_err(|_| "concurrent_signal: cap_copy target failed")?;
-        let child_done =
-            cap_copy(done, cs, 1 << 7).map_err(|_| "concurrent_signal: cap_copy done failed")?;
-
-        let th = cap_create_thread(ctx.memory_frame_base, ctx.aspace_cap, cs)
-            .map_err(|_| "concurrent_signal: create_thread failed")?;
+        let child_done = cap_copy(done, child.cs, 1 << 7)
+            .map_err(|_| "concurrent_signal: cap_copy done failed")?;
 
         // Pack: bits[15:0]=target_slot, bits[31:16]=done_slot, bits[47:32]=bit_index
         let arg = u64::from(child_target) | (u64::from(child_done) << 16) | ((i as u64) << 32);
 
         // SAFETY: Sequential setup; each child gets a unique stack index.
         let stack_top = ChildStack::top(unsafe { core::ptr::addr_of!(super::STRESS_STACKS[i]) });
-        thread_configure(th, sender_entry as *const () as u64, stack_top, arg)
-            .map_err(|_| "concurrent_signal: thread_configure failed")?;
-        thread_start(th).map_err(|_| "concurrent_signal: thread_start failed")?;
+        spawn::configure_and_start(&child, sender_entry, stack_top, arg)
+            .map_err(|_| "concurrent_signal: configure_and_start failed")?;
 
-        threads[i] = th;
-        cspaces[i] = cs;
+        threads[i] = child.th;
+        cspaces[i] = child.cs;
     }
 
     // Wait for all senders to report done. Each child ORs a unique bit into

--- a/core/ktest/src/stress/concurrent_signal.rs
+++ b/core/ktest/src/stress/concurrent_signal.rs
@@ -3,23 +3,32 @@
 
 //! Stress test: concurrent signal send/wait races.
 //!
-//! 4 child threads simultaneously send distinct bit patterns to the same signal.
-//! The parent waits for all children to finish, then verifies all bit patterns
-//! arrived in the accumulated signal state.
+//! `NUM_SENDERS` child threads simultaneously send distinct bit patterns
+//! to the same signal. The parent waits for all children to finish, then
+//! verifies every bit pattern arrived in the accumulated signal state.
 
 use syscall::{cap_copy, cap_create_signal, cap_delete, signal_send, signal_wait, thread_exit};
 
 use crate::{ChildStack, TestContext, TestResult, spawn};
 
-const NUM_SENDERS: usize = 16;
-const SEND_ITERATIONS: u64 = 2000;
+const NUM_SENDERS: usize = 64;
+const SEND_ITERATIONS: u64 = 5000;
 
-/// Each sender ORs its unique bit once per iteration.
-const SENDER_BITS: [u64; NUM_SENDERS] = [
-    0x1, 0x2, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80, 0x100, 0x200, 0x400, 0x800, 0x1000, 0x2000, 0x4000,
-    0x8000,
-];
-const ALL_BITS: u64 = 0xFFFF;
+/// Each sender ORs its unique bit (`1 << i`) once per iteration. The
+/// signal's bit width is 64; one sender per bit saturates the bitmask.
+const fn sender_bits() -> [u64; NUM_SENDERS]
+{
+    let mut bits = [0u64; NUM_SENDERS];
+    let mut i = 0;
+    while i < NUM_SENDERS
+    {
+        bits[i] = 1u64 << i;
+        i += 1;
+    }
+    bits
+}
+const SENDER_BITS: [u64; NUM_SENDERS] = sender_bits();
+const ALL_BITS: u64 = u64::MAX;
 
 pub fn run(ctx: &TestContext) -> TestResult
 {

--- a/core/ktest/src/stress/event_queue_fill_drain.rs
+++ b/core/ktest/src/stress/event_queue_fill_drain.rs
@@ -12,7 +12,7 @@ use syscall_abi::SyscallError;
 use crate::{TestContext, TestResult};
 
 const CAPACITY: u32 = 8;
-const CYCLES: usize = 200;
+const CYCLES: usize = 2000;
 
 pub fn run(ctx: &TestContext) -> TestResult
 {

--- a/core/ktest/src/stress/event_queue_fill_drain.rs
+++ b/core/ktest/src/stress/event_queue_fill_drain.rs
@@ -12,7 +12,7 @@ use syscall_abi::SyscallError;
 use crate::{TestContext, TestResult};
 
 const CAPACITY: u32 = 8;
-const CYCLES: usize = 2000;
+const CYCLES: usize = 200;
 
 pub fn run(ctx: &TestContext) -> TestResult
 {

--- a/core/ktest/src/stress/fpu_migration_churn.rs
+++ b/core/ktest/src/stress/fpu_migration_churn.rs
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+//! Stress: FPU + scheduler-migration churn.
+//!
+//! Runs the cross-CPU FPU preservation pattern (`unit::fpu::
+//! preempt_isolation_cross_cpu`) in a tight loop. Each iteration:
+//!
+//! 1. Mints a fresh thread, pins to CPU 0.
+//! 2. Child loads `PATTERN_A` into the entire extended-state register file
+//!    (`xmm0..xmm15` on `x86_64`; `f0..f31` on `riscv64`).
+//! 3. Child becomes `fpu_owner` of CPU 0, blocks on a signal.
+//! 4. Parent flips affinity to CPU 1 and wakes the child.
+//! 5. Child resumes (potentially on CPU 1), captures register file,
+//!    asserts no mismatch.
+//!
+//! The single-cycle version of this test (in `unit/fpu.rs`) catches the
+//! commit-`bd22687` regression on cold caches; this stress version
+//! exercises ~100 cycles to widen the race window for any residual
+//! eager-save / lazy-restore inconsistency under load.
+//!
+//! Skipped when `cpu_count < 2` (UP boot has nothing to migrate across).
+
+use syscall_abi::SystemInfoType;
+
+use crate::{TestContext, TestResult};
+
+const CYCLES: u32 = 100;
+
+pub fn run(ctx: &TestContext) -> TestResult
+{
+    let cpus = syscall::system_info(SystemInfoType::CpuCount as u64)
+        .map_err(|_| "stress::fpu_migration_churn: system_info(CpuCount) failed")?;
+    if cpus < 2
+    {
+        crate::log("ktest: stress::fpu_migration_churn SKIP (requires SMP)");
+        return Ok(());
+    }
+
+    for i in 0..CYCLES
+    {
+        crate::unit::fpu::preempt_isolation_cross_cpu(ctx).map_err(|_| {
+            // Log which iteration failed so failures are bisectable on the
+            // boot log.
+            crate::log_u64(
+                "stress::fpu_migration_churn: failure at iter=",
+                u64::from(i),
+            );
+            "stress::fpu_migration_churn: preempt_isolation_cross_cpu failed in churn"
+        })?;
+    }
+    Ok(())
+}

--- a/core/ktest/src/stress/idle_wake_race.rs
+++ b/core/ktest/src/stress/idle_wake_race.rs
@@ -35,7 +35,7 @@ use crate::{ChildStack, TestContext, TestResult};
 /// High enough to reliably catch a race that only manifests under a small
 /// timing window; low enough to run in well under a second on a healthy
 /// kernel (each iteration is sub-millisecond).
-const ITERATIONS: u32 = 50_000;
+const ITERATIONS: u32 = 10_000;
 
 /// Per-iteration outlier threshold, in microseconds.
 ///

--- a/core/ktest/src/stress/idle_wake_race.rs
+++ b/core/ktest/src/stress/idle_wake_race.rs
@@ -24,8 +24,7 @@
 //! Requires ≥ 2 CPUs. On UP configs, logs "SKIP" and passes trivially.
 
 use syscall::{
-    cap_copy, cap_create_cspace, cap_create_signal, cap_create_thread, cap_delete, signal_send,
-    signal_wait, system_info, thread_configure, thread_exit, thread_set_affinity, thread_start,
+    cap_copy, cap_create_signal, cap_delete, signal_send, signal_wait, system_info, thread_exit,
 };
 use syscall_abi::SystemInfoType;
 
@@ -93,32 +92,26 @@ pub fn run(ctx: &TestContext) -> TestResult
     let c2p = cap_create_signal(ctx.memory_frame_base)
         .map_err(|_| "stress::idle_wake_race: cap_create_signal (c2p) failed")?;
 
-    let cs = cap_create_cspace(ctx.memory_frame_base, 0, 4, 16)
-        .map_err(|_| "stress::idle_wake_race: cap_create_cspace failed")?;
+    let child = crate::spawn::new_child(ctx)
+        .map_err(|_| "stress::idle_wake_race: spawn::new_child failed")?;
 
-    let child_p2c = cap_copy(p2c, cs, RIGHTS_SIGNAL_WAIT)
+    let child_p2c = cap_copy(p2c, child.cs, RIGHTS_SIGNAL_WAIT)
         .map_err(|_| "stress::idle_wake_race: cap_copy (p2c) failed")?;
-    let child_c2p = cap_copy(c2p, cs, RIGHTS_SIGNAL_WAIT)
+    let child_c2p = cap_copy(c2p, child.cs, RIGHTS_SIGNAL_WAIT)
         .map_err(|_| "stress::idle_wake_race: cap_copy (c2p) failed")?;
 
     // SAFETY: single-threaded at this point; child not yet started.
     unsafe { CHILD_C2P_SLOT = child_c2p };
 
-    let th = cap_create_thread(ctx.memory_frame_base, ctx.aspace_cap, cs)
-        .map_err(|_| "stress::idle_wake_race: cap_create_thread failed")?;
-
     let stack_top = ChildStack::top(core::ptr::addr_of!(CHILD_STACK));
-    thread_configure(
-        th,
-        worker_entry as *const () as u64,
+    crate::spawn::configure_and_start_pinned(
+        &child,
+        worker_entry,
         stack_top,
         u64::from(child_p2c),
+        1,
     )
-    .map_err(|_| "stress::idle_wake_race: thread_configure failed")?;
-
-    thread_set_affinity(th, 1).map_err(|_| "stress::idle_wake_race: thread_set_affinity failed")?;
-
-    thread_start(th).map_err(|_| "stress::idle_wake_race: thread_start failed")?;
+    .map_err(|_| "stress::idle_wake_race: configure_and_start_pinned failed")?;
 
     // Wait for worker to reach its signal_wait loop.
     let ready =
@@ -198,8 +191,8 @@ pub fn run(ctx: &TestContext) -> TestResult
         signal_wait(c2p).map_err(|_| "stress::idle_wake_race: signal_wait (final ack) failed")?;
 
     // Cleanup.
-    cap_delete(th).map_err(|_| "stress::idle_wake_race: cap_delete (thread) failed")?;
-    cap_delete(cs).map_err(|_| "stress::idle_wake_race: cap_delete (cspace) failed")?;
+    cap_delete(child.th).map_err(|_| "stress::idle_wake_race: cap_delete (thread) failed")?;
+    cap_delete(child.cs).map_err(|_| "stress::idle_wake_race: cap_delete (cspace) failed")?;
     cap_delete(p2c).map_err(|_| "stress::idle_wake_race: cap_delete (p2c) failed")?;
     cap_delete(c2p).map_err(|_| "stress::idle_wake_race: cap_delete (c2p) failed")?;
 

--- a/core/ktest/src/stress/idle_wake_race.rs
+++ b/core/ktest/src/stress/idle_wake_race.rs
@@ -35,7 +35,7 @@ use crate::{ChildStack, TestContext, TestResult};
 /// High enough to reliably catch a race that only manifests under a small
 /// timing window; low enough to run in well under a second on a healthy
 /// kernel (each iteration is sub-millisecond).
-const ITERATIONS: u32 = 10_000;
+const ITERATIONS: u32 = 50_000;
 
 /// Per-iteration outlier threshold, in microseconds.
 ///

--- a/core/ktest/src/stress/mod.rs
+++ b/core/ktest/src/stress/mod.rs
@@ -33,7 +33,14 @@ mod thread_churn;
 use crate::{ChildStack, TestContext, run_integration_test};
 
 /// Maximum concurrent child threads across all stress tests.
-const MAX_STRESS_THREADS: usize = 16;
+///
+/// 64 matches the width of the `u64` signal bitmask used by tests that
+/// allocate one bit per worker (`concurrent_signal`, `retype_concurrent`,
+/// `cap_revoke_under_use`). Bumping past 64 requires refactoring those
+/// tests to use an atomic-counter ledger instead of one bit per worker.
+/// 64 × 16 KiB `ChildStack` = 1 MiB BSS — fits comfortably in ktest's
+/// segment caps.
+const MAX_STRESS_THREADS: usize = 64;
 
 /// Shared child stacks for stress tests. Tests run sequentially so stacks
 /// are never aliased.

--- a/core/ktest/src/stress/mod.rs
+++ b/core/ktest/src/stress/mod.rs
@@ -5,6 +5,11 @@
 
 //! Tier S — Stress and torture tests.
 //!
+//! Rule (durable):
+//!
+//! > **One file per race / resource invariant under stress. New race
+//! > class ⇒ new file.**
+//!
 //! These tests exercise race conditions, resource exhaustion, deep capability
 //! trees, and concurrent operations. They are **not** run by default; enable
 //! them with `ktest.filter=stress` in the kernel command line.

--- a/core/ktest/src/stress/mod.rs
+++ b/core/ktest/src/stress/mod.rs
@@ -20,10 +20,12 @@
 mod cap_delete_running;
 mod cap_revoke_under_use;
 mod cap_tree_deep;
+mod concurrent_event_producers;
 mod concurrent_ipc;
 mod concurrent_map_unmap;
 mod concurrent_signal;
 mod event_queue_fill_drain;
+mod fpu_migration_churn;
 mod idle_wake_race;
 mod retype_concurrent;
 mod thread_churn;
@@ -61,4 +63,9 @@ pub fn run_all(ctx: &TestContext)
         concurrent_map_unmap::run(ctx)
     );
     run_integration_test!("stress::retype_concurrent", retype_concurrent::run(ctx));
+    run_integration_test!("stress::fpu_migration_churn", fpu_migration_churn::run(ctx));
+    run_integration_test!(
+        "stress::concurrent_event_producers",
+        concurrent_event_producers::run(ctx)
+    );
 }

--- a/core/ktest/src/stress/retype_concurrent.rs
+++ b/core/ktest/src/stress/retype_concurrent.rs
@@ -24,21 +24,13 @@ use syscall_abi::CAP_INFO_FRAME_AVAILABLE;
 
 use crate::{ChildStack, TestContext, TestResult};
 
-const NUM_WORKERS: usize = 64;
-const ITERS_PER_WORKER: u64 = 1000;
-const ALL_BITS: u64 = u64::MAX;
-const fn worker_bits() -> [u64; NUM_WORKERS]
-{
-    let mut bits = [0u64; NUM_WORKERS];
-    let mut i = 0;
-    while i < NUM_WORKERS
-    {
-        bits[i] = 1u64 << i;
-        i += 1;
-    }
-    bits
-}
-const WORKER_BIT: [u64; NUM_WORKERS] = worker_bits();
+/// 8 — pre-ramp baseline. See `concurrent_signal.rs::NUM_SENDERS` for
+/// the kernel-side scaling pathologies that block ramping per-worker
+/// counts further in-tree. Iteration count was ramped (was 200).
+const NUM_WORKERS: usize = 8;
+const ITERS_PER_WORKER: u64 = 200;
+const ALL_BITS: u64 = 0xFF;
+const WORKER_BIT: [u64; NUM_WORKERS] = [0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80];
 
 pub fn run(ctx: &TestContext) -> TestResult
 {

--- a/core/ktest/src/stress/retype_concurrent.rs
+++ b/core/ktest/src/stress/retype_concurrent.rs
@@ -24,10 +24,21 @@ use syscall_abi::CAP_INFO_FRAME_AVAILABLE;
 
 use crate::{ChildStack, TestContext, TestResult};
 
-const NUM_WORKERS: usize = 8;
-const ITERS_PER_WORKER: u64 = 200;
-const ALL_BITS: u64 = 0xFF;
-const WORKER_BIT: [u64; NUM_WORKERS] = [0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80];
+const NUM_WORKERS: usize = 64;
+const ITERS_PER_WORKER: u64 = 1000;
+const ALL_BITS: u64 = u64::MAX;
+const fn worker_bits() -> [u64; NUM_WORKERS]
+{
+    let mut bits = [0u64; NUM_WORKERS];
+    let mut i = 0;
+    while i < NUM_WORKERS
+    {
+        bits[i] = 1u64 << i;
+        i += 1;
+    }
+    bits
+}
+const WORKER_BIT: [u64; NUM_WORKERS] = worker_bits();
 
 pub fn run(ctx: &TestContext) -> TestResult
 {

--- a/core/ktest/src/stress/thread_churn.rs
+++ b/core/ktest/src/stress/thread_churn.rs
@@ -10,7 +10,7 @@ use syscall::{cap_copy, cap_create_signal, cap_delete, signal_send, signal_wait,
 
 use crate::{ChildStack, TestContext, TestResult, spawn};
 
-const ITERATIONS: usize = 100;
+const ITERATIONS: usize = 1000;
 
 pub fn run(ctx: &TestContext) -> TestResult
 {

--- a/core/ktest/src/stress/thread_churn.rs
+++ b/core/ktest/src/stress/thread_churn.rs
@@ -6,12 +6,9 @@
 //! Creates and destroys 20 threads sequentially, verifying that kernel
 //! resource cleanup (TCBs, `CSpace` refcounts) works correctly under churn.
 
-use syscall::{
-    cap_copy, cap_create_cspace, cap_create_signal, cap_create_thread, cap_delete, signal_send,
-    signal_wait, thread_configure, thread_exit, thread_start,
-};
+use syscall::{cap_copy, cap_create_signal, cap_delete, signal_send, signal_wait, thread_exit};
 
-use crate::{ChildStack, TestContext, TestResult};
+use crate::{ChildStack, TestContext, TestResult, spawn};
 
 const ITERATIONS: usize = 100;
 
@@ -22,22 +19,14 @@ pub fn run(ctx: &TestContext) -> TestResult
 
     for _i in 0..ITERATIONS
     {
-        let cs = cap_create_cspace(ctx.memory_frame_base, 0, 4, 16)
-            .map_err(|_| "thread_churn: create_cspace failed")?;
-        let child_done = cap_copy(done, cs, 1 << 7).map_err(|_| "thread_churn: cap_copy failed")?;
-        let th = cap_create_thread(ctx.memory_frame_base, ctx.aspace_cap, cs)
-            .map_err(|_| "thread_churn: create_thread failed")?;
+        let child = spawn::new_child(ctx).map_err(|_| "thread_churn: spawn::new_child failed")?;
+        let child_done =
+            cap_copy(done, child.cs, 1 << 7).map_err(|_| "thread_churn: cap_copy failed")?;
 
         // SAFETY: Sequential execution; only one child uses STRESS_STACKS[0] at a time.
         let stack_top = ChildStack::top(unsafe { core::ptr::addr_of!(super::STRESS_STACKS[0]) });
-        thread_configure(
-            th,
-            churn_entry as *const () as u64,
-            stack_top,
-            u64::from(child_done),
-        )
-        .map_err(|_| "thread_churn: thread_configure failed")?;
-        thread_start(th).map_err(|_| "thread_churn: thread_start failed")?;
+        spawn::configure_and_start(&child, churn_entry, stack_top, u64::from(child_done))
+            .map_err(|_| "thread_churn: configure_and_start failed")?;
 
         // Wait for child to complete.
         let bits = signal_wait(done).map_err(|_| "thread_churn: signal_wait failed")?;
@@ -46,8 +35,8 @@ pub fn run(ctx: &TestContext) -> TestResult
             return Err("thread_churn: child sent unexpected bits");
         }
 
-        cap_delete(th).map_err(|_| "thread_churn: cap_delete thread failed")?;
-        cap_delete(cs).map_err(|_| "thread_churn: cap_delete cspace failed")?;
+        cap_delete(child.th).map_err(|_| "thread_churn: cap_delete thread failed")?;
+        cap_delete(child.cs).map_err(|_| "thread_churn: cap_delete cspace failed")?;
     }
 
     cap_delete(done).map_err(|_| "thread_churn: cap_delete done failed")?;

--- a/core/ktest/src/stress/thread_churn.rs
+++ b/core/ktest/src/stress/thread_churn.rs
@@ -10,7 +10,7 @@ use syscall::{cap_copy, cap_create_signal, cap_delete, signal_send, signal_wait,
 
 use crate::{ChildStack, TestContext, TestResult, spawn};
 
-const ITERATIONS: usize = 1000;
+const ITERATIONS: usize = 100;
 
 pub fn run(ctx: &TestContext) -> TestResult
 {

--- a/core/ktest/src/unit/cap.rs
+++ b/core/ktest/src/unit/cap.rs
@@ -14,8 +14,8 @@
 
 use syscall::{
     cap_copy, cap_create_aspace, cap_create_cspace, cap_create_endpoint, cap_create_signal,
-    cap_create_thread, cap_delete, cap_derive, cap_derive_token, cap_insert, cap_move, cap_revoke,
-    event_queue_create, signal_send, signal_wait,
+    cap_delete, cap_derive, cap_derive_token, cap_insert, cap_move, cap_revoke, event_queue_create,
+    signal_send, signal_wait,
 };
 use syscall_abi::SyscallError;
 
@@ -85,12 +85,10 @@ pub fn create_aspace(ctx: &TestContext) -> TestResult
 pub fn create_thread(ctx: &TestContext) -> TestResult
 {
     // Thread needs both an address space and a cspace to be bound to.
-    let cs = cap_create_cspace(ctx.memory_frame_base, 0, 4, 16)
-        .map_err(|_| "cap_create_cspace for thread test failed")?;
-    let th = cap_create_thread(ctx.memory_frame_base, ctx.aspace_cap, cs)
-        .map_err(|_| "cap_create_thread failed")?;
-    cap_delete(th).map_err(|_| "cap_delete thread failed")?;
-    cap_delete(cs).map_err(|_| "cap_delete cspace failed")?;
+    // `spawn::new_child` mints both via `cap_create_cspace` + `cap_create_thread`.
+    let child = crate::spawn::new_child(ctx).map_err(|_| "spawn::new_child failed")?;
+    cap_delete(child.th).map_err(|_| "cap_delete thread failed")?;
+    cap_delete(child.cs).map_err(|_| "cap_delete cspace failed")?;
     Ok(())
 }
 

--- a/core/ktest/src/unit/event.rs
+++ b/core/ktest/src/unit/event.rs
@@ -11,9 +11,9 @@
 //! blocks only when the queue is empty. We pre-fill queues before receiving.
 
 use syscall::{
-    cap_copy, cap_create_cspace, cap_create_signal, cap_create_thread, cap_delete, event_post,
-    event_queue_create, event_recv, event_recv_timeout, event_try_recv, signal_send, signal_wait,
-    system_info, thread_configure, thread_exit, thread_sleep, thread_start, thread_yield,
+    cap_copy, cap_create_signal, cap_delete, event_post, event_queue_create, event_recv,
+    event_recv_timeout, event_try_recv, signal_send, signal_wait, system_info, thread_exit,
+    thread_sleep, thread_yield,
 };
 use syscall_abi::{SyscallError, SystemInfoType};
 
@@ -108,24 +108,15 @@ pub fn recv_blocks_until_post(ctx: &TestContext) -> TestResult
     let sync = cap_create_signal(ctx.memory_frame_base)
         .map_err(|_| "cap_create_signal for sync failed")?;
 
-    let cs = cap_create_cspace(ctx.memory_frame_base, 0, 4, 16)
-        .map_err(|_| "cap_create_cspace failed")?;
+    let child = crate::spawn::new_child(ctx).map_err(|_| "spawn::new_child failed")?;
     // Pass all rights for the queue; SIGNAL right for the sync signal.
-    let child_eq = cap_copy(eq, cs, syscall::RIGHTS_ALL).map_err(|_| "cap_copy eq failed")?;
-    let child_sync = cap_copy(sync, cs, 1 << 7).map_err(|_| "cap_copy sync failed")?;
+    let child_eq = cap_copy(eq, child.cs, syscall::RIGHTS_ALL).map_err(|_| "cap_copy eq failed")?;
+    let child_sync = cap_copy(sync, child.cs, 1 << 7).map_err(|_| "cap_copy sync failed")?;
     let child_arg = u64::from(child_eq) | (u64::from(child_sync) << 16);
 
-    let th = cap_create_thread(ctx.memory_frame_base, ctx.aspace_cap, cs)
-        .map_err(|_| "cap_create_thread failed")?;
     let stack_top = ChildStack::top(core::ptr::addr_of!(RECV_BLOCKS_STACK));
-    thread_configure(
-        th,
-        recv_and_report_entry as *const () as u64,
-        stack_top,
-        child_arg,
-    )
-    .map_err(|_| "thread_configure failed")?;
-    thread_start(th).map_err(|_| "thread_start failed")?;
+    crate::spawn::configure_and_start(&child, recv_and_report_entry, stack_top, child_arg)
+        .map_err(|_| "configure_and_start failed")?;
 
     // Yield to let the child run and block on event_recv (queue is empty).
     thread_yield().map_err(|_| "thread_yield failed")?;
@@ -140,10 +131,10 @@ pub fn recv_blocks_until_post(ctx: &TestContext) -> TestResult
         return Err("child received wrong event payload (expected 0x42)");
     }
 
-    cap_delete(th).ok();
+    cap_delete(child.th).ok();
     cap_delete(eq).ok();
     cap_delete(sync).ok();
-    cap_delete(cs).ok();
+    cap_delete(child.cs).ok();
     Ok(())
 }
 
@@ -265,23 +256,14 @@ pub fn recv_timeout_payload_zero_wins(ctx: &TestContext) -> TestResult
 {
     let eq = event_queue_create(ctx.memory_frame_base, 4)
         .map_err(|_| "event_queue_create for zero-payload test failed")?;
-    let cs = cap_create_cspace(ctx.memory_frame_base, 0, 4, 16)
-        .map_err(|_| "cap_create_cspace failed")?;
-    let child_eq = cap_copy(eq, cs, syscall::RIGHTS_ALL).map_err(|_| "cap_copy eq failed")?;
+    let child = crate::spawn::new_child(ctx).map_err(|_| "spawn::new_child failed")?;
+    let child_eq = cap_copy(eq, child.cs, syscall::RIGHTS_ALL).map_err(|_| "cap_copy eq failed")?;
     // Encode the post payload as 0; the child will sleep ~10 ms, then post 0.
     let child_arg = u64::from(child_eq);
 
-    let th = cap_create_thread(ctx.memory_frame_base, ctx.aspace_cap, cs)
-        .map_err(|_| "cap_create_thread failed")?;
     let stack_top = ChildStack::top(core::ptr::addr_of!(TIMEOUT_ZERO_PAYLOAD_STACK));
-    thread_configure(
-        th,
-        post_zero_after_sleep_entry as *const () as u64,
-        stack_top,
-        child_arg,
-    )
-    .map_err(|_| "thread_configure failed")?;
-    thread_start(th).map_err(|_| "thread_start failed")?;
+    crate::spawn::configure_and_start(&child, post_zero_after_sleep_entry, stack_top, child_arg)
+        .map_err(|_| "configure_and_start failed")?;
 
     // Wait up to 1 s for the child's post; 0 is the legitimate payload.
     let payload = event_recv_timeout(eq, 1000)
@@ -291,9 +273,9 @@ pub fn recv_timeout_payload_zero_wins(ctx: &TestContext) -> TestResult
         return Err("event_recv_timeout returned wrong payload (expected legitimate 0)");
     }
 
-    cap_delete(th).ok();
+    cap_delete(child.th).ok();
     cap_delete(eq).ok();
-    cap_delete(cs).ok();
+    cap_delete(child.cs).ok();
     Ok(())
 }
 
@@ -303,22 +285,13 @@ pub fn recv_timeout_payload_nonzero_wins(ctx: &TestContext) -> TestResult
 {
     let eq = event_queue_create(ctx.memory_frame_base, 4)
         .map_err(|_| "event_queue_create for nonzero-payload test failed")?;
-    let cs = cap_create_cspace(ctx.memory_frame_base, 0, 4, 16)
-        .map_err(|_| "cap_create_cspace failed")?;
-    let child_eq = cap_copy(eq, cs, syscall::RIGHTS_ALL).map_err(|_| "cap_copy eq failed")?;
+    let child = crate::spawn::new_child(ctx).map_err(|_| "spawn::new_child failed")?;
+    let child_eq = cap_copy(eq, child.cs, syscall::RIGHTS_ALL).map_err(|_| "cap_copy eq failed")?;
     let child_arg = u64::from(child_eq);
 
-    let th = cap_create_thread(ctx.memory_frame_base, ctx.aspace_cap, cs)
-        .map_err(|_| "cap_create_thread failed")?;
     let stack_top = ChildStack::top(core::ptr::addr_of!(TIMEOUT_NONZERO_PAYLOAD_STACK));
-    thread_configure(
-        th,
-        post_cafe_after_sleep_entry as *const () as u64,
-        stack_top,
-        child_arg,
-    )
-    .map_err(|_| "thread_configure failed")?;
-    thread_start(th).map_err(|_| "thread_start failed")?;
+    crate::spawn::configure_and_start(&child, post_cafe_after_sleep_entry, stack_top, child_arg)
+        .map_err(|_| "configure_and_start failed")?;
 
     let payload = event_recv_timeout(eq, 1000).map_err(|_| "event_recv_timeout failed")?;
     if payload != 0xCAFE
@@ -326,9 +299,9 @@ pub fn recv_timeout_payload_nonzero_wins(ctx: &TestContext) -> TestResult
         return Err("event_recv_timeout returned wrong payload (expected 0xCAFE)");
     }
 
-    cap_delete(th).ok();
+    cap_delete(child.th).ok();
     cap_delete(eq).ok();
-    cap_delete(cs).ok();
+    cap_delete(child.cs).ok();
     Ok(())
 }
 
@@ -338,22 +311,13 @@ pub fn recv_timeout_zero_blocks_forever(ctx: &TestContext) -> TestResult
 {
     let eq = event_queue_create(ctx.memory_frame_base, 4)
         .map_err(|_| "event_queue_create for forever-block test failed")?;
-    let cs = cap_create_cspace(ctx.memory_frame_base, 0, 4, 16)
-        .map_err(|_| "cap_create_cspace failed")?;
-    let child_eq = cap_copy(eq, cs, syscall::RIGHTS_ALL).map_err(|_| "cap_copy eq failed")?;
+    let child = crate::spawn::new_child(ctx).map_err(|_| "spawn::new_child failed")?;
+    let child_eq = cap_copy(eq, child.cs, syscall::RIGHTS_ALL).map_err(|_| "cap_copy eq failed")?;
     let child_arg = u64::from(child_eq);
 
-    let th = cap_create_thread(ctx.memory_frame_base, ctx.aspace_cap, cs)
-        .map_err(|_| "cap_create_thread failed")?;
     let stack_top = ChildStack::top(core::ptr::addr_of!(TIMEOUT_FOREVER_STACK));
-    thread_configure(
-        th,
-        post_beef_after_sleep_entry as *const () as u64,
-        stack_top,
-        child_arg,
-    )
-    .map_err(|_| "thread_configure failed")?;
-    thread_start(th).map_err(|_| "thread_start failed")?;
+    crate::spawn::configure_and_start(&child, post_beef_after_sleep_entry, stack_top, child_arg)
+        .map_err(|_| "configure_and_start failed")?;
 
     let payload = event_recv_timeout(eq, 0)
         .map_err(|_| "event_recv_timeout(eq, 0) returned error (forever-block sentinel broken)")?;
@@ -362,9 +326,9 @@ pub fn recv_timeout_zero_blocks_forever(ctx: &TestContext) -> TestResult
         return Err("event_recv_timeout(eq, 0) returned wrong payload (expected 0xBEEF)");
     }
 
-    cap_delete(th).ok();
+    cap_delete(child.th).ok();
     cap_delete(eq).ok();
-    cap_delete(cs).ok();
+    cap_delete(child.cs).ok();
     Ok(())
 }
 

--- a/core/ktest/src/unit/fpu.rs
+++ b/core/ktest/src/unit/fpu.rs
@@ -629,9 +629,16 @@ extern "C" fn child_cross_entry(_arg: u64) -> !
             "mv a0, {sig_ready}",
             "li a1, 1",
             "ecall",
-            // SIGNAL_WAIT(sig_resume): a7=4, a0=sig_resume.
+            // SIGNAL_WAIT(sig_resume, 0): a7=4, a0=sig_resume, a1=0 (no
+            // timeout). MUST zero a1 explicitly — the kernel reads
+            // tf.arg(1) as `timeout_ms` (sys_signal_wait at
+            // core/kernel/src/syscall/ipc.rs:895), and the previous
+            // SIGNAL_SEND left a1=1 in the register file. Without this
+            // store the wait runs with a 1 ms timeout and the test
+            // races past the migration step it claims to validate.
             "li a7, 4",
             "mv a0, {sig_resume}",
+            "li a1, 0",
             "ecall",
             // Resumed on (potentially different) destination CPU.
             "fsd f0,    0({b})",

--- a/core/ktest/src/unit/fpu.rs
+++ b/core/ktest/src/unit/fpu.rs
@@ -14,17 +14,13 @@
 //! verifies both captures match the pattern the child wrote. Any
 //! cross-thread bleed surfaces as a mismatch and fails the test.
 
-#[cfg(target_arch = "x86_64")]
-use core::sync::atomic::AtomicU32;
-use core::sync::atomic::{AtomicU64, Ordering};
+use core::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 
-#[cfg(target_arch = "x86_64")]
 use syscall::system_info;
 use syscall::{
     cap_copy, cap_create_cspace, cap_create_signal, cap_create_thread, cap_delete, signal_send,
     signal_wait, thread_configure, thread_exit, thread_set_affinity, thread_start,
 };
-#[cfg(target_arch = "x86_64")]
 use syscall_abi::SystemInfoType;
 
 use crate::{ChildStack, TestContext, TestResult};
@@ -442,39 +438,35 @@ pub fn preempt_isolation(ctx: &TestContext) -> TestResult
 // ── Cross-CPU preemption-isolation (eager-save migration, per #108) ──────────
 
 /// Per-thread stack for the cross-CPU child.
-#[cfg(target_arch = "x86_64")]
 static mut STACK_CROSS: ChildStack = ChildStack::ZERO;
 /// Signal indices passed into the cross-CPU child by index (the child's
 /// cspace cap is published here so the inline-asm syscall sites can read
-/// them without crossing a Rust function boundary that would clobber
-/// xmm0..xmm15).
-#[cfg(target_arch = "x86_64")]
+/// them without crossing a Rust function boundary that would clobber the
+/// FP register file).
 static CROSS_SIG_READY: AtomicU32 = AtomicU32::new(0);
-#[cfg(target_arch = "x86_64")]
 static CROSS_SIG_RESUME: AtomicU32 = AtomicU32::new(0);
-#[cfg(target_arch = "x86_64")]
 static CROSS_SIG_DONE: AtomicU32 = AtomicU32::new(0);
 /// Mismatch count written by the cross-CPU child after the post-migration
 /// register capture. The parent reads it only after the `done` signal so
 /// the zero default is never mistaken for a pass.
-#[cfg(target_arch = "x86_64")]
 static CROSS_MISMATCHES: AtomicU64 = AtomicU64::new(0);
 /// CPU id observed by the cross-CPU child after migration, sanity-checked
 /// by the parent to confirm the migration actually happened.
-#[cfg(target_arch = "x86_64")]
 static CROSS_OBSERVED_CPU: AtomicU32 = AtomicU32::new(u32::MAX);
 
-/// Cross-CPU child entry: load `PATTERN_A` into xmm0..xmm15, signal "ready",
-/// block on "resume", then capture xmm0..xmm15 back to a stack buffer.
+/// Cross-CPU child entry: load `PATTERN_A` into the extended-state register
+/// file, signal "ready", block on "resume", then capture the registers
+/// back to a stack buffer.
 ///
 /// The entire load → block → capture sequence runs inside a single inline-
-/// asm block so no intervening Rust call clobbers xmm. The syscall ABI is
-/// embedded directly: rax = syscall number, rdi/rsi = args; the kernel
-/// preserves the live FP register file across the block because (a) the
-/// kernel itself is soft-float and (b) the FPU discipline keeps the
-/// child as `fpu_owner` of its current CPU until either another thread
-/// takes an `#NM` or the child itself context-switches out (at which
-/// point `switch_out_save` XSAVEs the live regs into the TCB area).
+/// asm block so no intervening Rust call clobbers FP state. The syscall ABI
+/// is embedded directly: the kernel preserves the live FP register file
+/// across the block because (a) the kernel itself is soft-float and (b) the
+/// FPU discipline keeps the child as `fpu_owner` of its current CPU until
+/// either another thread takes a lazy-restore trap or the child itself
+/// context-switches out (at which point `switch_out_save` saves the live
+/// regs into the TCB area before the publish that lets the destination CPU
+/// see the thread Ready).
 #[cfg(target_arch = "x86_64")]
 extern "C" fn child_cross_entry(_arg: u64) -> !
 {
@@ -570,6 +562,137 @@ extern "C" fn child_cross_entry(_arg: u64) -> !
     thread_exit();
 }
 
+/// RISC-V cross-CPU child entry: load `PATTERN_A` into f0..f31, signal
+/// "ready", block on "resume", then capture f0..f31 back to a stack buffer.
+///
+/// Same shape as the x86-64 sibling. ecall uses a7 as the syscall number
+/// and a0..a2 as args; the kernel is soft-float so the FP register file
+/// survives the syscall under the discipline described in the doc comment
+/// on `preempt_isolation_cross_cpu`.
+#[cfg(target_arch = "riscv64")]
+#[allow(clippy::too_many_lines)] // 32 FP loads + 32 FP stores dominate the body.
+extern "C" fn child_cross_entry(_arg: u64) -> !
+{
+    let pattern: u64 = PATTERN_A;
+    let mut buf = [0u64; 32];
+    let sig_ready = CROSS_SIG_READY.load(Ordering::Acquire);
+    let sig_resume = CROSS_SIG_RESUME.load(Ordering::Acquire);
+    let spin: u64 = 50_000;
+
+    // SAFETY: inline asm loads pattern into f0..f31, issues SIGNAL_SEND
+    // (a7=3) then SIGNAL_WAIT (a7=4) preserving the live FP register
+    // file across both, then stores f0..f31 into buf. The .option arch
+    // directive locally enables the D extension even though the kernel
+    // target is RV64IMAC; the trap-and-restore path will have made FS
+    // Dirty by the time these stores execute post-migration.
+    unsafe {
+        core::arch::asm!(
+            ".option push",
+            ".option arch, +d",
+            "fmv.d.x f0,  {p}",
+            "fmv.d.x f1,  {p}",
+            "fmv.d.x f2,  {p}",
+            "fmv.d.x f3,  {p}",
+            "fmv.d.x f4,  {p}",
+            "fmv.d.x f5,  {p}",
+            "fmv.d.x f6,  {p}",
+            "fmv.d.x f7,  {p}",
+            "fmv.d.x f8,  {p}",
+            "fmv.d.x f9,  {p}",
+            "fmv.d.x f10, {p}",
+            "fmv.d.x f11, {p}",
+            "fmv.d.x f12, {p}",
+            "fmv.d.x f13, {p}",
+            "fmv.d.x f14, {p}",
+            "fmv.d.x f15, {p}",
+            "fmv.d.x f16, {p}",
+            "fmv.d.x f17, {p}",
+            "fmv.d.x f18, {p}",
+            "fmv.d.x f19, {p}",
+            "fmv.d.x f20, {p}",
+            "fmv.d.x f21, {p}",
+            "fmv.d.x f22, {p}",
+            "fmv.d.x f23, {p}",
+            "fmv.d.x f24, {p}",
+            "fmv.d.x f25, {p}",
+            "fmv.d.x f26, {p}",
+            "fmv.d.x f27, {p}",
+            "fmv.d.x f28, {p}",
+            "fmv.d.x f29, {p}",
+            "fmv.d.x f30, {p}",
+            "fmv.d.x f31, {p}",
+            "2:",
+            "addi {it}, {it}, -1",
+            "bnez {it}, 2b",
+            // SIGNAL_SEND(sig_ready, 0x1): a7=3, a0=sig_ready, a1=1.
+            "li a7, 3",
+            "mv a0, {sig_ready}",
+            "li a1, 1",
+            "ecall",
+            // SIGNAL_WAIT(sig_resume): a7=4, a0=sig_resume.
+            "li a7, 4",
+            "mv a0, {sig_resume}",
+            "ecall",
+            // Resumed on (potentially different) destination CPU.
+            "fsd f0,    0({b})",
+            "fsd f1,    8({b})",
+            "fsd f2,   16({b})",
+            "fsd f3,   24({b})",
+            "fsd f4,   32({b})",
+            "fsd f5,   40({b})",
+            "fsd f6,   48({b})",
+            "fsd f7,   56({b})",
+            "fsd f8,   64({b})",
+            "fsd f9,   72({b})",
+            "fsd f10,  80({b})",
+            "fsd f11,  88({b})",
+            "fsd f12,  96({b})",
+            "fsd f13, 104({b})",
+            "fsd f14, 112({b})",
+            "fsd f15, 120({b})",
+            "fsd f16, 128({b})",
+            "fsd f17, 136({b})",
+            "fsd f18, 144({b})",
+            "fsd f19, 152({b})",
+            "fsd f20, 160({b})",
+            "fsd f21, 168({b})",
+            "fsd f22, 176({b})",
+            "fsd f23, 184({b})",
+            "fsd f24, 192({b})",
+            "fsd f25, 200({b})",
+            "fsd f26, 208({b})",
+            "fsd f27, 216({b})",
+            "fsd f28, 224({b})",
+            "fsd f29, 232({b})",
+            "fsd f30, 240({b})",
+            "fsd f31, 248({b})",
+            ".option pop",
+            p = in(reg) pattern,
+            b = in(reg) buf.as_mut_ptr(),
+            it = inout(reg) spin => _,
+            sig_ready = in(reg) u64::from(sig_ready),
+            sig_resume = in(reg) u64::from(sig_resume),
+            out("a0") _, out("a1") _, out("a7") _,
+            options(nostack),
+        );
+    }
+
+    let mut mismatches = 0u64;
+    for &v in &buf
+    {
+        if v != PATTERN_A
+        {
+            mismatches += 1;
+        }
+    }
+    CROSS_MISMATCHES.store(mismatches, Ordering::Release);
+    let cpu = system_info(SystemInfoType::CurrentCpu as u64).unwrap_or(u64::MAX);
+    CROSS_OBSERVED_CPU.store(u32::try_from(cpu).unwrap_or(u32::MAX), Ordering::Release);
+
+    let _ = signal_send(CROSS_SIG_DONE.load(Ordering::Acquire), 0x1);
+    thread_exit();
+}
+
 /// Cross-CPU FPU-migration correctness: a thread that became `fpu_owner`
 /// on CPU 0, blocked, then was woken with affinity changed to CPU 1, must
 /// observe its register file intact post-migration. After issue #108,
@@ -577,19 +700,8 @@ extern "C" fn child_cross_entry(_arg: u64) -> !
 /// `switch_out_save` persists the live regs into the TCB area before the
 /// scheduler lock release that publishes the thread's Ready state).
 ///
-/// Requires SMP; skips otherwise. Skipped on RISC-V (the equivalent
-/// `sstatus.FS/VS` dirty-tracking path is exercised by its own ktest).
-#[cfg(target_arch = "riscv64")]
-#[allow(clippy::unnecessary_wraps)]
-pub fn preempt_isolation_cross_cpu(_ctx: &TestContext) -> TestResult
-{
-    crate::log("ktest: fpu::preempt_isolation_cross_cpu SKIP (RISC-V out of scope for #65)");
-    Ok(())
-}
-
-/// Cross-CPU FPU-migration correctness (x86-64 only); see the
-/// architecture-neutral doc comment above.
-#[cfg(target_arch = "x86_64")]
+/// Requires SMP; skips on UP. Runs on both x86-64 (XSAVE/XRSTOR + `#NM`)
+/// and RISC-V (`sstatus.FS/VS` dirty-tracking + illegal-instruction trap).
 pub fn preempt_isolation_cross_cpu(ctx: &TestContext) -> TestResult
 {
     {

--- a/core/ktest/src/unit/hw.rs
+++ b/core/ktest/src/unit/hw.rs
@@ -5,15 +5,16 @@
 
 //! Tier 1 tests for hardware access syscalls.
 //!
-//! Covers: `SYS_MMIO_MAP`, `SYS_IRQ_REGISTER`, `SYS_IRQ_ACK`,
-//! `SYS_IOPORT_BIND`, `SYS_IOPORT_SPLIT`.
+//! Covers: `SYS_MMIO_MAP`, `SYS_MMIO_SPLIT`, `SYS_IRQ_REGISTER`,
+//! `SYS_IRQ_ACK`, `SYS_IRQ_SPLIT`, `SYS_IOPORT_BIND`, `SYS_IOPORT_SPLIT`,
+//! `SYS_SBI_CALL`.
 //!
 //! Tests that require specific hardware capability types (`MmioRegion`, Interrupt,
 //! `IoPortRange`) scan the initial capability set for a matching cap. If none is
 //! found in the current boot configuration, the test is skipped and reports Ok.
 //! Skips are logged to serial so they are visible in the test run output.
 
-use syscall::{aspace_query, cap_create_signal, irq_ack, irq_register};
+use syscall::{aspace_query, cap_create_signal, irq_ack, irq_register, irq_split, mmio_split};
 #[cfg(target_arch = "x86_64")]
 use syscall::{cap_create_cspace, cap_create_thread};
 use syscall_abi::SyscallError;
@@ -279,4 +280,129 @@ pub fn ioport_split(ctx: &TestContext) -> TestResult
         );
         Ok(())
     }
+}
+
+// ── SYS_MMIO_SPLIT ────────────────────────────────────────────────────────────
+
+/// `mmio_split` on the first `MmioRegion` ≥ 8 KiB returns two valid children
+/// with disjoint base/size. Skipped if no suitable cap exists.
+pub fn mmio_split_carves(ctx: &TestContext) -> TestResult
+{
+    let max_slots = syscall::cap_info(ctx.cspace_cap, syscall_abi::CAP_INFO_CSPACE_CAPACITY)
+        .map_or(ctx.aspace_cap, |n| u32::try_from(n).unwrap_or(u32::MAX));
+
+    for slot in 1u32..max_slots
+    {
+        // Probe: split at PAGE_SIZE. InvalidCapability ⇒ wrong tag.
+        // InvalidArgument ⇒ MmioRegion exists but too small.
+        match mmio_split(slot, 0x1000)
+        {
+            Err(e) if e == SyscallError::InvalidCapability as i64 =>
+            {}
+            Err(e) if e == SyscallError::InvalidArgument as i64 =>
+            {}
+            Err(_) => return Err("hw::mmio_split_carves: unexpected error from mmio_split"),
+            Ok((slot1, slot2)) =>
+            {
+                if slot1 == 0 || slot2 == 0 || slot1 == slot2
+                {
+                    return Err("hw::mmio_split_carves: split returned bad slot ids");
+                }
+                syscall::cap_delete(slot1).ok();
+                syscall::cap_delete(slot2).ok();
+                return Ok(());
+            }
+        }
+    }
+
+    crate::log("ktest: hw::mmio_split_carves SKIP (no MmioRegion caps in initial cap set)");
+    Ok(())
+}
+
+/// `mmio_split` on a Frame cap (wrong tag) must return `InvalidCapability`.
+pub fn mmio_split_wrong_tag_err(ctx: &TestContext) -> TestResult
+{
+    let err = mmio_split(ctx.memory_frame_base, 0x1000);
+    if err != Err(SyscallError::InvalidCapability as i64)
+    {
+        return Err("hw::mmio_split_wrong_tag_err: did not return InvalidCapability");
+    }
+    Ok(())
+}
+
+// ── SYS_IRQ_SPLIT ─────────────────────────────────────────────────────────────
+
+/// `irq_split` on the first Interrupt-range cap with `count > 1` returns two
+/// disjoint children. Skipped if no suitable cap exists.
+pub fn irq_split_carves(ctx: &TestContext) -> TestResult
+{
+    let max_slots = syscall::cap_info(ctx.cspace_cap, syscall_abi::CAP_INFO_CSPACE_CAPACITY)
+        .map_or(ctx.aspace_cap, |n| u32::try_from(n).unwrap_or(u32::MAX));
+
+    for slot in 1u32..max_slots
+    {
+        // Probe: split at base+1. Wrong-tag and unsplittable-range responses
+        // both leave the cap intact.
+        match irq_split(slot, 1)
+        {
+            Err(_) =>
+            {} // Wrong tag or non-splittable; keep scanning.
+            Ok((slot1, slot2)) =>
+            {
+                if slot1 == 0 || slot2 == 0 || slot1 == slot2
+                {
+                    return Err("hw::irq_split_carves: split returned bad slot ids");
+                }
+                syscall::cap_delete(slot1).ok();
+                syscall::cap_delete(slot2).ok();
+                return Ok(());
+            }
+        }
+    }
+
+    crate::log("ktest: hw::irq_split_carves SKIP (no Interrupt range caps with count>1)");
+    Ok(())
+}
+
+/// `irq_split` on a Frame cap (wrong tag) must return `InvalidCapability`.
+pub fn irq_split_wrong_tag_err(ctx: &TestContext) -> TestResult
+{
+    let err = irq_split(ctx.memory_frame_base, 0);
+    if err != Err(SyscallError::InvalidCapability as i64)
+    {
+        return Err("hw::irq_split_wrong_tag_err: did not return InvalidCapability");
+    }
+    Ok(())
+}
+
+// ── SYS_SBI_CALL ──────────────────────────────────────────────────────────────
+
+/// On RISC-V, `sbi_call(sbi_control_cap, EID=0x10, FID=0, …)` reads the SBI
+/// spec version. Verifies the call path: the kernel forwards to SBI and
+/// returns a plausible version (major in `0..=3`).
+#[cfg(target_arch = "riscv64")]
+pub fn sbi_call_get_spec_version(ctx: &TestContext) -> TestResult
+{
+    // EID_BASE = 0x10, FID_GET_SPEC_VERSION = 0 per the SBI base extension.
+    let version = syscall::sbi_call(ctx.sbi_control_cap, 0x10, 0, 0, 0, 0)
+        .map_err(|_| "hw::sbi_call_get_spec_version: sbi_call returned error")?;
+    let major = version >> 24;
+    if major > 3
+    {
+        return Err("hw::sbi_call_get_spec_version: implausible SBI major version");
+    }
+    Ok(())
+}
+
+/// On `x86_64`, `sbi_call` is unconditionally `NotSupported` regardless of
+/// arguments (the syscall is a RISC-V-only forwarder).
+#[cfg(target_arch = "x86_64")]
+pub fn sbi_call_not_supported_x86_64(_ctx: &TestContext) -> TestResult
+{
+    let err = syscall::sbi_call(0, 0, 0, 0, 0, 0);
+    if err != Err(SyscallError::NotSupported as i64)
+    {
+        return Err("hw::sbi_call_not_supported_x86_64: did not return NotSupported");
+    }
+    Ok(())
 }

--- a/core/ktest/src/unit/mod.rs
+++ b/core/ktest/src/unit/mod.rs
@@ -245,6 +245,14 @@ pub fn run_all(ctx: &TestContext)
         "signal::send_insufficient_rights",
         signal::send_insufficient_rights(ctx)
     );
+    run_test!(
+        "signal::wait_timeout_fires",
+        signal::wait_timeout_fires(ctx)
+    );
+    run_test!(
+        "signal::wait_timeout_returns_bits_first",
+        signal::wait_timeout_returns_bits_first(ctx)
+    );
 
     // ── Event queue syscalls ──────────────────────────────────────────────────
     run_test!("event::create", event::create(ctx));
@@ -413,6 +421,19 @@ pub fn run_all(ctx: &TestContext)
         "thread::load_balancer_skips_pinned",
         thread::load_balancer_skips_pinned(ctx)
     );
+    run_test!("thread::sleep_blocks_ms", thread::sleep_blocks_ms(ctx));
+    run_test!(
+        "thread::sleep_zero_is_noop",
+        thread::sleep_zero_is_noop(ctx)
+    );
+    run_test!(
+        "thread::bind_notification_fires_on_exit",
+        thread::bind_notification_fires_on_exit(ctx)
+    );
+    run_test!(
+        "thread::bind_notification_invalid_cap_err",
+        thread::bind_notification_invalid_cap_err(ctx)
+    );
 
     // ── Extended-state (FPU / SIMD / V) isolation ────────────────────────────
     run_test!("fpu::preempt_isolation", fpu::preempt_isolation(ctx));
@@ -423,9 +444,29 @@ pub fn run_all(ctx: &TestContext)
 
     // ── Hardware access syscalls ──────────────────────────────────────────────
     run_test!("hw::mmio_map", hw::mmio_map(ctx));
+    run_test!("hw::mmio_split_carves", hw::mmio_split_carves(ctx));
+    run_test!(
+        "hw::mmio_split_wrong_tag_err",
+        hw::mmio_split_wrong_tag_err(ctx)
+    );
     run_test!("hw::irq_register_ack", hw::irq_register_ack(ctx));
+    run_test!("hw::irq_split_carves", hw::irq_split_carves(ctx));
+    run_test!(
+        "hw::irq_split_wrong_tag_err",
+        hw::irq_split_wrong_tag_err(ctx)
+    );
     run_test!("hw::ioport_bind", hw::ioport_bind(ctx));
     run_test!("hw::ioport_split", hw::ioport_split(ctx));
+    #[cfg(target_arch = "riscv64")]
+    run_test!(
+        "hw::sbi_call_get_spec_version",
+        hw::sbi_call_get_spec_version(ctx)
+    );
+    #[cfg(target_arch = "x86_64")]
+    run_test!(
+        "hw::sbi_call_not_supported_x86_64",
+        hw::sbi_call_not_supported_x86_64(ctx)
+    );
 
     // ── System info syscalls ──────────────────────────────────────────────────
     run_test!("sysinfo::kernel_version", sysinfo::kernel_version(ctx));

--- a/core/ktest/src/unit/mod.rs
+++ b/core/ktest/src/unit/mod.rs
@@ -22,14 +22,15 @@
 //! Files:
 //! - `cap.rs`      — capability creation, copy, move, insert, derive, revoke, delete
 //! - `cap_info.rs` — read-only capability state inspection (`SYS_CAP_INFO`)
+//! - `retype.rs`   — retype primitive: aspace/cspace augment, PT budget, kernel PT pool
 //! - `mm.rs`       — memory map/unmap/protect, frame split, address space query
-//! - `signal.rs`   — signal send and wait
-//! - `event.rs`    — event queue post and receive
+//! - `signal.rs`   — signal send and wait (blocking and timeout)
+//! - `event.rs`    — event queue post and receive (blocking, try, timeout)
 //! - `wait_set.rs` — wait set add, remove, wait
 //! - `ipc.rs`      — IPC call, reply, recv, buffer set
-//! - `thread.rs`   — thread lifecycle, register read/write, priority, affinity
-//! - `fpu.rs`      — FPU / SIMD / V extended-state isolation across preemption
-//! - `hw.rs`       — MMIO, IRQ, I/O ports
+//! - `thread.rs`   — thread lifecycle, register read/write, priority, affinity, sleep, `bind_notification`
+//! - `fpu.rs`      — FPU / SIMD / V extended-state isolation across preemption and cross-CPU migration
+//! - `hw.rs`       — MMIO, IRQ, I/O ports, SBI
 //! - `sysinfo.rs`  — system info queries and debug log
 
 pub mod cap;

--- a/core/ktest/src/unit/mod.rs
+++ b/core/ktest/src/unit/mod.rs
@@ -5,10 +5,19 @@
 
 //! Tier 1 — per-syscall isolation tests.
 //!
-//! Each file in this module covers one logical group of related syscalls
-//! (mirroring the kernel's subsystem structure). Every kernel syscall must
-//! have at least one test here. Adding a new syscall means adding a section
-//! to the appropriate file.
+//! Rule (durable):
+//!
+//! > **One module per kernel subsystem under test. New subsystem ⇒ new
+//! > module.**
+//!
+//! Adding a new syscall means adding a section in the file for its
+//! kernel subsystem — not a new file. New file only when a new kernel
+//! subsystem is added. Files stay scoped; they don't grow unboundedly
+//! because each is one surface.
+//!
+//! Every kernel syscall must have at least one positive-path test here
+//! plus its most important negative paths (wrong rights, invalid
+//! arguments, wrong object state).
 //!
 //! Files:
 //! - `cap.rs`      — capability creation, copy, move, insert, derive, revoke, delete

--- a/core/ktest/src/unit/signal.rs
+++ b/core/ktest/src/unit/signal.rs
@@ -8,9 +8,10 @@
 //! Covers: `SYS_SIGNAL_SEND`, `SYS_SIGNAL_WAIT`.
 
 use syscall::{
-    cap_copy, cap_create_signal, cap_delete, cap_derive, signal_send, signal_wait, thread_exit,
+    cap_copy, cap_create_signal, cap_delete, cap_derive, signal_send, signal_wait,
+    signal_wait_timeout, system_info, thread_exit,
 };
-use syscall_abi::SyscallError;
+use syscall_abi::{SyscallError, SystemInfoType};
 
 use crate::{ChildStack, TestContext, TestResult};
 
@@ -187,6 +188,58 @@ pub fn send_insufficient_rights(ctx: &TestContext) -> TestResult
 
     cap_delete(wait_only).map_err(|_| "cap_delete wait_only failed")?;
     cap_delete(sig).map_err(|_| "cap_delete sig after send_insufficient_rights failed")?;
+    Ok(())
+}
+
+// ── SYS_SIGNAL_WAIT (timeout) ─────────────────────────────────────────────────
+
+/// `signal_wait_timeout` on an un-signalled cap returns `Ok(0)` after the
+/// timeout elapses; the elapsed wall time must be at least the requested
+/// timeout less a small slack.
+pub fn wait_timeout_fires(ctx: &TestContext) -> TestResult
+{
+    let sig = cap_create_signal(ctx.memory_frame_base)
+        .map_err(|_| "create_signal for wait_timeout_fires failed")?;
+
+    let t0 = system_info(SystemInfoType::ElapsedUs as u64)
+        .map_err(|_| "system_info(ElapsedUs) before wait failed")?;
+    let bits = signal_wait_timeout(sig, 50).map_err(|_| "signal_wait_timeout (50ms) failed")?;
+    let t1 = system_info(SystemInfoType::ElapsedUs as u64)
+        .map_err(|_| "system_info(ElapsedUs) after wait failed")?;
+
+    if bits != 0
+    {
+        return Err("signal_wait_timeout on idle cap returned non-zero bits");
+    }
+    // Allow ~10 ms slack for timer granularity on slow VMs.
+    let elapsed_us = t1.wrapping_sub(t0);
+    if elapsed_us < 40_000
+    {
+        return Err("signal_wait_timeout returned earlier than the requested timeout");
+    }
+
+    cap_delete(sig).map_err(|_| "cap_delete sig after wait_timeout_fires failed")?;
+    Ok(())
+}
+
+/// Pre-signalled bits must be returned immediately, ahead of the timeout.
+pub fn wait_timeout_returns_bits_first(ctx: &TestContext) -> TestResult
+{
+    let sig = cap_create_signal(ctx.memory_frame_base)
+        .map_err(|_| "create_signal for wait_timeout_returns_bits_first failed")?;
+
+    signal_send(sig, 0xABCD)
+        .map_err(|_| "signal_send before wait_timeout_returns_bits_first failed")?;
+
+    // Very large timeout — if we ever hit it, it's a real failure.
+    let bits = signal_wait_timeout(sig, 1_000_000)
+        .map_err(|_| "signal_wait_timeout with pending bits failed")?;
+    if bits != 0xABCD
+    {
+        return Err("signal_wait_timeout did not return pre-set bits");
+    }
+
+    cap_delete(sig).map_err(|_| "cap_delete sig after wait_timeout_returns_bits_first failed")?;
     Ok(())
 }
 

--- a/core/ktest/src/unit/signal.rs
+++ b/core/ktest/src/unit/signal.rs
@@ -8,8 +8,7 @@
 //! Covers: `SYS_SIGNAL_SEND`, `SYS_SIGNAL_WAIT`.
 
 use syscall::{
-    cap_copy, cap_create_cspace, cap_create_signal, cap_create_thread, cap_delete, cap_derive,
-    signal_send, signal_wait, thread_configure, thread_exit, thread_start,
+    cap_copy, cap_create_signal, cap_delete, cap_derive, signal_send, signal_wait, thread_exit,
 };
 use syscall_abi::SyscallError;
 
@@ -45,24 +44,15 @@ pub fn send_wait_blocking(ctx: &TestContext) -> TestResult
     let sig = cap_create_signal(ctx.memory_frame_base)
         .map_err(|_| "create_signal for blocking-wait test failed")?;
 
-    // Create a child CSpace and copy the signal cap (SIGNAL right only).
-    let cs = cap_create_cspace(ctx.memory_frame_base, 0, 4, 16)
-        .map_err(|_| "create_cspace for blocking-wait test failed")?;
-    let child_sig =
-        cap_copy(sig, cs, RIGHTS_SIGNAL).map_err(|_| "cap_copy signal into child CSpace failed")?;
-
-    let child_th = cap_create_thread(ctx.memory_frame_base, ctx.aspace_cap, cs)
-        .map_err(|_| "cap_create_thread for blocking-wait test failed")?;
+    // Create a child CSpace + thread, copy the signal cap (SIGNAL right only).
+    let child = crate::spawn::new_child(ctx)
+        .map_err(|_| "spawn::new_child for blocking-wait test failed")?;
+    let child_sig = cap_copy(sig, child.cs, RIGHTS_SIGNAL)
+        .map_err(|_| "cap_copy signal into child CSpace failed")?;
 
     let stack_top = ChildStack::top(core::ptr::addr_of!(CHILD_STACK));
-    thread_configure(
-        child_th,
-        sender_entry as *const () as u64,
-        stack_top,
-        u64::from(child_sig),
-    )
-    .map_err(|_| "thread_configure for blocking-wait test failed")?;
-    thread_start(child_th).map_err(|_| "thread_start for blocking-wait test failed")?;
+    crate::spawn::configure_and_start(&child, sender_entry, stack_top, u64::from(child_sig))
+        .map_err(|_| "configure_and_start for blocking-wait test failed")?;
 
     // Block until the child sends.
     let bits = signal_wait(sig).map_err(|_| "signal_wait (blocking) failed")?;
@@ -72,7 +62,7 @@ pub fn send_wait_blocking(ctx: &TestContext) -> TestResult
     }
 
     cap_delete(sig).map_err(|_| "cap_delete sig after blocking-wait test failed")?;
-    cap_delete(cs).map_err(|_| "cap_delete cs after blocking-wait test failed")?;
+    cap_delete(child.cs).map_err(|_| "cap_delete cs after blocking-wait test failed")?;
     Ok(())
 }
 

--- a/core/ktest/src/unit/thread.rs
+++ b/core/ktest/src/unit/thread.rs
@@ -22,9 +22,10 @@
 use core::sync::atomic::{AtomicU32, Ordering};
 
 use syscall::{
-    cap_copy, cap_create_cspace, cap_create_signal, cap_create_thread, cap_delete, signal_send,
-    signal_wait, signal_wait_timeout, system_info, thread_configure, thread_exit, thread_read_regs,
-    thread_set_affinity, thread_set_priority, thread_start, thread_stop, thread_write_regs,
+    cap_copy, cap_create_cspace, cap_create_signal, cap_create_thread, cap_delete,
+    event_queue_create, event_recv, signal_send, signal_wait, signal_wait_timeout, system_info,
+    thread_bind_notification, thread_configure, thread_exit, thread_read_regs, thread_set_affinity,
+    thread_set_priority, thread_sleep, thread_start, thread_stop, thread_write_regs,
 };
 use syscall_abi::{SyscallError, SystemInfoType};
 
@@ -1209,4 +1210,92 @@ fn phase2_entry() -> !
     let sig = PHASE2_SIG.load(Ordering::Acquire);
     signal_send(sig, 0x2).ok();
     thread_exit()
+}
+
+// ── SYS_THREAD_SLEEP ─────────────────────────────────────────────────────────
+
+/// `thread_sleep(50)` blocks the caller for at least ~40 ms wall clock
+/// (slack to absorb timer granularity on slow VMs).
+pub fn sleep_blocks_ms(_ctx: &TestContext) -> TestResult
+{
+    let t0 = system_info(SystemInfoType::ElapsedUs as u64)
+        .map_err(|_| "thread::sleep_blocks_ms: system_info(ElapsedUs) before failed")?;
+    thread_sleep(50).map_err(|_| "thread::sleep_blocks_ms: thread_sleep(50) failed")?;
+    let t1 = system_info(SystemInfoType::ElapsedUs as u64)
+        .map_err(|_| "thread::sleep_blocks_ms: system_info(ElapsedUs) after failed")?;
+    let elapsed_us = t1.wrapping_sub(t0);
+    if elapsed_us < 40_000
+    {
+        return Err("thread::sleep_blocks_ms: returned earlier than requested timeout");
+    }
+    Ok(())
+}
+
+/// `thread_sleep(0)` is a no-op — returns immediately with `Ok(())`.
+pub fn sleep_zero_is_noop(_ctx: &TestContext) -> TestResult
+{
+    thread_sleep(0).map_err(|_| "thread::sleep_zero_is_noop: thread_sleep(0) returned error")?;
+    Ok(())
+}
+
+// ── SYS_THREAD_BIND_NOTIFICATION ─────────────────────────────────────────────
+
+/// Stack for the `bind_notification` child.
+static mut BIND_NOTIF_STACK: crate::ChildStack = crate::ChildStack::ZERO;
+
+/// Child that exits immediately so its bound `EventQueue` receives the
+/// thread-death payload.
+fn bind_notif_exit_entry(_arg: u64) -> !
+{
+    thread_exit()
+}
+
+/// `thread_bind_notification(child, eq, correlator)` causes a payload
+/// carrying `correlator` to be posted to `eq` when the child thread exits.
+pub fn bind_notification_fires_on_exit(ctx: &TestContext) -> TestResult
+{
+    const CORRELATOR: u32 = 0xCAFEu32;
+
+    let eq = event_queue_create(ctx.memory_frame_base, 4)
+        .map_err(|_| "thread::bind_notification_fires_on_exit: event_queue_create failed")?;
+
+    let child = crate::spawn::new_child(ctx)
+        .map_err(|_| "thread::bind_notification_fires_on_exit: spawn::new_child failed")?;
+
+    // Bind BEFORE the child starts so the observer is registered when the
+    // thread first becomes Exited.
+    thread_bind_notification(child.th, eq, CORRELATOR)
+        .map_err(|_| "thread::bind_notification_fires_on_exit: thread_bind_notification failed")?;
+
+    let stack_top = crate::ChildStack::top(core::ptr::addr_of!(BIND_NOTIF_STACK));
+    crate::spawn::configure_and_start(&child, bind_notif_exit_entry, stack_top, 0)
+        .map_err(|_| "thread::bind_notification_fires_on_exit: configure_and_start failed")?;
+
+    // Block until the death notification arrives.
+    let payload =
+        event_recv(eq).map_err(|_| "thread::bind_notification_fires_on_exit: event_recv failed")?;
+
+    // The kernel packs the correlator into the high 32 bits of the payload.
+    let observed = (payload >> 32) as u32;
+    if observed != CORRELATOR
+    {
+        return Err("thread::bind_notification_fires_on_exit: wrong correlator on death payload");
+    }
+
+    cap_delete(child.th).ok();
+    cap_delete(child.cs).ok();
+    cap_delete(eq).ok();
+    Ok(())
+}
+
+/// `thread_bind_notification` with a null thread cap must return
+/// `InvalidCapability`.
+pub fn bind_notification_invalid_cap_err(_ctx: &TestContext) -> TestResult
+{
+    let err = thread_bind_notification(0, 0, 0);
+    if err != Err(SyscallError::InvalidCapability as i64)
+    {
+        return Err("thread::bind_notification_invalid_cap_err: did not return InvalidCapability");
+    }
+    Ok(())
 }

--- a/core/ktest/src/unit/wait_set.rs
+++ b/core/ktest/src/unit/wait_set.rs
@@ -13,10 +13,9 @@
 //! only the remaining member can wake the wait set after removal.
 
 use syscall::{
-    cap_copy, cap_create_cspace, cap_create_endpoint, cap_create_signal, cap_create_thread,
-    cap_delete, event_post, event_queue_create, event_recv, signal_send, signal_wait,
-    thread_configure, thread_exit, thread_start, wait_set_add, wait_set_create, wait_set_remove,
-    wait_set_wait,
+    cap_copy, cap_create_endpoint, cap_create_signal, cap_delete, event_post, event_queue_create,
+    event_recv, signal_send, signal_wait, thread_exit, wait_set_add, wait_set_create,
+    wait_set_remove, wait_set_wait,
 };
 
 use crate::{ChildStack, TestContext, TestResult};
@@ -103,22 +102,14 @@ pub fn blocking_wait(ctx: &TestContext) -> TestResult
     wait_set_add(ws, sig, 7).map_err(|_| "wait_set_add for blocking test failed")?;
 
     // Set up a child thread that sends on the signal.
-    let cs = cap_create_cspace(ctx.memory_frame_base, 0, 4, 16)
-        .map_err(|_| "cap_create_cspace for blocking test failed")?;
+    let child =
+        crate::spawn::new_child(ctx).map_err(|_| "spawn::new_child for blocking test failed")?;
     let child_sig =
-        cap_copy(sig, cs, RIGHTS_SIGNAL).map_err(|_| "cap_copy for blocking test failed")?;
-    let th = cap_create_thread(ctx.memory_frame_base, ctx.aspace_cap, cs)
-        .map_err(|_| "cap_create_thread for blocking test failed")?;
+        cap_copy(sig, child.cs, RIGHTS_SIGNAL).map_err(|_| "cap_copy for blocking test failed")?;
 
     let stack_top = ChildStack::top(core::ptr::addr_of!(CHILD_STACK));
-    thread_configure(
-        th,
-        sender_entry as *const () as u64,
-        stack_top,
-        u64::from(child_sig),
-    )
-    .map_err(|_| "thread_configure for blocking test failed")?;
-    thread_start(th).map_err(|_| "thread_start for blocking test failed")?;
+    crate::spawn::configure_and_start(&child, sender_entry, stack_top, u64::from(child_sig))
+        .map_err(|_| "configure_and_start for blocking test failed")?;
 
     // Block until the child fires the signal.
     let tok = wait_set_wait(ws).map_err(|_| "wait_set_wait (blocking) failed")?;
@@ -134,9 +125,9 @@ pub fn blocking_wait(ctx: &TestContext) -> TestResult
         return Err("signal bits after blocking wait_set_wait are wrong (expected 0xBEEF)");
     }
 
-    cap_delete(th).map_err(|_| "cap_delete th after blocking test failed")?;
+    cap_delete(child.th).map_err(|_| "cap_delete th after blocking test failed")?;
     cap_delete(sig).map_err(|_| "cap_delete sig after blocking test failed")?;
-    cap_delete(cs).map_err(|_| "cap_delete cs after blocking test failed")?;
+    cap_delete(child.cs).map_err(|_| "cap_delete cs after blocking test failed")?;
     cap_delete(ws).map_err(|_| "cap_delete ws after blocking test failed")?;
     Ok(())
 }


### PR DESCRIPTION
## Summary

Issue #24 (ktest cleanup pass) with user-approved scope expansion to add tests that close verified coverage gaps. Drift fixed; structural patterns adopted from the recent svctest redesign; new tests added across all three tiers + Tier S; two real kernel scaling bugs surfaced and filed as separate issues.

Closes #24

## Acceptance

- [x] ktest README accurately describes current ktest contents.
- [x] `cargo xtask run` with `init=ktest` passes on both arches.
- [x] Stale or duplicated scenarios are removed; module layout is coherent.

## What landed

**Cleanup + structural**
- Drift fixes (bench naming, log envelope, README tier tables, paths).
- Durable "one file per surface/scenario/race" rule banners across `unit/`, `integration/`, `stress/`, `bench/` (svctest pattern).
- `bench/mod.rs` split into per-surface files mirroring `unit/` (svctest pattern).
- `spawn::new_child` / `configure_and_start[_pinned]` helper, migrated across bench/stress/integration/unit call sites. Remaining `unit/{thread,ipc}.rs` migration tracked in #131.

**New Tier 1 (12 tests, close verified syscall gaps)**
- `signal::wait_timeout_fires` / `wait_timeout_returns_bits_first` (was: untested).
- `thread::sleep_blocks_ms` / `sleep_zero_is_noop` / `bind_notification_fires_on_exit` / `bind_notification_invalid_cap_err`.
- `hw::mmio_split_carves` / `mmio_split_wrong_tag_err` / `irq_split_carves` / `irq_split_wrong_tag_err` / `sbi_call_get_spec_version` (riscv64) / `sbi_call_not_supported_x86_64`.

**Fix the bogus arch-skipped FPU test**
- Implemented the riscv64 body of `fpu::preempt_isolation_cross_cpu` (was: unconditional SKIP with a "exercised by its own ktest" comment that referenced no such test).

**New Tier 2 (3 cross-subsystem scenarios)**
- `priority_preemption`, `shared_frame_two_aspaces`, `cap_move_into_fresh_cspace_then_ipc`.
- `fpu_survives_ipc_call` was scoped out; tracked in #130.

**New Tier S (2 stress)**
- `fpu_migration_churn`, `concurrent_event_producers`.

**New Tier 3 (3 benchmarks)**
- `mem_protect_pair`, `context_switch`, `tlb_shootdown_unmap`.

**Stress-tier ramp** (initially landed, then fully reverted — see Notes)

## Notes

The branch attempted to ramp every stress-tier concurrency knob (`NUM_*=64`, iteration counts ×5-10) to surface latent races on each boot rather than needing to repeat ktest many times. In-tree verification on `x86_64` QEMU/KVM SMP-4 surfaced **two distinct kernel-side scaling bugs**, both now filed and worked around:

- **#127** — `SYS_SIGNAL_WAIT` bit-63 ABI ambiguity: high-bit payloads alias the dispatcher's `cast_signed()` Err encoding, so per-bit accounting tops out at 63 distinct workers.
- **#128** — `cap_revoke` parent CPU starvation under spinner flood: even at NUM=16, accumulated scheduler state from prior ramped tests prevents the revoke parent from making progress on a 4-CPU host.

Per the branch's "kernel-flake stance" (don't modify the kernel; surface bugs as issues, don't hide them), the ramp was fully reverted. The harness still gains every structural improvement, every new test, the riscv64 FPU body fix, and every new benchmark. The ramp can be re-applied as a follow-up branch once #127 and #128 are fixed.

## Follow-ups filed

- #127 — kernel: `SYS_SIGNAL_WAIT` bit-63 ABI ambiguity.
- #128 — kernel/sched: `cap_revoke` parent CPU starvation under spinner flood.
- #130 — ktest: FPU state preservation across `SYS_IPC_CALL` (deferred test).
- #131 — ktest: migrate remaining `unit/{thread,ipc}.rs` spawn sites to `spawn` helper.

## Pre-merge audit

- `@pr-reviewer`: initial run flagged a BLOCKING riscv64 inline-asm defect (missing `li a1, 0` between SIGNAL_SEND and SIGNAL_WAIT — kernel reads stale `a1` as `timeout_ms=1`); fixed in `8aad676`. Same commit also closes the stale `Files:` banners and the dead `HOG_REMAINING` static the reviewer flagged.
- `@pr-auditor`: F1/F2/F3/F4 resolved — PR checkbox ticked, Issue #24 acceptance ticked, #130 and #131 filed.

## Test plan

- [x] `cargo xtask build` (x86_64)
- [x] `cargo xtask run` (x86_64), `[ktest] ALL TESTS PASSED` observed: 164/164 in ~4 s
- [x] `cargo xtask build --arch riscv64`
- [x] `cargo xtask run --arch riscv64` — CI: `validate (riscv64, debug, ktest)` and `validate (riscv64, release, ktest)` both green on the final commit