### PR TITLE
docs: README cleanup; add runtime-layer statement to architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,15 @@
 [![targets](https://img.shields.io/badge/targets-x86__64%20%7C%20RISC--V-blue)](docs/architecture.md)
 [![tag](https://img.shields.io/github/v/tag/kottlerg/seraph)](https://github.com/kottlerg/seraph/tags)
 
-Seraph is a microkernel operating system written in Rust, targeting x86-64 and RISC-V.
+Seraph is a microkernel operating system written in Rust, targeting
+x86-64 and RISC-V. The kernel provides only mechanism (IPC, scheduling,
+memory management, and capabilities); drivers, filesystems, and services
+live in userspace. Capabilities are the sole access control mechanism.
+Seraph defines its own native system interfaces, not a POSIX surface
+or any other OS's ABI. Userspace reaches them through standard language
+runtimes (`ruststd` and `libc`).
 
 ## Goals
-
 
 - Minimal, modular microkernel; most functionality in userspace
 - Capability-based security model throughout
@@ -17,17 +22,17 @@ Seraph is a microkernel operating system written in Rust, targeting x86-64 and R
 - Architecture-specific code isolated behind shared traits
 - Self-hosting as a long-term goal
 
-Summarized from [docs/architecture.md](docs/architecture.md); see there
-for the authoritative statement.
+The framing above and these goals are summarized from [docs/architecture.md](docs/architecture.md);
+see there for the authoritative statement.
 
 ## Structure
 
 | Directory | Purpose |
 |---|---|
 | `abi/` | Stable cross-boundary contracts |
-| `programs/` | General-purpose userspace applications and utilities |
 | `core/` | Core OS: bootloader, kernel, and the kernel-validation harness (ktest) |
 | `docs/` | Architecture and design documentation |
+| `programs/` | General-purpose userspace applications and utilities |
 | `rootfs/` | System files installed into the sysroot during builds (config files, etc) |
 | `runtime/` | Language runtime layers consumed by userspace (libc, ruststd) |
 | `services/` | Userspace OS processes: managers, drivers, filesystems, daemons |
@@ -39,29 +44,22 @@ for the authoritative statement.
 All build, run, and test operations are driven by `cargo xtask`. The full
 command reference lives in [xtask/README.md](xtask/README.md); toolchain
 requirements, sysroot layout, and QEMU / firmware configuration are in
-[docs/build-system.md](docs/build-system.md). The common recipes are
-summarized here for quick reference:
+[docs/build-system.md](docs/build-system.md). Common commands:
 
 ```sh
-cargo xtask build                        # build all components (x86_64, debug)
-cargo xtask build --arch riscv64         # build for RISC-V
-cargo xtask build --component boot       # build a single component
-cargo xtask mkdisk                       # re-mirror sysroot + repack disk image (no cargo); refresh after rootfs/sysroot edits
-cargo xtask run                          # launch the existing sysroot under QEMU (pure runner; no build)
-cargo xtask run --gdb                    # pause at startup, GDB on localhost:1234
-cargo xtask run-parallel --parallel 4 --runs 100   # N parallel QEMU runs for stress / race-hunting
-cargo xtask clean                        # remove sysroot/
-cargo xtask clean --all                  # remove sysroot/ and target/
-cargo xtask test                         # run all workspace tests on the host
+cargo xtask build                            # build (defaults: x86_64, debug)
+cargo xtask build --arch riscv64             # build for RISC-V
+cargo xtask mkdisk                           # repack disk.img after rootfs/ edits
+cargo xtask compose-bundle --harness ktest   # swap boot bundle to ktest harness
+cargo xtask run                              # launch existing sysroot under QEMU
+cargo xtask run --gdb                        # pause at start; GDB on :1234
+cargo xtask test                             # run host-side workspace tests
+cargo xtask clean [--all]                    # remove sysroot/ (and target/ with --all)
 ```
 
-`cargo xtask test` runs host-side unit tests, for all algorithmic components.
-In-tree QEMU-driven test harnesses cover three surfaces: `ktest` (kernel),
-`svctest` (services), and `usertest` (programs). The default boot is
-interactive — no harness runs. See [docs/testing.md](docs/testing.md) for
-the canonical tier taxonomy, the `[<harness>] ALL TESTS PASSED` marker, the
-per-program tester protocol, the sysroot layout under `/tests/`, and the
-recipe-dir gating mechanism that selects which harness runs in a given boot.
+Testing spans host-side `cargo xtask test` plus in-tree QEMU harnesses
+(`ktest`, `svctest`, `usertest`); the default boot is interactive and runs
+no harness. See [docs/testing.md](docs/testing.md) for the full model.
 
 ---
 
@@ -70,21 +68,33 @@ recipe-dir gating mechanism that selects which harness runs in a given boot.
 Overall project design documents live in [`docs/`](docs/):
 
 - [Architecture Overview](docs/architecture.md) — component structure and design philosophy
+- [System Bootstrap](docs/bootstrap.md) — end-to-end boot lifecycle summary (bootloader
+  steps, kernel phases, init bootstrap)
 - [Memory Model](docs/memory-model.md) — virtual address space layout, paging, allocation
-- [Userspace Memory Model](docs/userspace-memory-model.md) — three-surface VA model, memmgr authority, page-reservation contract
-- [Process Lifecycle](docs/process-lifecycle.md) — userspace boot order, ProcessInfo/InitInfo handover, process-death flow
+- [Userspace Memory Model](docs/userspace-memory-model.md) — three-surface VA model,
+  memmgr authority, page-reservation contract
+- [Process Lifecycle](docs/process-lifecycle.md) — userspace boot order,
+  ProcessInfo/InitInfo handover, process-death flow
 - [IPC Design](docs/ipc-design.md) — message passing, endpoints, synchronous vs async
 - [Capability Model](docs/capability-model.md) — permissions, delegation, revocation
-- [Namespace Model](docs/namespace-model.md) — node capabilities, per-entry rights and visibility, walking, sandboxing as cap-distribution
-- [Storage](docs/storage.md) — composition of vfsd, fs drivers, and block drivers; GPT role-GUID discovery; mount lifecycle
-- [System Bootstrap](docs/bootstrap.md) — end-to-end boot lifecycle summary (bootloader steps, kernel phases, init bootstrap)
-- [Device Management](docs/device-management.md) — platform enumeration, devmgr, driver binding, DMA safety
-- [Console Model](docs/console-model.md) — serial/console output ownership across boot; serial-driver-mediated userspace output
+- [Namespace Model](docs/namespace-model.md) — node capabilities, per-entry rights and
+  visibility, walking, sandboxing as cap-distribution
+- [Storage](docs/storage.md) — composition of vfsd, fs drivers, and block drivers;
+  GPT role-GUID discovery; mount lifecycle
+- [Device Management](docs/device-management.md) — platform enumeration, devmgr,
+  driver binding, DMA safety
+- [Console Model](docs/console-model.md) — serial/console output ownership across boot;
+  serial-driver-mediated userspace output
 - [Build System](docs/build-system.md) — toolchain, workspace layout, sysroot, xtask commands
-- [Coding Standards](docs/coding-standards.md) — Rust conventions, safety contracts, documentation rules
-- [Documentation Standards](docs/documentation-standards.md) — document hierarchy, authority, backlinks, required structure
-- [Conventions](docs/conventions.md) — versioning, backlog tracking via GitHub Issues, branch and PR workflow, CI gating, release production
-- [Testing](docs/testing.md) — tier taxonomy, marker format, per-program tester protocol, sysroot layout, gating
-- [Release Notes](docs/releases/README.md) — per-tag notes catalogue, naming, source-of-truth discipline, workflow integration
+- [Coding Standards](docs/coding-standards.md) — Rust conventions, safety contracts,
+  documentation rules
+- [Documentation Standards](docs/documentation-standards.md) — document hierarchy,
+  authority, backlinks, required structure
+- [Conventions](docs/conventions.md) — versioning, backlog tracking via GitHub Issues,
+  branch and PR workflow, CI gating, release production
+- [Testing](docs/testing.md) — tier taxonomy, marker format, per-program tester protocol,
+  sysroot layout, gating
+- [Release Notes](docs/releases/README.md) — per-tag notes catalogue, naming,
+  source-of-truth discipline, workflow integration
 
 Each component contains a `README.md` that references the design docs relevant to that module.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,7 +17,8 @@ Seraph defines its own native interfaces; POSIX API compatibility is not
 a goal. Filesystem formats and network protocols may be adopted as data
 formats, not as API commitments. Seraph does not provide binary
 compatibility with other operating systems. 32-bit and legacy x86 are
-not targeted.
+not targeted. Userspace targets these native interfaces through standard
+language runtimes (`ruststd`, `libc`), not through compatibility shims.
 
 ---
 


### PR DESCRIPTION
README cleanup:
- Intro expanded into a durable positioning paragraph; summary of
  docs/architecture.md.
- Structure table back to alphabetical (base->programs rename broke it).
- Doc list: System Bootstrap moved up to the overview position; long
  bullets wrapped to <=100 chars.
- xtask block trimmed and rewrapped; was scrolling horizontally on
  GitHub web.
- Testing paragraph collapsed; detail stays in docs/testing.md.

docs/architecture.md: one sentence appended to the Project Goals
paragraph naming `ruststd` and `libc` as the userspace runtime layer,
so the README intro's wording on that point is backed by authoritative
content.

Replaces #169 (wrong branch prefix).