### PR TITLE
fix(kernel/cap): bump MAX_CSPACES + surface registry overflow as OOM

### DIFF
--- a/core/kernel/docs/scheduler.md
+++ b/core/kernel/docs/scheduler.md
@@ -503,9 +503,19 @@ deferring to the next enqueue:
 
 ### Soft Affinity
 
-`tcb.preferred_cpu` records the CPU the thread was last assigned to. The load
-balancer uses this as a hint to avoid unnecessary migration (cache warmth). A thread
-may be migrated away from its preferred CPU when load balancing requires it.
+`tcb.preferred_cpu` records the CPU the thread was last assigned to. The
+wake-side placement (`select_target_cpu`) honours it as a sticky cache-
+warmth hint: it scans all CPUs for `min_load`, and if `preferred_cpu`'s
+load is within `LOAD_BALANCE_IMBALANCE_THRESHOLD` of `min_load`, the
+thread is re-placed on its preferred CPU. Beyond that threshold the
+thread is migrated to the least-loaded CPU. The threshold is the same
+hysteresis the pull balancer uses to decide an imbalance is real, so
+soft affinity, wake placement, and pull balancing share one knob.
+
+Hard affinity (`cpu_affinity != AFFINITY_ANY`) and save-window pinning
+(`context_saved == 0`) both short-circuit ahead of the soft-affinity
+check; see `select_target_cpu` in `core/kernel/src/sched/mod.rs` for
+the full policy.
 
 The scheduler does not expose soft affinity as a syscall parameter — it is an internal
 optimisation.

--- a/core/kernel/docs/scheduling-internals.md
+++ b/core/kernel/docs/scheduling-internals.md
@@ -206,6 +206,22 @@ Producer side (`enqueue_and_wake`, `core/kernel/src/sched/mod.rs`):
 
 The producer-side `state`/`ipc_state`/`blocked_on_object` writes belong to `enqueue_and_wake` — wake primitives MUST NOT do them under the source IPC lock. See Lock Hierarchy rule 9.
 
+### Target CPU selection (`select_target_cpu`)
+
+`enqueue_and_wake` resolves `target_cpu` via `select_target_cpu`. The
+selection policy is, in priority order: (1) hard affinity
+(`cpu_affinity != AFFINITY_ANY`), (2) save-window pinning to
+`preferred_cpu` while `context_saved == 0` (closes the cross-CPU
+`schedule()` spin against the source CPU's in-flight save), (3) sticky
+`preferred_cpu` when its load is within `LOAD_BALANCE_IMBALANCE_THRESHOLD`
+of the global `min_load`, and (4) the least-loaded CPU. The
+`LOAD_BALANCE_IMBALANCE_THRESHOLD` knob is shared with `try_pull_balance`
+so the wake-side stickiness and the pull-balancer's imbalance test
+agree on what counts as "real" load asymmetry. Issue #128 motivated the
+sticky-CPU rule: without it a thread blocked inside a busy multi-CPU
+runqueue can be re-placed on a different CPU at every wake and never
+land on a queue it can drain.
+
 Consumer side (`idle_thread_entry`, `core/kernel/src/sched/mod.rs:444+`):
 
 ```

--- a/core/kernel/docs/scheduling-internals.md
+++ b/core/kernel/docs/scheduling-internals.md
@@ -217,10 +217,12 @@ selection policy is, in priority order: (1) hard affinity
 of the global `min_load`, and (4) the least-loaded CPU. The
 `LOAD_BALANCE_IMBALANCE_THRESHOLD` knob is shared with `try_pull_balance`
 so the wake-side stickiness and the pull-balancer's imbalance test
-agree on what counts as "real" load asymmetry. Issue #128 motivated the
-sticky-CPU rule: without it a thread blocked inside a busy multi-CPU
-runqueue can be re-placed on a different CPU at every wake and never
-land on a queue it can drain.
+agree on what counts as "real" load asymmetry. The sticky-CPU rule
+originated from the #128 investigation as an independent
+cache-warmth alignment with the documented soft-affinity intent in
+`scheduler.md` § Soft Affinity; #128's actual root cause turned out
+to be unrelated (`CSpaceId` namespace exhaustion, see commits on
+that issue).
 
 Consumer side (`idle_thread_entry`, `core/kernel/src/sched/mod.rs:444+`):
 

--- a/core/kernel/src/cap/mod.rs
+++ b/core/kernel/src/cap/mod.rs
@@ -125,11 +125,31 @@ pub unsafe fn root_cspace_mut() -> Option<&'static mut CSpace>
     }
 }
 
-/// Monotonically increasing `CSpace` ID allocator. Root gets ID 0.
-static NEXT_CSPACE_ID: AtomicU32 = AtomicU32::new(0);
+/// Maximum number of `CSpaceId` slots ever allocated in a kernel lifetime.
+///
+/// The registry size bounds the `CSpaceId` namespace because the allocator
+/// is currently monotonic ([`NEXT_CSPACE_ID`] `fetch_add`) — IDs are not
+/// recycled on `unregister_cspace`. Cumulative-ever count, not live count:
+/// every `cap_create_cspace` consumes a fresh ID, so cap-creation churn
+/// (e.g. ktest stress's repeated child-CSpace allocation) eventually
+/// exhausts the namespace.
+///
+/// 65536 entries × 8 bytes = 512 KiB BSS for [`CSPACE_REGISTRY`]. Sized to
+/// cover the ramped ktest stress sequence (~14k `CSpace`s cumulatively) plus
+/// 4× headroom; a future change to recycle IDs (proper free-list /
+/// generation counters in `SlotId`) would let this shrink again. Tracked
+/// as a follow-up to #128 — see PR #136 body.
+const MAX_CSPACES: usize = 65536;
 
-/// Maximum number of live `CSpaces.` Sized for practical OS use.
-const MAX_CSPACES: usize = 4096;
+/// Monotonically increasing `CSpace` ID allocator. Root gets ID 0.
+///
+/// Currently does not recycle: a freed `CSpaceId` is never re-issued.
+/// Recycling would require either generation counters in `SlotId` to make
+/// stale references fail-fast, or an explicit walk of every other
+/// `CSpace`'s derivation tree to clear cross-`CSpace` back-links to the
+/// freed `CSpace` before reuse. Both are tracked as a follow-up; until
+/// then [`MAX_CSPACES`] is sized to absorb cumulative churn.
+static NEXT_CSPACE_ID: AtomicU32 = AtomicU32::new(0);
 
 /// Global registry mapping `CSpaceId` → raw *mut `CSpace.`
 ///
@@ -156,13 +176,21 @@ static CSPACE_REGISTRY: [AtomicPtr<CSpace>; MAX_CSPACES] = {
 
 /// Register a `CSpace` pointer under its ID.
 ///
-/// Called immediately after a [`CSpace`] is heap-allocated. Panics (in debug)
-/// or silently drops (in release) if `id >= MAX_CSPACES`.
-pub fn register_cspace(id: CSpaceId, ptr: *mut CSpace)
+/// Called immediately after a [`CSpace`] is heap-allocated. Returns
+/// `Err(())` if `id >= MAX_CSPACES` so the caller can surface
+/// `SyscallError::OutOfMemory` and roll back, rather than silently leaving
+/// the derivation tree unable to resolve the new `CSpace` (the
+/// pre-#128-fix behaviour that masked the namespace-exhaustion bug).
+pub fn register_cspace(id: CSpaceId, ptr: *mut CSpace) -> Result<(), ()>
 {
     if (id as usize) < MAX_CSPACES
     {
         CSPACE_REGISTRY[id as usize].store(ptr, Ordering::Release);
+        Ok(())
+    }
+    else
+    {
+        Err(())
     }
 }
 
@@ -176,6 +204,16 @@ pub fn unregister_cspace(id: CSpaceId)
     {
         CSPACE_REGISTRY[id as usize].store(core::ptr::null_mut(), Ordering::Release);
     }
+}
+
+/// Allocate a unique `CSpace` ID.
+///
+/// Called by `SYS_CAP_CREATE_CSPACE` when creating new `CSpace` objects at
+/// runtime. The root `CSpace` is assigned ID 0 at init time via this same
+/// counter. See [`NEXT_CSPACE_ID`] for the recycling caveat.
+pub fn alloc_cspace_id() -> CSpaceId
+{
+    NEXT_CSPACE_ID.fetch_add(1, Ordering::Relaxed)
 }
 
 /// Resolve a `CSpaceId` to a raw pointer.
@@ -193,11 +231,6 @@ pub fn lookup_cspace(id: CSpaceId) -> Option<*mut CSpace>
     if ptr.is_null() { None } else { Some(ptr) }
 }
 
-/// Allocate a unique `CSpace` ID.
-///
-/// Called by `SYS_CAP_CREATE_CSPACE` when creating new `CSpace` objects at
-/// runtime. The root `CSpace` is assigned ID 0 at init time via this same
-/// counter.
 /// Sum [`FrameObject::available_bytes`] across every [`CapTag::Frame`] cap
 /// in `cspace`. Used by Phase 9 to print the boot-handover ledger so that
 /// "RAM granted to userspace as retypable bytes" can be reconciled against
@@ -223,11 +256,6 @@ pub fn sum_frame_available_bytes(cspace: &cspace::CSpace) -> u64
         }
     });
     sum
-}
-
-pub fn alloc_cspace_id() -> CSpaceId
-{
-    NEXT_CSPACE_ID.fetch_add(1, Ordering::Relaxed)
 }
 
 /// Maximum slots in the root `CSpace` (full two-level directory).
@@ -915,7 +943,7 @@ pub fn init_capability_system(mmio_apertures: &[MmioAperture], boot_info_phys: u
         let block_count = unsafe { drain_and_install_seed(ram_buf) };
         let ram_blocks: &[RamBlock] = &ram_buf[..block_count];
 
-        let id = NEXT_CSPACE_ID.fetch_add(1, Ordering::Relaxed);
+        let id = alloc_cspace_id();
         // SAFETY: SEED installed above.
         let (_cs_kobj_nn, cs_ptr) = unsafe {
             boot_retype_cspace(
@@ -925,7 +953,8 @@ pub fn init_capability_system(mmio_apertures: &[MmioAperture], boot_info_phys: u
                 id,
             )
         };
-        register_cspace(id, cs_ptr);
+        register_cspace(id, cs_ptr)
+            .unwrap_or_else(|()| crate::fatal("root CSpace register: id exceeds MAX_CSPACES"));
 
         // SAFETY: cs_ptr is freshly constructed and exclusively owned
         // (single-threaded Phase 7).

--- a/core/kernel/src/cap/mod.rs
+++ b/core/kernel/src/cap/mod.rs
@@ -127,28 +127,19 @@ pub unsafe fn root_cspace_mut() -> Option<&'static mut CSpace>
 
 /// Maximum number of `CSpaceId` slots ever allocated in a kernel lifetime.
 ///
-/// The registry size bounds the `CSpaceId` namespace because the allocator
-/// is currently monotonic ([`NEXT_CSPACE_ID`] `fetch_add`) — IDs are not
-/// recycled on `unregister_cspace`. Cumulative-ever count, not live count:
-/// every `cap_create_cspace` consumes a fresh ID, so cap-creation churn
-/// (e.g. ktest stress's repeated child-CSpace allocation) eventually
-/// exhausts the namespace.
-///
-/// 65536 entries × 8 bytes = 512 KiB BSS for [`CSPACE_REGISTRY`]. Sized to
-/// cover the ramped ktest stress sequence (~14k `CSpace`s cumulatively) plus
-/// 4× headroom; a future change to recycle IDs (proper free-list /
-/// generation counters in `SlotId`) would let this shrink again. Tracked
-/// as a follow-up to #128 — see PR #136 body.
+/// The allocator is monotonic ([`NEXT_CSPACE_ID`] `fetch_add`); freed IDs
+/// are not reused. This is a cumulative-ever bound, not a live-`CSpace`
+/// bound — every `cap_create_cspace` consumes a fresh ID. 65536 × 8 B =
+/// 512 KiB BSS for [`CSPACE_REGISTRY`], sized to cover the ramped ktest
+/// stress sequence (~14k `CSpace`s cumulatively) with 4× headroom. Issue
+/// #137 tracks switching to a recycling allocator (needs either
+/// generation counters in `SlotId` or a pre-unregister drain of external
+/// derivation back-links — both touch substantial code paths).
 const MAX_CSPACES: usize = 65536;
 
-/// Monotonically increasing `CSpace` ID allocator. Root gets ID 0.
-///
-/// Currently does not recycle: a freed `CSpaceId` is never re-issued.
-/// Recycling would require either generation counters in `SlotId` to make
-/// stale references fail-fast, or an explicit walk of every other
-/// `CSpace`'s derivation tree to clear cross-`CSpace` back-links to the
-/// freed `CSpace` before reuse. Both are tracked as a follow-up; until
-/// then [`MAX_CSPACES`] is sized to absorb cumulative churn.
+/// Monotonically increasing `CSpace` ID allocator. Root gets ID 0. See
+/// [`MAX_CSPACES`] for the namespace-bound rationale and #137 for the
+/// recycling follow-up.
 static NEXT_CSPACE_ID: AtomicU32 = AtomicU32::new(0);
 
 /// Global registry mapping `CSpaceId` → raw *mut `CSpace.`
@@ -976,7 +967,7 @@ pub fn init_capability_system(mmio_apertures: &[MmioAperture], boot_info_phys: u
     // branch iterate `mmap` directly — `ram_blocks` is empty.
     #[cfg(test)]
     {
-        let id = NEXT_CSPACE_ID.fetch_add(1, Ordering::Relaxed);
+        let id = alloc_cspace_id();
         let mut cspace = Box::new(CSpace::new(id, ROOT_CSPACE_MAX_SLOTS));
         let empty: [RamBlock; 0] = [];
         let mut layout = populate_cspace(&mut cspace, &empty, mmap, mmio_apertures, info);

--- a/core/kernel/src/sched/mod.rs
+++ b/core/kernel/src/sched/mod.rs
@@ -1673,10 +1673,25 @@ pub unsafe fn enqueue_and_wake(tcb: *mut ThreadControlBlock, target_cpu: usize, 
 #[allow(unused_variables)]
 pub unsafe fn enqueue_and_wake(_tcb: *mut ThreadControlBlock, _target_cpu: usize, _priority: u8) {}
 
-/// Select target CPU for enqueueing a thread based on affinity and load.
+/// Select target CPU for enqueueing a thread based on affinity, soft
+/// affinity (cache warmth), and load.
 ///
-/// If the thread has explicit CPU affinity, returns that CPU. Otherwise,
-/// selects the least-loaded CPU for load balancing.
+/// Policy, in priority order:
+/// 1. **Hard affinity** (`cpu_affinity != AFFINITY_ANY`): return that CPU.
+/// 2. **Save-window pinning** (`context_saved == 0`): pin to
+///    `preferred_cpu` to avoid the cross-CPU `schedule()` spin against
+///    the source CPU's still-in-flight context save.
+/// 3. **Sticky preferred CPU**: scan all CPUs for `min_load`; if
+///    `preferred_cpu`'s load is within
+///    [`LOAD_BALANCE_IMBALANCE_THRESHOLD`] of `min_load`, return
+///    `preferred_cpu`. Cache-warmth bias matching the documented soft-
+///    affinity intent (`core/kernel/docs/scheduler.md` § Soft Affinity)
+///    and the same hysteresis the pull balancer applies before deciding
+///    an imbalance is real (`try_pull_balance`,
+///    `LOAD_BALANCE_IMBALANCE_THRESHOLD` site). Closes the per-wake CPU-
+///    bouncing pathology that starves a thread inside a busy multi-CPU
+///    runqueue (issue #128: `cap_revoke` parent vs. spinner flood).
+/// 4. **Min load**: return the least-loaded CPU.
 ///
 /// # Safety
 /// `tcb` must be a valid pointer to an initialized [`ThreadControlBlock`].
@@ -1696,6 +1711,8 @@ pub unsafe fn select_target_cpu(tcb: *mut ThreadControlBlock) -> usize
         return affinity as usize;
     }
 
+    let cpu_count = CPU_COUNT.load(core::sync::atomic::Ordering::Relaxed) as usize;
+
     // Save-window pinning: while `context_saved == 0` the source CPU is
     // mid-switch into `tcb.saved_state`. Migrating the wake to a different
     // CPU would force its `schedule()` to spin on the publication barrier;
@@ -1712,18 +1729,16 @@ pub unsafe fn select_target_cpu(tcb: *mut ThreadControlBlock) -> usize
         // SAFETY: preferred_cpu is set by every prior enqueue_and_wake;
         // bounded by CPU_COUNT at the source.
         let pref = unsafe { (*tcb).preferred_cpu } as usize;
-        let cpu_count = CPU_COUNT.load(core::sync::atomic::Ordering::Relaxed) as usize;
         if pref < cpu_count
         {
             return pref;
         }
     }
 
-    // No preference: load balance across all CPUs.
-    let cpu_count = CPU_COUNT.load(core::sync::atomic::Ordering::Relaxed) as usize;
+    // Scan all CPUs for min load. Used both as the fallback selection and as
+    // the reference value for the sticky-preferred-CPU comparison below.
     let mut min_load = u32::MAX;
     let mut min_cpu = 0;
-
     // SAFETY: scheduler slab covers cpu_count slots, all initialised by sched::init.
     for cpu in 0..cpu_count
     {
@@ -1733,6 +1748,22 @@ pub unsafe fn select_target_cpu(tcb: *mut ThreadControlBlock) -> usize
         {
             min_load = load;
             min_cpu = cpu;
+        }
+    }
+
+    // Sticky preferred CPU: stay if within the pull-balancer's imbalance
+    // threshold of the global minimum. See doc comment above.
+    // SAFETY: preferred_cpu is set by every prior enqueue_and_wake; bounded
+    // by CPU_COUNT at the source. The `< cpu_count` guard makes a stale or
+    // never-initialised value fall through to the min-load path.
+    let pref = unsafe { (*tcb).preferred_cpu } as usize;
+    if pref < cpu_count
+    {
+        // SAFETY: pref < cpu_count; slab initialised.
+        let pref_load = unsafe { (*scheduler_ptr(pref)).current_load() };
+        if pref_load <= min_load.saturating_add(LOAD_BALANCE_IMBALANCE_THRESHOLD)
+        {
+            return pref;
         }
     }
 

--- a/core/kernel/src/syscall/cap.rs
+++ b/core/kernel/src/syscall/cap.rs
@@ -649,12 +649,7 @@ pub fn sys_cap_create_cspace(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     unsafe { (*cs_ptr).set_kobj(cs_kobj_ptr) };
 
     // Register in the global registry so derivation lookups resolve.
-    // `register_cspace` now returns `Err` if `id >= MAX_CSPACES`
-    // (previously silently dropped, which made cross-CSpace derivation
-    // links unable to resolve into the new CSpace and was the actual
-    // root cause of #128 at the ramped stress concurrencies). Roll back
-    // the in-place wrapper/CSpace and the retype carve on registration
-    // failure so the source frame's accounting stays intact.
+    // Overflow → `SyscallError::OutOfMemory` with full rollback below.
     if crate::cap::register_cspace(id, cs_ptr).is_err()
     {
         // SAFETY: wrapper/cs not observed externally yet (registry

--- a/core/kernel/src/syscall/cap.rs
+++ b/core/kernel/src/syscall/cap.rs
@@ -649,7 +649,23 @@ pub fn sys_cap_create_cspace(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     unsafe { (*cs_ptr).set_kobj(cs_kobj_ptr) };
 
     // Register in the global registry so derivation lookups resolve.
-    crate::cap::register_cspace(id, cs_ptr);
+    // `register_cspace` now returns `Err` if `id >= MAX_CSPACES`
+    // (previously silently dropped, which made cross-CSpace derivation
+    // links unable to resolve into the new CSpace and was the actual
+    // root cause of #128 at the ramped stress concurrencies). Roll back
+    // the in-place wrapper/CSpace and the retype carve on registration
+    // failure so the source frame's accounting stays intact.
+    if crate::cap::register_cspace(id, cs_ptr).is_err()
+    {
+        // SAFETY: wrapper/cs not observed externally yet (registry
+        // rejected the entry; no slot in any CSpace points at `cs_ptr`).
+        unsafe {
+            core::ptr::drop_in_place(cs_kobj_ptr);
+            core::ptr::drop_in_place(cs_ptr);
+        }
+        retype_free(frame, offset, entry.raw_bytes);
+        return Err(SyscallError::OutOfMemory);
+    }
 
     // Hold a reference on the source Frame cap.
     // SAFETY: frame_obj_nn is live.
@@ -681,7 +697,7 @@ pub fn sys_cap_create_cspace(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     let nonnull = unsafe { NonNull::new_unchecked(cs_kobj_ptr.cast::<KernelObjectHeader>()) };
 
     // SAFETY: cspace validated non-null above; lock_raw/unlock_raw paired.
-    let idx = unsafe {
+    let insert_res = unsafe {
         let saved = (*cspace).lock.lock_raw();
         let r = (*cspace).insert_cap(
             CapTag::CSpace,
@@ -690,8 +706,30 @@ pub fn sys_cap_create_cspace(tf: &mut TrapFrame) -> Result<u64, SyscallError>
         );
         (*cspace).lock.unlock_raw(saved);
         r
-    }
-    .map_err(|_| SyscallError::OutOfMemory)?;
+    };
+    let Ok(idx) = insert_res
+    else
+    {
+        // Roll back the registry slot, the frame inc_ref, the in-place
+        // wrapper/CSpace constructions, and the retype carve. Without
+        // this rollback, a failed `insert_cap` would leak a live CSpace
+        // registry entry, leave `frame_obj_nn`'s refcount permanently
+        // incremented, and surrender the carved offset back to the
+        // retype allocator only when the source frame itself was
+        // dec_ref'd to zero.
+        crate::cap::unregister_cspace(id);
+        // SAFETY: wrapper/cs not observed externally (no slot in any
+        // CSpace points at `nonnull`, and we just removed the registry
+        // entry).
+        unsafe {
+            core::ptr::drop_in_place(cs_kobj_ptr);
+            core::ptr::drop_in_place(cs_ptr);
+        }
+        retype_free(frame, offset, entry.raw_bytes);
+        // SAFETY: matches the `frame_obj_nn.as_ref().inc_ref()` above.
+        unsafe { frame_obj_nn.as_ref().dec_ref() };
+        return Err(SyscallError::OutOfMemory);
+    };
 
     Ok(u64::from(idx.get()))
 }

--- a/core/ktest/README.md
+++ b/core/ktest/README.md
@@ -81,27 +81,30 @@ capability trees, and concurrent operations. **Not run by default**; enable with
 
 Order matches `stress/mod.rs` dispatch order.
 
-Concurrency knobs are currently held at their pre-`v0.1.0` baselines.
-An earlier in-tree experiment ramped these knobs to NUM=64 (per-test
-worker counts) and 5-10× iteration counts; two kernel-side scaling
-issues block taking the ramp further at this time. Once those are
-fixed, the per-test `NUM_*`/`CYCLES`/`ITERATIONS` constants should be
-revisited.
+Concurrency knobs ramp every per-test worker count to the `u64` signal-
+bitmask ceiling (64 workers) and iteration counts 5-10× higher than a
+trivial smoke-test would need. The point is that one full
+`ktest.filter=stress` boot exercises enough contention to surface latent
+races, rather than needing tens of repeat runs to flake-mine. The
+`u64` width caps per-test workers at 64; lifting that would require
+re-encoding the per-worker bookkeeping from a bitmask to an atomic-
+counter ledger. The `MAX_STRESS_THREADS = 64` cap in `stress/mod.rs`
+mirrors that ceiling (64 × 16 KiB child-stack BSS = 1 MiB).
 
-| File | Scenario |
-|---|---|
-| `cap_tree_deep.rs` | 8-level derivation chain with cascading revocation |
-| `event_queue_fill_drain.rs` | Fill/drain cycles on a capacity-8 queue (ring buffer wrap-around) |
-| `idle_wake_race.rs` | Race wake of an idle CPU with concurrent ready-queue entry under affinity migration |
-| `thread_churn.rs` | Rapid thread create/destroy cycles (TCB and CSpace cleanup) |
-| `cap_delete_running.rs` | Delete capabilities while child threads actively spin |
-| `concurrent_signal.rs` | Multiple threads sending distinct bits to one signal simultaneously |
-| `concurrent_ipc.rs` | Multiple callers racing on one endpoint (send-queue safety) |
-| `cap_revoke_under_use.rs` | Revoke root while child threads actively send on derived caps |
-| `concurrent_map_unmap.rs` | Multiple threads mapping/unmapping distinct VAs in the same address space |
-| `retype_concurrent.rs` | Multiple workers retyping concurrently against one Frame-backed allocator |
-| `fpu_migration_churn.rs` | 100 cycles of FPU-owner thread migration across CPUs; validates eager save / lazy restore under churn |
-| `concurrent_event_producers.rs` | Multiple producers post concurrently to one event queue; consumer verifies every producer's full sequence |
+| File | Scenario | Knobs |
+|---|---|---|
+| `cap_tree_deep.rs` | 8-level derivation chain with cascading revocation | `CHAIN_DEPTH=8`, `PASSES=500` |
+| `event_queue_fill_drain.rs` | Fill/drain cycles on a capacity-8 queue (ring buffer wrap-around) | `CAPACITY=8`, `CYCLES=2000` |
+| `idle_wake_race.rs` | Race wake of an idle CPU with concurrent ready-queue entry under affinity migration | `ITERATIONS=50_000` |
+| `thread_churn.rs` | Rapid thread create/destroy cycles (TCB and CSpace cleanup) | `ITERATIONS=1000` |
+| `cap_delete_running.rs` | Delete capabilities while child threads actively spin | `NUM_CHILDREN=16` |
+| `concurrent_signal.rs` | Multiple threads sending distinct bits to one signal simultaneously | `NUM_SENDERS=64`, `SEND_ITERATIONS=5000` |
+| `concurrent_ipc.rs` | Multiple callers racing on one endpoint (send-queue safety) | `NUM_CALLERS=64`, `CYCLES=200` |
+| `cap_revoke_under_use.rs` | Revoke root while child threads actively send on derived caps | `NUM_CHILDREN=64` |
+| `concurrent_map_unmap.rs` | Multiple threads mapping/unmapping distinct VAs in the same address space | `NUM_CHILDREN=16`, `MAP_ITERATIONS=1000` |
+| `retype_concurrent.rs` | Multiple workers retyping concurrently against one Frame-backed allocator | `NUM_WORKERS=64`, `ITERS_PER_WORKER=1000` |
+| `fpu_migration_churn.rs` | 100 cycles of FPU-owner thread migration across CPUs; validates eager save / lazy restore under churn | `CYCLES=100` |
+| `concurrent_event_producers.rs` | Multiple producers post concurrently to one event queue; consumer verifies every producer's full sequence | `NUM_PRODUCERS=4`, `MESSAGES_PER_PRODUCER=64` |
 
 ### Tier 3 — `src/bench/`
 

--- a/core/ktest/src/integration/tlb_coherency.rs
+++ b/core/ktest/src/integration/tlb_coherency.rs
@@ -29,7 +29,7 @@ use crate::{ChildStack, TestContext, TestResult};
 
 const TEST_VA: u64 = 0x5000_0000; // 1.25 GiB — distinct from other integration tests.
 const RIGHTS_SIGNAL_WAIT: u64 = (1 << 7) | (1 << 8);
-const CYCLES: usize = 20;
+const CYCLES: usize = 100;
 
 static mut CHILD_STACK: ChildStack = ChildStack::ZERO;
 

--- a/core/ktest/src/stress/cap_delete_running.rs
+++ b/core/ktest/src/stress/cap_delete_running.rs
@@ -21,12 +21,7 @@ use syscall::{cap_delete, thread_yield};
 
 use crate::{ChildStack, TestContext, TestResult, spawn};
 
-/// 4 — pre-ramp baseline. See `concurrent_signal.rs::NUM_SENDERS` for
-/// the kernel-side scaling pathologies. The follow-on hang in
-/// `cap_revoke_under_use` was observed even after this test ran to PASS
-/// at NUM=16, so kernel state appears to accumulate; keeping per-test
-/// concurrency at the pre-ramp baseline avoids cross-test interference.
-const NUM_CHILDREN: usize = 4;
+const NUM_CHILDREN: usize = 16;
 
 pub fn run(ctx: &TestContext) -> TestResult
 {

--- a/core/ktest/src/stress/cap_revoke_under_use.rs
+++ b/core/ktest/src/stress/cap_revoke_under_use.rs
@@ -3,9 +3,9 @@
 
 //! Stress test: revoke while derived capabilities are actively used.
 //!
-//! 4 child threads send on derived caps in a tight loop. The parent revokes
-//! the root cap mid-flight. Children detect errors and exit. Verifies no
-//! kernel panic or use-after-free occurs.
+//! `NUM_CHILDREN` threads send on derived caps in a tight loop. The parent
+//! revokes the root cap mid-flight. Children detect errors and exit.
+//! Verifies no kernel panic or use-after-free occurs.
 
 use syscall::{
     cap_copy, cap_create_signal, cap_delete, cap_derive, cap_revoke, signal_send, signal_wait,
@@ -14,11 +14,7 @@ use syscall::{
 
 use crate::{ChildStack, TestContext, TestResult, spawn};
 
-/// 16 — pre-ramp baseline. See the kernel-side notes on `NUM_SENDERS`
-/// in `concurrent_signal.rs` for the two scaling pathologies that block
-/// ramping this further; the `cap_revoke`-under-spinner-flood case is
-/// the one this test would normally surface.
-const NUM_CHILDREN: usize = 16;
+const NUM_CHILDREN: usize = 64;
 const RIGHTS_SIGNAL: u64 = 1 << 7;
 
 pub fn run(ctx: &TestContext) -> TestResult
@@ -28,7 +24,7 @@ pub fn run(ctx: &TestContext) -> TestResult
     let done = cap_create_signal(ctx.memory_frame_base)
         .map_err(|_| "cap_revoke_under_use: create done failed")?;
 
-    // Derive 4 children from root.
+    // Derive NUM_CHILDREN children from root.
     let mut derived = [0u32; NUM_CHILDREN];
     for slot in &mut derived
     {
@@ -36,7 +32,7 @@ pub fn run(ctx: &TestContext) -> TestResult
             cap_derive(root, RIGHTS_SIGNAL).map_err(|_| "cap_revoke_under_use: derive failed")?;
     }
 
-    // Spawn 4 threads, each sending on its derived cap.
+    // Spawn NUM_CHILDREN threads, each sending on its derived cap.
     let mut threads = [0u32; NUM_CHILDREN];
     let mut cspaces = [0u32; NUM_CHILDREN];
     for i in 0..NUM_CHILDREN

--- a/core/ktest/src/stress/cap_tree_deep.rs
+++ b/core/ktest/src/stress/cap_tree_deep.rs
@@ -11,7 +11,7 @@ use syscall::{cap_create_signal, cap_delete, cap_derive, cap_revoke, signal_send
 use crate::{TestContext, TestResult};
 
 const CHAIN_DEPTH: usize = 8;
-const PASSES: usize = 50;
+const PASSES: usize = 500;
 const RIGHTS_SIGNAL: u64 = 1 << 7;
 
 pub fn run(ctx: &TestContext) -> TestResult

--- a/core/ktest/src/stress/concurrent_ipc.rs
+++ b/core/ktest/src/stress/concurrent_ipc.rs
@@ -15,12 +15,8 @@ use syscall::{
 
 use crate::{ChildStack, TestContext, TestResult, spawn};
 
-/// 16 — see the kernel-side notes on `NUM_SENDERS` in
-/// `concurrent_signal.rs`. `CYCLES` is the pre-ramp baseline (in-tree
-/// experiments with `CYCLES=200` triggered the same follow-on hang in
-/// `cap_revoke_under_use`).
-const NUM_CALLERS: usize = 16;
-const CYCLES: usize = 50;
+const NUM_CALLERS: usize = 64;
+const CYCLES: usize = 200;
 
 // SEND + GRANT rights.
 const RIGHTS_SEND_GRANT: u64 = (1 << 4) | (1 << 6);

--- a/core/ktest/src/stress/concurrent_map_unmap.rs
+++ b/core/ktest/src/stress/concurrent_map_unmap.rs
@@ -3,9 +3,9 @@
 
 //! Stress test: concurrent memory map/unmap from multiple threads.
 //!
-//! 4 child threads each map and unmap a distinct VA range repeatedly, sharing
-//! the same address space. Exercises page table lock contention and TLB
-//! shootdown under load.
+//! `NUM_CHILDREN` threads each map and unmap a distinct VA range
+//! repeatedly, sharing the same address space. Exercises page table
+//! lock contention and TLB shootdown under load.
 
 use syscall::{
     cap_copy, cap_create_signal, cap_delete, mem_map, mem_unmap, signal_send, signal_wait,
@@ -14,12 +14,8 @@ use syscall::{
 
 use crate::{ChildStack, TestContext, TestResult, spawn};
 
-/// 4 — pre-ramp baseline. See `concurrent_signal.rs::NUM_SENDERS` for
-/// kernel-side reasons we cap per-test concurrency at the pre-ramp
-/// baseline. Iteration count is also baseline; in-tree experiments with
-/// `MAP_ITERATIONS=1000` triggered the same follow-on hang.
-const NUM_CHILDREN: usize = 4;
-const MAP_ITERATIONS: usize = 200;
+const NUM_CHILDREN: usize = 16;
+const MAP_ITERATIONS: usize = 1000;
 
 /// Base VA for stress mappings, well above normal test VAs.
 const STRESS_MAP_BASE: u64 = 0x5000_0000;
@@ -122,7 +118,9 @@ fn mapper_entry(arg: u64) -> !
     let done_slot = (arg & 0xFFFF) as u32;
     let frame_cap = ((arg >> 16) & 0xFFFF) as u32;
     let aspace = ((arg >> 32) & 0xFFFF) as u32;
-    let done_bit = (arg >> 48) & 0xFF;
+    // done_bit is `1u64 << i` for i in 0..NUM_CHILDREN; at NUM=16 it spans
+    // bits 0..15, so the mask is 16-bit not 8-bit.
+    let done_bit = (arg >> 48) & 0xFFFF;
 
     // Determine our child index from done_bit (1<<i → i).
     let child_idx = done_bit.trailing_zeros() as usize;

--- a/core/ktest/src/stress/concurrent_map_unmap.rs
+++ b/core/ktest/src/stress/concurrent_map_unmap.rs
@@ -17,6 +17,12 @@ use crate::{ChildStack, TestContext, TestResult, spawn};
 const NUM_CHILDREN: usize = 16;
 const MAP_ITERATIONS: usize = 1000;
 
+// done_bit is packed at bits 48..63 of the spawn arg (16-bit lane), so
+// `1u64 << i` must fit in 16 bits — bounding NUM_CHILDREN at 16. Raising
+// past 16 requires widening the lane or switching to bit-index packing
+// (see concurrent_signal.rs for the larger-lane idiom).
+const _: () = assert!(NUM_CHILDREN <= 16);
+
 /// Base VA for stress mappings, well above normal test VAs.
 const STRESS_MAP_BASE: u64 = 0x5000_0000;
 /// Spacing between each child's VA (16-page stride).
@@ -52,7 +58,7 @@ pub fn run(ctx: &TestContext) -> TestResult
 
         let done_bit = 1u64 << i;
         let va = STRESS_MAP_BASE + (i as u64) * VA_STRIDE;
-        // Pack: done_slot[15:0], child_frame[31:16], child_aspace[47:32], done_bit[55:48]
+        // Pack: done_slot[15:0], child_frame[31:16], child_aspace[47:32], done_bit[63:48]
         let arg = u64::from(child_done)
             | (u64::from(child_frame) << 16)
             | (u64::from(child_aspace) << 32)

--- a/core/ktest/src/stress/concurrent_signal.rs
+++ b/core/ktest/src/stress/concurrent_signal.rs
@@ -11,25 +11,24 @@ use syscall::{cap_copy, cap_create_signal, cap_delete, signal_send, signal_wait,
 
 use crate::{ChildStack, TestContext, TestResult, spawn};
 
-/// 16 — pre-ramp baseline. Above ~16-32 concurrently runnable spinning
-/// syscall threads on 4-CPU SMP, follow-on tests (notably
-/// `cap_revoke_under_use`) observe scheduler-fairness starvation. Until
-/// the kernel-side fairness issue is fixed, we keep this constant at the
-/// pre-ramp baseline so downstream stress tests aren't compromised.
-///
-/// Iteration count is the pre-ramp baseline; in-tree experiments showed
-/// the ramped 5000-iter variant left follow-on tests in a degraded state
-/// (notably `cap_revoke_under_use` hangs even at its own NUM=16). Filed
-/// separately; revisit once the kernel-side fairness issue is resolved.
-const NUM_SENDERS: usize = 16;
-const SEND_ITERATIONS: u64 = 2000;
+const NUM_SENDERS: usize = 64;
+const SEND_ITERATIONS: u64 = 5000;
 
-/// Each sender ORs its unique bit (`1 << i`) once per iteration.
-const SENDER_BITS: [u64; NUM_SENDERS] = [
-    0x1, 0x2, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80, 0x100, 0x200, 0x400, 0x800, 0x1000, 0x2000, 0x4000,
-    0x8000,
-];
-const ALL_BITS: u64 = 0xFFFF;
+/// Each sender ORs its unique bit (`1 << i`) once per iteration. The
+/// signal's bit width is 64; one sender per bit saturates the bitmask.
+const fn sender_bits() -> [u64; NUM_SENDERS]
+{
+    let mut bits = [0u64; NUM_SENDERS];
+    let mut i = 0;
+    while i < NUM_SENDERS
+    {
+        bits[i] = 1u64 << i;
+        i += 1;
+    }
+    bits
+}
+const SENDER_BITS: [u64; NUM_SENDERS] = sender_bits();
+const ALL_BITS: u64 = u64::MAX;
 
 pub fn run(ctx: &TestContext) -> TestResult
 {

--- a/core/ktest/src/stress/event_queue_fill_drain.rs
+++ b/core/ktest/src/stress/event_queue_fill_drain.rs
@@ -12,7 +12,7 @@ use syscall_abi::SyscallError;
 use crate::{TestContext, TestResult};
 
 const CAPACITY: u32 = 8;
-const CYCLES: usize = 200;
+const CYCLES: usize = 2000;
 
 pub fn run(ctx: &TestContext) -> TestResult
 {

--- a/core/ktest/src/stress/idle_wake_race.rs
+++ b/core/ktest/src/stress/idle_wake_race.rs
@@ -35,7 +35,7 @@ use crate::{ChildStack, TestContext, TestResult};
 /// High enough to reliably catch a race that only manifests under a small
 /// timing window; low enough to run in well under a second on a healthy
 /// kernel (each iteration is sub-millisecond).
-const ITERATIONS: u32 = 10_000;
+const ITERATIONS: u32 = 50_000;
 
 /// Per-iteration outlier threshold, in microseconds.
 ///

--- a/core/ktest/src/stress/retype_concurrent.rs
+++ b/core/ktest/src/stress/retype_concurrent.rs
@@ -24,13 +24,21 @@ use syscall_abi::CAP_INFO_FRAME_AVAILABLE;
 
 use crate::{ChildStack, TestContext, TestResult};
 
-/// 8 — pre-ramp baseline. See `concurrent_signal.rs::NUM_SENDERS` for
-/// the kernel-side scaling pathologies that block ramping per-worker
-/// counts further in-tree. Iteration count was ramped (was 200).
-const NUM_WORKERS: usize = 8;
-const ITERS_PER_WORKER: u64 = 200;
-const ALL_BITS: u64 = 0xFF;
-const WORKER_BIT: [u64; NUM_WORKERS] = [0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80];
+const NUM_WORKERS: usize = 64;
+const ITERS_PER_WORKER: u64 = 1000;
+const ALL_BITS: u64 = u64::MAX;
+const fn worker_bits() -> [u64; NUM_WORKERS]
+{
+    let mut bits = [0u64; NUM_WORKERS];
+    let mut i = 0;
+    while i < NUM_WORKERS
+    {
+        bits[i] = 1u64 << i;
+        i += 1;
+    }
+    bits
+}
+const WORKER_BIT: [u64; NUM_WORKERS] = worker_bits();
 
 pub fn run(ctx: &TestContext) -> TestResult
 {

--- a/core/ktest/src/stress/thread_churn.rs
+++ b/core/ktest/src/stress/thread_churn.rs
@@ -10,7 +10,7 @@ use syscall::{cap_copy, cap_create_signal, cap_delete, signal_send, signal_wait,
 
 use crate::{ChildStack, TestContext, TestResult, spawn};
 
-const ITERATIONS: usize = 100;
+const ITERATIONS: usize = 1000;
 
 pub fn run(ctx: &TestContext) -> TestResult
 {


### PR DESCRIPTION
## Summary

- Closes #128 by bumping `MAX_CSPACES` from 4096 to 65536 and surfacing registry overflow as `SyscallError::OutOfMemory` instead of silently dropping it (the silent-drop was exactly what masked the namespace-exhaustion bug as a "hang").
- The issue's filed "scheduler-fairness starvation" diagnosis was incorrect (~70% confidence noted). Instrumentation under the ramped stress sequence showed `cap_revoke` returning cleanly after walking only 64 of 128 nodes because the spawned children's CSpaces got IDs past `MAX_CSPACES` and were silently dropped from the registry, so `cap_copy`'s `link_child` couldn't wire the cross-CSpace derivation links.
- Restores commit 8ce32a2's stress-tier concurrency / iteration ramp that PR #129 reverted (commit 8334e06) as the workaround. Also corrects a latent `& 0xFF` mask bug in `concurrent_map_unmap`'s `done_bit` decode that the workaround had masked.
- Plugs a pre-existing rollback gap in `sys_cap_create_cspace` (registration failure no longer leaks the retype-carved offset, the frame inc_ref, or the in-place wrapper).
- Includes one orthogonal scheduler hygiene change (sticky `preferred_cpu` in `select_target_cpu`) that aligns the wake-side placement with the documented soft-affinity intent in `core/kernel/docs/scheduler.md`. Independent of #128; commit message states this explicitly.

## Why bump-only and not recycling

The first draft of this fix implemented a registry-as-bitmap allocator with `CSpaceId` recycling on `unregister_cspace`. That path passed in debug mode but corrupted derivation state in release mode due to two interacting issues the monotonic-counter behaviour had accidentally masked:

1. A `&CapabilitySlotPage` vs `&mut CapabilitySlot` aliasing hazard in the post-dealloc drain loop (release-mode codegen materialised the UB; debug-mode codegen happened not to).
2. The root CSpace's `CSpaceKernelObject` refcount transiently drops to zero during normal init startup (the self-cap insertion / cap-system bootstrap dance), which a monotonic ID allocator harmlessly tolerated but a recycling allocator turned into a catastrophic id-0 reuse.

Properly fixing recycling requires either generation counters on `SlotId` (so stale references fail-fast on lookup) or an explicit external-derivation-link drain at unregister time, plus reworking the root-cspace bootstrap so its refcount never reaches zero. All three are real work and warrant their own PR. The bump unblocks #128 and the stress ramp immediately; a follow-up issue should track proper recycling.

## Closes

Closes #128

## What landed

**`kernel/cap` — bump MAX_CSPACES + register error path (commit `357bfa3`)**
- `MAX_CSPACES`: 4096 → 65536 (512 KiB registry BSS, 4× headroom over the current ramped stress sequence's ~14k cumulative CSpaces).
- `register_cspace(id, ptr) -> Result<(), ()>` — overflow now returns `Err(())` instead of silently dropping the entry. The previous silent drop was exactly what allowed cross-CSpace derivation links to fall through `lookup_cspace` and quietly leave the derivation tree malformed.
- `sys_cap_create_cspace` propagates registration failure as `SyscallError::OutOfMemory` with full rollback of the in-place wrapper/CSpace, the retype carve, and the frame inc_ref.
- Root CSpace bootstrap propagates the same `Result` and `fatal`s on overflow (structurally unreachable at boot; keeps the path symmetric).
- `NEXT_CSPACE_ID` doc records the monotonic-allocator behaviour and points at the follow-up recycling work.

**`ktest` — restore stress concurrency ramp (commit `431639b`)**
- 11 stress/integration files back to 8ce32a2's values (NUM=64 where applicable, iteration counts ×5–10).
- `concurrent_signal.rs` and `retype_concurrent.rs` return to the const-fn bit-array helpers.
- `concurrent_map_unmap.rs` decode mask widened from `& 0xFF` to `& 0xFFFF` (bug surfaced once kernel fix unblocked the test at NUM=16).
- `cap_revoke_under_use.rs` docstring + inline comments corrected to `NUM_CHILDREN`.
- README stress-tier section rewritten with steady-state knob values.

**`kernel/sched` — sticky `preferred_cpu` in `select_target_cpu` (commit `914f491`)**
- Orthogonal hygiene change: after the min-load scan, prefer `tcb.preferred_cpu` when its load is within `LOAD_BALANCE_IMBALANCE_THRESHOLD` of the global minimum.
- Aligns wake-side placement with the documented soft-affinity intent (`core/kernel/docs/scheduler.md` § Soft Affinity); shares one knob with `try_pull_balance`'s imbalance check.
- Independent of #128; commit message states this explicitly.

## Test plan

- [x] `cargo xtask build` (x86_64, riscv64; debug + release)
- [x] `cargo xtask run` x86_64 init=ktest with ramp: `[ktest] ALL TESTS PASSED` 166/166 in ~7 s
- [x] `cargo xtask run` riscv64 init=ktest with ramp: `[ktest] ALL TESTS PASSED` 166/166 in ~7 s
- [x] x86_64 release svctest harness: `[svctest] ALL TESTS PASSED`
- [x] riscv64 release svctest harness: `[svctest] ALL TESTS PASSED`
- [x] `cargo xtask test`: host-side 61/61 PASS