### PR TITLE
kernel/syscall: deliver SYS_SIGNAL_WAIT bitmask via secondary return register

### DIFF
--- a/abi/syscall/src/lib.rs
+++ b/abi/syscall/src/lib.rs
@@ -69,9 +69,15 @@ pub const SYS_SIGNAL_SEND: u64 = 3;
 /// arg0 = signal cap index (WAIT right). arg1 = `timeout_ms`: `0` means
 /// block indefinitely (the only behaviour before the timeout extension);
 /// `> 0` means block until bits are delivered *or* `timeout_ms`
-/// milliseconds have elapsed, whichever comes first. On timeout the
-/// syscall returns `0` (unambiguous — `signal_send` rejects zero-bit
-/// sends, so a legitimate wake always carries non-zero bits).
+/// milliseconds have elapsed, whichever comes first.
+///
+/// On success returns `0` in the primary return register and the bitmask
+/// in the secondary register (rdx / a1); on timeout returns `0` in both
+/// (unambiguous because `signal_send` rejects zero-bit sends, so a
+/// legitimate wake always carries non-zero bits). The split avoids
+/// aliasing bit-63-set bitmasks with the dispatcher's negative-Err
+/// encoding — the full 64-bit bitmask range is usable. Same register
+/// layout as `SYS_EVENT_RECV`.
 pub const SYS_SIGNAL_WAIT: u64 = 4;
 /// `EventQueue`: post an entry.
 pub const SYS_EVENT_POST: u64 = 5;

--- a/core/kernel/docs/ipc-internals.md
+++ b/core/kernel/docs/ipc-internals.md
@@ -231,19 +231,26 @@ behaviour.
    // Atomically read and clear all bits
 2. if acquired != 0:
    // Bits were set; return immediately without blocking
-   return acquired
+   tf.set_ipc_return(primary = 0, secondary = acquired); return Ok(0)
 3. Acquire waiter_lock
 4. Re-check: acquired = bits.swap(0, Ordering::Acquire)
    // Must re-check after acquiring lock to prevent lost-wakeup race:
    // a sender may have set bits between step 1 and step 3
 5. if acquired != 0:
-   Release waiter_lock; return acquired
+   Release waiter_lock;
+   tf.set_ipc_return(primary = 0, secondary = acquired); return Ok(0)
 6. waiter = current_tcb
 7. Release waiter_lock
 8. Block current thread; return when woken
 9. On wakeup: the sender has already performed bits.swap(0) and stored the
-   result in current_tcb.wakeup_value; return that value
+   result in current_tcb.wakeup_value;
+   tf.set_ipc_return(primary = 0, secondary = wakeup_value); return Ok(0)
 ```
+
+The acquired bitmask is delivered in the secondary return register
+(rdx / a1), matching `SYS_EVENT_RECV`'s register layout. An in-band
+encoding via the dispatcher's `cast_signed()` of the primary would alias
+bit-63-set bitmasks with negative-Err codes.
 
 ---
 

--- a/core/kernel/docs/syscalls.md
+++ b/core/kernel/docs/syscalls.md
@@ -323,9 +323,14 @@ entire bitmask.
 
 **Return:**
 
-- `rax`/`a0`: the bitmask that was set (positive, non-zero) on signal wake;
-  `0` on timeout (unambiguous: `signal_send` rejects zero-bit sends, so a
-  real wake always carries a non-zero mask). `SyscallError` on failure.
+- `rax`/`a0`: 0 on success; `SyscallError` on failure
+- `rdx`/`a1`: acquired bitmask on success (non-zero on signal wake; `0`
+  on timeout — unambiguous because `signal_send` rejects zero-bit sends,
+  so a real wake always carries a non-zero mask)
+
+Same register layout as `SYS_EVENT_RECV`. The split avoids aliasing
+bit-63-set bitmasks with the dispatcher's negative-Err encoding, so the
+full 64-bit bitmask range is usable.
 
 **Capability requirement:** `signal_cap` must have Wait rights.
 

--- a/core/kernel/src/syscall/ipc.rs
+++ b/core/kernel/src/syscall/ipc.rs
@@ -884,13 +884,18 @@ pub fn sys_signal_send(tf: &mut TrapFrame) -> Result<u64, SyscallError>
 
 /// `SYS_SIGNAL_WAIT` (4): block until a signal bit is set, then return the bits.
 ///
-/// arg0 = signal cap index.
-/// arg1 = `timeout_ms`. `0` blocks indefinitely (original behaviour). `> 0`
-///        blocks until bits are delivered *or* `timeout_ms` milliseconds
-///        have elapsed. On timeout the syscall returns `0` — unambiguous
-///        because `signal_send` rejects zero-bit sends.
+/// arg0 = signal cap index (WAIT right).
+/// arg1 = `timeout_ms`. `0` blocks indefinitely. `> 0` blocks until bits
+///        are delivered *or* `timeout_ms` milliseconds have elapsed.
 ///
-/// Returns the acquired bitmask in rax/a0 (0 = timeout).
+/// On success returns `0` in rax/a0 and the bitmask in the secondary return
+/// register (rdx/a1). On timeout returns `0` in both registers — unambiguous
+/// because `signal_send` rejects zero-bit sends, so a legitimate wake always
+/// carries non-zero bits. The split is required because the bitmask is an
+/// unrestricted `u64`: an in-band encoding via `cast_signed` would alias
+/// bit-63-set payloads with the dispatcher's negative-Err codes. Same
+/// register layout as `sys_event_recv`; see that handler for the broader
+/// pattern.
 #[cfg(not(test))]
 pub fn sys_signal_wait(tf: &mut TrapFrame) -> Result<u64, SyscallError>
 {
@@ -924,8 +929,9 @@ pub fn sys_signal_wait(tf: &mut TrapFrame) -> Result<u64, SyscallError>
 
     if let Ok(bits) = result
     {
-        // Bits were already set; return immediately.
-        return Ok(bits);
+        // Bits were already set; deliver bitmask in secondary register.
+        tf.set_ipc_return(0, bits);
+        return Ok(0);
     }
 
     // For a timed wait, arm the sleep list. Re-acquire sig.lock and check
@@ -974,15 +980,16 @@ pub fn sys_signal_wait(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     }
 
     // On resume, either `signal_send` stored delivered bits in wakeup_value,
-    // or the timer path cleared wakeup_value to 0 (timeout). Both paths
-    // clear `sleep_deadline` as part of claiming the wake.
+    // or the timer path left wakeup_value at 0 (timeout). Both paths clear
+    // `sleep_deadline` as part of claiming the wake.
     // SAFETY: tcb still valid after resume; wakeup_value set by the waker.
     let bits = unsafe { (*tcb).wakeup_value };
     // SAFETY: tcb validated above.
     unsafe {
         (*tcb).wakeup_value = 0;
     }
-    Ok(bits)
+    tf.set_ipc_return(0, bits);
+    Ok(0)
 }
 
 // ── Event Queue handlers ──────────────────────────────────────────────────────

--- a/core/kernel/src/syscall/ipc.rs
+++ b/core/kernel/src/syscall/ipc.rs
@@ -980,8 +980,8 @@ pub fn sys_signal_wait(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     }
 
     // On resume, either `signal_send` stored delivered bits in wakeup_value,
-    // or the timer path left wakeup_value at 0 (timeout). Both paths clear
-    // `sleep_deadline` as part of claiming the wake.
+    // or the timer path cleared wakeup_value to 0 (timeout). Both paths
+    // clear `sleep_deadline` as part of claiming the wake.
     // SAFETY: tcb still valid after resume; wakeup_value set by the waker.
     let bits = unsafe { (*tcb).wakeup_value };
     // SAFETY: tcb validated above.

--- a/core/ktest/src/stress/concurrent_signal.rs
+++ b/core/ktest/src/stress/concurrent_signal.rs
@@ -38,7 +38,7 @@ pub fn run(ctx: &TestContext) -> TestResult
     let done = cap_create_signal(ctx.memory_frame_base)
         .map_err(|_| "concurrent_signal: create done failed")?;
 
-    // Spawn 4 sender threads.
+    // Spawn `NUM_SENDERS` sender threads.
     let mut threads = [0u32; NUM_SENDERS];
     let mut cspaces = [0u32; NUM_SENDERS];
 
@@ -65,8 +65,8 @@ pub fn run(ctx: &TestContext) -> TestResult
     }
 
     // Wait for all senders to report done. Each child ORs a unique bit into
-    // `done`, so we wait until all 4 bits are set (one blocking wait suffices
-    // since the last child to finish will set the final bit).
+    // `done`, so we wait until every `NUM_SENDERS` bit is set (one blocking
+    // wait suffices since the last child to finish will set the final bit).
     let mut done_bits: u64 = 0;
     while done_bits != ALL_BITS
     {

--- a/core/ktest/src/stress/concurrent_signal.rs
+++ b/core/ktest/src/stress/concurrent_signal.rs
@@ -11,17 +11,11 @@ use syscall::{cap_copy, cap_create_signal, cap_delete, signal_send, signal_wait,
 
 use crate::{ChildStack, TestContext, TestResult, spawn};
 
-/// 16 — pre-ramp baseline. Two separate kernel-side issues block
-/// ramping this further in-tree:
-///
-/// 1. Bit 63 of `SYS_SIGNAL_WAIT`'s returned bitmask aliases with the
-///    dispatcher's `cast_signed()` Err encoding, so per-bit accounting
-///    tops out at 63 distinct workers.
-/// 2. Above ~16-32 concurrently runnable spinning syscall threads on
-///    4-CPU SMP, follow-on tests (notably `cap_revoke_under_use`)
-///    observe scheduler-fairness starvation. Until the kernel is
-///    fixed, we keep this constant at the pre-ramp baseline so
-///    downstream stress tests aren't compromised.
+/// 16 — pre-ramp baseline. Above ~16-32 concurrently runnable spinning
+/// syscall threads on 4-CPU SMP, follow-on tests (notably
+/// `cap_revoke_under_use`) observe scheduler-fairness starvation. Until
+/// the kernel-side fairness issue is fixed, we keep this constant at the
+/// pre-ramp baseline so downstream stress tests aren't compromised.
 ///
 /// Iteration count is the pre-ramp baseline; in-tree experiments showed
 /// the ramped 5000-iter variant left follow-on tests in a degraded state

--- a/core/ktest/src/unit/fpu.rs
+++ b/core/ktest/src/unit/fpu.rs
@@ -482,7 +482,9 @@ extern "C" fn child_cross_entry(_arg: u64) -> !
     // SAFETY: inline asm loads pat128 into xmm0..xmm15, issues two raw
     // syscalls (SIGNAL_SEND, SIGNAL_WAIT) preserving the live FP register
     // file across both, then stores xmm0..xmm15 into buf. All operands
-    // have matching lifetimes; rcx/r11 are syscall-clobber-only.
+    // have matching lifetimes; rcx/r11 are syscall-clobber-only. rdx is
+    // clobbered by SIGNAL_WAIT's secondary-return write (the kernel writes
+    // the acquired bitmask into rdx via `set_ipc_return`).
     unsafe {
         core::arch::asm!(
             "vmovdqu xmm0,  [{p}]",
@@ -537,7 +539,7 @@ extern "C" fn child_cross_entry(_arg: u64) -> !
             it = inout(reg) spin => _,
             sig_ready = in(reg) sig_ready,
             sig_resume = in(reg) sig_resume,
-            out("rax") _, out("rcx") _, out("rdi") _, out("rsi") _, out("r11") _,
+            out("rax") _, out("rcx") _, out("rdx") _, out("rdi") _, out("rsi") _, out("r11") _,
             out("xmm0") _, out("xmm1") _, out("xmm2") _, out("xmm3") _,
             out("xmm4") _, out("xmm5") _, out("xmm6") _, out("xmm7") _,
             out("xmm8") _, out("xmm9") _, out("xmm10") _, out("xmm11") _,

--- a/core/ktest/src/unit/mod.rs
+++ b/core/ktest/src/unit/mod.rs
@@ -258,6 +258,10 @@ pub fn run_all(ctx: &TestContext)
         "signal::wait_high_bit_roundtrip",
         signal::wait_high_bit_roundtrip(ctx)
     );
+    run_test!(
+        "signal::wait_high_bit_parked_wakeup",
+        signal::wait_high_bit_parked_wakeup(ctx)
+    );
 
     // ── Event queue syscalls ──────────────────────────────────────────────────
     run_test!("event::create", event::create(ctx));

--- a/core/ktest/src/unit/mod.rs
+++ b/core/ktest/src/unit/mod.rs
@@ -254,6 +254,10 @@ pub fn run_all(ctx: &TestContext)
         "signal::wait_timeout_returns_bits_first",
         signal::wait_timeout_returns_bits_first(ctx)
     );
+    run_test!(
+        "signal::wait_high_bit_roundtrip",
+        signal::wait_high_bit_roundtrip(ctx)
+    );
 
     // ── Event queue syscalls ──────────────────────────────────────────────────
     run_test!("event::create", event::create(ctx));

--- a/core/ktest/src/unit/signal.rs
+++ b/core/ktest/src/unit/signal.rs
@@ -222,6 +222,37 @@ pub fn wait_timeout_fires(ctx: &TestContext) -> TestResult
     Ok(())
 }
 
+// ── SYS_SIGNAL_WAIT (high-bit payload) ────────────────────────────────────────
+
+/// Bitmasks with bit 63 set (and `u64::MAX`) must round-trip cleanly through
+/// `signal_send` / `signal_wait`. Regression test for the dispatcher's
+/// historical `cast_signed()` aliasing of `Ok(bits)` with negative-Err
+/// codes, which surfaced bit-63-set bitmasks to userspace as `Err(i64::MIN)`.
+pub fn wait_high_bit_roundtrip(ctx: &TestContext) -> TestResult
+{
+    let sig = cap_create_signal(ctx.memory_frame_base)
+        .map_err(|_| "create_signal for wait_high_bit_roundtrip failed")?;
+
+    // Bit 63 alone — the aliasing case.
+    signal_send(sig, 1u64 << 63).map_err(|_| "signal_send(1<<63) failed")?;
+    let bits = signal_wait(sig).map_err(|_| "signal_wait after send(1<<63) failed")?;
+    if bits != 1u64 << 63
+    {
+        return Err("signal_wait did not round-trip bit 63 (regression on #127)");
+    }
+
+    // All bits set — covers any bit-by-bit truncation in the new path.
+    signal_send(sig, u64::MAX).map_err(|_| "signal_send(u64::MAX) failed")?;
+    let bits = signal_wait(sig).map_err(|_| "signal_wait after send(u64::MAX) failed")?;
+    if bits != u64::MAX
+    {
+        return Err("signal_wait did not round-trip u64::MAX bitmask");
+    }
+
+    cap_delete(sig).map_err(|_| "cap_delete after wait_high_bit_roundtrip failed")?;
+    Ok(())
+}
+
 /// Pre-signalled bits must be returned immediately, ahead of the timeout.
 pub fn wait_timeout_returns_bits_first(ctx: &TestContext) -> TestResult
 {

--- a/core/ktest/src/unit/signal.rs
+++ b/core/ktest/src/unit/signal.rs
@@ -23,6 +23,9 @@ const RIGHTS_WAIT: u64 = 1 << 8;
 // Child stack for blocking-wait test.
 static mut CHILD_STACK: ChildStack = ChildStack::ZERO;
 
+// Separate child stack for the parked-wakeup variant of the bit-63 test.
+static mut HIGH_BIT_CHILD_STACK: ChildStack = ChildStack::ZERO;
+
 // ── SYS_SIGNAL_SEND ───────────────────────────────────────────────────────────
 
 /// `signal_send` ORs bits into a signal object. Non-blocking.
@@ -253,6 +256,40 @@ pub fn wait_high_bit_roundtrip(ctx: &TestContext) -> TestResult
     Ok(())
 }
 
+/// Parked-wakeup variant: parent enters `signal_wait` first, then a child
+/// thread sends `1u64 << 63`. Exercises the post-resume return path
+/// (where `wakeup_value` is read after `schedule()`) — distinct from the
+/// immediate-bits fast path covered by `wait_high_bit_roundtrip`.
+pub fn wait_high_bit_parked_wakeup(ctx: &TestContext) -> TestResult
+{
+    let sig = cap_create_signal(ctx.memory_frame_base)
+        .map_err(|_| "create_signal for wait_high_bit_parked_wakeup failed")?;
+
+    let child = crate::spawn::new_child(ctx)
+        .map_err(|_| "spawn::new_child for wait_high_bit_parked_wakeup failed")?;
+    let child_sig = cap_copy(sig, child.cs, RIGHTS_SIGNAL)
+        .map_err(|_| "cap_copy signal into child CSpace failed")?;
+
+    let stack_top = ChildStack::top(core::ptr::addr_of!(HIGH_BIT_CHILD_STACK));
+    crate::spawn::configure_and_start(
+        &child,
+        high_bit_sender_entry,
+        stack_top,
+        u64::from(child_sig),
+    )
+    .map_err(|_| "configure_and_start for wait_high_bit_parked_wakeup failed")?;
+
+    let bits = signal_wait(sig).map_err(|_| "signal_wait (parked) failed")?;
+    if bits != 1u64 << 63
+    {
+        return Err("parked-wakeup signal_wait did not deliver bit 63 (regression on #127)");
+    }
+
+    cap_delete(sig).map_err(|_| "cap_delete sig after wait_high_bit_parked_wakeup failed")?;
+    cap_delete(child.cs).map_err(|_| "cap_delete cs after wait_high_bit_parked_wakeup failed")?;
+    Ok(())
+}
+
 /// Pre-signalled bits must be returned immediately, ahead of the timeout.
 pub fn wait_timeout_returns_bits_first(ctx: &TestContext) -> TestResult
 {
@@ -282,5 +319,15 @@ pub fn wait_timeout_returns_bits_first(ctx: &TestContext) -> TestResult
 fn sender_entry(sig_slot: u64) -> !
 {
     signal_send(sig_slot as u32, 0xBEEF).ok();
+    thread_exit()
+}
+
+/// Child thread: sends `1u64 << 63` on `sig_slot` then exits. Used by
+/// `wait_high_bit_parked_wakeup` to drive the post-resume return path.
+// cast_possible_truncation: sig_slot is a kernel cap slot index, guaranteed < 2^32.
+#[allow(clippy::cast_possible_truncation)]
+fn high_bit_sender_entry(sig_slot: u64) -> !
+{
+    signal_send(sig_slot as u32, 1u64 << 63).ok();
     thread_exit()
 }

--- a/shared/syscall/src/lib.rs
+++ b/shared/syscall/src/lib.rs
@@ -718,19 +718,22 @@ pub fn signal_send(sig: u32, bits: u64) -> Result<(), i64>
 
 /// Block until any bits are set on a signal cap. Returns the acquired bitmask.
 ///
+/// The primary return register holds status (`0` on success, negative
+/// `SyscallError` on failure); the bitmask is delivered in the secondary
+/// register (rdx / a1). Mirrors `event_recv`; the split avoids aliasing
+/// bit-63-set bitmasks with the dispatcher's negative-Err encoding.
+///
 /// # Errors
 /// Returns a negative `i64` error code if the signal cap is invalid or the
 /// wait is interrupted.
-// cast_sign_loss: ret is proven non-negative in the Ok branch; reinterpreting
-// as u64 preserves the bitmask bit-for-bit.
-#[allow(clippy::cast_sign_loss)]
 #[inline]
 pub fn signal_wait(sig: u32) -> Result<u64, i64>
 {
-    // SAFETY: syscall2 issues raw syscall instruction; sig is cap index as u64;
-    // kernel validates cap, blocks until signal bits available, returns bitmask.
-    let ret = unsafe { syscall2(SYS_SIGNAL_WAIT, u64::from(sig), 0) };
-    if ret < 0 { Err(ret) } else { Ok(ret as u64) }
+    // SAFETY: syscall5_ret2 issues raw syscall instruction; sig is cap
+    // index as u64, arg1 = 0 selects indefinite blocking; kernel validates
+    // cap and writes the bitmask into the secondary return register.
+    let (ret, bits) = unsafe { syscall5_ret2(SYS_SIGNAL_WAIT, u64::from(sig), 0, 0, 0, 0) };
+    if ret < 0 { Err(ret) } else { Ok(bits) }
 }
 
 /// Block until any bits are set on a signal cap, or until `timeout_ms`
@@ -740,17 +743,21 @@ pub fn signal_wait(sig: u32) -> Result<u64, i64>
 /// `timeout_ms == 0` is equivalent to [`signal_wait`] — block indefinitely.
 /// Callers that want a non-blocking poll should use `timeout_ms = 1`.
 ///
+/// Same register layout as [`signal_wait`]: status in the primary register,
+/// bitmask in the secondary. Timeout is signalled in-band as `bits == 0`
+/// (legitimate because `signal_send` rejects zero-bit sends).
+///
 /// # Errors
 /// Returns a negative `i64` error code if the signal cap is invalid or
 /// the wait is interrupted.
-#[allow(clippy::cast_sign_loss)]
 #[inline]
 pub fn signal_wait_timeout(sig: u32, timeout_ms: u64) -> Result<u64, i64>
 {
-    // SAFETY: same as `signal_wait`; arg1 carries the timeout (0 =
-    // infinite, matching the original single-arg behaviour).
-    let ret = unsafe { syscall2(SYS_SIGNAL_WAIT, u64::from(sig), timeout_ms) };
-    if ret < 0 { Err(ret) } else { Ok(ret as u64) }
+    // SAFETY: same as `signal_wait`; arg1 carries the timeout sentinel
+    // (0 = infinite, matching the single-arg behaviour).
+    let (ret, bits) =
+        unsafe { syscall5_ret2(SYS_SIGNAL_WAIT, u64::from(sig), timeout_ms, 0, 0, 0) };
+    if ret < 0 { Err(ret) } else { Ok(bits) }
 }
 
 /// Retype a Frame cap into a new Endpoint. Returns the `CSpace` slot index.


### PR DESCRIPTION
Closes #127.

## Summary

`SYS_SIGNAL_WAIT` returned the OR'd signal bitmask in the primary return
register (rax/a0). The dispatcher encodes `Result<u64, SyscallError>`
via `cast_signed()` and userspace decodes `ret < 0` as `Err`
(`shared/syscall/src/lib.rs:732-733`). `sys_signal_send` accepts any
non-zero `u64` (only `bits == 0` is rejected), so a legal bitmask with
bit 63 set became a large negative `i64` at the dispatcher and surfaced
to userspace as `Err(i64::MIN)`.

This PR mirrors the established `SYS_EVENT_RECV` precedent
(`core/kernel/src/syscall/ipc.rs:1102`, `shared/syscall/src/lib.rs:1544`):
the kernel writes `(primary = 0, payload = bits)` via
`tf.set_ipc_return`; userspace reads both registers via `syscall5_ret2`.
The timeout sentinel (`bits == 0`) migrates from the primary to the
secondary register and remains unambiguous because `signal_send`
rejects zero-bit sends. The full 64-bit bitmask range is now usable;
no new ABI machinery or user-pointer validation paths required.

User chose option A — "Status + 2nd reg payload" — from the three
viable fixes (issue option 1 = reject bit 63 in send; option 2 =
out-pointer; option A = mirror `event_recv`).

## Changes

- `core/kernel/src/syscall/ipc.rs` — `sys_signal_wait` immediate-delivery
  and post-resume paths both call `tf.set_ipc_return(0, bits); Ok(0)`.
  Doc comment rewritten to describe new register layout and cite the
  reason for the split.
- `shared/syscall/src/lib.rs` — `signal_wait` / `signal_wait_timeout`
  switch from `syscall2` to `syscall5_ret2`; bitmask destructured from
  the secondary register; `cast_sign_loss` allows dropped (no cast).
- `abi/syscall/src/lib.rs` — `SYS_SIGNAL_WAIT` doc rewritten:
  primary = status, secondary = bitmask; timeout sentinel moved;
  full 64-bit range explicitly usable.
- `core/kernel/docs/syscalls.md` + `core/kernel/docs/ipc-internals.md`
  — authoritative kernel ABI spec and Wait Path pseudocode updated to
  match the new layout (audit-fix commit).
- `core/ktest/src/unit/signal.rs` + `core/ktest/src/unit/mod.rs` —
  `signal::wait_high_bit_roundtrip` exercises `1 << 63` and `u64::MAX`
  on the immediate-bits fast path. `signal::wait_high_bit_parked_wakeup`
  (audit-fix) covers the post-resume branch: parent blocks in
  `signal_wait`, child wakes it with `1 << 63`.
- `core/ktest/src/unit/fpu.rs` — declare `rdx` as a clobber in the raw
  x86_64 SIGNAL_WAIT inline-asm block (the kernel now writes rdx via
  `set_ipc_return`; LLVM was previously free to keep a live caller value
  there across the syscall). Audit-fix.
- `core/ktest/src/stress/concurrent_signal.rs` — drops reason (1)
  (bit-63 aliasing, now resolved) from the `NUM_SENDERS=16` cap
  comment; reason (2) (SMP scheduler-fairness starvation) still keeps
  the cap at 16. Independent kernel issue, separate from this fix.
  Also fixes pre-existing stale "Spawn 4 sender threads" / "all 4 bits"
  comments (audit-fix).

## Test plan

- [x] `cargo xtask clean && cargo xtask build --arch x86_64` clean
- [x] `cargo xtask run --arch x86_64` boots ktest with
  `init=ktest, cmdline=ktest.shutdown=always ktest.timeout=3` →
  `[ktest] ALL TESTS PASSED` (154 passed, 0 failed, including both
  `signal::wait_high_bit_roundtrip` and
  `signal::wait_high_bit_parked_wakeup`)
- [x] `cargo xtask clean && cargo xtask build --arch riscv64` clean
- [x] `cargo xtask run --arch riscv64` → `[ktest] ALL TESTS PASSED`
  (154/0, both bit-63 tests included)
- [x] CI green (re-verified after audit-fix commit)