### PR TITLE
kernel: close residual #117 stress::concurrent_ipc kernel #PF

### DIFF
--- a/core/kernel/docs/scheduling-internals.md
+++ b/core/kernel/docs/scheduling-internals.md
@@ -172,6 +172,11 @@ dealloc_object(Thread) (after the all-locks region releases):
 
 The Release in step 5 pairs with both the Acquire in step 6 (cross-CPU dequeue) and the Acquire in step 9 (TCB free). Without step 9, the lock release at step 3 lets `dealloc_object(Thread)` observe `sched.current = idle` (set at step 2) *while step 4 is still writing into `tcb.saved_state`* — freeing the TCB at that point lets the next allocation reuse the memory and `switch()` then corrupts the new allocation. The check is unconditional on the result of `running_on`, because the all-locks `running_on` snapshot can race step 2/3 and miss the in-flight switch. New TCBs initialise `context_saved = 1`, so the wait is bounded for threads that never ran.
 
+**`context_saved = 1` and `popfq` ordering inside `Context::switch` (issue #117).** Step 5 above hides a finer-grained ordering invariant inside the `switch()` asm itself. Both the `context_saved = 1` publication AND the `popfq` that restores `next.saved_state.rflags` (which may set `IF = 1`) MUST happen AFTER `mov rsp, [rsi + 8]` (the rsp swap to the next thread's kstack), not before it. Doing either earlier opens this window:
+1. `popfq` before the rsp swap re-enables interrupts while this CPU is still executing on the OUTGOING thread's kstack. A trap taken in that window pushes its iretq frame onto the outgoing kstack.
+2. Publishing `current.context_saved = 1` before the rsp swap satisfies step 6's Acquire spin for any peer CPU that just dequeued `current`. That peer's own `switch()` then executes its own rsp swap onto the SAME outgoing kstack, and any push/pop the peer does collides with the iretq frame from (1).
+The collision overwrites the trap return address, so `iretq` on this CPU returns to a wild RIP (typically `0` because the corruption zeroes the slot). The `stress::concurrent_ipc` ktest surfaces this as a kernel `#PF` at `rip = 0, cr2 = 0, err = 0x10` at ~0.2 % per run on x86_64 TCG with the racy ordering. Keeping both the publication and `popfq` below the rsp swap closes the window.
+
 ---
 
 ## Wake Protocol Invariants

--- a/core/kernel/src/arch/x86_64/context.rs
+++ b/core/kernel/src/arch/x86_64/context.rs
@@ -156,22 +156,14 @@ pub unsafe extern "C" fn switch(
         "pushfq",
         "pop rax",
         "mov [rdi + 72], rax",
-        // ── Save fs_base, then publish context_saved ──────────────────────
-        // saved_state.fs_base (offset 64) is the last field written during
-        // save. It must be globally visible before context_saved=1, because
-        // remote CPUs use the flag (Acquire) as the publication barrier
-        // for both cross-CPU dispatch (which then reads fs_base for the
-        // restore-side wrmsr) and dealloc UAF (which then frees the TCB
-        // body). See core/kernel/docs/scheduling-internals.md
-        // § Cross-CPU TCB Ownership.
-        //
-        // rdmsr clobbers rdx (which carries the save_flag pointer), so we
-        // stash it in r11 (caller-saved per System V AMD64; not part of
-        // SavedState). On x86-64 TSO, program-order stores are observed in
-        // program order by other CPUs, so the [rdi+64] store is visible
-        // before the [r11] store with no explicit fence; the scheduler-lock
-        // release at release_lock_only() happened in Rust before this asm
-        // and is independent of the publication barrier below.
+        // ── Save fs_base ──────────────────────────────────────────────────
+        // saved_state.fs_base (offset 64) is the last save-side field
+        // written. rdmsr clobbers rdx (which carries the save_flag
+        // pointer), so we stash it in r11 (caller-saved per System V
+        // AMD64; not part of SavedState). The `context_saved = 1`
+        // publication and the `popfq` that re-enables interrupts are
+        // both delayed until after the rsp swap (see #117 ordering note
+        // below in the restore phase).
         "mov r11, rdx", // r11 = save_flag (rdx clobbered by rdmsr)
         // fs_base: read the currently-live user TLS base from IA32_FS_BASE
         // (MSR 0xc0000100). rdmsr returns high 32 bits in edx, low 32 in
@@ -181,18 +173,25 @@ pub unsafe extern "C" fn switch(
         "shl rdx, 32",
         "or  rax, rdx",
         "mov [rdi + 64], rax", // saved_state.fs_base
-        // Publish context_saved = 1 only after every saved_state store is
-        // complete. The null check covers the boot path where save_flag is
-        // null (initial entry).
-        "test r11, r11",
-        "jz 1f",
-        "mov dword ptr [r11], 1", // *save_flag = 1
-        "1:",
         // ── Restore next thread ───────────────────────────────────────────
-        // Restore rflags first so the restored flags take effect early.
-        "mov rax, [rsi + 72]",
-        "push rax",
-        "popfq",
+        // #117 ordering invariant: `context_saved = 1` AND `popfq` (which
+        // restores `next.rflags`, re-enabling IF if the next thread had
+        // IF=1) must BOTH happen AFTER `mov rsp, [rsi + 8]`. Doing either
+        // earlier opens a fatal window:
+        //   (a) `popfq` before the rsp swap re-enables interrupts while
+        //       this CPU is still on the OUTGOING thread's kernel stack,
+        //       so any trap taken here pushes its iretq frame to the
+        //       outgoing kstack.
+        //   (b) Publishing `current.context_saved = 1` before the rsp
+        //       swap makes the outgoing TCB visible to peer CPUs as
+        //       "safe to dispatch" while this CPU is still using its
+        //       kstack. A peer that dispatches `current` will execute
+        //       its own `mov rsp, [rsi + 8]` onto the same outgoing
+        //       kstack — two CPUs sharing a kstack.
+        // Together (a) and (b) let a peer overwrite the iretq frame the
+        // trap in (a) pushed, so iretq on this CPU returns to a wild RIP
+        // — observed in stress::concurrent_ipc as a kernel #PF at RIP=0.
+        // Keep the publication and `popfq` below the rsp swap.
         // Restore fs_base into IA32_FS_BASE before any register the wrmsr
         // clobbers (rcx/rdx/rax) is finalised for the jump.
         "mov rax, [rsi + 64]",
@@ -206,7 +205,20 @@ pub unsafe extern "C" fn switch(
         "mov r12, [rsi + 32]",
         "mov rbp, [rsi + 24]",
         "mov rbx, [rsi + 16]",
-        "mov rsp, [rsi + 8]", // restore stack pointer
+        "mov rsp, [rsi + 8]", // restore stack pointer — now on next's kstack
+        // Publish context_saved = 1 only AFTER the rsp swap (see ordering
+        // note above). The null check covers the boot path where
+        // save_flag is null (initial entry).
+        "test r11, r11",
+        "jz 1f",
+        "mov dword ptr [r11], 1", // *save_flag = 1
+        "1:",
+        // Restore rflags (may re-enable IF). Doing this AFTER the rsp
+        // swap means an interrupt taken between popfq and `jmp rax`
+        // pushes its iretq frame to next's kstack, not the outgoing one.
+        "mov rax, [rsi + 72]",
+        "push rax",
+        "popfq",
         "mov rax, [rsi + 0]", // rip (jump target)
         "jmp rax",            // jump to next thread's rip
     );

--- a/core/kernel/src/ipc/endpoint.rs
+++ b/core/kernel/src/ipc/endpoint.rs
@@ -372,14 +372,30 @@ pub unsafe fn endpoint_reply(
     {
         return None;
     }
-    // Plain Release store is safe under ep.lock — concurrent
-    // cancel_ipc_block uses compare_exchange and only clears if it matched
-    // its own client, which already lost to our load above.
+    // CAS-claim the reply slot: `cancel_ipc_block`, the
+    // `dealloc_object_one(Thread)` reply-bound waker, and the timer
+    // `BlockedOnReply` arm in `sleep_check_wakeups` all CAS this slot
+    // independently of `ep.lock`. A plain load+store would let one of
+    // them clear `reply_tcb` between our load and store while we still
+    // proceed to wake `caller` — yielding two `enqueue_and_wake` calls
+    // on the same client and a double-enqueue. See issue #117.
     // SAFETY: server validated.
-    unsafe {
+    if unsafe {
         (*server)
             .reply_tcb
-            .store(core::ptr::null_mut(), core::sync::atomic::Ordering::Release);
+            .compare_exchange(
+                caller,
+                core::ptr::null_mut(),
+                core::sync::atomic::Ordering::AcqRel,
+                core::sync::atomic::Ordering::Acquire,
+            )
+            .is_err()
+    }
+    {
+        // A concurrent canceller / dealloc / timer already cleared the
+        // slot; they own the wake (and the client may already be
+        // Stopped or Exited).
+        return None;
     }
 
     // SAFETY: caller stored by endpoint_call/recv. State transitions

--- a/core/kernel/src/sched/mod.rs
+++ b/core/kernel/src/sched/mod.rs
@@ -475,6 +475,11 @@ pub fn sleep_list_remove(tcb: *mut ThreadControlBlock) -> bool
 /// If we reach a signal-waiter tcb here, we must arbitrate against a
 /// concurrent `signal_send` by taking `sig.lock` and checking whether we
 /// are still registered as the waiter before claiming the wake.
+// too_many_lines: flat dispatch over every claimable `IpcThreadState`
+// (signal, event queue, reply, plain sleep); each arm is independent and
+// short, and splitting would require duplicating the SLEEP_LIST snapshot
+// plumbing.
+#[allow(clippy::too_many_lines)]
 #[cfg(not(test))]
 pub fn sleep_check_wakeups()
 {
@@ -598,6 +603,62 @@ pub fn sleep_check_wakeups()
                 }
                 // SAFETY: paired with lock_raw above.
                 unsafe { (*eq_state).lock.unlock_raw(saved_eq) };
+                we_win
+            }
+
+            crate::sched::thread::IpcThreadState::BlockedOnReply if !blocked_on.is_null() =>
+            {
+                // BlockedOnReply: `blocked_on` is the SERVER's TCB. The
+                // server's `reply_tcb` points to this tcb (the client) until
+                // `endpoint_reply`, `cancel_ipc_block`, or
+                // `dealloc_object_one(Thread)`'s reply-bound waker clears
+                // it.
+                //
+                // Defensive guard: no current code path adds a
+                // `BlockedOnReply` TCB to the sleep list (the IPC
+                // call/recv path does not accept a timeout — see
+                // `sys_ipc_call` and `sys_ipc_recv` in
+                // `core/kernel/src/syscall/ipc.rs`). If a future timeout
+                // surface is introduced, the `_` fall-through below
+                // would treat a `BlockedOnReply` waiter as a plain sleep
+                // and claim the wake unconditionally, racing with a
+                // concurrent `endpoint_reply` / cancel / dealloc and
+                // producing a double-`enqueue_and_wake`. This arm
+                // forecloses that by CAS-claiming the server's
+                // `reply_tcb` slot the same way every other reply-side
+                // writer does.
+                //
+                // CAS the server's `reply_tcb` from `tcb` (us) to null;
+                // success means we claim the wake, failure means the
+                // server/cancel/dealloc beat us. Lock order: SLEEP_LIST_LOCK
+                // was released above; this is a lock-free atomic.
+                // cast_ptr_alignment suppressed for the same reason as the
+                // signal arm above.
+                #[allow(clippy::cast_ptr_alignment)]
+                let server = blocked_on.cast::<crate::sched::thread::ThreadControlBlock>();
+                // SAFETY: server is a valid TCB pointer; reply_tcb is AtomicPtr.
+                let we_win = unsafe {
+                    (*server)
+                        .reply_tcb
+                        .compare_exchange(
+                            tcb,
+                            core::ptr::null_mut(),
+                            core::sync::atomic::Ordering::AcqRel,
+                            core::sync::atomic::Ordering::Acquire,
+                        )
+                        .is_ok()
+                };
+                if we_win
+                {
+                    // SAFETY: tcb still valid; see above. State/ipc_state/
+                    // blocked_on_object are committed by enqueue_and_wake
+                    // under sched.lock.
+                    unsafe {
+                        (*tcb).wakeup_value = 0;
+                        (*tcb).timed_out = true;
+                        (*tcb).sleep_deadline = 0;
+                    }
+                }
                 we_win
             }
 


### PR DESCRIPTION
## Summary

- **Closes #117.** Residual `stress::concurrent_ipc` kernel `#PF` in the project's master is a two-CPU shared-kstack race in `Context::switch`'s x86_64 naked asm: `popfq` (re-enabling `IF=1` from `next.rflags`) AND the `context_saved = 1` publication BOTH happened BEFORE the rsp swap. A trap taken between popfq and rsp swap pushed its iretq frame to the OUTGOING thread's kstack; a peer CPU that dispatched the outgoing thread (because context_saved was already 1) then performed its own rsp swap onto the same kstack and overwrote that iretq frame. iretq on the original CPU returned to a wild RIP, observed as `rip=0, cr2=0, err=0x10` at ~0.2 % per run.
- **Fix** (commit `3fd0280`): in `core/kernel/src/arch/x86_64/context.rs::switch`, move both `popfq` and the `context_saved=1` publication to AFTER `mov rsp, [rsi + 8]`. After the rsp swap this CPU is on next's kstack, so traps push iretq frames onto next's kstack (not shared) and `context_saved` remains 0 (gating peer dispatch) until this CPU is fully off the outgoing kstack.
- **Companion** (commit `63ca8aa`): `endpoint_reply` now CAS-claims `(*server).reply_tcb`, matching the three other writers of the slot (`cancel_ipc_block`, the dealloc reply-bound waker, the dealloc client-side cleanup). `sleep_check_wakeups` grew a defensive explicit `BlockedOnReply` arm that CAS-claims the same slot — the IPC call/recv path does not accept a timeout today, but the arm forecloses the race a future timeout surface would re-open through the `_` fall-through. Not measurably contributing to the residual rate; shipped here because it touches the same surface.
- Issue #117 scope item (a) — "disambiguate the two candidate root causes via per-CPU `rax` capture" — was the load-bearing diagnostic step: a per-TCB `last_switch_in_rip` field (kept in working-tree only, not in this PR) stamped the switch's `mov rax, [rsi+0]` value into `next.saved_state.last_switch_in_rip`. Every captured trap thread had `last_switch_in_rip = 0`, proving switch into the trap TCB had never reached the stamping site. The fault was on the OUTGOING thread mid-restore, not on the incoming one.
- Issue #117 scope item (b) — "audit `ThreadControlBlock.trap_frame` and `.saved_state` cross-thread writers" — is implicitly resolved by the finding. The root cause is publication-order inside `switch()` itself, not a stray cross-thread writer. No additional writer audit is needed for #117 closure.
- Documentation: `core/kernel/docs/scheduling-internals.md` § Cross-CPU TCB Ownership records the new finer-grained ordering invariant inside `switch()`.

## Follow-up (not in this PR)

RISC-V `Context::switch` at `core/kernel/src/arch/riscv64/context.rs:178-200` has the analogous publication-before-sp-swap ordering. The interrupt-on-outgoing-kstack window (a) does not apply because `sstatus.SIE` stays masked across the swap, but window (b) — peer CPU observing `context_saved = 1`, reading `saved_state.sp` (= outgoing sp), and dispatching onto the same outgoing kstack while this hart is still pre-`ld sp` — is structurally present. Tracked in a separate issue.

## Test plan

- [x] `cargo xtask build --arch x86_64` — clean build.
- [x] `cargo xtask build --arch riscv64` — clean build.
- [x] `cargo xtask run --arch x86_64` with `init=ktest cmdline=ktest.filter=unit,integration,stress,bench ktest.shutdown=always ktest.timeout=0` — `[ktest] ALL TESTS PASSED`, 164/164.
- [x] `cargo xtask run --arch riscv64` (same boot.conf) — `[ktest] ALL TESTS PASSED`, 164/164.
- [x] `SERAPH_ACCEL=tcg cargo xtask run-parallel --arch x86_64 --parallel 4 --runs 1000 --timeout 60` — sweep #1: **0 hangs / 1000**.
- [x] Same command, sweep #2: **0 hangs / 1000**.
- [x] Combined: **0 hangs / 2000**. Pre-fix baseline was ~2–3 hangs / 1000; `p(0/2000 under baseline)` ≈ 0.7 %.
- [x] CI: full workflow green on both arches, both modes, all three harnesses.

Closes #117