### PR TITLE
fix/142: stabilise affinity_migrate_ready_queued; default run-parallel --fail regex

### DIFF
--- a/core/ktest/src/main.rs
+++ b/core/ktest/src/main.rs
@@ -142,6 +142,12 @@ pub struct TestContext
     /// `x86_64`).
     pub cspace_cap: u32,
 
+    /// ktest's own `Thread` capability slot (CONTROL right), provided by
+    /// the kernel via `InitInfo::thread_cap`. Tests that need to pin the
+    /// harness thread to a specific CPU or adjust its priority for the
+    /// duration of a test use this cap.
+    pub thread_cap: u32,
+
     /// Pointer to the registered IPC buffer page (4 KiB, page-aligned).
     ///
     /// Registered with `ipc_buffer_set` before any tests run. Passed into
@@ -271,6 +277,7 @@ fn run(info_ptr: u64) -> !
     let ctx = TestContext {
         aspace_cap,
         cspace_cap: info.cspace_cap,
+        thread_cap: info.thread_cap,
         ipc_buf: ipc_buf_ptr,
         memory_frame_base: info.memory_frame_base,
         sbi_control_cap: info.sbi_control_cap,

--- a/core/ktest/src/unit/thread.rs
+++ b/core/ktest/src/unit/thread.rs
@@ -607,12 +607,26 @@ pub fn affinity_bind_cpu1(ctx: &TestContext) -> TestResult
 
 /// `thread_set_affinity` actively migrates a Ready thread queued on another CPU.
 ///
-/// Spawns child T pinned to CPU 0 at the same priority as the parent. Because
-/// the parent is already running on CPU 0 when T is started, T sits Ready in
-/// CPU 0's run queue. The parent then changes T's affinity to CPU 1: the
-/// active-migration path in `sys_thread_set_affinity` must dequeue T from
-/// CPU 0 and re-enqueue it on CPU 1 so that when the parent blocks in
-/// `signal_wait`, T runs on CPU 1.
+/// The precondition this test exercises — T is Ready and queued on CPU 0 at
+/// the moment of `thread_set_affinity(T, 1)` — must be made deterministic
+/// from userspace. Two invariants combined make it so:
+///
+/// 1. **Parent pinned to CPU 0.** The harness pins itself to CPU 0 via its
+///    own `Thread` cap (`ctx.thread_cap`) and yields, forcing the
+///    affinity-aware re-enqueue in `schedule()` to land it on CPU 0. Without
+///    this, CPU 0 may be idle when `thread_start(T)` enqueues T, and the
+///    wake-IPI lets CPU 0 dispatch T (the only Ready thread there) before
+///    the active-migration call.
+/// 2. **T at priority 1 (below the parent's `PRIORITY_DEFAULT` of 10).**
+///    Even with parent on CPU 0, same-priority FIFO would let a timer-driven
+///    `schedule()` re-enqueue parent at the tail and dispatch T at the head.
+///    Strict-lower priority guarantees CPU 0's `dequeue_highest` always
+///    returns parent, leaving T queued.
+///
+/// Together these make `sys_thread_set_affinity` deterministically observe
+/// `state == Ready` for T on CPU 0, exercising `migrate_ready_thread`. When
+/// the parent then blocks in `signal_wait`, CPU 1 picks T (its only Ready
+/// thread) and T reports CPU 1.
 ///
 /// T reports the CPU it actually ran on via `SystemInfoType::CurrentCpu`,
 /// encoded in the signal value. Without active migration, T would stay on
@@ -629,6 +643,26 @@ pub fn affinity_migrate_ready_queued(ctx: &TestContext) -> TestResult
         return Ok(());
     }
 
+    // Pin the harness to CPU 0 and yield to force migration there. The
+    // affinity-recheck branch of `schedule()` (`sched/mod.rs` re-enqueue
+    // path) routes the yielding parent cross-CPU to CPU 0; when `yield`
+    // returns, the parent is running on CPU 0.
+    thread_set_affinity(ctx.thread_cap, 0)
+        .map_err(|_| "thread_set_affinity(self, 0) for affinity_migrate_ready_queued failed")?;
+    syscall::thread_yield().map_err(|_| "thread_yield to land parent on CPU 0 failed")?;
+
+    let result = affinity_migrate_ready_queued_body(ctx);
+
+    // Restore the harness's affinity regardless of test outcome so later
+    // tests start from the default any-CPU placement.
+    thread_set_affinity(ctx.thread_cap, u32::MAX)
+        .map_err(|_| "restoring parent affinity to AFFINITY_ANY failed")?;
+
+    result
+}
+
+fn affinity_migrate_ready_queued_body(ctx: &TestContext) -> TestResult
+{
     let sig = cap_create_signal(ctx.memory_frame_base)
         .map_err(|_| "create_signal for affinity_migrate_ready_queued failed")?;
     let cs = cap_create_cspace(ctx.memory_frame_base, 0, 4, 16)
@@ -641,6 +675,13 @@ pub fn affinity_migrate_ready_queued(ctx: &TestContext) -> TestResult
     // Pin to CPU 0 initially so T's first enqueue lands on CPU 0's run queue.
     thread_set_affinity(th, 0).map_err(|_| "initial thread_set_affinity(0) failed")?;
 
+    // Priority 1 (strict-lower than the parent's default of 10) so CPU 0's
+    // `dequeue_highest` always selects the parent over T while both are
+    // Ready/Running there. Priority 1 is below SCHED_ELEVATED_MIN so no
+    // SchedControl cap is required (sched_idx = 0).
+    thread_set_priority(th, 1, 0)
+        .map_err(|_| "thread_set_priority(1) for affinity_migrate_ready_queued failed")?;
+
     let stack_top = ChildStack::top(core::ptr::addr_of!(STACK_AFFINITY_MIGRATE_READY));
     thread_configure(
         th,
@@ -651,20 +692,21 @@ pub fn affinity_migrate_ready_queued(ctx: &TestContext) -> TestResult
     .map_err(|_| "thread_configure for affinity_migrate_ready_queued failed")?;
     thread_start(th).map_err(|_| "thread_start for affinity_migrate_ready_queued failed")?;
 
-    // T is now Ready, queued on CPU 0. The parent is also Running on CPU 0
-    // (same priority, FIFO) so T has not yet been picked. Switch T's affinity
-    // to CPU 1 — the active-migration path must dequeue T from CPU 0 and
-    // re-enqueue it on CPU 1.
+    // T is Ready, queued on CPU 0 at priority 1; the parent is Running on
+    // CPU 0 at priority 10 (pinned by the outer wrapper), so no scheduling
+    // event can dispatch T here. Switch T's affinity to CPU 1 — the
+    // active-migration path must dequeue T from CPU 0 and re-enqueue it on
+    // CPU 1.
     thread_set_affinity(th, 1).map_err(|_| "active migration thread_set_affinity(1) failed")?;
 
     // Block on the signal: parent leaves CPU 0, CPU 1 runs T which reports
     // its actual CPU id back through the signal bits. `report_cpu_entry`
-    // encodes the CPU id as `1u64 << cpu` so the wake always lands even
-    // if a Ready→Running race on CPU 0 dispatches T before the migration
-    // (otherwise `signal_send(sig, 0)` would be rejected and the test
-    // would hang instead of failing — see issue #116). The 5 s timeout
-    // is a defensive backstop: any missed-wake from a different cause
-    // also degrades to a deterministic test FAIL rather than a HANG.
+    // encodes the CPU id as `1u64 << cpu` (always non-zero) so any missed
+    // wake — including a `cpu == 0` report from an unexpected stale-CPU
+    // run — surfaces as a deterministic test FAIL instead of a HANG.
+    // `signal_send(sig, 0)` would be rejected and the parent would park
+    // indefinitely (see issue #116). The 5 s timeout is a defensive
+    // backstop against any other missed-wake mode.
     let bits = signal_wait_timeout(sig, 5_000)
         .map_err(|_| "signal_wait for affinity_migrate_ready_queued failed")?;
     if bits == 0

--- a/core/ktest/src/unit/thread.rs
+++ b/core/ktest/src/unit/thread.rs
@@ -617,11 +617,12 @@ pub fn affinity_bind_cpu1(ctx: &TestContext) -> TestResult
 ///    this, CPU 0 may be idle when `thread_start(T)` enqueues T, and the
 ///    wake-IPI lets CPU 0 dispatch T (the only Ready thread there) before
 ///    the active-migration call.
-/// 2. **T at priority 1 (below the parent's `PRIORITY_DEFAULT` of 10).**
-///    Even with parent on CPU 0, same-priority FIFO would let a timer-driven
-///    `schedule()` re-enqueue parent at the tail and dispatch T at the head.
-///    Strict-lower priority guarantees CPU 0's `dequeue_highest` always
-///    returns parent, leaving T queued.
+/// 2. **T at priority 1 (below the parent's `INIT_PRIORITY` of 15).**
+///    Both the harness and any thread minted via `cap_create_thread`
+///    default to `INIT_PRIORITY`. Without this step, same-priority FIFO
+///    would let a timer-driven `schedule()` re-enqueue parent at the tail
+///    and dispatch T at the head. Strict-lower priority guarantees CPU 0's
+///    `dequeue_highest` always returns parent, leaving T queued.
 ///
 /// Together these make `sys_thread_set_affinity` deterministically observe
 /// `state == Ready` for T on CPU 0, exercising `migrate_ready_thread`. When
@@ -654,11 +655,11 @@ pub fn affinity_migrate_ready_queued(ctx: &TestContext) -> TestResult
     let result = affinity_migrate_ready_queued_body(ctx);
 
     // Restore the harness's affinity regardless of test outcome so later
-    // tests start from the default any-CPU placement.
-    thread_set_affinity(ctx.thread_cap, u32::MAX)
-        .map_err(|_| "restoring parent affinity to AFFINITY_ANY failed")?;
-
-    result
+    // tests start from the default any-CPU placement. Preserve the body's
+    // error if both fail — the body's failure is the proximate cause.
+    let restore = thread_set_affinity(ctx.thread_cap, u32::MAX)
+        .map_err(|_| "restoring parent affinity to AFFINITY_ANY failed");
+    result.and(restore)
 }
 
 fn affinity_migrate_ready_queued_body(ctx: &TestContext) -> TestResult
@@ -675,10 +676,11 @@ fn affinity_migrate_ready_queued_body(ctx: &TestContext) -> TestResult
     // Pin to CPU 0 initially so T's first enqueue lands on CPU 0's run queue.
     thread_set_affinity(th, 0).map_err(|_| "initial thread_set_affinity(0) failed")?;
 
-    // Priority 1 (strict-lower than the parent's default of 10) so CPU 0's
-    // `dequeue_highest` always selects the parent over T while both are
-    // Ready/Running there. Priority 1 is below SCHED_ELEVATED_MIN so no
-    // SchedControl cap is required (sched_idx = 0).
+    // Priority 1 (strict-lower than the parent's INIT_PRIORITY of 15) so
+    // CPU 0's `dequeue_highest` always selects the parent over T while
+    // both are Ready/Running there. Priority 1 is below
+    // SCHED_ELEVATED_MIN so no SchedControl cap is required
+    // (sched_idx = 0).
     thread_set_priority(th, 1, 0)
         .map_err(|_| "thread_set_priority(1) for affinity_migrate_ready_queued failed")?;
 
@@ -693,20 +695,21 @@ fn affinity_migrate_ready_queued_body(ctx: &TestContext) -> TestResult
     thread_start(th).map_err(|_| "thread_start for affinity_migrate_ready_queued failed")?;
 
     // T is Ready, queued on CPU 0 at priority 1; the parent is Running on
-    // CPU 0 at priority 10 (pinned by the outer wrapper), so no scheduling
-    // event can dispatch T here. Switch T's affinity to CPU 1 — the
-    // active-migration path must dequeue T from CPU 0 and re-enqueue it on
-    // CPU 1.
+    // CPU 0 at INIT_PRIORITY=15 (pinned by the outer wrapper), so no
+    // scheduling event can dispatch T here. Switch T's affinity to CPU 1
+    // — the active-migration path must dequeue T from CPU 0 and re-enqueue
+    // it on CPU 1.
     thread_set_affinity(th, 1).map_err(|_| "active migration thread_set_affinity(1) failed")?;
 
     // Block on the signal: parent leaves CPU 0, CPU 1 runs T which reports
     // its actual CPU id back through the signal bits. `report_cpu_entry`
-    // encodes the CPU id as `1u64 << cpu` (always non-zero) so any missed
-    // wake — including a `cpu == 0` report from an unexpected stale-CPU
-    // run — surfaces as a deterministic test FAIL instead of a HANG.
-    // `signal_send(sig, 0)` would be rejected and the parent would park
-    // indefinitely (see issue #116). The 5 s timeout is a defensive
-    // backstop against any other missed-wake mode.
+    // encodes the CPU id as `1u64.wrapping_shl(cpu)` (always non-zero by
+    // the modulo-64 shift semantics) so any missed wake — including a
+    // `cpu == 0` report from an unexpected stale-CPU run — surfaces as a
+    // deterministic test FAIL instead of a HANG. `signal_send(sig, 0)`
+    // would be rejected and the parent would park indefinitely (see
+    // issue #116). The 5 s timeout is a defensive backstop against any
+    // other missed-wake mode.
     let bits = signal_wait_timeout(sig, 5_000)
         .map_err(|_| "signal_wait for affinity_migrate_ready_queued failed")?;
     if bits == 0

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -220,7 +220,7 @@ cargo xtask run-parallel \
 | `--timeout` | `30` | Per-run timeout in seconds; expired runs are SIGKILLed and classified `HANG` (unless a pass marker matched first) |
 | `--cpus` | `4` | vCPUs per guest |
 | `--pass` | `ALL TESTS PASSED` | Regex marking a successful run. The default matches the cross-harness terminal marker `[<harness>] ALL TESTS PASSED` standardised in [docs/testing.md](../docs/testing.md). On match the log is discarded and the run is classified `PASS` |
-| `--fail` | (none) | Regex marking a failed run; the **first** match wins. On match the log is preserved as `FAIL-<run>.log`. Failure takes precedence over success |
+| `--fail` | `SOME TESTS FAILED` | Regex marking a failed run; the **first** match wins. The default matches the cross-harness terminal marker `[<harness>] SOME TESTS FAILED` standardised in [docs/testing.md](../docs/testing.md). On match the log is preserved as `FAIL-<run>.log`. Failure takes precedence over success. Override with a never-matching pattern (e.g. `'$.^'`) to disable |
 
 **Mode-agnostic**: xtask does not know about ktest, svctest, or any other
 rootfs configuration. Pass/fail markers come from the invoker. The default

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -237,7 +237,7 @@ pub struct RunParallelArgs
     /// Regex marking a successful run. On match the log is discarded and
     /// the run is classified PASS. The default matches the cross-harness
     /// terminal marker `[<harness>] ALL TESTS PASSED` standardised in
-    /// [`docs/testing.md`](../../../docs/testing.md); override for other
+    /// [`docs/testing.md`](../../docs/testing.md); override for other
     /// rootfs configurations.
     #[arg(long, default_value = "ALL TESTS PASSED")]
     pub pass: String,
@@ -246,7 +246,7 @@ pub struct RunParallelArgs
     /// FAIL-<run>.log. Failure takes precedence over success. The default
     /// matches the cross-harness terminal marker
     /// `[<harness>] SOME TESTS FAILED` standardised in
-    /// [`docs/testing.md`](../../../docs/testing.md); override with a
+    /// [`docs/testing.md`](../../docs/testing.md); override with a
     /// never-matching pattern (e.g. `'$.^'`) to disable.
     #[arg(long, default_value = "SOME TESTS FAILED")]
     pub fail: String,

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -243,7 +243,11 @@ pub struct RunParallelArgs
     pub pass: String,
 
     /// Regex marking a failed run. On match the log is preserved as
-    /// FAIL-<run>.log. Failure takes precedence over success.
-    #[arg(long)]
-    pub fail: Option<String>,
+    /// FAIL-<run>.log. Failure takes precedence over success. The default
+    /// matches the cross-harness terminal marker
+    /// `[<harness>] SOME TESTS FAILED` standardised in
+    /// [`docs/testing.md`](../../../docs/testing.md); override with a
+    /// never-matching pattern (e.g. `'$.^'`) to disable.
+    #[arg(long, default_value = "SOME TESTS FAILED")]
+    pub fail: String,
 }

--- a/xtask/src/commands/run_parallel.rs
+++ b/xtask/src/commands/run_parallel.rs
@@ -105,11 +105,8 @@ pub fn run(ctx: &BuildContext, args: &RunParallelArgs) -> Result<()>
     validate_args(args)?;
     let pass_re =
         Regex::new(&args.pass).with_context(|| format!("invalid --pass regex {:?}", args.pass))?;
-    let fail_re = match &args.fail
-    {
-        Some(s) => Some(Regex::new(s).with_context(|| format!("invalid --fail regex {:?}", s))?),
-        None => None,
-    };
+    let fail_re =
+        Regex::new(&args.fail).with_context(|| format!("invalid --fail regex {:?}", args.fail))?;
 
     validate_sysroot_for_launch(ctx, args.arch)?;
 
@@ -244,8 +241,7 @@ pub fn run(ctx: &BuildContext, args: &RunParallelArgs) -> Result<()>
                 let elapsed = started.elapsed();
 
                 let log_text = read_log(&log_path).unwrap_or_default();
-                let (status, matched) =
-                    classify(exit_rc, hung, &log_text, &pass_re, fail_re.as_ref());
+                let (status, matched) = classify(exit_rc, hung, &log_text, &pass_re, &fail_re);
 
                 let outcome = RunOutcome {
                     run: run_id,
@@ -439,17 +435,14 @@ fn classify(
     hung: bool,
     log: &str,
     pass_re: &Regex,
-    fail_re: Option<&Regex>,
+    fail_re: &Regex,
 ) -> (Status, Option<String>)
 {
     // Failure marker beats everything: a panic anywhere in the log invalidates
     // any PASS line. Use the first hit — earliest failure is the proximate cause.
-    if let Some(re) = fail_re
+    if let Some(m) = fail_re.find(log)
     {
-        if let Some(m) = re.find(log)
-        {
-            return (Status::Fail, Some(line_containing(log, m.start())));
-        }
+        return (Status::Fail, Some(line_containing(log, m.start())));
     }
     // Pass marker beats watchdog: a kernel that prints PASS and then idles
     // (no shutdown path) reaches the timeout but is functionally successful.


### PR DESCRIPTION
## Summary

Two fixes for #142:

1. **ktest** — `thread::affinity_migrate_ready_queued` stabilised by pinning the harness to CPU 0 (via newly-exposed `ctx.thread_cap`) and creating T at strict-lower priority. The kernel was correct; the test's "T stays Ready, queued on CPU 0" precondition was never enforced from userspace and dissolved whenever the harness drifted off CPU 0 or a timer tick rotated the same-priority FIFO.
2. **xtask** — `run-parallel --fail` now defaults to `SOME TESTS FAILED` (the cross-harness marker fixed in `docs/testing.md`). Previously `Option<String>` with no default, so runs that printed the fail marker and shut down cleanly were misclassified `Status::Ok`.

Closes #142

## Acceptance

#142 has no formal `## Acceptance` section; the issue's investigation steps + side-finding define the closure surface:

- [x] Reproduce the flake locally with `run-parallel`.
- [x] Determine whether the cause is the scheduler's active-migration path (kernel) or the test's "T stays Ready" precondition (test). Verdict: test precondition, not kernel.
- [x] Eliminate the flake. 200/200 PASS on each of riscv64 debug and x86_64 release at `parallel=4`.
- [x] Fix the run-parallel classifier so `SOME TESTS FAILED` is reported as `Status::Fail`, not `Status::Ok` (side-finding).

## Test plan

- [x] `cargo xtask build` (x86_64, debug)
- [x] `cargo xtask build --arch riscv64` (debug)
- [x] `cargo xtask build --arch x86_64 --release`
- [x] `cargo xtask run-parallel --arch riscv64 --runs 200 --parallel 4 --timeout 60` — `pass=200 ok=0 fail=0 hang=0 err=0`
- [x] `cargo xtask run-parallel --arch x86_64 --runs 200 --parallel 4 --timeout 60` — `pass=197 ok=0 fail=0 hang=3 err=0`; all 3 hangs are pre-existing and tracked: 2 × `ExitBootServices` firmware flake (#101), 1 × `stress::concurrent_ipc` watchdog (#144 — exact signature match). `affinity_migrate_ready_queued` itself passed in 200/200 runs on both archs.
- [x] Classifier fix verified: a deliberate run that printed `[ktest] SOME TESTS FAILED` was correctly classified `Status::Fail` (under the old code it would have been `Status::Ok`).

## Notes

- No kernel changes. The `sys_thread_set_affinity` path and `migrate_ready_thread` are correct; the bug was test-side fragility.
- A small ergonomic gap surfaced during the investigation — there is no userspace primitive for creating a thread in Ready state that is not yet eligible to dispatch. The fix navigates around it with a pinning+priority composition trick. Filed as **#145** (design, kernel, abi-syscall, ktest; no milestone) for tracking.
- The new `TestContext::thread_cap` field is populated from `InitInfo::thread_cap` and is generally useful for any future ktest that needs to manipulate the harness thread itself.