### PR TITLE
boot: bound ExitBootServices retry under parallel-load UEFI/OVMF contention (#101)

### DIFF
--- a/core/boot/docs/boot-flow.md
+++ b/core/boot/docs/boot-flow.md
@@ -145,8 +145,10 @@ Detail: [uefi-environment.md](uefi-environment.md)
 
 `ExitBootServices` is called with the map key from step 7. If the call fails due to
 a stale key (indicating that UEFI performed allocations between the query and the
-call), the memory map is re-queried and the call is retried once. After a successful
-exit, UEFI boot services are unavailable; no further UEFI calls are made.
+call), the memory map is re-queried into the existing buffer and the call is retried,
+in a bounded loop (up to `EXIT_BOOT_SERVICES_MAX_ATTEMPTS`). This tolerates a key
+that is invalidated repeatedly under host CPU contention. After a successful exit,
+UEFI boot services are unavailable; no further UEFI calls are made.
 
 Detail: [uefi-environment.md](uefi-environment.md)
 

--- a/core/boot/docs/uefi-environment.md
+++ b/core/boot/docs/uefi-environment.md
@@ -108,10 +108,10 @@ The acquisition sequence:
 5. Sort entries by physical_base ascending.
 ```
 
-The buffer allocation in step 2 increases the map size by one entry (the new
-`EfiLoaderData` region). The buffer allocated in step 2 must be sized to accommodate
-this extra entry; in practice, adding 16 extra entries of slack when sizing the buffer
-is sufficient.
+The buffer allocation in step 2 increases the map size by at least one entry (the new
+`EfiLoaderData` region). The buffer must be sized to accommodate this; the bootloader
+adds 16 entries of slack, a prudent margin that also absorbs the further growth seen
+when `ExitBootServices` re-queries the map under contention (see below).
 
 ### UEFI Memory Type Translation
 
@@ -130,17 +130,27 @@ The call sequence:
 1. Perform the final memory map acquisition (above).
 2. Call BootServices->ExitBootServices(image_handle, map_key).
 3. If the call returns EFI_INVALID_PARAMETER (stale map key):
-   a. Call GetMemoryMap again with the existing buffer (no new allocation).
+   a. Call GetMemoryMap again with the existing buffer (no new allocation),
+      passing the full allocated buffer capacity as the size in-param.
    b. Update map_key from the new call.
-   c. Retry ExitBootServices once.
-   d. If still failing: halt immediately — the environment is unrecoverable.
-4. On success: UEFI boot services are now permanently unavailable.
+   c. Retry ExitBootServices.
+   d. Repeat from step 3 up to EXIT_BOOT_SERVICES_MAX_ATTEMPTS times total.
+   e. If still failing after the bound: halt — the environment is unrecoverable.
+4. Any status other than EFI_SUCCESS or EFI_INVALID_PARAMETER: halt immediately
+   (not a stale-key condition, so retrying cannot help).
+5. On success: UEFI boot services are now permanently unavailable.
 ```
 
-The retry handles the rare case where UEFI performs an internal allocation between
-step 1 and step 2 — some firmware implementations do this for housekeeping. The
-retry uses the existing buffer rather than allocating a new one (which would
-invalidate the key again).
+The retry handles the case where UEFI performs an internal allocation between the
+final query and the exit call — some firmware does this for housekeeping, and under
+host CPU contention (e.g. parallel QEMU/OVMF instances sharing host cores) the vCPU
+can be descheduled in that window, letting a firmware event allocate and invalidate
+the key repeatedly across attempts. A *single* retry is therefore insufficient; the
+loop is bounded at `EXIT_BOOT_SERVICES_MAX_ATTEMPTS` (16) attempts. Each re-query
+reuses the existing buffer — allocating a new one would invalidate the key again —
+and passes the allocated buffer capacity, so it tolerates a map that grew since the
+previous query. No delay is inserted between the query and the exit call: that would
+only widen the invalidation window.
 
 ### Post-Exit Constraints
 
@@ -162,7 +172,8 @@ The bootloader performs no allocation-dependent operations after `ExitBootServic
 ## Error Handling Strategy
 
 All errors in the bootloader are fatal. There is no recovery path, no retry beyond
-the single `ExitBootServices` retry described above, and no fallback configuration.
+the bounded `ExitBootServices` retry loop described above, and no fallback
+configuration.
 
 ### BootError Type
 
@@ -170,19 +181,19 @@ All fallible functions in the bootloader return `Result<T, BootError>`,
 defined in [`boot/src/error.rs`](../src/error.rs). The variant set covers
 protocol-location failure, UEFI status-code propagation, ESP file-not-found,
 ELF validation failure, W^X violation, allocation failure, `ExitBootServices`
-failure after retry, and bundle parse/validation failure (`InvalidBundle`);
-the source is the authority on the variant list and payloads.
+failure after the bounded retry loop, and bundle parse/validation failure
+(`InvalidBundle`); the source is the authority on the variant list and payloads.
 
 The top-level `efi_main` propagates errors to a single fatal handler that
 reports the error and halts. There is no recovery path and no retry beyond
-the single `ExitBootServices` retry described above.
+the bounded `ExitBootServices` retry loop described above.
 
 ### Error Reporting
 
-Before `ExitBootServices`, error messages are written to the UEFI console output
-(`SystemTable->ConOut`). After `ExitBootServices`, the UEFI console is no longer
-accessible; only a serial/framebuffer path would be available, but the current
-implementation has no post-exit output path.
+Error messages are written through the boot console (serial + framebuffer; see
+[console.md](console.md)), which does not depend on UEFI boot services and so
+remains available after `ExitBootServices`. A fatal `ExitBootServices` failure is
+therefore reported the same way as any earlier failure.
 
 Error reporting writes a short descriptive message and halts:
 
@@ -197,24 +208,23 @@ sufficient to identify which step failed and why.
 
 ## Console Output
 
-### Before ExitBootServices
+The boot console writes to two backends directly, bypassing `ConOut` entirely
+(the firmware text-output protocol is never used). Both backends are direct
+hardware access and so are independent of UEFI boot services:
 
-Two output paths are available:
+**Serial** — the platform UART (16550 COM1 on x86-64; a discovered ns16550a on
+RISC-V), driven by direct port/MMIO access.
 
-**UEFI console** — `SystemTable->ConOut->OutputString`. This is always available but
-the display quality depends on the firmware. It supports wide characters (`CHAR16`);
-the bootloader converts ASCII boot messages to wide character strings before output.
-
-**GOP framebuffer** — if `EFI_GRAPHICS_OUTPUT_PROTOCOL` is available and reports a
-pixel framebuffer, the bootloader maps a minimal bitmap font and writes directly to
-the framebuffer. This is more reliable on modern hardware where the UEFI console
-implementation may be slow or redirect to a serial port.
+**GOP framebuffer** — if `EFI_GRAPHICS_OUTPUT_PROTOCOL` reported a pixel
+framebuffer at step 1, the bootloader writes glyphs from a minimal bitmap font
+straight to the framebuffer MMIO.
 
 ### After ExitBootServices
 
-The UEFI console (`ConOut`) is unavailable. The current implementation has no
-output path after `ExitBootServices`. The normal path proceeds directly to `BootInfo`
-population and kernel handoff without any further output.
+Because neither backend depends on boot services, console output continues to
+work after `ExitBootServices`: the `step 9/10` and `step 10/10` progress lines,
+and any fatal message, are emitted over serial and framebuffer right up to kernel
+handoff.
 
 ---
 

--- a/core/boot/docs/uefi-environment.md
+++ b/core/boot/docs/uefi-environment.md
@@ -208,23 +208,16 @@ sufficient to identify which step failed and why.
 
 ## Console Output
 
-The boot console writes to two backends directly, bypassing `ConOut` entirely
-(the firmware text-output protocol is never used). Both backends are direct
-hardware access and so are independent of UEFI boot services:
-
-**Serial** — the platform UART (16550 COM1 on x86-64; a discovered ns16550a on
-RISC-V), driven by direct port/MMIO access.
-
-**GOP framebuffer** — if `EFI_GRAPHICS_OUTPUT_PROTOCOL` reported a pixel
-framebuffer at step 1, the bootloader writes glyphs from a minimal bitmap font
-straight to the framebuffer MMIO.
+The boot console (serial + framebuffer; see [console.md](console.md) for the
+backends) reaches the hardware directly and never uses the firmware text-output
+protocol (`ConOut`). The property that matters here is that neither backend
+depends on UEFI boot services.
 
 ### After ExitBootServices
 
-Because neither backend depends on boot services, console output continues to
-work after `ExitBootServices`: the `step 9/10` and `step 10/10` progress lines,
-and any fatal message, are emitted over serial and framebuffer right up to kernel
-handoff.
+Because the console is boot-services-independent, output continues right up to
+kernel handoff: the `step 9/10` and `step 10/10` progress lines, and any fatal
+message, are emitted after the exit call.
 
 ---
 

--- a/core/boot/src/error.rs
+++ b/core/boot/src/error.rs
@@ -36,7 +36,8 @@ pub enum BootError
     /// A physical memory allocation failed.
     OutOfMemory,
 
-    /// `ExitBootServices` failed even after one retry with a refreshed map key.
+    /// `ExitBootServices` failed even after the bounded retry loop, each attempt
+    /// refreshing the map key from the existing buffer.
     ExitBootServicesFailed,
 
     /// The bootstrap.bundle file is missing, malformed, or violates an
@@ -100,7 +101,7 @@ impl BootError
             BootError::InvalidElf(_) => "kernel ELF validation failed",
             BootError::WxViolation => "ELF segment has writable+executable permissions (W^X)",
             BootError::OutOfMemory => "physical memory allocation failed",
-            BootError::ExitBootServicesFailed => "ExitBootServices failed after retry",
+            BootError::ExitBootServicesFailed => "ExitBootServices failed after retries",
             BootError::InvalidBundle(_) => "bootstrap.bundle is malformed or missing",
         }
     }

--- a/core/boot/src/memory_map.rs
+++ b/core/boot/src/memory_map.rs
@@ -425,6 +425,7 @@ mod tests
         let stride = size_of::<EfiMemoryDescriptor>();
         let uefi_map = MemoryMapResult {
             buffer_phys: descs.as_ptr() as u64,
+            buffer_size: descs.len() * stride,
             map_size: descs.len() * stride,
             map_key: 0,
             descriptor_size: stride,
@@ -537,6 +538,7 @@ mod tests
         unsafe { core::ptr::write(buf.as_mut_ptr() as *mut EfiMemoryDescriptor, desc) };
         let uefi_map = MemoryMapResult {
             buffer_phys: buf.as_ptr() as u64,
+            buffer_size: stride,
             map_size: stride,
             map_key: 0,
             descriptor_size: stride,

--- a/core/boot/src/uefi.rs
+++ b/core/boot/src/uefi.rs
@@ -197,7 +197,12 @@ pub struct MemoryMapResult
 {
     /// Physical address of the memory map buffer (allocated by caller).
     pub buffer_phys: u64,
-    /// Total size of the map in the buffer, in bytes.
+    /// Allocated capacity of the buffer, in bytes. Distinct from `map_size`:
+    /// `GetMemoryMap` overwrites its size in-param with the (smaller) actual map
+    /// size on success, so a re-query must pass this capacity, not `map_size`.
+    pub buffer_size: usize,
+    /// Size of the map currently in the buffer, in bytes (the value `GetMemoryMap`
+    /// reported it wrote). This is what `translate_memory_map` iterates over.
     pub map_size: usize,
     /// Map key used by `ExitBootServices`.
     pub map_key: usize,
@@ -718,8 +723,10 @@ pub unsafe fn allocate_pages_max_addr(
 /// map key). Returns the buffer address, map size, map key, and descriptor size.
 /// The caller must use this as the final allocation before `ExitBootServices`.
 ///
-/// Adds 16 extra entries of slack to accommodate the allocation of the buffer
-/// itself, as required by the UEFI specification.
+/// Sizes the buffer with 16 entries of slack beyond the reported requirement.
+/// The buffer allocation itself adds at least one descriptor; the extra margin
+/// also absorbs further growth seen when `exit_boot_services` re-queries under
+/// contention (see [`exit_boot_services`]).
 ///
 /// # Safety
 /// `bs` must be valid boot services.
@@ -753,9 +760,10 @@ pub unsafe fn get_memory_map(bs: *mut EfiBootServices) -> Result<MemoryMapResult
     let pages = map_size.div_ceil(4096);
     // SAFETY: bs is valid.
     let buffer_phys = unsafe { allocate_pages(bs, pages)? };
+    let buffer_size = pages * 4096;
 
     // Second call: fill the buffer. This call's map_key is the one to use.
-    map_size = pages * 4096;
+    map_size = buffer_size;
     // SAFETY: buffer_phys is a valid allocated region of map_size bytes.
     // cast_possible_truncation: buffer_phys is a UEFI physical address; on all supported
     // targets (x86_64, riscv64) usize is 64-bit, so the cast is exact.
@@ -776,18 +784,40 @@ pub unsafe fn get_memory_map(bs: *mut EfiBootServices) -> Result<MemoryMapResult
 
     Ok(MemoryMapResult {
         buffer_phys,
+        buffer_size,
         map_size,
         map_key,
         descriptor_size,
     })
 }
 
-/// Call `ExitBootServices`, retrying once on stale-key failure.
+/// Maximum number of `ExitBootServices` attempts before giving up.
+///
+/// UEFI may invalidate the map key between `GetMemoryMap` and `ExitBootServices`
+/// when a firmware event allocates memory in that window; the call then returns
+/// `EFI_INVALID_PARAMETER`. Under host CPU contention (parallel QEMU/OVMF) the
+/// vCPU can be descheduled in that window repeatedly, so the invalidation can
+/// recur across consecutive attempts. A bounded loop retries until a tight
+/// `GetMemoryMap`→`ExitBootServices` pair lands without an intervening
+/// allocation.
+///
+/// The observed two-attempt failure rate (≈0.2–1.7%) implies a per-attempt
+/// failure probability of roughly 0.045–0.13; 16 attempts drive the residual
+/// below ~1e-14 even at the high end, with wide margin for correlated
+/// contention bursts. Each extra attempt is one cheap firmware call pair into
+/// the existing buffer, so the bound is generous rather than tuned.
+const EXIT_BOOT_SERVICES_MAX_ATTEMPTS: u32 = 16;
+
+/// Call `ExitBootServices`, retrying on stale-key failure up to
+/// [`EXIT_BOOT_SERVICES_MAX_ATTEMPTS`] times.
 ///
 /// After a successful call, UEFI boot services are permanently unavailable.
 /// No UEFI calls may be made after this function returns `Ok(())`.
 ///
-/// On retry, re-queries the map using the existing buffer (no new allocation).
+/// Each retry re-queries the map into the existing buffer (no new allocation,
+/// which would invalidate the key again) to obtain a fresh key. The re-query
+/// passes the allocated buffer capacity, so it tolerates a map that grew since
+/// the previous query.
 ///
 /// # Safety
 /// `bs` must be valid boot services. `image` must be a valid image handle.
@@ -799,50 +829,53 @@ pub unsafe fn exit_boot_services(
     map: &mut MemoryMapResult,
 ) -> Result<(), BootError>
 {
-    // SAFETY: bs, image, and map_key are valid.
-    let status = unsafe { ((*bs).exit_boot_services)(image, map.map_key) };
-    if status == EFI_SUCCESS
+    let mut attempt: u32 = 0;
+    loop
     {
-        return Ok(());
-    }
-    if status != EFI_INVALID_PARAMETER
-    {
-        return Err(BootError::ExitBootServicesFailed);
-    }
+        // SAFETY: bs, image, and map_key are valid.
+        let status = unsafe { ((*bs).exit_boot_services)(image, map.map_key) };
+        if status == EFI_SUCCESS
+        {
+            return Ok(());
+        }
+        // EFI_INVALID_PARAMETER is the only status that means "stale key"; any
+        // other status is a genuine error that a retry cannot resolve.
+        if status != EFI_INVALID_PARAMETER
+        {
+            return Err(BootError::ExitBootServicesFailed);
+        }
+        attempt += 1;
+        if attempt >= EXIT_BOOT_SERVICES_MAX_ATTEMPTS
+        {
+            return Err(BootError::ExitBootServicesFailed);
+        }
 
-    // Stale key: re-query the map using the existing buffer (no new allocation).
-    let mut descriptor_size: usize = map.descriptor_size;
-    let mut descriptor_version: u32 = 0;
-    let mut map_size = map.map_size;
-    // SAFETY: buffer_phys is the existing allocated buffer.
-    // cast_possible_truncation: buffer_phys is a UEFI u64 address; usize is 64-bit on all
-    // supported targets, so the cast to *mut is exact.
-    #[allow(clippy::cast_possible_truncation)]
-    let status = unsafe {
-        ((*bs).get_memory_map)(
-            core::ptr::addr_of_mut!(map_size),
-            map.buffer_phys as *mut EfiMemoryDescriptor,
-            core::ptr::addr_of_mut!(map.map_key),
-            core::ptr::addr_of_mut!(descriptor_size),
-            core::ptr::addr_of_mut!(descriptor_version),
-        )
-    };
-    if status != EFI_SUCCESS
-    {
-        return Err(BootError::ExitBootServicesFailed);
-    }
-    map.map_size = map_size;
-
-    // Retry with the fresh key.
-    // SAFETY: map.map_key is fresh from the re-query above.
-    let status = unsafe { ((*bs).exit_boot_services)(image, map.map_key) };
-    if status == EFI_SUCCESS
-    {
-        Ok(())
-    }
-    else
-    {
-        Err(BootError::ExitBootServicesFailed)
+        // Stale key: re-query the map using the existing buffer (no new
+        // allocation). map_size is reset to the full buffer capacity each
+        // iteration because GetMemoryMap overwrites it with the smaller actual
+        // size on success; passing the prior actual size could fail with
+        // EFI_BUFFER_TOO_SMALL if the map grew under contention.
+        let mut descriptor_size: usize = map.descriptor_size;
+        let mut descriptor_version: u32 = 0;
+        let mut map_size = map.buffer_size;
+        // SAFETY: buffer_phys is the existing allocated buffer of buffer_size bytes.
+        // cast_possible_truncation: buffer_phys is a UEFI u64 address; usize is 64-bit on all
+        // supported targets, so the cast to *mut is exact.
+        #[allow(clippy::cast_possible_truncation)]
+        let status = unsafe {
+            ((*bs).get_memory_map)(
+                core::ptr::addr_of_mut!(map_size),
+                map.buffer_phys as *mut EfiMemoryDescriptor,
+                core::ptr::addr_of_mut!(map.map_key),
+                core::ptr::addr_of_mut!(descriptor_size),
+                core::ptr::addr_of_mut!(descriptor_version),
+            )
+        };
+        if status != EFI_SUCCESS
+        {
+            return Err(BootError::ExitBootServicesFailed);
+        }
+        map.map_size = map_size;
     }
 }
 


### PR DESCRIPTION
## Summary

Resolves #101 — the bootloader's `ExitBootServices` retry exhausted under
parallel-load UEFI/OVMF contention.

Under host CPU contention (parallel QEMU/OVMF), the vCPU is descheduled in the
`GetMemoryMap`→`ExitBootServices` window; a firmware event allocates memory and the
stale map key yields `EFI_INVALID_PARAMETER`. The old path
(`core/boot/src/uefi.rs`) retried **exactly once**, so two unlucky passes exhausted
it and the boot bailed with `SERAPH BOOT FATAL: ExitBootServices failed after retry`.

### Changes
- **Bounded retry loop.** Replace the single retry with a loop bounded at
  `EXIT_BOOT_SERVICES_MAX_ATTEMPTS = 16`, re-querying the memory map into the existing
  buffer (no new allocation) for a fresh key each iteration. `EFI_INVALID_PARAMETER`
  is the only retryable status; any other status fails immediately. No delay is
  inserted between `GetMemoryMap` and `ExitBootServices` — that would only widen the
  invalidation window.
- **Buffer-capacity fix (latent defect, same surface).** The re-query passed the
  previous map's *actual* byte-size as the `GetMemoryMap` capacity in-param instead of
  the *allocated buffer capacity*, so a map that grew under contention could fail with
  `EFI_BUFFER_TOO_SMALL`. Added `MemoryMapResult::buffer_size` (allocated capacity) and
  pass it on every re-query, reset per iteration.
- **Doc drift.** Corrected `uefi-environment.md`: the boot console writes serial +
  framebuffer directly (never `ConOut`), so output continues after `ExitBootServices`
  (the step 9/10, step 10/10, and fatal lines). Updated `boot-flow.md` step 8 and the
  `ExitBootServices` retry docs to describe the bounded loop.

## Test plan

All via `cargo xtask`. Built and booted on **both** arches.

- [x] `cargo xtask build` succeeds on x86_64 and riscv64.
- [x] `cargo xtask test` — host unit tests pass (incl. boot crate, 29 tests).
- [x] ktest boots clean: `[ktest] ALL TESTS PASSED` on x86_64 and riscv64.
- [x] **Contention sweep** (the #101 surface). Scoped to the bootloader: `--pass`
  matches the first line printed *after* `ExitBootServices` succeeds
  (`boot: step 9/10`), `--fail 'SERAPH BOOT FATAL'`, short `--timeout`, heavy host
  oversubscription. Host is 16-core, so 4× oversubscription (the original repro's
  ratio) = `--cpus 1 --parallel 64`:

  | config | pass | fail | hang | HANGs w/ FATAL |
  |---|---|---|---|---|
  | parallel=64 (4×), timeout=10s, 64 runs | 46 | **0** | 18 | 0 (all starvation) |
  | parallel=64 (4×), timeout=15s, 64 runs | 63 | **0** | 1 | 0 (step-4 starvation) |
  | parallel=32 (2×), timeout=40s, 64 runs | 64 | **0** | 0 | — |

  `fail=0` in every config — no `ExitBootServices` FATAL occurred; every boot that
  completed the bootloader reached step 9. The HANGs are watchdog kills of
  CPU-starved-but-progressing guests (last log line is an *early* step, e.g. step 4),
  not the #101 signature (step 8 → FATAL). A large 3200-run 4× sweep result will be
  posted as a comment.

### Acceptance (issue #101)
- [x] No boot hangs attributable to `ExitBootServices` exhaustion under parallel load
  (`fail=0` across all sweeps). Note: the issue's literal `--pass 'ktest: ALL TESTS
  PASSED'` marker string is stale — the real ktest marker is `[ktest] ALL TESTS PASSED`.
- [x] No single-shot boot-time regression — the success path still returns on the
  first `ExitBootServices` call (one call), identical to before.

### Verification caveat
The baseline failure is rare (≤1.7%, often far lower), so a clean sweep is
necessary-but-not-sufficient evidence. The primary correctness argument is structural:
a **bounded** loop that re-queries with the **correct buffer capacity** each iteration,
versus exactly-once before.
