### PR TITLE
docs: add system-scope storage.md; trim device-management.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Overall project design documents live in [`docs/`](docs/):
 - [IPC Design](docs/ipc-design.md) — message passing, endpoints, synchronous vs async
 - [Capability Model](docs/capability-model.md) — permissions, delegation, revocation
 - [Namespace Model](docs/namespace-model.md) — node capabilities, per-entry rights and visibility, walking, sandboxing as cap-distribution
+- [Storage](docs/storage.md) — composition of vfsd, fs drivers, and block drivers; GPT role-GUID discovery; mount lifecycle
 - [System Bootstrap](docs/bootstrap.md) — end-to-end boot lifecycle summary (bootloader steps, kernel phases, init bootstrap)
 - [Device Management](docs/device-management.md) — platform enumeration, devmgr, driver binding, DMA safety
 - [Build System](docs/build-system.md) — toolchain, workspace layout, sysroot, xtask commands

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -105,7 +105,9 @@ Isolated userspace processes. Access hardware only through capabilities
 granted by devmgr.
 
 **vfsd**
-Unified filesystem namespace over separate fs driver processes.
+Unified filesystem namespace over separate fs driver processes. The
+system-scope composition (cap-delegation chain, GPT role-GUID
+discovery, mount lifecycle) is specified in [storage.md](storage.md).
 
 **fs drivers**
 Separate binaries in `fs/` (FAT, ext4, tmpfs, etc.), launched by vfsd.

--- a/docs/capability-model.md
+++ b/docs/capability-model.md
@@ -434,4 +434,4 @@ The kernel does not provide:
 
 ## Summarized By
 
-[README.md](../README.md), [Architecture Overview](architecture.md), [init](../services/init/README.md), [namespace-model.md](namespace-model.md)
+[README.md](../README.md), [Architecture Overview](architecture.md), [storage.md](storage.md), [init](../services/init/README.md), [namespace-model.md](namespace-model.md)

--- a/docs/device-management.md
+++ b/docs/device-management.md
@@ -50,21 +50,11 @@ authoritative cap-by-cap list.
 
 ### What devmgr does
 
-1. **Parse firmware tables** — walks ACPI or Device Tree to resolve interrupt
-   routing, power domains, and the full PCI hierarchy.
-
-2. **Enumerate PCI** — maps the ECAM region and reads configuration space to
-   discover all devices, BARs, and interrupt assignments.
-
-3. **Bind drivers** — for each device, spawns a driver process, delegates
-   per-device capabilities (MMIO, interrupt, optionally DMA), and routes the
-   driver's endpoint to the consuming service.
-
-4. **Expose a device registry** — maintains an IPC service for querying device
-   capabilities.
-
-5. **Handle hotplug** — on supported platforms, receives hotplug notifications
-   and dynamically spawns or terminates driver processes.
+devmgr's per-responsibility specification — firmware-table parsing,
+PCI enumeration, driver binding, device-registry IPC, and hotplug —
+is in [`services/devmgr/README.md`](../services/devmgr/README.md) §
+Responsibilities. This document covers only the system-scope
+boundary devmgr sits inside.
 
 ### Security boundary
 
@@ -148,8 +138,12 @@ devmgr is not a dependency of vfsd or netd directly — those services receive d
 endpoints after devmgr has completed initial binding. The dependency ordering is
 managed by init's bootstrap sequence (for early boot) and svcmgr (for restarts).
 
+Storage-side cap delegation downstream of devmgr (whole-disk
+endpoint → vfsd → partition-scoped endpoint → fs driver) is
+specified in [`storage.md`](storage.md).
+
 ---
 
 ## Summarized By
 
-[README.md](../README.md), [Architecture Overview](architecture.md), [devmgr](../services/devmgr/README.md), [drivers](../services/drivers/README.md)
+[README.md](../README.md), [Architecture Overview](architecture.md), [storage.md](storage.md), [devmgr](../services/devmgr/README.md), [drivers](../services/drivers/README.md)

--- a/docs/namespace-model.md
+++ b/docs/namespace-model.md
@@ -292,4 +292,4 @@ This makes the mechanism agnostic to:
 
 ## Summarized By
 
-[README.md](../README.md), [docs/capability-model.md](capability-model.md), [shared/namespace-protocol/README.md](../shared/namespace-protocol/README.md), [services/vfsd/docs/namespace-composition.md](../services/vfsd/docs/namespace-composition.md)
+[README.md](../README.md), [docs/capability-model.md](capability-model.md), [docs/storage.md](storage.md), [shared/namespace-protocol/README.md](../shared/namespace-protocol/README.md), [services/vfsd/docs/namespace-composition.md](../services/vfsd/docs/namespace-composition.md)

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -1,0 +1,245 @@
+# Storage
+
+System-scope composition of the Seraph storage stack: how `vfsd`,
+filesystem drivers, and block drivers are linked by capability
+delegation and how mounts are established at boot.
+
+---
+
+## Composition Principle
+
+Storage is three layers of independent userspace processes linked
+exclusively by capability delegation:
+
+| Layer | Process | Owns |
+|---|---|---|
+| Block | `virtio-blk` (per disk) | Hardware MMIO, IRQ, descriptor rings |
+| Filesystem | one fs driver per mount (e.g. `fatfs`) | On-disk format, BPB, FAT chains |
+| Namespace | `vfsd` (single instance) | Synthetic root, GPT discovery, mount tree |
+
+The kernel transports capabilities and bytes; it holds no filesystem
+state and contains no filesystem code. All composition is in
+userspace.
+
+Four system-scope invariants govern the stack:
+
+- **vfsd holds no on-disk storage and is off the I/O path after the
+  walk.** Once a client has walked `NS_LOOKUP` into a mounted
+  filesystem, subsequent reads and writes go directly to the owning
+  fs driver. vfsd is not a proxy.
+- **One fs-driver process per mount.** A crash in one mount cannot
+  corrupt another. `vfsd` is the supervisor for the fs-driver
+  lifecycle.
+- **Block access is partition-scoped at the capability layer.** The
+  block driver exposes one untokened whole-disk endpoint (held by
+  vfsd alone) and tokened per-partition endpoints (handed to fs
+  drivers). Out-of-bounds LBAs are rejected by the block driver on
+  every request.
+- **System root is delivered, never discovered.** Every process's
+  namespace authority arrives as `ProcessInfo.system_root_cap`
+  installed by `procmgr_labels::CONFIGURE_NAMESPACE` on spawn.
+  There is no ambient mount table and no global lookup.
+
+The cap-as-namespace principles these invariants rest on are
+specified in [`namespace-model.md`](namespace-model.md).
+
+---
+
+## Capability Delegation Chain
+
+Storage authority flows from the kernel's initial cap mint outward in
+one direction. Each arrow is a single capability transfer; revoking
+any link kills the subtree beneath it.
+
+```
+kernel (phase 7) mints MmioRegion + IRQ from BootInfo
+  → init delegates MmioRegion + IRQ caps to devmgr
+    → devmgr binds virtio-blk; delegates per-device MMIO + IRQ
+      → virtio-blk publishes its whole-disk service endpoint to devmgr
+        → vfsd queries devmgr's device registry → whole-disk SEND
+          → vfsd issues REGISTER_PARTITION (whole-disk endpoint only)
+            → vfsd derives a tokened per-partition SEND
+              → vfsd spawns fs driver; injects partition-scoped block cap
+                → fs driver issues FS_MOUNT, reads BPB, replies OK
+                  → vfsd captures fs driver's root namespace cap
+                    → init pulls system root via GET_SYSTEM_ROOT_CAP
+                      → init distributes copies via CONFIGURE_NAMESPACE
+```
+
+The kernel half (BootInfo → MmioRegion mint → devmgr → driver binding)
+is owned by [`device-management.md`](device-management.md). Token
+semantics, derivation, and revocation are owned by
+[`capability-model.md`](capability-model.md) §"Tokens".
+
+`REGISTER_PARTITION` is rejected over tokened callers: only the holder
+of the whole-disk endpoint (vfsd) can mint a partition binding. The
+block driver enforces the LBA bound on every read and write against
+the caller's token. See
+[`services/drivers/virtio/blk/README.md`](../services/drivers/virtio/blk/README.md).
+
+---
+
+## GPT Role-GUID Discovery
+
+Partition identity in Seraph is a GPT type GUID, not a position, label,
+or on-disk UUID. The model is:
+
+- **Seraph-minted root GUIDs are arch-distinguished**, following the
+  Discoverable Partitions Specification convention. A single disk
+  image may carry both an `x86_64` and a `riscv64` root partition;
+  the vfsd binary selects by its own compile-time `target_arch`.
+  Authoritative GUID values are
+  [`SERAPH_ROOT_X86_64`](../abi/boot-protocol/src/role_guids.rs),
+  [`SERAPH_ROOT_RISCV64`](../abi/boot-protocol/src/role_guids.rs),
+  and the arch-neutral [`SERAPH_DATA`](../abi/boot-protocol/src/role_guids.rs)
+  in [`abi/boot-protocol/src/role_guids.rs`](../abi/boot-protocol/src/role_guids.rs).
+- **The EFI System Partition is auto-mounted at `/esp`** after the
+  root mount completes, using the standard ESP type GUID
+  `c12a7328-f81f-11d2-ba4b-00a0c93ec93b`. No caller issues a
+  `MOUNT` for `/esp`; vfsd does so internally as part of root-mount
+  handling. ESP mount is best-effort and failure is non-fatal.
+- **DPS-style priority tie-break.** Where multiple partitions match
+  a role GUID, GPT attribute bits 48–63 are compared as an unsigned
+  priority; the highest wins. Tied non-zero priorities are a fatal
+  boot error — the configuration is ambiguous and must be repaired.
+- **Nothing else binds.** There is no `mounts.conf`, no `/etc/fstab`,
+  no kernel command line carrying mount config, no on-disk
+  filesystem label or UUID consulted by vfsd. The GUID is the
+  binding.
+
+The boot-protocol v8 retirement of `BootInfo.command_line` and the
+prior `mounts.conf` file completed this transition; the role-GUID
+model is the present and only mount-discovery mechanism. The wire
+shape vfsd uses internally (a `MountRole` byte mapped to a type GUID)
+is owned by [`services/vfsd/docs/vfs-ipc-interface.md`](../services/vfsd/docs/vfs-ipc-interface.md).
+
+---
+
+## Mount Establishment Lifecycle
+
+Three actors cooperate to bring a filesystem online:
+
+**init** holds two storage-relevant caps after vfsd is spawned: an
+untokened SEND on vfsd's service endpoint (for the un-gated `MOUNT`
+call), and a `SEED_AUTHORITY`-tokened SEND on the same endpoint
+(required by the `GET_SYSTEM_ROOT_CAP` gate). Init issues exactly
+one `MOUNT` request — the root — over the untokened SEND, then pulls
+the system root via `GET_SYSTEM_ROOT_CAP`, then distributes per-child
+copies on every spawn via `procmgr_labels::CONFIGURE_NAMESPACE`.
+Init retains no further filesystem access of its own.
+
+**vfsd** parses the GPT once at startup, resolves the role byte to a
+type GUID, looks the partition up in its parsed table, registers the
+partition bound with virtio-blk, spawns the fs driver, sends
+`FS_MOUNT` to validate the BPB, and captures the driver's root cap
+into the synthetic root (see
+[`services/vfsd/docs/namespace-composition.md`](../services/vfsd/docs/namespace-composition.md)).
+When the requested role is the rootfs, vfsd additionally auto-mounts
+the ESP at `/esp` inside the same handler before replying.
+
+**fs driver** runs as a separate process. After `FS_MOUNT` succeeds,
+it serves the cap-native `NS_*` protocol plus the surviving
+`FS_*` labels against per-node tokened SEND caps on its own
+endpoint. The block endpoint it receives is partition-scoped at
+delivery time; the fs driver reads and writes by partition-relative
+LBA.
+
+### First-mount structural constraint
+
+The first fatfs process is spawned from the boot-module cap, not via
+the namespace. `/bin/fatfs` is unreachable until root mounts, so the
+fatfs that brings root online cannot be spawned from disk —
+chicken-and-egg. Subsequent fs-driver respawns walk vfsd's own
+held system-root cap to `/bin/fatfs` and pass the resulting file cap
+to procmgr via `CREATE_FROM_FILE`. The first-mount path is permanent
+by structure.
+
+---
+
+## fs ↔ block IPC Contract
+
+The contract between fs drivers and the block driver has three
+elements:
+
+- **Two-tier endpoint.** Whole-disk untokened (vfsd only) versus
+  per-partition tokened (fs drivers). The block driver distinguishes
+  by the kernel-supplied caller token.
+- **Partition-scoped LBA.** Reads and writes carry an LBA relative
+  to the caller token's partition base. The block driver enforces
+  the bound on every request.
+- **Single-page Frame-cap DMA.** Each read or write transfers one
+  Frame cap as the DMA target; the Frame is moved back to the caller
+  in every reply (success or error). The block driver never retains
+  the data Frame.
+
+Authoritative wire shapes for `REGISTER_PARTITION`,
+`BLK_READ_INTO_FRAME`, and `BLK_WRITE_FROM_FRAME` live in
+[`services/drivers/virtio/blk/README.md`](../services/drivers/virtio/blk/README.md).
+The fs-driver side — `FS_MOUNT`, `FS_READ`, `FS_READ_FRAME`,
+`FS_RELEASE_FRAME`, `FS_WRITE`, `FS_WRITE_FRAME`, `FS_CLOSE`, and
+the directory-mutation labels — is owned by
+[`services/fs/docs/fs-driver-protocol.md`](../services/fs/docs/fs-driver-protocol.md).
+
+DMA safety (IOMMU vs. no-IOMMU policy) is a devmgr concern, not a
+storage concern; see [`device-management.md`](device-management.md)
+§"DMA Safety Model".
+
+---
+
+## Failure and Revocation Invariants
+
+The supported failure-handling primitives are:
+
+- **fs-driver crash.** vfsd MAY respawn a failed fs driver and
+  reinstall the new root cap. Other mounts are unaffected; the
+  block driver is unaffected. The respawn path uses
+  `CREATE_FROM_FILE` against vfsd's own held system-root cap walked
+  to `/bin/<driver>`.
+- **Mount-tree-wide revocation.** `cap_revoke` on an fs driver's
+  namespace endpoint cascades through the kernel derivation graph
+  and invalidates every cap ever derived from it: the synthetic-
+  root entry, the `MOUNT` caller's copy, and every per-file cap
+  previously walked through that mount. This is the supported
+  primitive for "tear down a mount."
+- **Per-mount per-cap revocation is not supported.** The two-derive
+  install scheme (one cap to the `MOUNT` caller, one captured by
+  vfsd's synthetic root) gives per-slot ownership for `cap_delete`
+  but not per-cap revocation. Revoking the synthetic-root entry
+  alone cascades to sibling derivations and behaves equivalently to
+  the destroy-driver hammer. See
+  [`services/vfsd/docs/namespace-composition.md`](../services/vfsd/docs/namespace-composition.md)
+  §"Revocation".
+- **Unmount is not implemented at v0.1.0.** The mount tree is
+  permanent for the lifetime of the vfsd process.
+
+---
+
+## What the Storage System Is Not
+
+To prevent inference of behavior that does not exist:
+
+- **No kernel-side filesystem code.** The kernel has no notion of
+  files, directories, mounts, or filesystem labels. It transports
+  caps and bytes, nothing more.
+- **No ambient mount table.** No `/proc/mounts`, no namespace
+  inheritance, no kernel mount-table syscall. Mounts are entries in
+  vfsd's synthetic root, reachable only via a held cap on vfsd's
+  namespace endpoint.
+- **No filesystem labels or on-disk UUIDs as identity.** Partition
+  identity is the GPT type GUID plus DPS attribute-bit priority.
+  Filesystem-level labels (FAT volume label, ext4 superblock UUID,
+  etc.) are not consulted by vfsd.
+- **No boot-time mount configuration file.** Discovery is GPT-driven
+  and arch-conditional; there is no `mounts.conf`, no `/etc/fstab`,
+  and no kernel command line carrying mount config (boot-protocol
+  v8 retired `command_line` entirely).
+- **No process-global filesystem authority.** A process delivered no
+  namespace cap has no filesystem access; `std::fs` returns
+  `Unsupported`. There is no fallback to a system identity.
+
+---
+
+## Summarized By
+
+[README.md](../README.md),
+[architecture.md](architecture.md)

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -209,8 +209,8 @@ The supported failure-handling primitives are:
   the destroy-driver hammer. See
   [`services/vfsd/docs/namespace-composition.md`](../services/vfsd/docs/namespace-composition.md)
   §"Revocation".
-- **Unmount is not implemented at v0.1.0.** The mount tree is
-  permanent for the lifetime of the vfsd process.
+- **Unmount is not implemented.** The mount tree is permanent for
+  the lifetime of the vfsd process.
 
 ---
 

--- a/services/devmgr/README.md
+++ b/services/devmgr/README.md
@@ -98,4 +98,4 @@ MUST NOT be started independently of devmgr. See
 
 ## Summarized By
 
-[docs/device-management.md](../../docs/device-management.md)
+[docs/device-management.md](../../docs/device-management.md), [docs/storage.md](../../docs/storage.md)

--- a/services/drivers/virtio/blk/README.md
+++ b/services/drivers/virtio/blk/README.md
@@ -187,4 +187,4 @@ values in the `CapDescriptor.aux0` field, per
 
 ## Summarized By
 
-None
+[docs/storage.md](../../../../docs/storage.md)

--- a/services/fs/README.md
+++ b/services/fs/README.md
@@ -84,4 +84,4 @@ re-install the new root cap.
 
 ## Summarized By
 
-None
+[docs/storage.md](../../docs/storage.md)

--- a/services/fs/docs/fs-driver-protocol.md
+++ b/services/fs/docs/fs-driver-protocol.md
@@ -497,4 +497,4 @@ bound on every `BLK_READ_INTO_FRAME`. See
 
 ## Summarized By
 
-[services/fs/README.md](../README.md), [services/fs/fat/README.md](../fat/README.md)
+[services/fs/README.md](../README.md), [services/fs/fat/README.md](../fat/README.md), [docs/storage.md](../../../docs/storage.md)

--- a/services/vfsd/README.md
+++ b/services/vfsd/README.md
@@ -112,4 +112,4 @@ per-mount partition tokens are derived from it. See
 
 ## Summarized By
 
-None
+[docs/storage.md](../../docs/storage.md)

--- a/services/vfsd/docs/namespace-composition.md
+++ b/services/vfsd/docs/namespace-composition.md
@@ -205,4 +205,4 @@ seeing different roots) and `cap_revoke`-driven unmount.
 
 ## Summarized By
 
-[services/vfsd/README.md](../README.md)
+[services/vfsd/README.md](../README.md), [docs/storage.md](../../../docs/storage.md)

--- a/services/vfsd/docs/vfs-ipc-interface.md
+++ b/services/vfsd/docs/vfs-ipc-interface.md
@@ -101,4 +101,4 @@ via the root mount's transparent delegation.
 
 ## Summarized By
 
-[services/vfsd/README.md](../README.md)
+[services/vfsd/README.md](../README.md), [docs/storage.md](../../../docs/storage.md)


### PR DESCRIPTION
## Summary

- Adds `docs/storage.md` as the system-scope authority for how `vfsd`, fs drivers, and block drivers compose: composition principle, cap-delegation chain, GPT role-GUID partition discovery, mount-establishment lifecycle, fs↔block IPC contract (summary), and failure/revocation invariants.
- Trims `docs/device-management.md`: replaces the "What devmgr does" enumeration (which duplicated `services/devmgr/README.md`) with a single-line pointer; adds `storage.md` cross-link. System-scope sections (boot descriptors, firmware passthrough, DMA safety, IOMMU) unchanged.
- Adds the required `## Summarized By` backlinks to vfsd, fs, virtio-blk, devmgr, namespace-model, capability-model, and the relevant component design docs per `documentation-standards.md`.

## Scope adjustment (flagged)

Issue #16 lists "mount configuration in `boot.conf`" as a scope item. That surface was retired with boot-protocol v8 (commit `c922c99`); discovery is now GPT role-GUID driven. `storage.md` documents the replacement model (Seraph-minted type GUIDs, DPS arch selection, EFI System Partition auto-mount at `/esp`) rather than the dead `boot.conf` surface. User-confirmed in the planning round.

Companion device-management.md trim is in-scope per the issue's adjacent context note ("docs: trim docs/device-management.md to system-scope"). User-confirmed as same-PR work.

## Authority discipline

- `storage.md` restates no wire shapes (`NS_*`, `MOUNT`, `FS_*`, `BLK_*`, `REGISTER_PARTITION`). Authoritative shapes remain in their component docs; storage.md links rather than duplicates.
- `storage.md` length: 245 lines (target 200–280, parallels `device-management.md` post-trim and `namespace-model.md`).

## Test plan

- [x] `cargo xtask build` (x86_64) — green
- [x] `cargo xtask build --arch riscv64` — green (with `cargo xtask clean` between)
- [x] `cargo xtask test` (host-side) — 62 passed, 0 failed
- [x] Link-graph hygiene: `grep -rn "docs/storage.md"` returns every backlinked doc + root README + architecture.md + device-management.md cross-link
- [x] No wire-table restatement in storage.md (`grep -E '\| label \| .* \|' docs/storage.md` empty)
- [x] CI build-test matrix — green across all 13 jobs (host-tests + 12 validate jobs on x86_64/riscv64 × debug/release × ktest/svctest/usertest)
- [x] pr-reviewer + pr-auditor verdicts addressed (three should-fix backlink-propagation gaps fixed in follow-up commit)

Closes #16.