### PR TITLE
init/docs: restructure per documentation-standards

### DIFF
--- a/services/init/README.md
+++ b/services/init/README.md
@@ -1,9 +1,9 @@
 # init
 
 Bootstrap service and first userspace process. The kernel starts init at the end
-of its initialization sequence. Init is a minimal bootstrapper — it starts early
-services, delegates all capabilities, and exits. It is not a long-lived service
-manager.
+of its initialization sequence. Init runs a three-stage bootstrap — raw memmgr /
+procmgr creation, root mount, then handover to svcmgr — and exits. It is not a
+long-lived service manager.
 
 ---
 
@@ -12,189 +12,60 @@ manager.
 ```
 init/
 ├── Cargo.toml                  # Workspace member; no_std binary
+├── README.md
+├── docs/
+│   └── bootstrap.md            # Authoritative stage enumeration + capability flow
 └── src/
-    └── main.rs                 # _start() entry point, bootstrap sequence
+    ├── main.rs                 # _start, run() orchestration across the three stages
+    ├── bootstrap.rs            # Raw memmgr / procmgr ELF-load + kernel-object setup
+    ├── service.rs              # IPC-driven spawns (devmgr, vfsd, svcmgr, logd, RTC, timed, pwrmgr) and phase3_svcmgr_handover
+    ├── mount.rs                # Root MOUNT exchange + GET_SYSTEM_ROOT_CAP pull
+    ├── logging.rs              # init-logd thread (serves the log endpoint until real-logd takes over)
+    ├── walk.rs                 # /bin/<name> path walker over the seed system-root cap
+    └── arch/                   # Per-arch serial init (x86-64, riscv64)
 ```
 
-Init depends on `shared/elf` for ELF parsing (to load procmgr from its boot
-module) and `shared/syscall` for raw syscall wrappers (to create procmgr's
-process without IPC).
+Init depends on `shared/elf` for ELF parsing (used to load memmgr and procmgr
+from their bundle entries) and `shared/syscall` for raw syscall wrappers (used
+to create memmgr and procmgr without IPC).
 
 ---
 
-## Role
+## Bootstrap
 
-Init's responsibilities are strictly bounded:
+Init runs three stages between `_start` and `sys_thread_exit`:
 
-1. **Start memmgr** — init contains a minimal ELF parser (from
-   `shared/elf`) and uses raw syscall wrappers (from `shared/syscall`)
-   to create memmgr's process directly, without IPC. Init transfers the
-   full RAM Frame cap pool from its own CSpace into memmgr's CSpace via
-   the derive-twice pattern, then serves a single bootstrap-IPC round
-   carrying the slot range so memmgr knows where its pool lives.
+1. **Raw bootstrap** — version-check `InitInfo`, set up the IPC buffer, mint
+   endpoints, spawn init-logd, bring up memmgr and procmgr via raw syscalls,
+   then drive procmgr IPC to create devmgr and vfsd.
+2. **Root mount** — issue `MOUNT(MountRole::Root, "/")` to vfsd (vfsd resolves
+   the role to the arch-specific Seraph root GPT type-GUID), pull the seed
+   `system_root_cap` via `GET_SYSTEM_ROOT_CAP`, then launch real-logd from
+   `/bin/logd` and hand off the master log endpoint via `HANDOVER_PULL`.
+3. **Handover** — spawn svcmgr, RTC + timed, and pwrmgr; publish the
+   well-known caps (`rootfs.root`, `pwrmgr.shutdown`, `pwrmgr.deny`,
+   `svcmgr`); register every init-bootstrapped service with svcmgr via
+   `REGISTER_SERVICE`; signal `HANDOVER_COMPLETE`; hand init's own
+   kernel objects + reclaimable Frame caps to procmgr via
+   `REGISTER_INIT_TEARDOWN`; call `sys_thread_exit`. Procmgr's death-EQ
+   observer then runs the reap path.
 
-2. **Start procmgr** — init creates procmgr the same way (raw syscalls,
-   no IPC). Before starting procmgr's thread, init calls
-   `memmgr.REGISTER_PROCESS` to mint procmgr's `memmgr_endpoint_cap`
-   and writes it into procmgr's `ProcessInfo` so procmgr's std heap
-   bootstrap reaches memmgr on its first call.
-
-3. **Request early service startup** — init requests procmgr to start
-   the remaining early services in order: devmgr, svcmgr, drivers, VFS,
-   and optionally net. Tier-1 services (devmgr, vfsd, drivers) are
-   spawned via boot-module `CREATE_PROCESS` *before* init has a
-   namespace cap, so they hold none — their `ProcessInfo.system_root_cap`
-   is zero, which is correct for kernel-adjacent services that have no
-   business reading the filesystem.
-
-4. **Acquire the seed system-root cap** — after the role-driven
-   root mount completes (init sends `MOUNT(MountRole::Root, "/")`;
-   vfsd resolves the role to the arch-specific Seraph root GPT
-   type-GUID), init issues
-   `vfsd_labels::GET_SYSTEM_ROOT_CAP` to vfsd. The returned tokened
-   SEND on vfsd's namespace endpoint at `NodeId::ROOT` with full
-   rights is init's seed: every later Phase 3 child receives a
-   `cap_copy` of it via `procmgr_labels::CONFIGURE_NAMESPACE`. Init
-   is the cap-distribution authority for tier-3 services; there is no
-   procmgr broadcast.
-
-5. **Delegate capabilities** — for each service, init derives and
-   transfers the appropriate subset of its initial capabilities via
-   IPC. Init retains derived intermediary copies (for potential
-   revocation), not the roots.
-
-6. **Launch real logd (Phase 2 epilogue)** — immediately after the
-   seed `system_root_cap` is acquired, init walks
-   `/bin/logd` and spawns real-logd via
-   `procmgr_labels::CREATE_FROM_FILE`. The bootstrap round
-   delivers (a) a RECV cap on the master log endpoint, (b) a
-   one-shot SEND cap on the same endpoint for `HANDOVER_PULL`,
-   (c) a tokened SEND on procmgr carrying
-   `procmgr_labels::DEATH_EQ_AUTHORITY`, and (d) the arch serial
-   authority (`IoPortRange` on x86-64, `SbiControl` on RISC-V).
-   logd pulls init-logd's captured state via `HANDOVER_PULL`;
-   init-logd's receive loop self-terminates on the final reply.
-   See [`services/logd/README.md`](../logd/README.md) and
-   [`services/logd/docs/handover-protocol.md`](../logd/docs/handover-protocol.md).
-
-7. **Spawn Phase 3 services from VFS** — svcmgr, logd, the per-arch
-   RTC driver, timed, and pwrmgr are loaded by walking init's seed
-   system-root cap to `/bin/<name>` and issuing
-   `procmgr_labels::CREATE_FROM_FILE`. Each spawn site picks a
-   namespace policy that init installs via
-   `procmgr_labels::CONFIGURE_NAMESPACE` before `START_PROCESS`:
-
-   | Service | Policy | Notes |
-   |---|---|---|
-   | `svcmgr` | `Universal` | Reads `/etc/svcmgr/services.d/`, walks `/bin/<name>` for launched services, re-applies per-service `.svc` attenuation on restart. |
-   | `pwrmgr` | `None` | Owns `IoPortRange` / `SbiControl` / ACPI frames; no FS. |
-   | `logd` | `None` | Owns the master log endpoint and arch serial authority; no FS. |
-   | `timed` | `None` | Queries the svcmgr registry for `rtc.primary`; no FS. |
-   | `cmos-rtc` / `goldfish-rtc` | `None` | Hardware-only driver; serves a single RTC read. |
-
-   The `NsPolicy` enum and the `configure_child_namespace` helper
-   live in [`src/service.rs`](src/service.rs). `crasher` and
-   `svctest` are no longer spawned by init — they are launched by
-   svcmgr after handover from their `.svc` recipes
-   (see [`services/svcmgr/docs/service-definitions.md`](../svcmgr/docs/service-definitions.md)).
-   `hello`, `stdiotest`, and other `/bin/` binaries are spawned
-   on-demand by individual tests via `std::process::Command`. See
-   [`docs/namespace-model.md`](../../docs/namespace-model.md) for
-   the underlying namespace-cap distribution invariants.
-
-8. **Publish well-known caps + register pwrmgr with svcmgr** —
-   before signalling handover, init publishes the named caps
-   post-#21 consumers resolve through `services.d/<name>.svc`
-   `seed = ...` lines, using
-   `svcmgr_labels::PUBLISH_ENDPOINT` with a
-   `PUBLISH_AUTHORITY`-tokened `RIGHTS_SEND_GRANT` cap on svcmgr's
-   service endpoint:
-
-   * `rootfs.root` — tokened SEND on the root filesystem's namespace
-     endpoint at its root directory (FS-driver-agnostic by design).
-   * `pwrmgr.shutdown` — `SHUTDOWN_AUTHORITY`-tokened SEND on
-     pwrmgr's service endpoint.
-   * `pwrmgr.deny` — no-authority SEND on pwrmgr's service endpoint
-     (negative-test twin).
-   * `svcmgr` — un-tokened SEND on svcmgr's own service endpoint.
-
-   Init also registers each foundational service it bootstrapped
-   with svcmgr via the v3 `REGISTER_SERVICE` wire (name + thread
-   cap; recipe lives in `services.d/<name>.svc`). The registration
-   set in this PR is `memmgr`, `procmgr`, `devmgr`, `vfsd`, `logd`,
-   `timed`, and `pwrmgr`. svcmgr reconciles each against its
-   matching `.svc` file and binds death-notification.
-
-   Names are centralised in `ipc::published_names`. Recipes (binary,
-   argv, env, restart policy, criticality, namespace shape, seed
-   names) live on disk at `/etc/svcmgr/services.d/<name>.svc`, not
-   on the wire — see
-   [`services/svcmgr/docs/service-definitions.md`](../svcmgr/docs/service-definitions.md).
-
-9. **Reap handoff and exit** — init hands its own `AddressSpace`,
-   `CSpace`, main `Thread`, and init-logd `Thread` caps plus every
-   reclaimable Frame cap (segments, stack, `InitInfo` region, IPC
-   buffer) to procmgr via `procmgr_labels::REGISTER_INIT_TEARDOWN`
-   (multi-round; IPC cap-transfer MOVES the caps out of init's
-   CSpace). After `INIT_TEARDOWN_DONE`, init calls
-   `sys_thread_exit`. The kernel mints all four resource classes at
-   Phase 9 with `RETYPE` + `owns_memory=true` + the full
-   `available_bytes` ledger + `register_owned_range`, so each cap is
-   eligible for `memmgr.DONATE_FRAMES` ingestion.
-
-   Procmgr's death-EQ observer (bound on init's main thread with
-   `INIT_REAP_CORRELATOR`) fires on the exit and runs
-   [`init_reap::run_reap`](../procmgr/src/init_reap.rs):
-
-   1. `cap_delete` both `Thread` caps → TCBs reclaimed.
-   2. `cap_revoke + cap_delete` init's `AddressSpace` → PT chunks
-      `retype_free`'d, every user-page mapping vanishes.
-   3. `DONATE_FRAMES` the accumulated Frame caps to memmgr → the
-      segment / stack / `InitInfo` / IPC-buffer pages enter
-      memmgr's pool, safely (no aliasing — the AS is already dead).
-   4. `cap_revoke + cap_delete` init's `CSpace` → cascade dec_refs
-      every cap init still held (endpoint SENDs, endpoint slab
-      Frame, leftover `FrameAlloc` tails). Those with
-      `owns_memory=true` return their pages to the kernel buddy via
-      `dealloc_object`'s `free_range` (kernel-internal, not
-      memmgr's pool).
-   5. Procmgr logs a summary line. No init-related kernel object
-      remains; svcmgr takes over as the resident supervisor.
-
-memmgr and procmgr are the only two processes init creates via raw
-syscalls. Every later service is spawned via IPC to procmgr.
-
-After the split, the only `no_std` userspace services in the running
-system are init and memmgr; everything else is std-built.
+See [docs/bootstrap.md](docs/bootstrap.md) for the authoritative
+stage-by-stage enumeration, source citations, and per-stage capability
+transfer table.
 
 ---
 
 ## What init does NOT do
 
-- Does not supervise services or restart them on crash (svcmgr's responsibility)
-- Does not hold raw process-creation fallback capabilities after delegating them
-  to svcmgr
-- Does not read a service dependency graph file at runtime (bootstrap order is
-  compiled in)
-- Does not remain resident after bootstrap completes
-
----
-
-## Capability flow
-
-At entry, init holds the full initial CSpace populated by the kernel:
-- Thread, AddressSpace, and CSpace caps for itself
-- Frame caps for all usable physical memory
-- One MmioRegion cap per coarse MMIO aperture
-- One root Interrupt range cap (narrowed per-device in userspace via `sys_irq_split`)
-- IoPortRange cap covering the full 64K port space (x86-64)
-- SbiControl cap (RISC-V)
-- Read-only Frame caps covering the ACPI RSDP page, each `AcpiReclaimable` region, and the DTB blob — devmgr parses firmware tables from these
-- SchedControl cap
-- Frame caps for boot module images (procmgr, devmgr, drivers, etc.)
-
-Init derives and transfers these to services using the "derive twice" pattern
-(see `docs/capability-model.md`) so it can revoke if needed before svcmgr takes over.
+- Does not supervise services or restart them on crash (svcmgr's
+  responsibility).
+- Does not hold raw process-creation fallback capabilities after delegating
+  them to svcmgr.
+- Does not read a service dependency graph file at runtime (bootstrap order
+  is compiled in).
+- Does not remain resident after bootstrap completes — procmgr reaps init's
+  address space, CSpace, and threads after `sys_thread_exit`.
 
 ---
 
@@ -203,15 +74,22 @@ Init derives and transfers these to services using the "derive twice" pattern
 | Document | Content |
 |---|---|
 | [docs/architecture.md](../../docs/architecture.md) | Bootstrap sequence, init/memmgr/procmgr/svcmgr roles |
+| [docs/bootstrap.md](../../docs/bootstrap.md) | System-scope end-to-end boot lifecycle |
 | [docs/process-lifecycle.md](../../docs/process-lifecycle.md) | Userspace boot order, ProcessInfo/InitInfo handover, authority transfer |
-| [abi/boot-protocol/](../../abi/boot-protocol/) | InitImage, boot modules, initial CSpace |
-| [abi/init-protocol/](../../abi/init-protocol/) | Kernel-to-init handover (`InitInfo`) |
-| [docs/capability-model.md](../../docs/capability-model.md) | Initial capability distribution |
-| [services/memmgr/README.md](../memmgr/README.md) | First service init creates; receives the RAM frame pool |
+| [docs/capability-model.md](../../docs/capability-model.md) | Initial capability distribution, derive-twice pattern |
+| [docs/namespace-model.md](../../docs/namespace-model.md) | Namespace-cap distribution invariants |
+| [abi/boot-protocol/](../../abi/boot-protocol/) | `BootInfo`, `bootstrap.bundle`, initial CSpace |
+| [abi/init-protocol/](../../abi/init-protocol/) | Kernel-to-init handover (`InitInfo`, module-name table) |
+| [services/memmgr/README.md](../memmgr/README.md) | First service init creates; receives the RAM Frame pool |
+| [services/procmgr/README.md](../procmgr/README.md) | Owns process creation post-bootstrap; runs init's reap path |
+| [services/svcmgr/README.md](../svcmgr/README.md) | Takes over as resident supervisor after `HANDOVER_COMPLETE` |
+| [services/logd/README.md](../logd/README.md) | Master log endpoint owner post-Phase-2-epilogue |
+| [services/pwrmgr/README.md](../pwrmgr/README.md) | Receives arch authority + ACPI Frame caps during handover |
 | [docs/coding-standards.md](../../docs/coding-standards.md) | Formatting, naming, safety rules |
+| [docs/documentation-standards.md](../../docs/documentation-standards.md) | Document hierarchy, authority, backlinks |
 
 ---
 
 ## Summarized By
 
-[Architecture Overview](../../docs/architecture.md), [System Bootstrap](../../docs/bootstrap.md), [Process Lifecycle](../../docs/process-lifecycle.md)
+[Architecture Overview](../../docs/architecture.md), [System Bootstrap](../../docs/bootstrap.md), [Process Lifecycle](../../docs/process-lifecycle.md), [logd](../logd/README.md), [memmgr](../memmgr/README.md), [pwrmgr](../pwrmgr/README.md)

--- a/services/init/README.md
+++ b/services/init/README.md
@@ -60,8 +60,10 @@ transfer table.
 
 - Does not supervise services or restart them on crash (svcmgr's
   responsibility).
-- Does not hold raw process-creation fallback capabilities after delegating
-  them to svcmgr.
+- Does not retain raw process-creation capabilities — the kernel-object
+  retypes (`cap_create_aspace` / `cap_create_cspace` / `cap_create_thread`)
+  used to bring up memmgr and procmgr happen only in init's Raw bootstrap
+  stage; after that, every process is created via procmgr IPC.
 - Does not read a service dependency graph file at runtime (bootstrap order
   is compiled in).
 - Does not remain resident after bootstrap completes — procmgr reaps init's

--- a/services/init/docs/bootstrap.md
+++ b/services/init/docs/bootstrap.md
@@ -1,25 +1,227 @@
 # init Bootstrap Stages
 
-Placeholder: authoritative enumeration of the stages init follows between
-kernel handoff and `sys_thread_exit`. Content to be written during the
-init-review cycle.
+Authoritative enumeration of the work init performs between kernel
+handoff (`_start`) and `sys_thread_exit`, organised into three
+stages: **Raw bootstrap**, **Root mount**, **Handover**. The names
+used in source `log()` strings — `"phase 1 bootstrap complete"`,
+`"phase 2: mounting root filesystem"`, `"phase 2 epilogue"`,
+`"phase 3: ..."` — are the searchable equivalents and remain stable.
 
 ---
 
-## Status
+## Stages
 
-This document exists so that top-level summaries (notably
-[`docs/bootstrap.md`](../../../docs/bootstrap.md)) can link an authoritative
-component-scope target for init's bootstrap sequence. The actual enumeration
-of stages — starting memmgr and procmgr via raw syscalls, requesting
-early-service startup, delegating capabilities, registering services with
-svcmgr, exiting — will be filled in when the init-review round runs. Until
-then, [`init/README.md`](../README.md) carries the role-level description and
-[`docs/process-lifecycle.md`](../../../docs/process-lifecycle.md) is the
-authoritative system-scope description of the userspace boot order.
+### Raw bootstrap
+
+Init reaches `run()` (`../src/main.rs:375`) with the kernel-supplied
+`InitInfo` populated and the initial CSpace seeded (see
+[Capability flow](#capability-flow)). It performs the work required to
+stand memmgr and procmgr up via raw syscalls, then delegates further
+process creation to procmgr IPC.
+
+- Version-check `InitInfo` against `INIT_PROTOCOL_VERSION` and exit
+  on mismatch (`../src/main.rs:382`).
+- Initialise the per-arch serial path used for FATAL pre-IPC errors
+  (`../src/main.rs:389`).
+- Build the `FrameAlloc` bump allocator over the kernel-provided
+  memory pool (`../src/main.rs:391`).
+- Reserve a Frame to back kernel-object retypes (the endpoint slab;
+  one page suffices for the eight endpoints init creates)
+  (`../src/main.rs:396`).
+- Map a fresh IPC buffer page at `INIT_IPC_BUF_VA` and register it
+  with the kernel (`../src/main.rs:404`–`../src/main.rs:427`).
+- Mint endpoint objects: init's bootstrap endpoint, procmgr's
+  service endpoint, memmgr's service endpoint, svcmgr's service
+  endpoint (`../src/main.rs:461`; minted here so procmgr can receive
+  an un-tokened SEND on it during procmgr's bootstrap round), and
+  the master log endpoint (`../src/main.rs:483`).
+- Spawn the init-logd thread, which serves the log endpoint until
+  real-logd takes over via `HANDOVER_PULL`
+  (`../src/main.rs:494`, with the receive loop in
+  `../src/logging.rs`). After this point init's own `log()` lines
+  ride IPC through init-logd to the serial UART.
+- Bootstrap memmgr via raw `cap_create_aspace` / `cap_create_cspace`
+  / `cap_create_thread`, ELF-load it from the `memmgr` bundle
+  entry, prepare its `ProcessInfo` page, and configure its main
+  thread but defer `thread_start`
+  (`bootstrap::bootstrap_memmgr` at `../src/bootstrap.rs:429`,
+  called from `../src/main.rs:527`).
+- Bootstrap procmgr the same way; procmgr's `ProcessInfo` receives
+  the memmgr SEND cap so its std heap reaches memmgr on the first
+  allocation (`bootstrap::bootstrap_procmgr` at
+  `../src/bootstrap.rs:796`, called from `../src/main.rs:537`).
+- Donate the remaining RAM Frame caps to memmgr's CSpace, serve a
+  single bootstrap-IPC round carrying the donated slot range
+  (so memmgr knows where its pool lives), then donate the
+  boot-module Frame caps that backed procmgr/devmgr/vfsd
+  (`../src/main.rs:630`, `../src/main.rs:652`).
+- Start procmgr's thread and serve procmgr's bootstrap IPC, handing
+  it the log endpoint SEND and svcmgr's service endpoint SEND
+  (`../src/main.rs:696`).
+- Request procmgr to create devmgr via boot-module
+  `CREATE_PROCESS` and serve devmgr's multi-round bootstrap
+  (hardware caps: MMIO apertures, Interrupt range, ACPI Frame caps)
+  (`../src/main.rs:782` + `service::create_devmgr_with_caps` at
+  `../src/service.rs:371`).
+- Request procmgr to create vfsd the same way and serve its
+  bootstrap (`../src/main.rs:800` +
+  `service::create_vfsd_with_caps` at `../src/service.rs:950`).
+- Closing marker: `"phase 1 bootstrap complete"`
+  (`../src/main.rs:821`).
+
+### Root mount
+
+vfsd identifies the root partition by GPT type-GUID
+(`boot_protocol::role_guids::SERAPH_ROOT_<arch>`), so init names
+only the *role* and vfsd performs the partition lookup. Init's
+contribution is the MOUNT exchange and the seed-cap pull; the ESP
+and any further partitions are discovered and mounted by vfsd
+directly without init involvement.
+
+- Send `MOUNT(MountRole::Root, "/")` to vfsd
+  (`../src/main.rs:830` → `mount::send_mount` at
+  `../src/mount.rs:63`). The wire payload is the `MountRole`
+  discriminant byte (`../src/mount.rs:30`, currently a single
+  variant `Root = 0`) plus the mount-point path.
+- Pull the seed system-root cap via `GET_SYSTEM_ROOT_CAP`
+  (`../src/main.rs:846` → `mount::request_system_root` at
+  `../src/mount.rs:100`). The reply is a tokened SEND on vfsd's
+  namespace endpoint at the synthetic root with full namespace
+  rights — every later child receives a `cap_copy` of it via
+  `procmgr_labels::CONFIGURE_NAMESPACE`.
+- **Phase 2 epilogue** — walk `/bin/logd`, request procmgr to
+  create real-logd via `CREATE_FROM_FILE`, and serve its bootstrap
+  round (RECV cap on the master log endpoint, one-shot SEND for
+  `HANDOVER_PULL`, `DEATH_EQ_AUTHORITY`-tokened SEND on procmgr,
+  arch serial authority). Real-logd pulls init-logd's captured
+  state via `HANDOVER_PULL`; init-logd self-terminates on the
+  final reply. See
+  [`../../logd/docs/handover-protocol.md`](../../logd/docs/handover-protocol.md)
+  (`../src/main.rs:866` → `service::create_and_start_logd` at
+  `../src/service.rs:1595`).
+- Closing marker: `"phase 2 bootstrap complete"`
+  (`../src/main.rs:881`).
+
+### Handover
+
+`service::phase3_svcmgr_handover` (`../src/service.rs:1231`, called
+from `../src/main.rs:886`) brings up the remaining bootstrap
+services, transfers the system-wide service registry to svcmgr,
+publishes the well-known caps, registers init-bootstrapped
+services with svcmgr, and hands init's own kernel objects to
+procmgr for reaping.
+
+- Spawn svcmgr from `/bin/svcmgr` with the `Universal` namespace
+  policy and serve its bootstrap round
+  (`../src/service.rs:1260` → `create_svcmgr_from_file` at
+  `../src/service.rs:1058`; `setup_and_start_svcmgr` at
+  `../src/service.rs:1134`).
+- Bring up the wallclock chain: per-arch RTC driver
+  (cmos-rtc on x86-64, goldfish-rtc on RISC-V), followed by timed
+  (`../src/service.rs:1289` → `bring_up_wallclock` at
+  `../src/service.rs:2121`, with `create_and_start_rtc_driver` at
+  `../src/service.rs:1914` and `create_and_start_timed` at
+  `../src/service.rs:2045`).
+- Spawn pwrmgr with the arch authority cap
+  (`IoPortRange` on x86-64, `SbiControl` on RISC-V) and the
+  ACPI Frame caps; capture pwrmgr's service endpoint and main
+  thread cap (`../src/service.rs:1300` →
+  `create_and_start_pwrmgr` at `../src/service.rs:719`).
+- Derive a `PUBLISH_AUTHORITY`-tokened `RIGHTS_SEND_GRANT` cap on
+  svcmgr's service endpoint (`../src/service.rs:1326`) and
+  publish four well-known names via `PUBLISH_ENDPOINT`:
+  - `rootfs.root` — tokened SEND on the root filesystem's
+    namespace endpoint at its root directory (FS-driver-agnostic
+    by design) (`../src/service.rs:1336`).
+  - `pwrmgr.shutdown` — `SHUTDOWN_AUTHORITY`-tokened SEND on
+    pwrmgr's service endpoint (`../src/service.rs:1354`).
+  - `pwrmgr.deny` — non-AUTHORITY SEND on pwrmgr's service
+    endpoint (negative-test twin) (`../src/service.rs:1370`).
+  - `svcmgr` — un-tokened SEND on svcmgr's own service endpoint
+    (`../src/service.rs:1390`).
+
+  Name constants are centralised in `ipc::published_names`.
+- Register each init-bootstrapped service with svcmgr via the v3
+  `REGISTER_SERVICE` wire (name + thread cap)
+  (`../src/service.rs:1411`–`../src/service.rs:1433`;
+  `register_service` helper at `../src/service.rs:1194`).
+  Registration set: `memmgr`, `procmgr`, `devmgr`, `vfsd`,
+  `logd`, `timed`, `pwrmgr`. svcmgr reconciles each against the
+  matching `<name>.svc` recipe in `/etc/svcmgr/services.d/` and
+  binds death-notification — see
+  [`../../svcmgr/docs/service-definitions.md`](../../svcmgr/docs/service-definitions.md).
+- Signal `HANDOVER_COMPLETE` (`../src/service.rs:1435`). svcmgr
+  scans `services.d/` and launches any defined-but-unregistered
+  services from disk.
+- Hand init's kernel-object caps (`AddressSpace`, `CSpace`, main
+  `Thread`, init-logd `Thread`) and every reclaimable Frame cap
+  (segments, stack, `InitInfo` region, IPC buffer) to procmgr via
+  `REGISTER_INIT_TEARDOWN` (`../src/service.rs:1448` →
+  `handoff_to_procmgr_reap` at `../src/service.rs:1469`). IPC
+  cap-transfer MOVES the caps, so they leave init's CSpace.
+- Call `sys_thread_exit` (`../src/service.rs:1457`). Procmgr's
+  death-EQ observer (bound on init's main thread with
+  `INIT_REAP_CORRELATOR`) fires and runs
+  [`init_reap::run_reap`](../../procmgr/src/init_reap.rs): both
+  Thread caps are deleted, init's `AddressSpace` is revoked +
+  deleted (PT chunks `retype_free`'d, user-page mappings
+  vanish), the accumulated Frame caps are `DONATE_FRAMES`'d to
+  memmgr's pool, init's `CSpace` is revoked + deleted (cascading
+  dec_ref through every remaining cap; `owns_memory=true` caps
+  return their pages to the kernel buddy via `dealloc_object`),
+  and procmgr logs a summary line. No init-related kernel object
+  remains; svcmgr is the resident supervisor from this point on.
+
+memmgr and procmgr are the only two processes init creates via
+raw syscalls. Every later service spawn goes through procmgr IPC.
+After the raw bootstrap completes, the only `no_std` userspace
+services in the running system are init and memmgr; everything
+else is std-built.
+
+---
+
+## Capability flow
+
+### Initial CSpace at `_start`
+
+The kernel populates init's CSpace before transferring control. Init
+holds:
+
+| Class | Content |
+|---|---|
+| Self-objects | `Thread`, `AddressSpace`, `CSpace` caps for init itself |
+| Memory | `Frame` caps covering every usable physical memory page |
+| MMIO | One `MmioRegion` cap per coarse MMIO aperture |
+| Interrupts | One root `Interrupt` range cap (narrowed per-device in userspace via `sys_irq_split`) |
+| I/O ports (x86-64) | `IoPortRange` cap covering the full 64 KiB port space |
+| SBI (RISC-V) | `SbiControl` cap |
+| Firmware tables | Read-only `Frame` caps covering the ACPI RSDP page, each `AcpiReclaimable` region, and the DTB blob |
+| Scheduler | `SchedControl` cap |
+| Boot modules | `Frame` caps for each boot-module image inside `bootstrap.bundle` (procmgr, memmgr, devmgr, vfsd, …) — resolved by name via the `init_protocol` module-name table |
+
+Init derives and transfers these to services using the
+**derive-twice** pattern documented in
+[`../../../docs/capability-model.md`](../../../docs/capability-model.md):
+init retains intermediary derivations (revocable) rather than the
+roots, so it can revoke a child's authority before the handover to
+svcmgr if needed.
+
+### Per-stage authority transfers
+
+| Stage | Recipient | Authority transferred |
+|---|---|---|
+| Raw bootstrap | memmgr | RAM `Frame` pool (every Frame cap not consumed by init/procmgr setup) |
+| Raw bootstrap | procmgr | memmgr SEND cap, log endpoint SEND, svcmgr service endpoint SEND, boot-module `Frame` caps for downstream `CREATE_PROCESS` |
+| Raw bootstrap | devmgr | MMIO apertures, Interrupt range, ACPI/DTB Frame caps |
+| Raw bootstrap | vfsd | `INGEST_AUTHORITY`- and `SEED_AUTHORITY`-tokened caps on vfsd's own service endpoint (init keeps no FS access of its own) |
+| Root mount | logd | RECV on the master log endpoint, one-shot SEND for `HANDOVER_PULL`, `DEATH_EQ_AUTHORITY`-tokened SEND on procmgr, arch serial authority (`IoPortRange` on x86-64, `SbiControl` on RISC-V) |
+| Handover | svcmgr | `Universal` namespace seed (full `system_root_cap`), RECV on svcmgr's service endpoint, raw process-creation fallback (documented future restart path for procmgr) |
+| Handover | pwrmgr | Remaining arch authority (`IoPortRange` / `SbiControl`) + ACPI region Frame caps |
+| Handover (publish) | svcmgr registry | `rootfs.root`, `pwrmgr.shutdown`, `pwrmgr.deny`, `svcmgr` named caps |
+| Reap | procmgr | Init's `AddressSpace`, `CSpace`, main `Thread`, init-logd `Thread`, every reclaimable Frame cap (segments, stack, `InitInfo` region, IPC buffer) |
 
 ---
 
 ## Summarized By
 
-[docs/bootstrap.md](../../../docs/bootstrap.md), [docs/process-lifecycle.md](../../../docs/process-lifecycle.md)
+[init/README.md](../README.md), [docs/bootstrap.md](../../../docs/bootstrap.md), [docs/process-lifecycle.md](../../../docs/process-lifecycle.md)

--- a/services/init/docs/bootstrap.md
+++ b/services/init/docs/bootstrap.md
@@ -213,9 +213,9 @@ svcmgr if needed.
 | Raw bootstrap | memmgr | RAM `Frame` pool (every Frame cap not consumed by init/procmgr setup) |
 | Raw bootstrap | procmgr | memmgr SEND cap, log endpoint SEND, svcmgr service endpoint SEND, boot-module `Frame` caps for downstream `CREATE_PROCESS` |
 | Raw bootstrap | devmgr | MMIO apertures, Interrupt range, ACPI/DTB Frame caps |
-| Raw bootstrap | vfsd | `INGEST_AUTHORITY`- and `SEED_AUTHORITY`-tokened caps on vfsd's own service endpoint (init keeps no FS access of its own) |
+| Raw bootstrap | vfsd | `SEED_AUTHORITY`-tokened SEND on vfsd's own service endpoint (gates `GET_SYSTEM_ROOT_CAP`); the un-tokened service-endpoint SEND init holds is used for the un-gated MOUNT call. Init keeps no FS access of its own. |
 | Root mount | logd | RECV on the master log endpoint, one-shot SEND for `HANDOVER_PULL`, `DEATH_EQ_AUTHORITY`-tokened SEND on procmgr, arch serial authority (`IoPortRange` on x86-64, `SbiControl` on RISC-V) |
-| Handover | svcmgr | `Universal` namespace seed (full `system_root_cap`), RECV on svcmgr's service endpoint, raw process-creation fallback (documented future restart path for procmgr) |
+| Handover | svcmgr | `Universal` namespace seed (full `system_root_cap`) installed via `procmgr_labels::CONFIGURE_NAMESPACE` before `START_PROCESS`; in the bootstrap round, full-rights SEND on its own service endpoint and on the local svcmgr-bootstrap endpoint |
 | Handover | pwrmgr | Remaining arch authority (`IoPortRange` / `SbiControl`) + ACPI region Frame caps |
 | Handover (publish) | svcmgr registry | `rootfs.root`, `pwrmgr.shutdown`, `pwrmgr.deny`, `svcmgr` named caps |
 | Reap | procmgr | Init's `AddressSpace`, `CSpace`, main `Thread`, init-logd `Thread`, every reclaimable Frame cap (segments, stack, `InitInfo` region, IPC buffer) |


### PR DESCRIPTION
## Summary

- Fills `services/init/docs/bootstrap.md` with the authoritative stage enumeration (Raw bootstrap / Root mount / Handover) + capability-flow table, replacing the 22-line placeholder. Reflects the post-#138 mount surface (no cmdline parse, `MountRole`-based MOUNT, vfsd GPT type-GUID discovery).
- Slims `services/init/README.md` from a 9-item authoritative `Role` section + restated cap-flow to summary + routing per `docs/documentation-standards.md` §"Discoverability and Linking". Fixes the stale `Source Layout` block (was `main.rs` only). Adds `logd` / `memmgr` / `pwrmgr` to `Summarized By` (peer READMEs that already summarize init content).
- Fleshes out #78 — `init/svcmgr` migration tracking issue — with the three concrete candidates surfaced by this audit (pwrmgr spawn, RTC + timed bringup, `REGISTER_SERVICE` notifications) with file:line citations, prerequisite cap transfers, and cross-references to #17 and #106. Pinned to milestone `v0.1.0`. (Issue edit, not in this branch.)

Closes #14.

## Test plan

Docs-only change; no QEMU run gates the merge. Verified:

- [x] Every `file:line` citation in `services/init/docs/bootstrap.md` resolves against `services/init/src/` at HEAD (`a1b79fb`).
- [x] Every relative link in `services/init/README.md` and `services/init/docs/bootstrap.md` resolves to an existing path (18 link targets checked).
- [x] README's `Bootstrap` section contains only summary-form prose; no restatement of stage enumeration, IPC wire shapes, or cap-flow detail.
- [x] `bootstrap.md` `Summarized By` lists `init/README.md`; `README.md` `Summarized By` lists the three system docs plus `logd` / `memmgr` / `pwrmgr` READMEs.
- [x] `gh issue view 78` shows the rewritten body, three concrete candidates, v0.1.0 milestone, and `cleanup` / `init` / `svcmgr` labels.
- [x] CI green on the existing build/test matrix (13/13 checks; one riscv64-debug ktest flake on first run — unrelated SMP affinity test — passed on rerun; flake filed as #142).

## Pre-merge audit

- pr-reviewer: BLOCKING ISSUES → resolved in 69e03a2 (vfsd row was claiming a non-existent `INGEST_AUTHORITY` transfer; svcmgr row was claiming non-existent "raw process-creation fallback" transfer; README's "after delegating them to svcmgr" half was misleading given there is no such delegation in current code).
- pr-auditor: AUDIT FAIL → resolved by ticking the CI checkbox in this body update.