### PR TITLE
ci: stage one harness per cell in burn-in; add usertest

### DIFF
--- a/.github/workflows/burnin.yml
+++ b/.github/workflows/burnin.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           cargo xtask run-parallel \
             --arch ${{ matrix.arch }} \
-            --parallel 4 --runs 20 --timeout 60
+            --parallel 2 --runs 20 --timeout 180
 
       - name: Upload run-parallel logs
         if: always()

--- a/.github/workflows/burnin.yml
+++ b/.github/workflows/burnin.yml
@@ -20,6 +20,13 @@ jobs:
       matrix:
         arch: [x86_64, riscv64]
         profile: [debug, release]
+        # One harness per cell, matching build-test.yml: each cell builds
+        # once, stages exactly one recipe (or swaps boot.conf for ktest),
+        # then burns it in. Avoids back-to-back fatfs/sysroot state
+        # accumulation across harnesses and lets a failing tier surface as
+        # a single named cell. See docs/testing.md for the recipe-dir
+        # gating contract.
+        tester: [ktest, svctest, usertest]
     steps:
       - uses: actions/checkout@v6
 
@@ -48,7 +55,7 @@ jobs:
         with:
           shared-key: burnin-${{ matrix.arch }}-${{ matrix.profile }}
 
-      - name: Build (${{ matrix.arch }}, ${{ matrix.profile }}) — svctest config
+      - name: Build (${{ matrix.arch }}, ${{ matrix.profile }})
         run: |
           if [ "${{ matrix.profile }}" = "release" ]; then
             cargo xtask build --arch ${{ matrix.arch }} --release
@@ -56,41 +63,41 @@ jobs:
             cargo xtask build --arch ${{ matrix.arch }}
           fi
 
-      - name: svctest burn-in (4 × 20 iterations)
-        id: svctest-burnin
+      - name: Stage ${{ matrix.tester }} and repack disk
+        # Recipe staging: svctest and usertest live in
+        # `sysroot/config/svcmgr/tests/` (svcmgr does not scan that
+        # directory); cp into services/ to enable. `cargo xtask mkdisk`
+        # re-mirrors rootfs and repacks the FAT image without invoking
+        # cargo. ktest swaps the bundle's `init` entry via
+        # `cargo xtask compose-bundle --harness ktest`, which repacks
+        # the disk image as part of the compose step.
+        run: |
+          case "${{ matrix.tester }}" in
+            svctest)
+              cp sysroot/config/svcmgr/tests/svctest.svc \
+                 sysroot/config/svcmgr/services/
+              cargo xtask mkdisk --arch ${{ matrix.arch }}
+              ;;
+            usertest)
+              cp sysroot/config/svcmgr/tests/usertest.svc \
+                 sysroot/config/svcmgr/services/
+              cargo xtask mkdisk --arch ${{ matrix.arch }}
+              ;;
+            ktest)
+              cargo xtask compose-bundle --arch ${{ matrix.arch }} --harness ktest
+              ;;
+          esac
+
+      - name: Burn in ${{ matrix.tester }} (4 × 20 iterations)
         run: |
           cargo xtask run-parallel \
             --arch ${{ matrix.arch }} \
             --parallel 4 --runs 20 --timeout 60
 
-      - name: Upload svctest logs
+      - name: Upload run-parallel logs
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: burnin-svctest-${{ matrix.arch }}-${{ matrix.profile }}
-          path: target/xtask/run-parallel/**/*.log
-          if-no-files-found: ignore
-
-      - name: Compose the bundle for ktest
-        # `compose-bundle --harness ktest` overwrites
-        # sysroot/esp/EFI/seraph/bootstrap.bundle with the single-entry
-        # ktest bundle and repacks disk.img. No cargo rebuild is needed
-        # because the ktest binary was produced by the earlier
-        # `cargo xtask build` and lives at sysroot/tests/ktest.
-        run: |
-          cargo xtask compose-bundle --arch ${{ matrix.arch }} --harness ktest
-
-      - name: ktest burn-in (4 × 20 iterations)
-        id: ktest-burnin
-        run: |
-          cargo xtask run-parallel \
-            --arch ${{ matrix.arch }} \
-            --parallel 4 --runs 20 --timeout 60
-
-      - name: Upload ktest logs
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: burnin-ktest-${{ matrix.arch }}-${{ matrix.profile }}
+          name: burnin-${{ matrix.arch }}-${{ matrix.profile }}-${{ matrix.tester }}
           path: target/xtask/run-parallel/**/*.log
           if-no-files-found: ignore

--- a/.github/workflows/burnin.yml
+++ b/.github/workflows/burnin.yml
@@ -88,7 +88,7 @@ jobs:
               ;;
           esac
 
-      - name: Burn in ${{ matrix.tester }} (4 × 20 iterations)
+      - name: Burn in ${{ matrix.tester }} (20 iterations, 2 parallel)
         run: |
           cargo xtask run-parallel \
             --arch ${{ matrix.arch }} \

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -220,7 +220,7 @@ cargo xtask run-parallel \
 | `--timeout` | `30` | Per-run timeout in seconds; expired runs are SIGKILLed and classified `HANG` (unless a pass marker matched first) |
 | `--cpus` | `4` | vCPUs per guest |
 | `--pass` | `ALL TESTS PASSED` | Regex marking a successful run. The default matches the cross-harness terminal marker `[<harness>] ALL TESTS PASSED` standardised in [docs/testing.md](../docs/testing.md). On match the log is discarded and the run is classified `PASS` |
-| `--fail` | `SOME TESTS FAILED` | Regex marking a failed run; the **first** match wins. The default matches the cross-harness terminal marker `[<harness>] SOME TESTS FAILED` standardised in [docs/testing.md](../docs/testing.md). On match the log is preserved as `FAIL-<run>.log`. Failure takes precedence over success. Override with a never-matching pattern (e.g. `'$.^'`) to disable |
+| `--fail` | `SOME TESTS FAILED\|KERNEL EXCEPTION\|FATAL:\|PANIC( at \|: )` | Regex marking a failed run; the **first** match wins. Matches the cross-harness terminal marker `[<harness>] SOME TESTS FAILED` ([docs/testing.md](../docs/testing.md)) plus the kernel's own death markers (`KERNEL EXCEPTION` + `FATAL:` for a hardware trap, `PANIC at`/`PANIC:` for a Rust `panic!`) so a crash classifies `FAIL` rather than `HANG`. The benign `USERSPACE FAULT` path matches none of these. On match the log is preserved as `FAIL-<run>.log`. Failure takes precedence over success. Override with a never-matching pattern (e.g. `'$.^'`) to disable |
 
 **Mode-agnostic**: xtask does not know about ktest, svctest, or any other
 rootfs configuration. Pass/fail markers come from the invoker. The default

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -252,7 +252,7 @@ pub struct RunParallelArgs
     /// Regex marking a failed run. On match the log is preserved as
     /// FAIL-<run>.log. Failure takes precedence over success. The default
     /// matches the cross-harness terminal marker
-    /// `[<harness>] SOME TESTS FAILED` (`docs/testing.md`) plus the kernel's
+    /// `[<harness>] SOME TESTS FAILED` ([`docs/testing.md`](../../docs/testing.md)) plus the kernel's
     /// own death markers, so a crash classifies as FAIL rather than HANG: a
     /// hardware trap prints `KERNEL EXCEPTION` then `FATAL:`
     /// (`core/kernel/src/main.rs` `fatal()`), and a Rust `panic!` prints

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -210,6 +210,13 @@ pub enum TestComponent
 
 // ── RunParallel ───────────────────────────────────────────────────────────────
 
+/// Default `--fail` regex for `run-parallel`. Matches the cross-harness
+/// `SOME TESTS FAILED` marker plus the kernel's death markers so a crash is
+/// classified FAIL rather than HANG. `KERNEL EXCEPTION` + `FATAL:` cover the
+/// hardware-trap path; `PANIC( at |: )` covers the Rust `#[panic_handler]`.
+/// The benign `USERSPACE FAULT` path matches none of these.
+pub const DEFAULT_FAIL_REGEX: &str = r"SOME TESTS FAILED|KERNEL EXCEPTION|FATAL:|PANIC( at |: )";
+
 #[derive(Parser)]
 pub struct RunParallelArgs
 {
@@ -245,9 +252,13 @@ pub struct RunParallelArgs
     /// Regex marking a failed run. On match the log is preserved as
     /// FAIL-<run>.log. Failure takes precedence over success. The default
     /// matches the cross-harness terminal marker
-    /// `[<harness>] SOME TESTS FAILED` standardised in
-    /// [`docs/testing.md`](../../docs/testing.md); override with a
-    /// never-matching pattern (e.g. `'$.^'`) to disable.
-    #[arg(long, default_value = "SOME TESTS FAILED")]
+    /// `[<harness>] SOME TESTS FAILED` (`docs/testing.md`) plus the kernel's
+    /// own death markers, so a crash classifies as FAIL rather than HANG: a
+    /// hardware trap prints `KERNEL EXCEPTION` then `FATAL:`
+    /// (`core/kernel/src/main.rs` `fatal()`), and a Rust `panic!` prints
+    /// `PANIC at`/`PANIC:` (the `#[panic_handler]`). The benign userspace
+    /// fault path prints `USERSPACE FAULT`, which none of these match.
+    /// Override with a never-matching pattern (e.g. `'$.^'`) to disable.
+    #[arg(long, default_value = DEFAULT_FAIL_REGEX)]
     pub fail: String,
 }

--- a/xtask/src/commands/run_parallel.rs
+++ b/xtask/src/commands/run_parallel.rs
@@ -643,3 +643,73 @@ fn us_to_s(us: u128) -> f64
 {
     us as f64 / 1_000_000.0
 }
+
+#[cfg(test)]
+mod tests
+{
+    use super::*;
+    use crate::cli::DEFAULT_FAIL_REGEX;
+
+    fn default_regexes() -> (Regex, Regex)
+    {
+        (
+            Regex::new("ALL TESTS PASSED").unwrap(),
+            Regex::new(DEFAULT_FAIL_REGEX).unwrap(),
+        )
+    }
+
+    fn classify_log(log: &str) -> Status
+    {
+        let (pass, fail) = default_regexes();
+        // exit_rc=0, hung=false: the kernel halts after a panic, so QEMU is
+        // SIGKILLed by the watchdog in practice; pass `hung=true` only where a
+        // test exercises the timeout path explicitly.
+        classify(0, false, log, &pass, &fail).0
+    }
+
+    #[test]
+    fn kernel_exception_classifies_fail()
+    {
+        let log = "[20.09] ktest: stress::concurrent_ipc starting\n\
+                   [22.86] kernel: KERNEL EXCEPTION: cpu=0 cause=#PF page fault (vec=14 err=0x10)\n\
+                   [22.86] kernel:   rip=0x0000000000000000  cr2=0x0000000000000000\n\
+                   [22.86] kernel: FATAL: unhandled kernel exception\n";
+        assert!(matches!(classify_log(log), Status::Fail));
+    }
+
+    #[test]
+    fn rust_panic_classifies_fail()
+    {
+        let located = "\nPANIC at core/kernel/src/sched/mod.rs:42: assertion failed\n";
+        let bare = "\nPANIC: explicit halt\n";
+        assert!(matches!(classify_log(located), Status::Fail));
+        assert!(matches!(classify_log(bare), Status::Fail));
+    }
+
+    #[test]
+    fn boot_phase_fatal_classifies_fail()
+    {
+        let log = "[0.10] kernel: FATAL: Phase 9: init image missing or has no entry point\n";
+        assert!(matches!(classify_log(log), Status::Fail));
+    }
+
+    #[test]
+    fn userspace_fault_with_pass_marker_classifies_pass()
+    {
+        // crasher's deliberate userspace fault must NOT trip the fail regex;
+        // a run that also prints the terminal marker is a PASS.
+        let log = "[2.16] kernel: USERSPACE FAULT: tid=27 cpu=1 cause=store/AMO page fault (scause=0xf)\n\
+                   [2.17] kernel:   rip=0x0000000000012bf8  fs_base=0x0000000000000000\n\
+                   [4.27] [usertest] ALL TESTS PASSED\n";
+        assert!(matches!(classify_log(log), Status::Pass));
+    }
+
+    #[test]
+    fn clean_exit_without_marker_classifies_ok()
+    {
+        assert!(matches!(
+            classify_log("[1.0] booting\n[2.0] idle\n"),
+            Status::Ok
+        ));
+    }
+}

--- a/xtask/src/commands/run_parallel.rs
+++ b/xtask/src/commands/run_parallel.rs
@@ -678,12 +678,17 @@ mod tests
     }
 
     #[test]
-    fn rust_panic_classifies_fail()
+    fn located_rust_panic_classifies_fail()
     {
-        let located = "\nPANIC at core/kernel/src/sched/mod.rs:42: assertion failed\n";
-        let bare = "\nPANIC: explicit halt\n";
-        assert!(matches!(classify_log(located), Status::Fail));
-        assert!(matches!(classify_log(bare), Status::Fail));
+        let log = "\nPANIC at core/kernel/src/sched/mod.rs:42: assertion failed\n";
+        assert!(matches!(classify_log(log), Status::Fail));
+    }
+
+    #[test]
+    fn bare_rust_panic_classifies_fail()
+    {
+        let log = "\nPANIC: explicit halt\n";
+        assert!(matches!(classify_log(log), Status::Fail));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fix the burn-in workflow hanging on every run. The `svctest burn-in` step
  invoked `run-parallel` directly after `build` with **no recipe staged**.
  Per `docs/testing.md`, the default boot is interactive (no harness runs),
  so each QEMU instance booted to a shell and hung until the timeout across
  all cells.
- Bring `burnin.yml` in line with `build-test.yml`: add a `tester` matrix
  dimension (`ktest`, `svctest`, `usertest`) and reuse build-test's proven
  staging block (`cp` recipe + `mkdisk`, or `compose-bundle --harness ktest`)
  so each cell stages exactly one harness before the `--parallel 2 --runs 20`
  burn-in. Adds the previously-missing `usertest` tier and inherits the
  one-harness-per-cell isolation that avoids back-to-back fatfs/sysroot state
  accumulation.
- `xtask/run-parallel`: broaden the default `--fail` regex to also match the
  kernel's own death markers (`KERNEL EXCEPTION`/`FATAL:`/`PANIC`). A crashed
  guest halts without shutting down QEMU, so it was classified **HANG** (a
  timeout) rather than FAIL — which mislabels a hard crash as capacity. This
  is what made the failing cells below read as "too slow" at first glance.
  Labeling only (the run still idles to the timeout; early-abort is #161).

## Files touched
`.github/workflows/burnin.yml`, `xtask/src/cli.rs`,
`xtask/src/commands/run_parallel.rs`, `xtask/README.md`. No kernel/service
code changes — the tested kernel and services are identical to master, so the
burn-in result below reflects pre-existing behaviour.

## Burn-in result on this branch
Manual dispatch [run 26405522251](https://github.com/kottlerg/seraph/actions/runs/26405522251)
went 8/12 green. The 4 red cells are **pre-existing kernel bugs the harness
correctly surfaced**:
- x86_64 ktest (both profiles) + 1 x86_64 svctest: residual
  `stress::concurrent_ipc` kernel `#PF` (null instruction-fetch), the
  regression of closed #117 — filed as **#160**.
- 1 riscv64 usertest: pass marker shredded by `crasher`'s fault-dump
  interleaving on COM1 — root cause is crasher being an unconditional default
  service; folded into **#107**.

Burn-in cannot go fully green until #160 is fixed. That is a tracked
pre-existing kernel bug, **not** a regression from this PR, and burn-in runs
only on `workflow_dispatch`/tag push, so it gates no normal development.

## Test plan
- [x] `cargo xtask build` succeeds on x86_64 and riscv64.
- [x] `cargo xtask test` passes, including new `classify()` unit tests for the
      broadened `--fail` regex (kernel markers → FAIL; `USERSPACE FAULT` +
      pass marker → PASS).
- [x] Manual `burn-in` dispatch on this branch exercises all 12 cells; the
      harness stages one recipe per cell and runs the burn-in (run 26405522251).

Closes nothing; surfaces #160 and the #107 crasher-gating follow-up.
