### PR TITLE
readme: cleanup intro, structure ordering, and xtask quick-reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,13 @@
 [![targets](https://img.shields.io/badge/targets-x86__64%20%7C%20RISC--V-blue)](docs/architecture.md)
 [![tag](https://img.shields.io/github/v/tag/kottlerg/seraph)](https://github.com/kottlerg/seraph/tags)
 
-Seraph is a microkernel operating system written in Rust, targeting x86-64 and RISC-V.
+Seraph is a microkernel operating system written in Rust, targeting
+x86-64 and RISC-V. The kernel provides only mechanism (IPC, scheduling,
+memory management, and capabilities); drivers, filesystems, and services
+live in userspace. Capabilities are the sole access control mechanism.
+Seraph defines its own native system interfaces, not a POSIX surface
+or any other OS's ABI. Userspace reaches them through standard language
+runtimes (`ruststd`, with `libc` to follow).
 
 ## Goals
 
@@ -25,9 +31,9 @@ for the authoritative statement.
 | Directory | Purpose |
 |---|---|
 | `abi/` | Stable cross-boundary contracts |
-| `programs/` | General-purpose userspace applications and utilities |
 | `core/` | Core OS: bootloader, kernel, and the kernel-validation harness (ktest) |
 | `docs/` | Architecture and design documentation |
+| `programs/` | General-purpose userspace applications and utilities |
 | `rootfs/` | System files installed into the sysroot during builds (config files, etc) |
 | `runtime/` | Language runtime layers consumed by userspace (libc, ruststd) |
 | `services/` | Userspace OS processes: managers, drivers, filesystems, daemons |
@@ -39,29 +45,22 @@ for the authoritative statement.
 All build, run, and test operations are driven by `cargo xtask`. The full
 command reference lives in [xtask/README.md](xtask/README.md); toolchain
 requirements, sysroot layout, and QEMU / firmware configuration are in
-[docs/build-system.md](docs/build-system.md). The common recipes are
-summarized here for quick reference:
+[docs/build-system.md](docs/build-system.md). Common commands:
 
 ```sh
-cargo xtask build                        # build all components (x86_64, debug)
-cargo xtask build --arch riscv64         # build for RISC-V
-cargo xtask build --component boot       # build a single component
-cargo xtask mkdisk                       # re-mirror sysroot + repack disk image (no cargo); refresh after rootfs/sysroot edits
-cargo xtask run                          # launch the existing sysroot under QEMU (pure runner; no build)
-cargo xtask run --gdb                    # pause at startup, GDB on localhost:1234
-cargo xtask run-parallel --parallel 4 --runs 100   # N parallel QEMU runs for stress / race-hunting
-cargo xtask clean                        # remove sysroot/
-cargo xtask clean --all                  # remove sysroot/ and target/
-cargo xtask test                         # run all workspace tests on the host
+cargo xtask build                            # build (defaults: x86_64, debug)
+cargo xtask build --arch riscv64             # build for RISC-V
+cargo xtask mkdisk                           # repack disk.img after rootfs/ edits
+cargo xtask compose-bundle --harness ktest   # swap boot bundle to ktest harness
+cargo xtask run                              # launch existing sysroot under QEMU
+cargo xtask run --gdb                        # pause at start; GDB on :1234
+cargo xtask test                             # run host-side workspace tests
+cargo xtask clean [--all]                    # remove sysroot/ (and target/ with --all)
 ```
 
-`cargo xtask test` runs host-side unit tests, for all algorithmic components.
-In-tree QEMU-driven test harnesses cover three surfaces: `ktest` (kernel),
-`svctest` (services), and `usertest` (programs). The default boot is
-interactive — no harness runs. See [docs/testing.md](docs/testing.md) for
-the canonical tier taxonomy, the `[<harness>] ALL TESTS PASSED` marker, the
-per-program tester protocol, the sysroot layout under `/tests/`, and the
-recipe-dir gating mechanism that selects which harness runs in a given boot.
+Testing spans host-side `cargo xtask test` plus in-tree QEMU harnesses
+(`ktest`, `svctest`, `usertest`); the default boot is interactive and runs
+no harness. See [docs/testing.md](docs/testing.md) for the full model.
 
 ---
 
@@ -70,6 +69,7 @@ recipe-dir gating mechanism that selects which harness runs in a given boot.
 Overall project design documents live in [`docs/`](docs/):
 
 - [Architecture Overview](docs/architecture.md) — component structure and design philosophy
+- [System Bootstrap](docs/bootstrap.md) — end-to-end boot lifecycle summary (bootloader steps, kernel phases, init bootstrap)
 - [Memory Model](docs/memory-model.md) — virtual address space layout, paging, allocation
 - [Userspace Memory Model](docs/userspace-memory-model.md) — three-surface VA model, memmgr authority, page-reservation contract
 - [Process Lifecycle](docs/process-lifecycle.md) — userspace boot order, ProcessInfo/InitInfo handover, process-death flow
@@ -77,7 +77,6 @@ Overall project design documents live in [`docs/`](docs/):
 - [Capability Model](docs/capability-model.md) — permissions, delegation, revocation
 - [Namespace Model](docs/namespace-model.md) — node capabilities, per-entry rights and visibility, walking, sandboxing as cap-distribution
 - [Storage](docs/storage.md) — composition of vfsd, fs drivers, and block drivers; GPT role-GUID discovery; mount lifecycle
-- [System Bootstrap](docs/bootstrap.md) — end-to-end boot lifecycle summary (bootloader steps, kernel phases, init bootstrap)
 - [Device Management](docs/device-management.md) — platform enumeration, devmgr, driver binding, DMA safety
 - [Console Model](docs/console-model.md) — serial/console output ownership across boot; serial-driver-mediated userspace output
 - [Build System](docs/build-system.md) — toolchain, workspace layout, sysroot, xtask commands


### PR DESCRIPTION
README-only cleanup. Single commit, no code or doc-authority changes.

## Changes

- **Intro paragraph**: expanded the one-line tagline into a durable
  positioning paragraph. Names the mechanism/policy split (kernel =
  mechanism, userspace = policy), the capability-only access model, and
  the two-sided API stance (native OS surface, conventional programming
  surface via `ruststd`, with `libc` to follow). No current-state claims;
  durable across releases. Both claims verified against the codebase
  (`runtime/ruststd/` consumed by `programs/hello`, `services/vfsd`, etc.;
  `lookup_cap()` at `core/kernel/src/syscall/mod.rs:360-393` gating every
  syscall entry).
- **Structure table**: restore alphabetical order. The `base` → `programs`
  rename had broken it.
- **Documentation list**: promote `System Bootstrap` to sit under
  `Architecture Overview`, since it is a whole-boot summary rather than
  a subsystem doc. Rest of the order unchanged.
- **xtask quick-reference**: trim and re-align. Longest line was ~124
  chars (caused horizontal scroll on GitHub web), now ~87. Drops
  `--component` and `run-parallel`; keeps `mkdisk` and `compose-bundle`
  which cover distinct workflow paths (rootfs refresh, harness swap).
  Lead-in collapsed from "The common recipes are summarized here for
  quick reference:" to "Common commands:".
- **Testing paragraph**: collapsed from seven lines to three; the
  marker/sysroot/gating detail now lives only in `docs/testing.md`.

## Scope notes

- Pre-existing em dashes in the `— description` doc-list pattern
  (lines 71-89) are project-wide style across ~20 documents. Not
  touched here; that's a separate decision if pursued.
- No linked Issue; this is a drive-by docs cleanup surfaced by the
  recent `base` → `programs` rename.

## Test plan

- Visual: render at https://github.com/kottlerg/seraph/blob/docs/readme-cleanup/README.md.
- No code changed; `cargo xtask build` and `cargo xtask run` not
  applicable to a README-only diff.