### PR TITLE
kernel/cap: recycle CSpaceIds with epoch-stamped SlotId + pre-unregister drain (#137)

### DIFF
--- a/core/kernel/docs/capability-internals.md
+++ b/core/kernel/docs/capability-internals.md
@@ -115,12 +115,17 @@ pub struct CapabilitySlot
 }
 ```
 
-The slot is 56 bytes (`#[repr(C)]`). 64 slots per CSpace page = 3584 bytes, fitting
-in a 4096-byte slab bin.
+The slot is 72 bytes (`#[repr(C)]`). 56 slots per CSpace page = 4032 bytes, fitting
+in a 4096-byte slab bin with 64 B of tail slack.
 
-`SlotId` is a global identifier combining a CSpace ID and a slot index:
-`(CSpaceId, usize)`. This allows derivation tree traversal across CSpace boundaries
-without holding per-CSpace locks longer than necessary.
+`SlotId` is a global identifier combining a CSpace ID, an epoch generation
+counter, and a slot index: `{cspace_id: u32, epoch: u32, index: NonZeroU32}`
+(12 bytes; `Option<SlotId>` niche-optimises to the same size via the
+`NonZeroU32` index). This allows derivation tree traversal across CSpace
+boundaries without holding per-CSpace locks longer than necessary, and lets
+`lookup_cspace(id, expected_epoch)` fail fast when a CSpace's id has been
+recycled — a stale `SlotId` stamped with the pre-recycle epoch cannot
+mis-target the new tenant. See #137 for the recycling allocator design.
 
 ### Capability Tags
 

--- a/core/kernel/src/cap/cspace.rs
+++ b/core/kernel/src/cap/cspace.rs
@@ -7,7 +7,7 @@
 //!
 //! A [`CSpace`] is a two-level directory of [`CapabilitySlot`]s. The directory
 //! has [`L1_SIZE`] entries; each points to a [`CSpacePage`] containing
-//! [`L2_SIZE`] slots. Maximum capacity: `L1_SIZE * L2_SIZE = 16384` slots.
+//! [`L2_SIZE`] slots. Maximum capacity: `L1_SIZE * L2_SIZE = 14336` slots.
 //!
 //! ## Free list
 //!
@@ -18,10 +18,10 @@
 //! ## Growth
 //!
 //! `CSpace` pages are allocated on demand by [`CSpace::grow`]. The first page
-//! skips slot 0 (always null); subsequent pages contribute all 64 slots to the
+//! skips slot 0 (always null); subsequent pages contribute all 56 slots to the
 //! free list.
 
-// cast_possible_truncation: usize→u32 slot index bounded by L1_SIZE * L2_SIZE (16384).
+// cast_possible_truncation: usize→u32 slot index bounded by L1_SIZE * L2_SIZE (14336).
 #![allow(clippy::cast_possible_truncation)]
 
 // `alloc` is needed by the host-test stubs (CSpace::grow heap fallback,
@@ -41,10 +41,11 @@ use super::slot::{CSpaceId, CapTag, CapabilitySlot, Rights};
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
-/// Slots per `CSpace` page (64 × 56 B = 3584 B, fits in a 4096-byte slab bin).
-pub const L2_SIZE: usize = 64;
+/// Slots per `CSpace` page (56 × 72 B = 4032 B, fits in a 4096-byte slab bin
+/// with 64 B of tail slack).
+pub const L2_SIZE: usize = 56;
 
-/// Directory entries per `CSpace` (max 256 × 64 = 16384 slots).
+/// Directory entries per `CSpace` (max 256 × 56 = 14336 slots).
 pub const L1_SIZE: usize = 256;
 
 // ── Error type ────────────────────────────────────────────────────────────────
@@ -685,9 +686,9 @@ mod tests
     #[test]
     fn max_slots_enforced()
     {
-        // max_slots = 63: exactly one page minus slot 0.
-        let mut cs = CSpace::new(0, 63);
-        for _ in 0..63
+        // max_slots = L2_SIZE - 1: exactly one page minus slot 0.
+        let mut cs = CSpace::new(0, L2_SIZE - 1);
+        for _ in 0..(L2_SIZE - 1)
         {
             cs.allocate_slot().unwrap();
         }

--- a/core/kernel/src/cap/cspace.rs
+++ b/core/kernel/src/cap/cspace.rs
@@ -77,6 +77,16 @@ struct CSpacePage
     slots: [CapabilitySlot; L2_SIZE],
 }
 
+// CSpacePage MUST fit in a single 4 KiB page — `alloc_slot_page` returns
+// `PAGE_SIZE`-aligned bytes and the kernel casts that to `*mut CSpacePage`
+// expecting one struct per allocation. A regression that grows
+// `CapabilitySlot` beyond the headroom would overflow the slab silently;
+// the assertion makes that a build error.
+const _: () = assert!(
+    core::mem::size_of::<CSpacePage>() <= crate::mm::PAGE_SIZE,
+    "CSpacePage exceeds PAGE_SIZE — reduce L2_SIZE or shrink CapabilitySlot"
+);
+
 // ── CSpace ────────────────────────────────────────────────────────────────────
 
 /// A capability space: a growable indexed collection of capability slots.
@@ -97,7 +107,7 @@ struct CSpacePage
 pub struct CSpace
 {
     id: CSpaceId,
-    /// Two-level directory; each Some entry is a 64-slot page.
+    /// Two-level directory; each Some entry is an `L2_SIZE`-slot page.
     /// Pages are stored as raw `NonNull` pointers so the heap-backed and
     /// retype-pool-backed paths can coexist with different reclamation
     /// semantics. The `kobj` field discriminates: null = heap (Drop walks

--- a/core/kernel/src/cap/cspace.rs
+++ b/core/kernel/src/cap/cspace.rs
@@ -312,6 +312,24 @@ impl CSpace
         Some(&mut page.slots[slot_idx])
     }
 
+    /// Return the raw page pointer for a directory entry, or `None` if the
+    /// entry is unmapped or `page_idx` is out of range.
+    ///
+    /// Used by the pre-unregister derivation drain in
+    /// `dealloc_object(CSpaceObj)` to determine which pages of the dying
+    /// `CSpace` are populated without holding a `&self` borrow across
+    /// per-slot calls into foreign `CSpace`s. The returned pointer is for
+    /// presence-testing only — callers MUST go through `slot`/`slot_mut`
+    /// for any actual read or write.
+    pub(crate) fn page_at(&self, page_idx: usize) -> Option<core::ptr::NonNull<u8>>
+    {
+        self.directory
+            .get(page_idx)
+            .copied()
+            .flatten()
+            .map(core::ptr::NonNull::cast::<u8>)
+    }
+
     /// Return a slot to the free list and clear its contents.
     ///
     /// Silently ignores an out-of-range, unmapped, or zero index.

--- a/core/kernel/src/cap/derivation.rs
+++ b/core/kernel/src/cap/derivation.rs
@@ -133,7 +133,7 @@ impl DerivationLock
 /// is valid only while the lock is held and the `CSpace` is live.
 unsafe fn resolve_slot_mut(id: SlotId) -> Option<&'static mut super::slot::CapabilitySlot>
 {
-    let cs_ptr = crate::cap::lookup_cspace(id.cspace_id)?;
+    let cs_ptr = crate::cap::lookup_cspace(id.cspace_id, id.epoch)?;
     // SAFETY: cspace registry lookup validated; CSpace pointer lives as long as the registry entry.
     let cs = unsafe { &mut *cs_ptr };
     cs.slot_mut(id.index.get())
@@ -429,7 +429,7 @@ pub unsafe fn revoke_subtree(root: SlotId) -> &'static [Option<NonNull<KernelObj
             continue;
         };
 
-        let Some(cs_ptr) = crate::cap::lookup_cspace(node_id.cspace_id)
+        let Some(cs_ptr) = crate::cap::lookup_cspace(node_id.cspace_id, node_id.epoch)
         else
         {
             continue;

--- a/core/kernel/src/cap/mod.rs
+++ b/core/kernel/src/cap/mod.rs
@@ -137,10 +137,12 @@ pub unsafe fn root_cspace_mut() -> Option<&'static mut CSpace>
 /// `CSpaceObj`) additionally scrubs the back-links in steady state.
 ///
 /// Live-count peaks in ktest stress today sit in the low hundreds; 4096
-/// gives 10–40× headroom while reclaiming the ~480 KiB of BSS the
-/// pre-#137 65536-entry registry burned. A future workload that genuinely
-/// needs more live `CSpace`s only has to bump this constant — no layout,
-/// ABI, or algorithmic change is required.
+/// gives 10–40× headroom while reclaiming ~448 KiB of BSS the
+/// pre-#137 65536-entry registry burned (65536 × 8 B = 512 KiB old
+/// registry vs 4096 × 16 B = 64 KiB new registry + 4096 × 4 B = 16 KiB
+/// free list = 80 KiB total). A future workload that genuinely needs
+/// more live `CSpace`s only has to bump this constant — no layout, ABI,
+/// or algorithmic change is required.
 const MAX_CSPACES: usize = 4096;
 
 /// High-water mark for the bump-allocator side of `alloc_cspace_id` — only
@@ -219,7 +221,6 @@ static mut CSPACE_FREE_LIST_LEN: usize = 0;
 /// only push ids in `[0, MAX_CSPACES)` and `MAX_CSPACES` slots fit), the
 /// id leaks rather than panicking.
 #[cfg(not(test))]
-#[allow(dead_code)] // Wired into `dealloc_object(CSpaceObj)` by the next commit.
 fn push_free(id: CSpaceId)
 {
     // SAFETY: lock serialises all free-list mutations.
@@ -355,7 +356,6 @@ pub fn unregister_cspace(id: CSpaceId)
 /// lifetime; the `HDR_FLAG_IS_ROOT` clamp in `dec_ref` should already make
 /// it unreachable, but defense-in-depth catches misroutes here.
 #[cfg(not(test))]
-#[allow(dead_code)] // Wired into `dealloc_object(CSpaceObj)` by the next commit.
 pub fn free_cspace_id(id: CSpaceId)
 {
     assert!(id != 0, "free_cspace_id: root CSpace cannot be recycled");
@@ -461,7 +461,11 @@ const ROOT_CSPACE_MAX_SLOTS: usize = 14336;
 /// the root; userspace init then mints, copies, and derives ~700 more
 /// caps during memmgr / procmgr bootstrap (kernel-object inserts +
 /// per-RAM-Frame derive/copy chains in `finalize_memmgr`). Sized at
-/// 1024 slots so the pre-memmgr-handover footprint fits with headroom.
+/// 1536 slots: roughly 1.8× the observed ~850-cap pre-memmgr-handover
+/// peak. The headroom absorbs realistic per-RAM-block-count growth
+/// (more drained blocks ⇒ more init-time Frame-cap derivations) and
+/// per-service growth (more boot modules ⇒ more module-frame caps)
+/// without revisiting this knob.
 ///
 /// MUST be kept in sync with the boot footprint: a target below the
 /// peak boot slot count means `pre_allocate`'s grow loop hits an
@@ -470,7 +474,7 @@ const ROOT_CSPACE_MAX_SLOTS: usize = 14336;
 /// surfaces an unexpected `OutOfMemory`. After memmgr is alive, further
 /// growth is bounded only by `ROOT_CSPACE_MAX_SLOTS`.
 #[cfg(not(test))]
-const ROOT_CSPACE_INIT_SLOT_CAPACITY: u64 = 1024;
+const ROOT_CSPACE_INIT_SLOT_CAPACITY: u64 = 1536;
 
 /// Pages carved from `SEED_FRAME` for the root `CSpace` slab: page 0 is the
 /// wrapper page (`CSpaceKernelObject` + inlined `CSpace`); the remaining

--- a/core/kernel/src/cap/mod.rs
+++ b/core/kernel/src/cap/mod.rs
@@ -125,101 +125,298 @@ pub unsafe fn root_cspace_mut() -> Option<&'static mut CSpace>
     }
 }
 
-/// Maximum number of `CSpaceId` slots ever allocated in a kernel lifetime.
+/// Maximum number of `CSpace`s that can be live in the registry at one time.
 ///
-/// The allocator is monotonic ([`NEXT_CSPACE_ID`] `fetch_add`); freed IDs
-/// are not reused. This is a cumulative-ever bound, not a live-`CSpace`
-/// bound — every `cap_create_cspace` consumes a fresh ID. 65536 × 8 B =
-/// 512 KiB BSS for [`CSPACE_REGISTRY`], sized to cover the ramped ktest
-/// stress sequence (~14k `CSpace`s cumulatively) with 4× headroom. Issue
-/// #137 tracks switching to a recycling allocator (needs either
-/// generation counters in `SlotId` or a pre-unregister drain of external
-/// derivation back-links — both touch substantial code paths).
+/// IDs are recycled via the [`CSPACE_FREE_LIST`] free list once
+/// [`free_cspace_id`] runs at the end of a `CSpace`'s `dealloc_object` pass,
+/// so this is a live-count bound — not the cumulative-ever bound it used to
+/// be under the pre-#137 monotonic allocator. Per-id generation counters in
+/// [`CSPACE_REGISTRY`] make any pre-existing stale `SlotId` resolution fail
+/// fast on epoch mismatch, so recycling cannot mis-target a recycled
+/// tenant. The pre-unregister derivation drain (`dealloc_object` for
+/// `CSpaceObj`) additionally scrubs the back-links in steady state.
 const MAX_CSPACES: usize = 65536;
 
-/// Monotonically increasing `CSpace` ID allocator. Root gets ID 0. See
-/// [`MAX_CSPACES`] for the namespace-bound rationale and #137 for the
-/// recycling follow-up.
-static NEXT_CSPACE_ID: AtomicU32 = AtomicU32::new(0);
+/// High-water mark for the bump-allocator side of `alloc_cspace_id` — only
+/// consulted when the free list is empty. Once `HIGH_WATER_CSPACE_ID` reaches
+/// `MAX_CSPACES`, no new id can be minted until a prior id is recycled.
+static HIGH_WATER_CSPACE_ID: AtomicU32 = AtomicU32::new(0);
 
-/// Global registry mapping `CSpaceId` → raw *mut `CSpace.`
+/// One slot of the global `CSpace` registry.
 ///
-/// Populated by [`register_cspace`] when a `CSpace` is created, cleared by
-/// [`unregister_cspace`] when the backing object is freed. Required for
-/// derivation tree traversal: `SlotId` stores a `CSpaceId`, and we need
-/// O(1) resolution to the actual `CSpace` to read/write derivation pointers.
+/// `ptr` is the live `CSpace` pointer or null when the slot is vacant.
+/// `epoch` is a generation counter incremented each time an id is freed
+/// (see [`free_cspace_id`]); a `SlotId` stamped with a stale epoch fails
+/// resolution at [`lookup_cspace`] so a recycled id cannot alias a foreign
+/// derivation link into the new tenant.
+///
+/// `align(16)` colocates `ptr` and `epoch` on the same cache line and leaves
+/// room for a future 16-byte CAS if contention warrants it.
+#[repr(C, align(16))]
+struct CSpaceRegistryEntry
+{
+    ptr: AtomicPtr<CSpace>,
+    epoch: AtomicU32,
+    _pad: [u8; 4],
+}
+
+impl CSpaceRegistryEntry
+{
+    const fn empty() -> Self
+    {
+        Self {
+            ptr: AtomicPtr::new(core::ptr::null_mut()),
+            // Epoch starts at 1 so the sentinel value `0` (used by the
+            // free-list intrusive encoding in `CapabilitySlot::set_next_free`)
+            // never matches any live entry — a stale lookup of a free-listed
+            // slot resolves to `None` rather than the root `CSpace`.
+            epoch: AtomicU32::new(1),
+            _pad: [0; 4],
+        }
+    }
+}
+
+/// Global registry mapping `CSpaceId` → (`*mut CSpace`, epoch).
+///
+/// Populated by [`register_cspace`] when a `CSpace` is created. Cleared by
+/// [`unregister_cspace`] when the backing object is freed. The epoch is
+/// bumped by [`free_cspace_id`] at the end of `dealloc_object` so any
+/// stale `SlotId` carrying the old epoch fails fast on subsequent
+/// resolution.
 ///
 /// # Safety invariant
-/// A non-null entry is valid as long as the corresponding `CSpaceKernelObject`
+/// A non-null `ptr` is valid as long as the corresponding `CSpaceKernelObject`
 /// refcount is > 0. After `dec_ref` reaches 0 and `dealloc_object` runs,
-/// `unregister_cspace` clears the entry before the memory is freed.
-// SAFETY: AtomicPtr<CSpace> is Send+Sync; array-of-atomics is always valid
-// for static initialisation.
-static CSPACE_REGISTRY: [AtomicPtr<CSpace>; MAX_CSPACES] = {
-    // SAFETY: AtomicPtr<T> is repr(transparent) over *mut T; zero-initialized usize array
-    // is valid array of null AtomicPtr values.
+/// `unregister_cspace` clears `ptr` before the memory is freed, and
+/// `free_cspace_id` bumps `epoch` before the id returns to the free list.
+static CSPACE_REGISTRY: [CSpaceRegistryEntry; MAX_CSPACES] =
+    [const { CSpaceRegistryEntry::empty() }; MAX_CSPACES];
+
+/// Free list of returned `CSpaceId`s, popped LIFO before
+/// [`HIGH_WATER_CSPACE_ID`] is bumped.
+///
+/// Protected by [`CSPACE_FREE_LIST_LOCK`]. The stack stores released ids;
+/// `len` is the number of valid entries. Single global spinlock is fine —
+/// cap-create/destroy is rare relative to IPC/map fast paths, and the
+/// critical sections are O(1) push/pop.
+#[cfg(not(test))]
+static CSPACE_FREE_LIST_LOCK: crate::sync::Spinlock = crate::sync::Spinlock::new();
+#[cfg(not(test))]
+static mut CSPACE_FREE_LIST: [CSpaceId; MAX_CSPACES] = [0; MAX_CSPACES];
+#[cfg(not(test))]
+static mut CSPACE_FREE_LIST_LEN: usize = 0;
+
+/// Push a recycled id onto the free list.
+///
+/// Called from [`free_cspace_id`] after the epoch bump. Saturating: if the
+/// free list is already at capacity (impossible by construction since we
+/// only push ids in `[0, MAX_CSPACES)` and `MAX_CSPACES` slots fit), the
+/// id leaks rather than panicking.
+#[cfg(not(test))]
+#[allow(dead_code)] // Wired into `dealloc_object(CSpaceObj)` by the next commit.
+fn push_free(id: CSpaceId)
+{
+    // SAFETY: lock serialises all free-list mutations.
+    let saved = unsafe { CSPACE_FREE_LIST_LOCK.lock_raw() };
+    // SAFETY: single-writer access under lock.
     unsafe {
-        core::mem::transmute::<[usize; MAX_CSPACES], [AtomicPtr<CSpace>; MAX_CSPACES]>(
-            [0usize; MAX_CSPACES],
-        )
+        if CSPACE_FREE_LIST_LEN < MAX_CSPACES
+        {
+            CSPACE_FREE_LIST[CSPACE_FREE_LIST_LEN] = id;
+            CSPACE_FREE_LIST_LEN += 1;
+        }
     }
-};
+    // SAFETY: paired with lock_raw above.
+    unsafe { CSPACE_FREE_LIST_LOCK.unlock_raw(saved) };
+}
+
+/// Pop a recycled id from the free list, or `None` if empty.
+#[cfg(not(test))]
+fn pop_free() -> Option<CSpaceId>
+{
+    // SAFETY: lock serialises all free-list mutations.
+    let saved = unsafe { CSPACE_FREE_LIST_LOCK.lock_raw() };
+    // SAFETY: single-writer access under lock.
+    let id = unsafe {
+        if CSPACE_FREE_LIST_LEN > 0
+        {
+            CSPACE_FREE_LIST_LEN -= 1;
+            Some(CSPACE_FREE_LIST[CSPACE_FREE_LIST_LEN])
+        }
+        else
+        {
+            None
+        }
+    };
+    // SAFETY: paired with lock_raw above.
+    unsafe { CSPACE_FREE_LIST_LOCK.unlock_raw(saved) };
+    id
+}
+
+/// Allocate a unique `CSpace` ID.
+///
+/// Pops a recycled id off the free list first; otherwise bumps the
+/// high-water counter. Returns `None` once `MAX_CSPACES` are simultaneously
+/// live (callers must surface `SyscallError::OutOfMemory`).
+///
+/// The root `CSpace` receives id `0` at init time via the high-water path
+/// — Phase 7 runs before any `free_cspace_id` could populate the free list,
+/// so the root deterministically gets id 0 (and is hard-rejected from
+/// returning to the free list by [`free_cspace_id`]).
+#[cfg(not(test))]
+pub fn alloc_cspace_id() -> Option<CSpaceId>
+{
+    if let Some(id) = pop_free()
+    {
+        return Some(id);
+    }
+    let next = HIGH_WATER_CSPACE_ID.fetch_add(1, Ordering::Relaxed);
+    if (next as usize) >= MAX_CSPACES
+    {
+        // Clamp so the counter doesn't wrap u32 under sustained pressure.
+        HIGH_WATER_CSPACE_ID.store(MAX_CSPACES as u32, Ordering::Relaxed);
+        return None;
+    }
+    Some(next)
+}
+
+/// Test-only stub: monotonic allocation, no recycling.
+///
+/// The host-side test path doesn't exercise the lock primitive or the BSS
+/// free list (no SMP, no interrupts), and tests only ever create the single
+/// root CSpace before tearing down. The simple monotonic allocator matches
+/// the pre-#137 behavior exactly.
+#[cfg(test)]
+pub fn alloc_cspace_id() -> Option<CSpaceId>
+{
+    let next = HIGH_WATER_CSPACE_ID.fetch_add(1, Ordering::Relaxed);
+    if (next as usize) >= MAX_CSPACES
+    {
+        return None;
+    }
+    Some(next)
+}
 
 /// Register a `CSpace` pointer under its ID.
 ///
-/// Called immediately after a [`CSpace`] is heap-allocated. Returns
-/// `Err(())` if `id >= MAX_CSPACES` so the caller can surface
-/// `SyscallError::OutOfMemory` and roll back, rather than silently leaving
-/// the derivation tree unable to resolve the new `CSpace` (the
-/// pre-#128-fix behaviour that masked the namespace-exhaustion bug).
-pub fn register_cspace(id: CSpaceId, ptr: *mut CSpace) -> Result<(), ()>
+/// Called immediately after a [`CSpace`] is allocated. Returns the registry
+/// entry's current epoch so the caller can stamp `SlotId`s minted in this
+/// `CSpace`'s lifetime. Returns `Err(())` if `id >= MAX_CSPACES`.
+pub fn register_cspace(id: CSpaceId, ptr: *mut CSpace) -> Result<u32, ()>
 {
-    if (id as usize) < MAX_CSPACES
+    if (id as usize) >= MAX_CSPACES
     {
-        CSPACE_REGISTRY[id as usize].store(ptr, Ordering::Release);
-        Ok(())
+        return Err(());
     }
-    else
-    {
-        Err(())
-    }
+    let entry = &CSPACE_REGISTRY[id as usize];
+    debug_assert!(
+        entry.ptr.load(Ordering::Acquire).is_null(),
+        "register_cspace: id {id} already registered"
+    );
+    entry.ptr.store(ptr, Ordering::Release);
+    Ok(entry.epoch.load(Ordering::Acquire))
 }
 
 /// Clear a `CSpace` registration.
 ///
 /// Called from `dealloc_object` for `ObjectType::CSpaceObj` *before* freeing
-/// the backing allocation, so no dangling pointer is observable.
+/// the backing allocation, so no dangling pointer is observable. The
+/// generation bump that retires this id is deferred to [`free_cspace_id`]
+/// so the pre-unregister derivation drain can still resolve foreign
+/// back-links into this `CSpace`'s live (now-quiescent) registry entry.
 pub fn unregister_cspace(id: CSpaceId)
 {
     if (id as usize) < MAX_CSPACES
     {
-        CSPACE_REGISTRY[id as usize].store(core::ptr::null_mut(), Ordering::Release);
+        CSPACE_REGISTRY[id as usize]
+            .ptr
+            .store(core::ptr::null_mut(), Ordering::Release);
     }
 }
 
-/// Allocate a unique `CSpace` ID.
+/// Bump the registry epoch for `id` and return it to the free list.
 ///
-/// Called by `SYS_CAP_CREATE_CSPACE` when creating new `CSpace` objects at
-/// runtime. The root `CSpace` is assigned ID 0 at init time via this same
-/// counter. See [`NEXT_CSPACE_ID`] for the recycling caveat.
-pub fn alloc_cspace_id() -> CSpaceId
+/// Pre-condition: `unregister_cspace(id)` has run (registry `ptr` is null).
+/// Bumping the epoch invalidates any surviving `SlotId` stamped with the
+/// old value — subsequent `lookup_cspace(id, old_epoch)` returns `None`.
+///
+/// If the epoch would overflow `u32`, the id is permanently retired: not
+/// pushed back to the free list. The eventually-leaked-id rate is bounded
+/// by `u32::MAX` recycles per id, which is unreachable in any realistic
+/// system lifetime (≥13 years at 10k recycles/sec/id).
+///
+/// Asserts `id != 0`: the root `CSpace`'s id is reserved for kernel
+/// lifetime; the `HDR_FLAG_IS_ROOT` clamp in `dec_ref` should already make
+/// it unreachable, but defense-in-depth catches misroutes here.
+#[cfg(not(test))]
+#[allow(dead_code)] // Wired into `dealloc_object(CSpaceObj)` by the next commit.
+pub fn free_cspace_id(id: CSpaceId)
 {
-    NEXT_CSPACE_ID.fetch_add(1, Ordering::Relaxed)
+    assert!(id != 0, "free_cspace_id: root CSpace cannot be recycled");
+    debug_assert!((id as usize) < MAX_CSPACES);
+    let entry = &CSPACE_REGISTRY[id as usize];
+    debug_assert!(
+        entry.ptr.load(Ordering::Acquire).is_null(),
+        "free_cspace_id called before unregister_cspace for id {id}"
+    );
+    let prev = entry.epoch.fetch_add(1, Ordering::AcqRel);
+    if prev == u32::MAX
+    {
+        // Retired: the next fetch_add would wrap to 0, which the registry
+        // initialiser treats as "no entry"/free-list sentinel. Leak the id
+        // rather than risk aliasing.
+        crate::kprintln!("cspace: id {id} retired (epoch wraparound)");
+        return;
+    }
+    push_free(id);
 }
 
-/// Resolve a `CSpaceId` to a raw pointer.
+/// Read the current epoch for a registry entry. Returns 0 if `id` is out
+/// of range (a stale `SlotId` carrying an out-of-range `cspace_id` is
+/// always rejected by `lookup_cspace` regardless).
+pub fn registry_epoch(id: CSpaceId) -> u32
+{
+    if (id as usize) >= MAX_CSPACES
+    {
+        return 0;
+    }
+    CSPACE_REGISTRY[id as usize].epoch.load(Ordering::Acquire)
+}
+
+/// Resolve a `CSpaceId` and expected epoch to a raw pointer.
 ///
-/// Returns `None` if `id` is out of range or not yet registered. The returned
-/// pointer is valid only while the corresponding `CSpaceKernelObject` has a
-/// positive refcount and `DERIVATION_LOCK` is held by the caller.
-pub fn lookup_cspace(id: CSpaceId) -> Option<*mut CSpace>
+/// Returns `None` if `id` is out of range, the slot is vacant, or the
+/// stamped epoch doesn't match the registry's current value. The double
+/// epoch load brackets the ptr load so a concurrent `unregister →
+/// free_cspace_id → reuse → register` sequence cannot present a
+/// newly-registered ptr alongside an old expected epoch.
+///
+/// The returned pointer is valid only while the corresponding
+/// `CSpaceKernelObject` has a positive refcount and (for derivation-tree
+/// reads) `DERIVATION_LOCK` is held.
+pub fn lookup_cspace(id: CSpaceId, expected_epoch: u32) -> Option<*mut CSpace>
 {
     if (id as usize) >= MAX_CSPACES
     {
         return None;
     }
-    let ptr = CSPACE_REGISTRY[id as usize].load(Ordering::Acquire);
-    if ptr.is_null() { None } else { Some(ptr) }
+    let entry = &CSPACE_REGISTRY[id as usize];
+    let e1 = entry.epoch.load(Ordering::Acquire);
+    if e1 != expected_epoch
+    {
+        return None;
+    }
+    let ptr = entry.ptr.load(Ordering::Acquire);
+    if ptr.is_null()
+    {
+        return None;
+    }
+    let e2 = entry.epoch.load(Ordering::Acquire);
+    if e2 != expected_epoch
+    {
+        return None;
+    }
+    Some(ptr)
 }
 
 /// Sum [`FrameObject::available_bytes`] across every [`CapTag::Frame`] cap
@@ -945,7 +1142,12 @@ pub fn init_capability_system(mmio_apertures: &[MmioAperture], boot_info_phys: u
         let block_count = unsafe { drain_and_install_seed(ram_buf) };
         let ram_blocks: &[RamBlock] = &ram_buf[..block_count];
 
-        let id = alloc_cspace_id();
+        let id = alloc_cspace_id()
+            .unwrap_or_else(|| crate::fatal("root CSpace: alloc_cspace_id exhausted at boot"));
+        debug_assert_eq!(
+            id, 0,
+            "root CSpace must receive id 0 (free list empty at boot)"
+        );
         // SAFETY: SEED installed above.
         let (_cs_kobj_nn, cs_ptr) = unsafe {
             boot_retype_cspace(
@@ -955,7 +1157,10 @@ pub fn init_capability_system(mmio_apertures: &[MmioAperture], boot_info_phys: u
                 id,
             )
         };
-        register_cspace(id, cs_ptr)
+        // The root CSpace's epoch is fixed at 1 (initial registry value) and
+        // never bumps — it's never recycled (asserted in `free_cspace_id`),
+        // so we discard the returned value.
+        let _root_epoch = register_cspace(id, cs_ptr)
             .unwrap_or_else(|()| crate::fatal("root CSpace register: id exceeds MAX_CSPACES"));
 
         // SAFETY: cs_ptr is freshly constructed and exclusively owned
@@ -978,7 +1183,7 @@ pub fn init_capability_system(mmio_apertures: &[MmioAperture], boot_info_phys: u
     // branch iterate `mmap` directly — `ram_blocks` is empty.
     #[cfg(test)]
     {
-        let id = alloc_cspace_id();
+        let id = alloc_cspace_id().expect("root CSpace: alloc_cspace_id exhausted at boot");
         let mut cspace = Box::new(CSpace::new(id, ROOT_CSPACE_MAX_SLOTS));
         let empty: [RamBlock; 0] = [];
         let mut layout = populate_cspace(&mut cspace, &empty, mmap, mmio_apertures, info);
@@ -1927,8 +2132,8 @@ pub unsafe fn move_cap_between_cspaces(
     let new_idx = new_idx_nz.get();
 
     let src_idx_nz = core::num::NonZeroU32::new(src_idx).ok_or(SyscallError::InvalidCapability)?;
-    let src_slot_id = SlotId::new(src_cspace_id, src_idx_nz);
-    let dst_slot_id = SlotId::new(dst_cspace_id, new_idx_nz);
+    let src_slot_id = SlotId::current(src_cspace_id, src_idx_nz);
+    let dst_slot_id = SlotId::current(dst_cspace_id, new_idx_nz);
 
     // Read derivation links from the source slot.
     let (src_parent, src_first_child, src_prev, src_next) = {
@@ -1958,7 +2163,7 @@ pub unsafe fn move_cap_between_cspaces(
 
     // Update parent's first_child if it pointed to source.
     if let Some(parent_id) = src_parent
-        && let Some(parent_cs) = lookup_cspace(parent_id.cspace_id)
+        && let Some(parent_cs) = lookup_cspace(parent_id.cspace_id, parent_id.epoch)
     {
         // SAFETY: parent_cs returned by lookup_cspace is valid; parent_id.index from derivation link is within bounds.
         if let Some(parent_slot) = unsafe { (*parent_cs).slot_mut(parent_id.index.get()) }
@@ -1970,7 +2175,7 @@ pub unsafe fn move_cap_between_cspaces(
 
     // Update prev sibling's next pointer.
     if let Some(prev_id) = src_prev
-        && let Some(prev_cs) = lookup_cspace(prev_id.cspace_id)
+        && let Some(prev_cs) = lookup_cspace(prev_id.cspace_id, prev_id.epoch)
     {
         // SAFETY: prev_cs returned by lookup_cspace is valid; prev_id.index from derivation link is within bounds.
         if let Some(prev_slot) = unsafe { (*prev_cs).slot_mut(prev_id.index.get()) }
@@ -1982,7 +2187,7 @@ pub unsafe fn move_cap_between_cspaces(
 
     // Update next sibling's prev pointer.
     if let Some(next_id) = src_next
-        && let Some(next_cs) = lookup_cspace(next_id.cspace_id)
+        && let Some(next_cs) = lookup_cspace(next_id.cspace_id, next_id.epoch)
     {
         // SAFETY: next_cs returned by lookup_cspace is valid; next_id.index from derivation link is within bounds.
         if let Some(next_slot) = unsafe { (*next_cs).slot_mut(next_id.index.get()) }
@@ -1997,7 +2202,7 @@ pub unsafe fn move_cap_between_cspaces(
     let mut child_cur = src_first_child;
     while let Some(child_id) = child_cur
     {
-        child_cur = if let Some(child_cs) = lookup_cspace(child_id.cspace_id)
+        child_cur = if let Some(child_cs) = lookup_cspace(child_id.cspace_id, child_id.epoch)
         {
             // SAFETY: child_cs returned by lookup_cspace is valid; child_id.index from derivation link is within bounds.
             if let Some(child_slot) = unsafe { (*child_cs).slot_mut(child_id.index.get()) }

--- a/core/kernel/src/cap/mod.rs
+++ b/core/kernel/src/cap/mod.rs
@@ -314,7 +314,8 @@ static mut SEED_FRAME: object::FrameObject = object::FrameObject {
     header: object::KernelObjectHeader {
         ref_count: AtomicU32::new(1),
         obj_type: object::ObjectType::Frame,
-        _pad: [0; 3],
+        flags: 0,
+        _pad: [0; 2],
         ancestor: AtomicPtr::new(core::ptr::null_mut()),
     },
     base: 0,
@@ -703,6 +704,11 @@ pub(crate) unsafe fn boot_retype_cspace(
             },
         );
     }
+    // The root CSpace is pinned for kernel lifetime: marking it here makes
+    // `dec_ref` clamp at 1, so any upstream refcount mismanagement of the
+    // wrapper / self-cap pair cannot route it through `dealloc_object`.
+    // SAFETY: header just written, exclusively owned, single-threaded boot.
+    unsafe { (*cs_kobj_ptr).header.flags |= crate::cap::object::HDR_FLAG_IS_ROOT };
 
     // SAFETY: cs_ptr just constructed.
     unsafe { (*cs_ptr).set_kobj(cs_kobj_ptr) };

--- a/core/kernel/src/cap/mod.rs
+++ b/core/kernel/src/cap/mod.rs
@@ -250,13 +250,13 @@ pub fn sum_frame_available_bytes(cspace: &cspace::CSpace) -> u64
 }
 
 /// Maximum slots in the root `CSpace` (full two-level directory).
-const ROOT_CSPACE_MAX_SLOTS: usize = 16384;
+const ROOT_CSPACE_MAX_SLOTS: usize = 14336;
 
 /// Pages carved from `SEED_FRAME` for the root `CSpace` slab: page 0 is the
 /// wrapper page (`CSpaceKernelObject` + inlined `CSpace`); the remaining
 /// pages seed the slot-page pool. `populate_cspace` plus
 /// [`mint_module_frame_caps`] mint ~150 caps into the root, occupying ~3
-/// slot pages (64 slots each); 16 pool pages = 1 KiB-cap headroom.
+/// slot pages (56 slots each); 16 pool pages = 1 KiB-cap headroom.
 #[cfg(not(test))]
 const ROOT_CSPACE_INIT_PAGES: u64 = 17;
 

--- a/core/kernel/src/cap/mod.rs
+++ b/core/kernel/src/cap/mod.rs
@@ -455,13 +455,32 @@ pub fn sum_frame_available_bytes(cspace: &cspace::CSpace) -> u64
 /// Maximum slots in the root `CSpace` (full two-level directory).
 const ROOT_CSPACE_MAX_SLOTS: usize = 14336;
 
+/// Target slot capacity for the root `CSpace`'s initial slot-page pool.
+///
+/// `populate_cspace` plus [`mint_module_frame_caps`] mint ~150 caps into
+/// the root; userspace init then mints, copies, and derives ~700 more
+/// caps during memmgr / procmgr bootstrap (kernel-object inserts +
+/// per-RAM-Frame derive/copy chains in `finalize_memmgr`). Sized at
+/// 1024 slots so the pre-memmgr-handover footprint fits with headroom.
+///
+/// MUST be kept in sync with the boot footprint: a target below the
+/// peak boot slot count means `pre_allocate`'s grow loop hits an
+/// exhausted pool, the syscall errors out, and the userspace caller
+/// either retries indefinitely (e.g. `request_round` in a child) or
+/// surfaces an unexpected `OutOfMemory`. After memmgr is alive, further
+/// growth is bounded only by `ROOT_CSPACE_MAX_SLOTS`.
+#[cfg(not(test))]
+const ROOT_CSPACE_INIT_SLOT_CAPACITY: u64 = 1024;
+
 /// Pages carved from `SEED_FRAME` for the root `CSpace` slab: page 0 is the
 /// wrapper page (`CSpaceKernelObject` + inlined `CSpace`); the remaining
-/// pages seed the slot-page pool. `populate_cspace` plus
-/// [`mint_module_frame_caps`] mint ~150 caps into the root, occupying ~3
-/// slot pages (56 slots each); 16 pool pages = 1 KiB-cap headroom.
+/// pages seed the slot-page pool. Sized so the pool holds at least
+/// [`ROOT_CSPACE_INIT_SLOT_CAPACITY`] slots regardless of `L2_SIZE`
+/// (slots-per-page). The slot-0 reservation on page 0 costs one slot
+/// and is absorbed by rounding up.
 #[cfg(not(test))]
-const ROOT_CSPACE_INIT_PAGES: u64 = 17;
+const ROOT_CSPACE_INIT_PAGES: u64 =
+    1 + ROOT_CSPACE_INIT_SLOT_CAPACITY.div_ceil(cspace::L2_SIZE as u64);
 
 // ── Phase-7 seed Frame cap ───────────────────────────────────────────────────
 

--- a/core/kernel/src/cap/mod.rs
+++ b/core/kernel/src/cap/mod.rs
@@ -135,7 +135,13 @@ pub unsafe fn root_cspace_mut() -> Option<&'static mut CSpace>
 /// fast on epoch mismatch, so recycling cannot mis-target a recycled
 /// tenant. The pre-unregister derivation drain (`dealloc_object` for
 /// `CSpaceObj`) additionally scrubs the back-links in steady state.
-const MAX_CSPACES: usize = 65536;
+///
+/// Live-count peaks in ktest stress today sit in the low hundreds; 4096
+/// gives 10–40× headroom while reclaiming the ~480 KiB of BSS the
+/// pre-#137 65536-entry registry burned. A future workload that genuinely
+/// needs more live `CSpace`s only has to bump this constant — no layout,
+/// ABI, or algorithmic change is required.
+const MAX_CSPACES: usize = 4096;
 
 /// High-water mark for the bump-allocator side of `alloc_cspace_id` — only
 /// consulted when the free list is empty. Once `HIGH_WATER_CSPACE_ID` reaches

--- a/core/kernel/src/cap/mod.rs
+++ b/core/kernel/src/cap/mod.rs
@@ -137,12 +137,12 @@ pub unsafe fn root_cspace_mut() -> Option<&'static mut CSpace>
 /// `CSpaceObj`) additionally scrubs the back-links in steady state.
 ///
 /// Live-count peaks in ktest stress today sit in the low hundreds; 4096
-/// gives 10–40× headroom while reclaiming ~448 KiB of BSS the
+/// gives 10–40× headroom while reclaiming ~432 KiB of BSS the
 /// pre-#137 65536-entry registry burned (65536 × 8 B = 512 KiB old
 /// registry vs 4096 × 16 B = 64 KiB new registry + 4096 × 4 B = 16 KiB
-/// free list = 80 KiB total). A future workload that genuinely needs
-/// more live `CSpace`s only has to bump this constant — no layout, ABI,
-/// or algorithmic change is required.
+/// free list = 80 KiB total; 512 − 80 = 432 KiB net). A future workload
+/// that genuinely needs more live `CSpace`s only has to bump this
+/// constant — no layout, ABI, or algorithmic change is required.
 const MAX_CSPACES: usize = 4096;
 
 /// High-water mark for the bump-allocator side of `alloc_cspace_id` — only

--- a/core/kernel/src/cap/object.rs
+++ b/core/kernel/src/cap/object.rs
@@ -103,15 +103,26 @@ pub struct KernelObjectHeader
     pub ref_count: AtomicU32,
     /// Concrete type, for use during deallocation.
     pub obj_type: ObjectType,
+    /// Lifecycle flags. See `HDR_FLAG_*` constants. Currently only used to
+    /// mark the boot root `CSpace` as undestroyable.
+    pub flags: u8,
     // Padding to reach 8-byte alignment for the ancestor pointer below.
     #[allow(clippy::pub_underscore_fields)]
-    pub _pad: [u8; 3],
+    pub _pad: [u8; 2],
     /// Pointer to the `FrameObject`'s header this object was retyped from,
     /// or null if allocated via the legacy heap path. Set once at creation,
     /// read at deallocation. `AtomicPtr` for the unforgeable null sentinel
     /// without imposing const-init constraints on construction.
     pub ancestor: AtomicPtr<KernelObjectHeader>,
 }
+
+/// `flags` bit: this header belongs to the boot root `CSpace` and MUST NOT
+/// be deallocated. `dec_ref` intercepts the `→ 0` transition for these
+/// headers and returns 1, keeping the object alive regardless of upstream
+/// refcount mismanagement. Stamped in
+/// [`crate::cap::boot_retype_cspace`] for the root `CSpace`; never set
+/// elsewhere.
+pub const HDR_FLAG_IS_ROOT: u8 = 0x01;
 
 // SAFETY: ancestor is a back-pointer to a kernel object whose lifetime is
 // guaranteed by retype's refcount semantics. Send+Sync via the surrounding
@@ -132,7 +143,8 @@ impl KernelObjectHeader
         Self {
             ref_count: AtomicU32::new(1),
             obj_type,
-            _pad: [0; 3],
+            flags: 0,
+            _pad: [0; 2],
             ancestor: AtomicPtr::new(core::ptr::null_mut()),
         }
     }
@@ -147,7 +159,8 @@ impl KernelObjectHeader
         Self {
             ref_count: AtomicU32::new(1),
             obj_type,
-            _pad: [0; 3],
+            flags: 0,
+            _pad: [0; 2],
             ancestor: AtomicPtr::new(ancestor.as_ptr()),
         }
     }
@@ -163,6 +176,13 @@ impl KernelObjectHeader
     ///
     /// Returns 0 when the object has no remaining capability references; the
     /// caller is responsible for freeing the object at that point.
+    ///
+    /// Headers carrying [`HDR_FLAG_IS_ROOT`] (the boot root `CSpace`) clamp at
+    /// 1: the dec is applied, but if the result would be 0 we restore the
+    /// `ref_count` to 1 and report 1 to the caller. The root `CSpace` lives
+    /// for kernel lifetime and never reaches `dealloc_object`, even if
+    /// upstream refcount accounting mismanages the ancillary slot/wrapper
+    /// pair.
     pub fn dec_ref(&self) -> u32
     {
         let prev = self.ref_count.fetch_sub(1, Ordering::Release);
@@ -173,7 +193,13 @@ impl KernelObjectHeader
             self,
             self.ancestor.load(Ordering::Relaxed),
         );
-        prev - 1
+        let new = prev - 1;
+        if new == 0 && (self.flags & HDR_FLAG_IS_ROOT) != 0
+        {
+            self.ref_count.store(1, Ordering::Release);
+            return 1;
+        }
+        new
     }
 }
 

--- a/core/kernel/src/cap/object.rs
+++ b/core/kernel/src/cap/object.rs
@@ -1790,23 +1790,33 @@ unsafe fn dealloc_object_one(
                 let dying_epoch = crate::cap::registry_epoch(id);
 
                 // ── Pre-unregister derivation drain ──
-                // Hold DERIVATION_LOCK exclusively across the drain and the
-                // subsequent for_each_object dec_ref pass. The drain walks
-                // each populated slot, snapshots its outgoing derivation
-                // pointers under a brief per-slot &mut, clears them, then
-                // splices the corresponding back-links in foreign slots
-                // with no borrow into the dying CSpace held.
+                // Hold DERIVATION_LOCK exclusively for the drain + unregister
+                // pair only. The drain walks each populated slot, snapshots
+                // its outgoing derivation pointers under a brief per-slot
+                // &mut, clears them, then splices the corresponding back-
+                // links in foreign slots. `unregister_cspace` runs inside
+                // the same critical section so any concurrent foreign reader
+                // sees a consistent "drained, then absent" transition.
+                //
+                // The lock MUST be released BEFORE the `for_each_object`
+                // dec_ref cascade below: a slot in the dying CSpace may hold
+                // a CSpace cap whose dec_ref drives a nested
+                // `dealloc_object(CSpaceObj)` call, which would re-enter
+                // this same non-recursive lock and deadlock. The drain
+                // already removed every foreign back-link before this
+                // point, so the dec_ref cascade has no derivation-tree
+                // work to do — releasing is safe.
                 crate::cap::derivation::DERIVATION_LOCK.write_lock();
                 // SAFETY: DERIVATION_LOCK held; cs_ptr uniquely owned at
                 // refcount=0; registry entry still live (unregister below).
                 unsafe { drain_dying_cspace(cs_ptr, id, dying_epoch) };
-
-                // After the drain, no foreign slot back-links into this
-                // CSpace remain. Now clear the registry pointer so any
-                // subsequent lookup of the dying id resolves to None.
                 crate::cap::unregister_cspace(id);
+                crate::cap::derivation::DERIVATION_LOCK.write_unlock();
 
-                // Dec-ref all objects referenced by non-null slots.
+                // Dec-ref all objects referenced by non-null slots. Runs
+                // without DERIVATION_LOCK so nested CSpaceObj deallocs (a
+                // dying CSpace whose slots hold caps to other CSpaces) can
+                // acquire it themselves without re-entry.
                 // SAFETY: cs_ptr non-null; for_each_object handles iteration.
                 unsafe {
                     (*cs_ptr).for_each_object(|obj_ptr| {
@@ -1828,7 +1838,6 @@ unsafe fn dealloc_object_one(
                     core::ptr::drop_in_place(cs_ptr);
                 }
 
-                crate::cap::derivation::DERIVATION_LOCK.write_unlock();
                 // Don't recycle id 0 (root CSpace's id). The root is also
                 // pinned by HDR_FLAG_IS_ROOT so this branch is unreachable
                 // for the root in practice; the guard is defense-in-depth.

--- a/core/kernel/src/cap/object.rs
+++ b/core/kernel/src/cap/object.rs
@@ -177,14 +177,42 @@ impl KernelObjectHeader
     /// Returns 0 when the object has no remaining capability references; the
     /// caller is responsible for freeing the object at that point.
     ///
-    /// Headers carrying [`HDR_FLAG_IS_ROOT`] (the boot root `CSpace`) clamp at
-    /// 1: the dec is applied, but if the result would be 0 we restore the
-    /// `ref_count` to 1 and report 1 to the caller. The root `CSpace` lives
-    /// for kernel lifetime and never reaches `dealloc_object`, even if
-    /// upstream refcount accounting mismanages the ancillary slot/wrapper
-    /// pair.
+    /// Headers carrying [`HDR_FLAG_IS_ROOT`] (the boot root `CSpace`) clamp
+    /// at 1 via a CAS loop: when the current count is 1 the operation is a
+    /// no-op (returns 1); otherwise it decrements by one. The CAS form
+    /// avoids the fetch_sub-then-restore window in which a concurrent dec
+    /// would see 0 and underflow. The root `CSpace` lives for kernel
+    /// lifetime and never reaches `dealloc_object`, even if upstream
+    /// refcount accounting mismanages the ancillary slot/wrapper pair.
     pub fn dec_ref(&self) -> u32
     {
+        if (self.flags & HDR_FLAG_IS_ROOT) != 0
+        {
+            // Root path: CAS the floor in atomically so concurrent decs
+            // cannot observe a transient 0.
+            let mut cur = self.ref_count.load(Ordering::Relaxed);
+            loop
+            {
+                debug_assert!(
+                    cur != 0,
+                    "dec_ref underflow on IS_ROOT header: obj_type={:?} self={:p}",
+                    self.obj_type,
+                    self,
+                );
+                let new = if cur == 1 { 1 } else { cur - 1 };
+                match self.ref_count.compare_exchange_weak(
+                    cur,
+                    new,
+                    Ordering::Release,
+                    Ordering::Relaxed,
+                )
+                {
+                    Ok(_) => return new,
+                    Err(actual) => cur = actual,
+                }
+            }
+        }
+
         let prev = self.ref_count.fetch_sub(1, Ordering::Release);
         debug_assert!(
             prev != 0,
@@ -193,13 +221,7 @@ impl KernelObjectHeader
             self,
             self.ancestor.load(Ordering::Relaxed),
         );
-        let new = prev - 1;
-        if new == 0 && (self.flags & HDR_FLAG_IS_ROOT) != 0
-        {
-            self.ref_count.store(1, Ordering::Release);
-            return 1;
-        }
-        new
+        prev - 1
     }
 }
 

--- a/core/kernel/src/cap/object.rs
+++ b/core/kernel/src/cap/object.rs
@@ -1757,6 +1757,14 @@ unsafe fn dealloc_object_one(
         // least one chunk slot covering the wrapper plus the slot-page pool.
         // Reclamation walks the chunk slots and `retype_free`s each one
         // wholesale, then `dec_ref`s the ancestor.
+        //
+        // Before `unregister_cspace` and the dec_ref cascade run, the
+        // derivation tree's external back-links into this dying `CSpace`
+        // are scrubbed by [`drain_dying_cspace`]. Combined with the
+        // [`SlotId`] epoch check in `lookup_cspace`, this is the
+        // defense-in-depth that lets `free_cspace_id` recycle the id
+        // safely: foreign slots cannot retain a back-link, and any that
+        // somehow slip through fail-fast on epoch mismatch.
         ObjectType::CSpaceObj =>
         {
             // SAFETY: ptr points at an in-place CSpaceKernelObject; header at offset 0.
@@ -1768,10 +1776,34 @@ unsafe fn dealloc_object_one(
                 "dealloc CSpaceObj: heap-backed CSpace reached typed-memory dealloc path"
             );
 
+            // Captured for the final `free_cspace_id` after the lock release;
+            // 0 means "no dying id" (cs_ptr was null), which short-circuits
+            // the free-list push below.
+            let mut dying_id: crate::cap::slot::CSpaceId = 0;
+            let mut needs_free_id = false;
+
             if !cs_ptr.is_null()
             {
                 // SAFETY: cs_ptr non-null; allocated at creation.
                 let id = unsafe { (*cs_ptr).id() };
+                dying_id = id;
+                let dying_epoch = crate::cap::registry_epoch(id);
+
+                // ── Pre-unregister derivation drain ──
+                // Hold DERIVATION_LOCK exclusively across the drain and the
+                // subsequent for_each_object dec_ref pass. The drain walks
+                // each populated slot, snapshots its outgoing derivation
+                // pointers under a brief per-slot &mut, clears them, then
+                // splices the corresponding back-links in foreign slots
+                // with no borrow into the dying CSpace held.
+                crate::cap::derivation::DERIVATION_LOCK.write_lock();
+                // SAFETY: DERIVATION_LOCK held; cs_ptr uniquely owned at
+                // refcount=0; registry entry still live (unregister below).
+                unsafe { drain_dying_cspace(cs_ptr, id, dying_epoch) };
+
+                // After the drain, no foreign slot back-links into this
+                // CSpace remain. Now clear the registry pointer so any
+                // subsequent lookup of the dying id resolves to None.
                 crate::cap::unregister_cspace(id);
 
                 // Dec-ref all objects referenced by non-null slots.
@@ -1795,6 +1827,12 @@ unsafe fn dealloc_object_one(
                 unsafe {
                     core::ptr::drop_in_place(cs_ptr);
                 }
+
+                crate::cap::derivation::DERIVATION_LOCK.write_unlock();
+                // Don't recycle id 0 (root CSpace's id). The root is also
+                // pinned by HDR_FLAG_IS_ROOT so this branch is unreachable
+                // for the root in practice; the guard is defense-in-depth.
+                needs_free_id = id != 0;
             }
 
             // Snapshot every chunk slot before freeing — `retype_free`
@@ -1832,6 +1870,15 @@ unsafe fn dealloc_object_one(
                     let anc_nn = unsafe { NonNull::new_unchecked(anc_ptr) };
                     push_ancestor(worklist, head, anc_nn);
                 }
+            }
+
+            // Recycle the id last, after all of the dying CSpace's storage
+            // is reclaimed and DERIVATION_LOCK is released. Bumping the
+            // epoch now invalidates any surviving SlotId stamped with the
+            // pre-recycle value — subsequent `lookup_cspace` returns None.
+            if needs_free_id
+            {
+                crate::cap::free_cspace_id(dying_id);
             }
 
             // No separate `Box::from_raw(obj)` — the wrapper lives inside
@@ -2183,6 +2230,228 @@ unsafe fn dealloc_object_one(
                 push_ancestor(worklist, head, ancestor_nn);
             }
         }
+    }
+}
+
+// ── CSpace teardown helpers ──────────────────────────────────────────────────
+
+/// Pre-unregister derivation drain for a dying `CSpace`.
+///
+/// Iterates each populated slot in `cs_ptr` and splices the slot out of its
+/// foreign back-link chains so that, after `unregister_cspace` runs, no
+/// foreign slot in any other `CSpace` retains a derivation pointer into the
+/// dying one. Combined with the per-id epoch check in
+/// `crate::cap::lookup_cspace`, this lets `free_cspace_id` recycle the id
+/// safely.
+///
+/// ## Aliasing avoidance
+///
+/// PR #136's first recycling attempt hit a release-mode aliasing UB: an
+/// outer iteration holding `&CSpacePage` while an inner closure took
+/// `&mut CapabilitySlot` to a slot inside the same page. This drain
+/// avoids the hazard structurally — no borrow into `cs_ptr` is held
+/// across foreign-slot accesses. The per-slot scope is:
+///
+/// 1. A brief `unsafe { (*cs_ptr).slot_mut(idx) }` produces a
+///    `&mut CapabilitySlot` purely to snapshot the four `deriv_*` fields
+///    into stack locals and clear them in place. The borrow ends at the
+///    block boundary.
+/// 2. The foreign-write step calls into [`drain_foreign_back_links`],
+///    which only accesses foreign `CSpace`s via fresh
+///    `lookup_cspace`/`slot_mut` calls. Intra-cspace siblings/children
+///    are short-circuited and never re-borrowed from inside this scope.
+///
+/// # Safety
+///
+/// Caller MUST hold `DERIVATION_LOCK` write lock. `cs_ptr` MUST be a valid
+/// `CSpace` pointer whose refcount has reached zero (i.e. exclusive
+/// ownership). The registry entry for `dying_id` MUST still be live
+/// (i.e. `unregister_cspace` has not yet run); the deferred unregister
+/// allows the drain itself to splice through `lookup_cspace`.
+#[cfg(not(test))]
+unsafe fn drain_dying_cspace(
+    cs_ptr: *mut crate::cap::cspace::CSpace,
+    dying_id: crate::cap::slot::CSpaceId,
+    dying_epoch: u32,
+)
+{
+    use crate::cap::cspace::{L1_SIZE, L2_SIZE};
+    use crate::cap::slot::{CapTag, SlotId};
+    use core::num::NonZeroU32;
+
+    for page_idx in 0..L1_SIZE
+    {
+        // Presence-test the page without holding a `&CSpace` borrow into
+        // the per-slot scope below.
+        // SAFETY: cs_ptr is uniquely owned; `page_at` takes `&self` briefly
+        // and returns before the borrow can be observed elsewhere.
+        if unsafe { (*cs_ptr).page_at(page_idx) }.is_none()
+        {
+            continue;
+        }
+        let start = usize::from(page_idx == 0);
+        for slot_idx_in_page in start..L2_SIZE
+        {
+            let global_idx = (page_idx * L2_SIZE + slot_idx_in_page) as u32;
+            let Some(global_idx_nz) = NonZeroU32::new(global_idx)
+            else
+            {
+                continue;
+            };
+
+            // Step A — local read + clear under a brief per-slot &mut.
+            // The borrow ends at the block boundary; the four snapshots
+            // are `Copy` and outlive it.
+            // SAFETY: cs_ptr is uniquely owned (refcount=0); the &mut
+            // produced by slot_mut is the only borrow into this slot for
+            // the duration of the block and is dropped before any foreign
+            // access.
+            let (parent, fc, prev, next, populated) = unsafe {
+                if let Some(slot) = (*cs_ptr).slot_mut(global_idx)
+                {
+                    if slot.tag == CapTag::Null
+                    {
+                        (None, None, None, None, false)
+                    }
+                    else
+                    {
+                        let p = slot.deriv_parent;
+                        let c = slot.deriv_first_child;
+                        let pr = slot.deriv_prev_sibling;
+                        let nx = slot.deriv_next_sibling;
+                        slot.deriv_parent = None;
+                        slot.deriv_first_child = None;
+                        slot.deriv_prev_sibling = None;
+                        slot.deriv_next_sibling = None;
+                        (p, c, pr, nx, true)
+                    }
+                }
+                else
+                {
+                    (None, None, None, None, false)
+                }
+            };
+            if !populated
+            {
+                continue;
+            }
+
+            let self_id = SlotId::with_epoch(dying_id, dying_epoch, global_idx_nz);
+
+            // Step B — foreign splice. No borrow into `cs_ptr` is held.
+            // SAFETY: DERIVATION_LOCK held; foreign cspaces resolved via
+            // registry lookup with epoch validation.
+            unsafe {
+                drain_foreign_back_links(self_id, dying_id, parent, fc, prev, next);
+            }
+        }
+    }
+}
+
+/// Splice `self_id`'s back-references out of foreign `CSpace` slots.
+///
+/// Intra-cspace back-links (where the back-reference lives in the dying
+/// `CSpace` itself) are skipped — those slots are either already cleared
+/// by an earlier iteration of [`drain_dying_cspace`] or will be cleared
+/// shortly. Their derivation pointers don't matter because the entire
+/// dying `CSpace`'s storage is about to be reclaimed.
+///
+/// For the children walk: a foreign child has its `deriv_parent` nulled
+/// (orphaned). Intra-cspace children are skipped for the same reason
+/// above. `next_sibling` advancement reads through `slot()` (immutable),
+/// which is safe because we never re-enter Step A's `&mut` for the dying
+/// `CSpace` inside this function's scope.
+///
+/// # Safety
+///
+/// Caller MUST hold `DERIVATION_LOCK` write lock. `dying_id`'s registry
+/// entry MUST still be live so `lookup_cspace(dying_id, dying_epoch)`
+/// resolves for the intra-cspace child-chain walk.
+#[cfg(not(test))]
+unsafe fn drain_foreign_back_links(
+    self_id: crate::cap::slot::SlotId,
+    dying_id: crate::cap::slot::CSpaceId,
+    parent: Option<crate::cap::slot::SlotId>,
+    first_child: Option<crate::cap::slot::SlotId>,
+    prev: Option<crate::cap::slot::SlotId>,
+    next: Option<crate::cap::slot::SlotId>,
+)
+{
+    // Parent: if first_child pointed at self_id, redirect to next sibling.
+    // (We don't attempt to find a different non-dying child; the next
+    // sibling may itself be in dying — that's fine, epoch defense will
+    // reject it on the next lookup after `free_cspace_id`.)
+    if let Some(p) = parent
+        && p.cspace_id != dying_id
+        && let Some(parent_cs) = crate::cap::lookup_cspace(p.cspace_id, p.epoch)
+    {
+        // SAFETY: parent_cs from registry; DERIVATION_LOCK held.
+        if let Some(parent_slot) = unsafe { (*parent_cs).slot_mut(p.index.get()) }
+            && parent_slot.deriv_first_child == Some(self_id)
+        {
+            parent_slot.deriv_first_child = next;
+        }
+    }
+
+    // Prev sibling: splice self_id out of the chain (its next becomes our next).
+    if let Some(pr) = prev
+        && pr.cspace_id != dying_id
+        && let Some(prev_cs) = crate::cap::lookup_cspace(pr.cspace_id, pr.epoch)
+    {
+        // SAFETY: prev_cs from registry; DERIVATION_LOCK held.
+        if let Some(prev_slot) = unsafe { (*prev_cs).slot_mut(pr.index.get()) }
+            && prev_slot.deriv_next_sibling == Some(self_id)
+        {
+            prev_slot.deriv_next_sibling = next;
+        }
+    }
+
+    // Next sibling: splice self_id out of the chain (its prev becomes our prev).
+    if let Some(nx) = next
+        && nx.cspace_id != dying_id
+        && let Some(next_cs) = crate::cap::lookup_cspace(nx.cspace_id, nx.epoch)
+    {
+        // SAFETY: next_cs from registry; DERIVATION_LOCK held.
+        if let Some(next_slot) = unsafe { (*next_cs).slot_mut(nx.index.get()) }
+            && next_slot.deriv_prev_sibling == Some(self_id)
+        {
+            next_slot.deriv_prev_sibling = prev;
+        }
+    }
+
+    // Children chain: orphan each foreign child by nulling its
+    // deriv_parent. Walk via next_sibling. Intra-cspace children are
+    // visited only to read next_sibling and continue the walk.
+    let mut cur = first_child;
+    while let Some(c) = cur
+    {
+        let next_in_chain = if c.cspace_id == dying_id
+        {
+            // Intra-cspace: don't touch (it's being iterated independently).
+            // Read next_sibling via immutable `slot()` to advance the walk.
+            // SAFETY: lookup returns the dying CSpace's ptr; immutable `&`
+            // borrow is exclusive with respect to drain_dying_cspace's
+            // per-slot `&mut` because Step A's scope already ended.
+            crate::cap::lookup_cspace(c.cspace_id, c.epoch)
+                .and_then(|cs| unsafe { (*cs).slot(c.index.get()) })
+                .and_then(|s| s.deriv_next_sibling)
+        }
+        else
+        {
+            // Foreign: resolve, snapshot next_sibling, null deriv_parent.
+            // SAFETY: foreign cspace lookup; DERIVATION_LOCK held.
+            crate::cap::lookup_cspace(c.cspace_id, c.epoch).and_then(|cs| unsafe {
+                (*cs).slot_mut(c.index.get()).and_then(|slot| {
+                    let n = slot.deriv_next_sibling;
+                    if slot.deriv_parent == Some(self_id)
+                    {
+                        slot.deriv_parent = None;
+                    }
+                    n
+                })
+            })
+        };
+        cur = next_in_chain;
     }
 }
 

--- a/core/kernel/src/cap/slot.rs
+++ b/core/kernel/src/cap/slot.rs
@@ -96,6 +96,21 @@ impl SlotId
             index,
         }
     }
+
+    /// Construct a `SlotId` by snapshotting the registry's current epoch
+    /// for `cspace_id`.
+    ///
+    /// The natural form for derivation-tree write sites: the link is being
+    /// stamped now, so the current registry epoch is the correct value.
+    /// Callers must hold a proof that the cspace is currently live (e.g.
+    /// they just resolved a slot in it, or it is the caller's own cspace).
+    /// If the registry has already retired this id, `registry_epoch`
+    /// returns the bumped value and the `SlotId` stamps with that — but
+    /// the caller's proof-of-life should make that case impossible.
+    pub fn current(cspace_id: CSpaceId, index: NonZeroU32) -> Self
+    {
+        Self::with_epoch(cspace_id, crate::cap::registry_epoch(cspace_id), index)
+    }
 }
 
 // ── Capability tag ────────────────────────────────────────────────────────────

--- a/core/kernel/src/cap/slot.rs
+++ b/core/kernel/src/cap/slot.rs
@@ -6,20 +6,24 @@
 //! Capability slot foundation types.
 //!
 //! [`CapabilitySlot`] is the fixed-size record stored in `CSpace` pages.
-//! The layout is `#[repr(C)]` and exactly 56 bytes.
+//! The layout is `#[repr(C)]` and exactly 72 bytes.
 //!
 //! ## Intrusive free list
 //!
 //! When a slot is free (`tag == Null`), the `deriv_parent` field is repurposed
 //! to store the next-free index. Call [`CapabilitySlot::set_next_free`] and
 //! [`CapabilitySlot::next_free`] to encode/decode; do not read `deriv_parent`
-//! directly on a free slot.
+//! directly on a free slot. The `epoch` field of the encoded `SlotId` is the
+//! free-list sentinel value `0` and MUST NOT appear in any live derivation
+//! link — derivation links carry the registry epoch that was current when
+//! they were stamped.
 //!
 //! ## Size derivation
 //!
-//! `Option<SlotId>` is 8 bytes because `SlotId.index` is [`NonZeroU32`], which
-//! provides a niche enabling the Option discriminant to be stored in the zero
-//! value — no extra bytes needed. This is verified by the size test below.
+//! `SlotId` is 12 bytes: `(cspace_id: u32, epoch: u32, index: NonZeroU32)`.
+//! `Option<SlotId>` is 12 bytes because `SlotId.index` is [`NonZeroU32`],
+//! which provides a niche enabling the Option discriminant to be stored in
+//! the zero value — no extra bytes needed. Verified by the size tests below.
 
 use core::num::NonZeroU32;
 use core::ptr::NonNull;
@@ -31,23 +35,44 @@ use super::object::KernelObjectHeader;
 /// Unique identifier for a capability space.
 pub type CSpaceId = u32;
 
-/// A reference to a specific capability slot by `CSpace` ID and index.
+/// A reference to a specific capability slot by `CSpace` ID, generation
+/// epoch, and index.
 ///
-/// `index` is [`NonZeroU32`] because slot 0 is permanently null and is never a
-/// valid derivation target. This gives `Option<SlotId>` the same 8-byte size as
-/// `SlotId` itself via niche optimization.
+/// `index` is [`NonZeroU32`] because slot 0 is permanently null and is never
+/// a valid derivation target. This gives `Option<SlotId>` the same 12-byte
+/// size as `SlotId` itself via niche optimization.
+///
+/// `epoch` is the generation counter from the `CSpace` registry at the time
+/// this `SlotId` was stamped. Once `CSpaceId` recycling is enabled (see
+/// #137), `lookup_cspace` compares the stamped epoch to the registry's
+/// current epoch and fails fast on mismatch, so a stale `SlotId` referring
+/// to a freed `CSpace` cannot mis-target a recycled tenant. The reserved
+/// value `epoch == 0` is the free-list sentinel; it appears only in the
+/// intrusive next-free encoding stored in a `CapTag::Null` slot's
+/// `deriv_parent` and MUST NOT appear in any live derivation link.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SlotId
 {
     /// The `CSpace` this slot belongs to.
     pub cspace_id: CSpaceId,
+    /// Registry generation counter stamped at construction. Compared on
+    /// `lookup_cspace` once recycling is enabled.
+    pub epoch: u32,
     /// Slot index within that `CSpace`. Never zero.
     pub index: NonZeroU32,
 }
 
 impl SlotId
 {
-    /// Construct a `SlotId` from a statically non-zero index.
+    /// Construct a `SlotId` with epoch `0`.
+    ///
+    /// Used by call sites that do not yet thread a real registry epoch
+    /// through. While `CSpaceId` recycling remains gated (no `free_cspace_id`
+    /// has run, so every live entry has epoch `1`+ when registered), every
+    /// site still works against a registry that ignores the supplied epoch
+    /// on `lookup_cspace`. Sites that need to stamp a `SlotId` with the
+    /// registry's current value should use [`Self::with_epoch`] together
+    /// with `cap::registry_epoch`.
     ///
     /// Callers holding a raw `u32` must first convert via [`NonZeroU32::new`]
     /// and route the `None` case through their subsystem's error channel
@@ -55,7 +80,21 @@ impl SlotId
     /// zero indices become graceful errors rather than kernel panics.
     pub fn new(cspace_id: CSpaceId, index: NonZeroU32) -> Self
     {
-        Self { cspace_id, index }
+        Self {
+            cspace_id,
+            epoch: 0,
+            index,
+        }
+    }
+
+    /// Construct a `SlotId` with an explicit epoch.
+    pub fn with_epoch(cspace_id: CSpaceId, epoch: u32, index: NonZeroU32) -> Self
+    {
+        Self {
+            cspace_id,
+            epoch,
+            index,
+        }
     }
 }
 
@@ -240,11 +279,11 @@ pub fn violates_wx(rights: Rights) -> bool
 
 /// A single capability slot in a `CSpace` page.
 ///
-/// Fixed at 56 bytes (`#[repr(C)]`). Slot 0 in every `CSpace` is permanently
+/// Fixed at 72 bytes (`#[repr(C)]`). Slot 0 in every `CSpace` is permanently
 /// null. Non-null slots hold a typed reference to a kernel object and an
 /// associated rights bitmask.
 ///
-/// ## Layout (56 bytes)
+/// ## Layout (72 bytes)
 ///
 /// ```text
 ///  offset  size  field
@@ -253,16 +292,19 @@ pub fn violates_wx(rights: Rights) -> bool
 ///       4     4  rights
 ///       8     8  token  (caller-identifying label; 0 = untokened)
 ///      16     8  object (naturally 8-byte aligned at offset 16)
-///      24     8  deriv_parent   (next_free index when tag == Null)
-///      32     8  deriv_first_child
-///      40     8  deriv_next_sibling
-///      48     8  deriv_prev_sibling
-/// total: 56 bytes
+///      24    12  deriv_parent   (next_free index when tag == Null)
+///      36    12  deriv_first_child
+///      48    12  deriv_next_sibling
+///      60    12  deriv_prev_sibling
+/// total: 72 bytes
 /// ```
 ///
-/// Without explicit `pad`, `#[repr(C)]` would insert 2 bytes before `rights`
-/// (to satisfy 4-byte alignment) and 6 bytes before `token` (8-byte alignment),
-/// yielding 64 bytes. The 3-byte pad absorbs both gaps.
+/// Each `Option<SlotId>` derivation pointer is 12 bytes (3 × u32, niche on
+/// `index: NonZeroU32`). Without explicit `pad`, `#[repr(C)]` would insert 2
+/// bytes before `rights` (to satisfy 4-byte alignment) and 6 bytes before
+/// `token` (8-byte alignment); the 3-byte pad absorbs both gaps. The struct
+/// alignment is 8 (from `token` and `object`); 72 is already a multiple of 8
+/// so no trailing pad is required.
 #[repr(C)]
 pub struct CapabilitySlot
 {
@@ -337,6 +379,11 @@ impl CapabilitySlot
     ///
     /// The free list never contains slot 0 (it is permanently null), so the
     /// non-zero invariant is encoded in the argument type.
+    ///
+    /// `cspace_id` and `epoch` in the encoded `SlotId` are sentinel zeros —
+    /// the free-list reader only consults `index`. A live derivation link is
+    /// always stamped with the registry's non-zero epoch, so `epoch == 0`
+    /// unambiguously distinguishes the two encodings.
     pub fn set_next_free(&mut self, next: Option<NonZeroU32>)
     {
         self.tag = CapTag::Null;
@@ -349,6 +396,7 @@ impl CapabilitySlot
         self.deriv_prev_sibling = None;
         self.deriv_parent = next.map(|index| SlotId {
             cspace_id: 0,
+            epoch: 0,
             index,
         });
     }
@@ -375,16 +423,22 @@ mod tests
     use core::mem::size_of;
 
     #[test]
-    fn capability_slot_is_56_bytes()
+    fn capability_slot_is_72_bytes()
     {
-        assert_eq!(size_of::<CapabilitySlot>(), 56);
+        assert_eq!(size_of::<CapabilitySlot>(), 72);
     }
 
     #[test]
-    fn option_slot_id_is_8_bytes()
+    fn slot_id_is_12_bytes()
     {
-        // Verifies niche optimization via NonZeroU32.
-        assert_eq!(size_of::<Option<SlotId>>(), 8);
+        assert_eq!(size_of::<SlotId>(), 12);
+    }
+
+    #[test]
+    fn option_slot_id_is_12_bytes()
+    {
+        // Verifies niche optimization via NonZeroU32 survives the epoch widen.
+        assert_eq!(size_of::<Option<SlotId>>(), 12);
     }
 
     #[test]
@@ -480,7 +534,17 @@ mod tests
     {
         let id = SlotId::new(1, NonZeroU32::new(5).unwrap());
         assert_eq!(id.cspace_id, 1);
+        assert_eq!(id.epoch, 0);
         assert_eq!(id.index.get(), 5);
+    }
+
+    #[test]
+    fn slot_id_with_epoch()
+    {
+        let id = SlotId::with_epoch(7, 42, NonZeroU32::new(3).unwrap());
+        assert_eq!(id.cspace_id, 7);
+        assert_eq!(id.epoch, 42);
+        assert_eq!(id.index.get(), 3);
     }
 
     #[test]

--- a/core/kernel/src/main.rs
+++ b/core/kernel/src/main.rs
@@ -1013,6 +1013,14 @@ unsafe fn kernel_entry_post_rebase(
                 .unwrap_or_else(|| fatal("Phase 9: ROOT_CSPACE wrapper not wired"));
             // SAFETY: cs_kobj_ptr is in-place inside the SEED slab; header at offset 0.
             let cs_nn = unsafe { NonNull::new_unchecked(cs_kobj_ptr.cast::<KernelObjectHeader>()) };
+            // The root CSpace wrapper now has two logical holders: init's TCB
+            // (`init_tcb.cspace`, set below) and the self-cap slot inserted
+            // here. `insert_cap` does not bump the refcount of the inserted
+            // object — it's the caller's responsibility — so we inc here.
+            // `HDR_FLAG_IS_ROOT` (stamped in `boot_retype_cspace`) is the
+            // belt-and-suspenders defense if this accounting ever drifts.
+            // SAFETY: header at offset 0 of cs_kobj_ptr; single-threaded boot.
+            unsafe { cs_nn.as_ref().inc_ref() };
             cs.insert_cap(
                 CapTag::CSpace,
                 Rights::INSERT | Rights::DELETE | Rights::DERIVE,

--- a/core/kernel/src/syscall/cap.rs
+++ b/core/kernel/src/syscall/cap.rs
@@ -489,7 +489,7 @@ pub fn sys_cap_create_aspace(tf: &mut TrapFrame) -> Result<u64, SyscallError>
 ///        empty pool that requires immediate augment-mode refill before any
 ///        cap can be inserted). Augment-mode accepts `init_pages >= 1`.
 /// arg3 = `max_slots` (create-mode only): hard cap on usable slots
-///        (clamped to `[1, 16384]`). Ignored in augment mode.
+///        (clamped to `[1, 14336]`). Ignored in augment mode.
 ///
 /// Create-mode slab layout:
 /// - page 0 — wrapper page: [`CSpaceKernelObject`] at offset 0, immediately
@@ -497,7 +497,7 @@ pub fn sys_cap_create_aspace(tf: &mut TrapFrame) -> Result<u64, SyscallError>
 ///   pointer indexes into this same page.
 /// - pages `1..init_pages` — slot-page pool, drawn on demand by
 ///   [`CSpace::grow`](crate::cap::cspace::CSpace::grow) when the directory
-///   needs another 64-slot leaf.
+///   needs another 56-slot leaf.
 ///
 /// Create-mode returns the new `CSpace` slot index. Augment-mode returns 0.
 #[cfg(not(test))]
@@ -516,7 +516,7 @@ pub fn sys_cap_create_cspace(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     use core::ptr::NonNull;
     use core::sync::atomic::AtomicU64;
 
-    const MAX_SLOTS: usize = 16384;
+    const MAX_SLOTS: usize = 14336;
 
     let frame_idx = tf.arg(0) as u32;
     let augment_idx = tf.arg(1) as u32;

--- a/core/kernel/src/syscall/cap.rs
+++ b/core/kernel/src/syscall/cap.rs
@@ -621,7 +621,15 @@ pub fn sys_cap_create_cspace(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     // SAFETY: wrapper_virt is page-aligned; cs_offset stays inside page 0.
     let cs_ptr = unsafe { wrapper_virt.add(cs_offset) }.cast::<CSpace>();
 
-    let id = alloc_cspace_id();
+    let Some(id) = alloc_cspace_id()
+    else
+    {
+        // Free list empty and high-water at MAX_CSPACES — namespace
+        // exhausted. Surface to userspace; the retype carve is undone below
+        // by `retype_free` after the error return.
+        retype_free(frame, offset, entry.raw_bytes);
+        return Err(SyscallError::OutOfMemory);
+    };
 
     // Construct CSpace in place.
     // SAFETY: cs_ptr lives inside the wrapper page, exclusively owned.
@@ -650,6 +658,9 @@ pub fn sys_cap_create_cspace(tf: &mut TrapFrame) -> Result<u64, SyscallError>
 
     // Register in the global registry so derivation lookups resolve.
     // Overflow → `SyscallError::OutOfMemory` with full rollback below.
+    // The returned epoch is the current registry value — `SlotId`s minted
+    // for this CSpace's slots during its lifetime stamp with it via
+    // `SlotId::current`.
     if crate::cap::register_cspace(id, cs_ptr).is_err()
     {
         // SAFETY: wrapper/cs not observed externally yet (registry
@@ -1080,8 +1091,8 @@ pub fn sys_cap_copy(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     let new_idx = new_idx_nz.get();
 
     // Wire derivation tree: new slot is a child of the source slot.
-    let parent = crate::cap::slot::SlotId::new(caller_cspace_id, src_idx_nz);
-    let child = crate::cap::slot::SlotId::new(dest_cs_id, new_idx_nz);
+    let parent = crate::cap::slot::SlotId::current(caller_cspace_id, src_idx_nz);
+    let child = crate::cap::slot::SlotId::current(dest_cs_id, new_idx_nz);
     crate::cap::DERIVATION_LOCK.write_lock();
     // SAFETY: DERIVATION_LOCK held; parent/child are valid SlotIds just created.
     unsafe {
@@ -1182,8 +1193,8 @@ pub fn sys_cap_derive(tf: &mut TrapFrame) -> Result<u64, SyscallError>
 
     // Wire derivation link.
     let src_idx_nz = core::num::NonZeroU32::new(src_idx).ok_or(SyscallError::InvalidCapability)?;
-    let parent = crate::cap::slot::SlotId::new(cspace_id, src_idx_nz);
-    let child = crate::cap::slot::SlotId::new(cspace_id, new_idx_nz);
+    let parent = crate::cap::slot::SlotId::current(cspace_id, src_idx_nz);
+    let child = crate::cap::slot::SlotId::current(cspace_id, new_idx_nz);
     crate::cap::DERIVATION_LOCK.write_lock();
     // SAFETY: DERIVATION_LOCK held; parent/child are valid SlotIds.
     unsafe {
@@ -1296,8 +1307,8 @@ pub fn sys_cap_derive_token(tf: &mut TrapFrame) -> Result<u64, SyscallError>
 
     // Wire derivation link.
     let src_idx_nz = core::num::NonZeroU32::new(src_idx).ok_or(SyscallError::InvalidCapability)?;
-    let parent = crate::cap::slot::SlotId::new(cspace_id, src_idx_nz);
-    let child = crate::cap::slot::SlotId::new(cspace_id, new_idx_nz);
+    let parent = crate::cap::slot::SlotId::current(cspace_id, src_idx_nz);
+    let child = crate::cap::slot::SlotId::current(cspace_id, new_idx_nz);
     crate::cap::DERIVATION_LOCK.write_lock();
     // SAFETY: DERIVATION_LOCK held; parent/child are valid SlotIds.
     unsafe {
@@ -1339,7 +1350,7 @@ pub fn sys_cap_delete(tf: &mut TrapFrame) -> Result<u64, SyscallError>
 
     let slot_idx_nz =
         core::num::NonZeroU32::new(slot_idx).ok_or(SyscallError::InvalidCapability)?;
-    let node = crate::cap::slot::SlotId::new(cspace_id, slot_idx_nz);
+    let node = crate::cap::slot::SlotId::current(cspace_id, slot_idx_nz);
 
     // Resolve the slot, unlink, and clear under DERIVATION_LOCK so a concurrent
     // revoke_subtree on a parent cap cannot race-clear this slot between the
@@ -1448,7 +1459,7 @@ pub fn sys_cap_revoke(tf: &mut TrapFrame) -> Result<u64, SyscallError>
 
     let slot_idx_nz =
         core::num::NonZeroU32::new(slot_idx).ok_or(SyscallError::InvalidCapability)?;
-    let root = crate::cap::slot::SlotId::new(cspace_id, slot_idx_nz);
+    let root = crate::cap::slot::SlotId::current(cspace_id, slot_idx_nz);
 
     // Revoke the subtree under the lock; snapshot the dealloc list to a
     // stack-local array so we can release the lock before calling
@@ -1694,8 +1705,8 @@ pub fn sys_cap_move(tf: &mut TrapFrame) -> Result<u64, SyscallError>
         return Err(SyscallError::InvalidArgument);
     }
 
-    let src_slot_id = SlotId::new(src_cspace_id, src_idx_nz);
-    let dst_slot_id = SlotId::new(dest_cspace_id, dest_idx_nz);
+    let src_slot_id = SlotId::current(src_cspace_id, src_idx_nz);
+    let dst_slot_id = SlotId::current(dest_cspace_id, dest_idx_nz);
 
     // Copy derivation links to destination.
     let (src_parent, src_first_child, src_prev, src_next) = {
@@ -1723,7 +1734,7 @@ pub fn sys_cap_move(tf: &mut TrapFrame) -> Result<u64, SyscallError>
 
     // Update parent's child pointer.
     if let Some(parent_id) = src_parent
-        && let Some(parent_cs) = crate::cap::lookup_cspace(parent_id.cspace_id)
+        && let Some(parent_cs) = crate::cap::lookup_cspace(parent_id.cspace_id, parent_id.epoch)
     {
         // SAFETY: parent_cs from registry; DERIVATION_LOCK held.
         if let Some(parent_slot) = unsafe { (*parent_cs).slot_mut(parent_id.index.get()) }
@@ -1735,7 +1746,7 @@ pub fn sys_cap_move(tf: &mut TrapFrame) -> Result<u64, SyscallError>
 
     // Update siblings' pointers.
     if let Some(prev_id) = src_prev
-        && let Some(prev_cs) = crate::cap::lookup_cspace(prev_id.cspace_id)
+        && let Some(prev_cs) = crate::cap::lookup_cspace(prev_id.cspace_id, prev_id.epoch)
     {
         // SAFETY: prev_cs from registry; DERIVATION_LOCK held.
         if let Some(prev_slot) = unsafe { (*prev_cs).slot_mut(prev_id.index.get()) }
@@ -1745,7 +1756,7 @@ pub fn sys_cap_move(tf: &mut TrapFrame) -> Result<u64, SyscallError>
         }
     }
     if let Some(next_id) = src_next
-        && let Some(next_cs) = crate::cap::lookup_cspace(next_id.cspace_id)
+        && let Some(next_cs) = crate::cap::lookup_cspace(next_id.cspace_id, next_id.epoch)
     {
         // SAFETY: next_cs from registry; DERIVATION_LOCK held.
         if let Some(next_slot) = unsafe { (*next_cs).slot_mut(next_id.index.get()) }
@@ -1759,7 +1770,8 @@ pub fn sys_cap_move(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     let mut child_cur = src_first_child;
     while let Some(child_id) = child_cur
     {
-        child_cur = if let Some(child_cs) = crate::cap::lookup_cspace(child_id.cspace_id)
+        child_cur = if let Some(child_cs) =
+            crate::cap::lookup_cspace(child_id.cspace_id, child_id.epoch)
         {
             // SAFETY: child_cs from registry; DERIVATION_LOCK held.
             if let Some(child_slot) = unsafe { (*child_cs).slot_mut(child_id.index.get()) }
@@ -1933,8 +1945,8 @@ pub fn sys_cap_insert(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     })?;
 
     // Wire derivation link.
-    let parent = crate::cap::slot::SlotId::new(src_cspace_id, src_idx_nz);
-    let child = crate::cap::slot::SlotId::new(dest_cspace_id, dest_slot_idx_nz);
+    let parent = crate::cap::slot::SlotId::current(src_cspace_id, src_idx_nz);
+    let child = crate::cap::slot::SlotId::current(dest_cspace_id, dest_slot_idx_nz);
     crate::cap::DERIVATION_LOCK.write_lock();
     // SAFETY: DERIVATION_LOCK held; parent/child are valid SlotIds.
     unsafe {

--- a/core/kernel/src/syscall/hw.rs
+++ b/core/kernel/src/syscall/hw.rs
@@ -618,9 +618,9 @@ pub fn sys_mmio_split(tf: &mut TrapFrame) -> Result<u64, SyscallError>
 
     DERIVATION_LOCK.write_lock();
 
-    let orig_node = SlotId::new(cspace_id, mmio_idx_nz);
-    let child1_id = SlotId::new(cspace_id, slot1_nz);
-    let child2_id = SlotId::new(cspace_id, slot2_nz);
+    let orig_node = SlotId::current(cspace_id, mmio_idx_nz);
+    let child1_id = SlotId::current(cspace_id, slot1_nz);
+    let child2_id = SlotId::current(cspace_id, slot2_nz);
 
     // Read the original's parent before we modify anything.
     // SAFETY: caller_cspace validated; mmio_idx within CSpace bounds.
@@ -822,9 +822,9 @@ pub fn sys_irq_split(tf: &mut TrapFrame) -> Result<u64, SyscallError>
 
     DERIVATION_LOCK.write_lock();
 
-    let orig_node = SlotId::new(cspace_id, irq_idx_nz);
-    let child1_id = SlotId::new(cspace_id, slot1_nz);
-    let child2_id = SlotId::new(cspace_id, slot2_nz);
+    let orig_node = SlotId::current(cspace_id, irq_idx_nz);
+    let child1_id = SlotId::current(cspace_id, slot1_nz);
+    let child2_id = SlotId::current(cspace_id, slot2_nz);
 
     // SAFETY: caller_cspace validated; irq_idx within CSpace bounds.
     let orig_parent = unsafe { (*caller_cspace).slot(irq_idx).and_then(|s| s.deriv_parent) };
@@ -1062,9 +1062,9 @@ pub fn sys_ioport_split(tf: &mut TrapFrame) -> Result<u64, SyscallError>
 
         DERIVATION_LOCK.write_lock();
 
-        let orig_node = SlotId::new(cspace_id, port_idx_nz);
-        let child1_id = SlotId::new(cspace_id, slot1_nz);
-        let child2_id = SlotId::new(cspace_id, slot2_nz);
+        let orig_node = SlotId::current(cspace_id, port_idx_nz);
+        let child1_id = SlotId::current(cspace_id, slot1_nz);
+        let child2_id = SlotId::current(cspace_id, slot2_nz);
 
         // SAFETY: caller_cspace validated; port_idx within CSpace bounds.
         let orig_parent = unsafe { (*caller_cspace).slot(port_idx).and_then(|s| s.deriv_parent) };

--- a/core/kernel/src/syscall/mem.rs
+++ b/core/kernel/src/syscall/mem.rs
@@ -549,7 +549,7 @@ pub fn sys_frame_split(tf: &mut TrapFrame) -> Result<u64, SyscallError>
 
     let frame_idx_nz =
         core::num::NonZeroU32::new(frame_idx).ok_or(SyscallError::InvalidCapability)?;
-    let parent_id = SlotId::new(cspace_id, frame_idx_nz);
+    let parent_id = SlotId::current(cspace_id, frame_idx_nz);
 
     // ── Acquire locks (DERIVATION outer, frame-write inner) ──────────────────
     DERIVATION_LOCK.write_lock();
@@ -649,7 +649,7 @@ pub fn sys_frame_split(tf: &mut TrapFrame) -> Result<u64, SyscallError>
         return Err(SyscallError::OutOfMemory);
     };
     let tail_slot = tail_slot_nz.get();
-    let tail_id = SlotId::new(cspace_id, tail_slot_nz);
+    let tail_id = SlotId::current(cspace_id, tail_slot_nz);
 
     // ── Wire derivation: tail becomes a sibling of parent under parent's parent ──
 
@@ -862,7 +862,7 @@ pub fn sys_frame_merge(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     };
     // SAFETY: caller_cspace validated non-null.
     let cspace_id = unsafe { (*caller_cspace).id() };
-    let tail_id = SlotId::new(cspace_id, tail_idx_nz);
+    let tail_id = SlotId::current(cspace_id, tail_idx_nz);
     let _ = parent_idx_nz; // parent slot not unlinked (it stays alive)
 
     // SAFETY: DERIVATION_LOCK held; indices within CSpace bounds.

--- a/core/ktest/src/stress/cspace_recycle.rs
+++ b/core/ktest/src/stress/cspace_recycle.rs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+//! Stress test: repeated `CSpace` create + delete past the old cumulative bound.
+//!
+//! Before #137, `CSpaceId` allocation was monotonic (`fetch_add`) and the
+//! namespace was bounded by *cumulative* creates, not live count. The
+//! pre-#137 ceiling was `MAX_CSPACES = 65536`; the ramped ktest sequence
+//! peaked at ~14k cumulative `CSpace`s, with 4× headroom.
+//!
+//! Recycling makes the namespace bounded by *live* count. To prove it, we
+//! create and immediately destroy 10000 `CSpace`s in a tight loop. With
+//! `MAX_CSPACES = 4096` (post-#137), this iteration count is 2.4× the
+//! ceiling; if recycling were broken, `cap_create_cspace` would surface
+//! `SyscallError::OutOfMemory` at iteration ~4096 and the loop would fail
+//! its first negative return.
+
+use syscall::{cap_create_cspace, cap_delete};
+
+use crate::{TestContext, TestResult};
+
+/// Number of create/delete cycles. Chosen well above `MAX_CSPACES = 4096`
+/// so a recycling regression aborts the loop before the test completes.
+const ITERATIONS: usize = 10_000;
+
+pub fn run(ctx: &TestContext) -> TestResult
+{
+    for _ in 0..ITERATIONS
+    {
+        // Smallest viable CSpace: 4 init_pages (wrapper page + 3 pool pages,
+        // matching `unit/cap.rs::insert_out_of_bounds_err`'s sizing) and
+        // 64 max_slots (well below L1_SIZE * L2_SIZE = 14336).
+        let cs = cap_create_cspace(ctx.memory_frame_base, 0, 4, 64)
+            .map_err(|_| "cspace_recycle: cap_create_cspace failed (namespace exhausted?)")?;
+        cap_delete(cs).map_err(|_| "cspace_recycle: cap_delete failed")?;
+    }
+    Ok(())
+}

--- a/core/ktest/src/stress/mod.rs
+++ b/core/ktest/src/stress/mod.rs
@@ -24,6 +24,7 @@ mod concurrent_event_producers;
 mod concurrent_ipc;
 mod concurrent_map_unmap;
 mod concurrent_signal;
+mod cspace_recycle;
 mod event_queue_fill_drain;
 mod fpu_migration_churn;
 mod idle_wake_race;
@@ -53,6 +54,7 @@ static mut STRESS_STACKS: [ChildStack; MAX_STRESS_THREADS] = [ChildStack::ZERO; 
 pub fn run_all(ctx: &TestContext)
 {
     run_integration_test!("stress::cap_tree_deep", cap_tree_deep::run(ctx));
+    run_integration_test!("stress::cspace_recycle", cspace_recycle::run(ctx));
     run_integration_test!(
         "stress::event_queue_fill_drain",
         event_queue_fill_drain::run(ctx)

--- a/core/ktest/src/unit/cap.rs
+++ b/core/ktest/src/unit/cap.rs
@@ -343,7 +343,7 @@ pub fn insert_out_of_bounds_err(ctx: &TestContext) -> TestResult
 {
     let sig = cap_create_signal(ctx.memory_frame_base)
         .map_err(|_| "create_signal for insert_oob test failed")?;
-    // CSpace capacity is clamped to [256, 16384]; create the smallest possible.
+    // CSpace capacity is clamped to [256, 14336]; create the smallest possible.
     let dest_cs = cap_create_cspace(ctx.memory_frame_base, 0, 4, 16)
         .map_err(|_| "create_cspace for insert_oob test failed")?;
 

--- a/core/ktest/src/unit/hw.rs
+++ b/core/ktest/src/unit/hw.rs
@@ -25,11 +25,11 @@ use crate::{TestContext, TestResult};
 const MMIO_TEST_VA: u64 = 0x5000_0000;
 
 /// Kernel pin: every `CSpace` is clamped to at most `L1_SIZE * L2_SIZE`
-/// (256 * 64 = 16384) slots. Used as a fallback if `cap_info` ever
+/// (256 * 56 = 14336) slots. Used as a fallback if `cap_info` ever
 /// returns a value larger than `u32::MAX`, which the kernel's own
 /// invariants forbid today.
 #[cfg(target_arch = "x86_64")]
-const ROOT_CSPACE_MAX_SLOTS: u32 = 16384;
+const ROOT_CSPACE_MAX_SLOTS: u32 = 14336;
 
 // ── SYS_MMIO_MAP ──────────────────────────────────────────────────────────────
 

--- a/core/ktest/src/unit/retype.rs
+++ b/core/ktest/src/unit/retype.rs
@@ -200,7 +200,7 @@ pub fn cspace_grow_consumes_pool(ctx: &TestContext) -> TestResult
         .map_err(|_| "retype::cspace_grow: cap_create_endpoint failed")?;
 
     // Copy enough times to spill past the first slot page. ~70 copies
-    // forces at least one grow on a typical 64-slot page.
+    // forces at least one grow on an `L2_SIZE`-slot page (currently 56).
     let copies = 70usize;
     for _ in 0..copies
     {

--- a/services/init/src/main.rs
+++ b/services/init/src/main.rs
@@ -125,14 +125,16 @@ pub(crate) const THREAD_RETYPE_PAGES: u64 = 6;
 pub(crate) const ASPACE_RETYPE_PAGES: u64 = 33;
 
 /// Pages init carves for memmgr/procmgr's `CSpace`. Each slot page holds
-/// 64 capability slots (3584 B); the +1 covers per-FrameObject allocator
-/// metadata. Mirrors procmgr's constant.
+/// `L2_SIZE` capability slots (currently 56 slots × 72 B = 4032 B/page);
+/// the +1 covers per-FrameObject allocator metadata. Mirrors procmgr's
+/// constant.
 ///
 /// Sized for the long-lived service's full lifetime: procmgr accumulates
 /// per-child caps (aspace, cspace, thread, frame slabs, derived rights
-/// caps) while children are alive. 33 pages → 32 slot pages → 2048 slots
-/// = ~32 children (aspace/cspace/thread/4 frame caps each) plus working
-/// caps. Larger workloads refill via augment-mode `cap_create_cspace`.
+/// caps) while children are alive. 33 pages → 32 slot pages → ~1792
+/// slots = ~28 children (aspace/cspace/thread/4 frame caps each) plus
+/// working caps. Larger workloads refill via augment-mode
+/// `cap_create_cspace`.
 pub(crate) const CSPACE_RETYPE_PAGES: u64 = 33;
 
 /// Base for init's scratch mappings (`ProcessInfo` frames, ELF pages).

--- a/services/procmgr/src/main.rs
+++ b/services/procmgr/src/main.rs
@@ -215,10 +215,11 @@ pub(crate) const THREAD_RETYPE_PAGES: u64 = 6;
 pub(crate) const ASPACE_RETYPE_PAGES: u64 = 33;
 
 /// Pages requested from memmgr for the child's `CSpace` retype slab.
-/// Each slot page holds 64 capability slots (3584 B); the +1 covers the
-/// per-Frame allocator metadata footprint. Larger `CSpace`s refill via
-/// augment-mode `cap_create_cspace`. Five pages → 4 slot pages → 256
-/// slots covers a small driver's lifetime.
+/// Each slot page holds `L2_SIZE` capability slots (currently 56 slots
+/// × 72 B = 4032 B/page); the +1 covers the per-Frame allocator
+/// metadata footprint. Larger `CSpace`s refill via augment-mode
+/// `cap_create_cspace`. Five pages → 4 slot pages → ~224 slots covers a
+/// small driver's lifetime.
 pub(crate) const CSPACE_RETYPE_PAGES: u64 = 5;
 
 /// Register a new child with memmgr. On success returns

--- a/shared/syscall/src/lib.rs
+++ b/shared/syscall/src/lib.rs
@@ -526,7 +526,7 @@ unsafe fn syscall6(nr: u64, a0: u64, a1: u64, a2: u64, a3: u64, a4: u64, a5: u64
 
 /// Pack up to `MSG_CAP_SLOTS_MAX` `CSpace` slot indices into a single `u64`.
 ///
-/// Each index occupies 16 bits (sufficient for max `CSpace` size of 16384 slots).
+/// Each index occupies 16 bits (sufficient for max `CSpace` size of 14336 slots).
 /// Indices beyond `MSG_CAP_SLOTS_MAX` are silently ignored.
 ///
 /// Pass the result as arg4 of `SYS_IPC_CALL` or arg3 of `SYS_IPC_REPLY`.
@@ -772,7 +772,7 @@ pub fn signal_wait_timeout(sig: u32, timeout_ms: u64) -> Result<u64, i64>
 /// `RIGHTS_RETYPE`, has insufficient `available_bytes`, or the caller's
 /// `CSpace` is full.
 // cast_possible_truncation, cast_sign_loss: ret is a non-negative CSpace slot index
-// guaranteed to fit in u32 (max CSpace size is 16384).
+// guaranteed to fit in u32 (max CSpace size is 14336).
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 #[inline]
 pub fn cap_create_endpoint(frame_cap: u32) -> Result<u32, i64>
@@ -794,7 +794,7 @@ pub fn cap_create_endpoint(frame_cap: u32) -> Result<u32, i64>
 /// `RIGHTS_RETYPE`, has insufficient `available_bytes`, or the caller's
 /// `CSpace` is full.
 // cast_possible_truncation, cast_sign_loss: ret is a non-negative CSpace slot index
-// guaranteed to fit in u32 (max CSpace size is 16384).
+// guaranteed to fit in u32 (max CSpace size is 14336).
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 #[inline]
 pub fn cap_create_signal(frame_cap: u32) -> Result<u32, i64>
@@ -848,7 +848,7 @@ pub fn cap_create_aspace(frame_cap: u32, augment_target: u32, init_pages: u64) -
 /// one). `init_pages` must be `>= 1`.
 ///
 /// `augment_target`:
-/// - `0` → create new with `max_slots` (clamped to `[1, 16384]`); returns
+/// - `0` → create new with `max_slots` (clamped to `[1, 14336]`); returns
 ///   the new cap slot index.
 /// - non-zero → augment that `CSpace`'s growth pool; returns `0`. The
 ///   `max_slots` argument is ignored in augment mode.
@@ -890,7 +890,7 @@ pub fn cap_create_cspace(
 /// cap lacks `RETYPE` or sufficient `available_bytes`, or the caller's
 /// `CSpace` is full.
 // cast_possible_truncation, cast_sign_loss: ret is a non-negative CSpace slot index
-// guaranteed to fit in u32 (max CSpace size is 16384).
+// guaranteed to fit in u32 (max CSpace size is 14336).
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 #[inline]
 pub fn cap_create_thread(frame_cap: u32, aspace_cap: u32, cspace_cap: u32) -> Result<u32, i64>
@@ -1246,7 +1246,7 @@ pub fn thread_start(thread_cap: u32) -> Result<(), i64>
 /// Returns a negative `i64` error code if either cap is invalid, the caller
 /// lacks sufficient rights, or the destination `CSpace` is full.
 // cast_possible_truncation, cast_sign_loss: ret is a non-negative CSpace slot index
-// guaranteed to fit in u32 (max CSpace size is 16384).
+// guaranteed to fit in u32 (max CSpace size is 14336).
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 #[inline]
 pub fn cap_copy(src_slot: u32, dest_cspace_cap: u32, rights_mask: u64) -> Result<u32, i64>
@@ -1275,7 +1275,7 @@ pub fn cap_copy(src_slot: u32, dest_cspace_cap: u32, rights_mask: u64) -> Result
 /// Returns a negative `i64` error code if the source cap is invalid or the
 /// `CSpace` is full.
 // cast_possible_truncation, cast_sign_loss: ret is a non-negative CSpace slot index
-// guaranteed to fit in u32 (max CSpace size is 16384).
+// guaranteed to fit in u32 (max CSpace size is 14336).
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 pub fn cap_derive(src_slot: u32, rights_mask: u64) -> Result<u32, i64>
 {
@@ -1298,7 +1298,7 @@ pub fn cap_derive(src_slot: u32, rights_mask: u64) -> Result<u32, i64>
 /// Returns a negative `i64` error code if the source cap is invalid, the token
 /// is zero, the source already has a token, or the `CSpace` is full.
 // cast_possible_truncation, cast_sign_loss: ret is a non-negative CSpace slot index
-// guaranteed to fit in u32 (max CSpace size is 16384).
+// guaranteed to fit in u32 (max CSpace size is 14336).
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 pub fn cap_derive_token(src_slot: u32, rights_mask: u64, token: u64) -> Result<u32, i64>
 {
@@ -1355,7 +1355,7 @@ pub fn cap_revoke(slot: u32) -> Result<(), i64>
 /// Returns a negative `i64` error code if either cap is invalid, the
 /// destination `CSpace` is full, or `dest_index` is already occupied.
 // cast_possible_truncation, cast_sign_loss: ret is a non-negative CSpace slot index
-// guaranteed to fit in u32 (max CSpace size is 16384).
+// guaranteed to fit in u32 (max CSpace size is 14336).
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 pub fn cap_move(src_slot: u32, dest_cspace_cap: u32, dest_index: u32) -> Result<u32, i64>
 {
@@ -1502,7 +1502,7 @@ pub fn aspace_query(aspace_cap: u32, virt: u64) -> Result<u64, i64>
 /// `RIGHTS_RETYPE`, has insufficient `available_bytes`, `capacity` is out
 /// of range, or the `CSpace` is full.
 // cast_possible_truncation, cast_sign_loss: ret is a non-negative CSpace slot index
-// guaranteed to fit in u32 (max CSpace size is 16384).
+// guaranteed to fit in u32 (max CSpace size is 14336).
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 #[inline]
 pub fn event_queue_create(frame_cap: u32, capacity: u32) -> Result<u32, i64>
@@ -1597,7 +1597,7 @@ pub fn event_recv_timeout(queue_cap: u32, timeout_ms: u64) -> Result<u64, i64>
 /// Returns a negative `i64` error code if `frame_cap` is invalid, lacks
 /// `RIGHTS_RETYPE`, or the `CSpace` is full.
 // cast_possible_truncation, cast_sign_loss: ret is a non-negative CSpace slot index
-// guaranteed to fit in u32 (max CSpace size is 16384).
+// guaranteed to fit in u32 (max CSpace size is 14336).
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 #[inline]
 pub fn wait_set_create(frame_cap: u32) -> Result<u32, i64>


### PR DESCRIPTION
Closes #137.

## Approach

Three independent mechanisms, layered, to make the `CSpaceId` namespace bounded by live count rather than cumulative:

1. **Recycling allocator** — LIFO free list popped before bumping a high-water counter; id 0 (root) hard-rejected from returning to the pool.
2. **Epoch-stamped `SlotId`** — `(cspace_id, epoch, index)`. Every `free_cspace_id` bumps the registry epoch; `lookup_cspace(id, expected_epoch)` fails fast on mismatch. `u32` epoch with retire-on-wrap (≈13 years at a hostile 10k recycles/sec/id; retired ids leak rather than wrap).
3. **Pre-unregister derivation drain** — `dealloc_object(CSpaceObj)` scrubs foreign back-links before `unregister_cspace`. Per-slot interleaved local-read / foreign-write pattern structurally avoids PR #136's release-mode aliasing UB.

Plus a root-CSpace fix: missing `inc_ref` at Phase-9 self-cap insert added; `HDR_FLAG_IS_ROOT` clamps `dec_ref → 0` for the root header (defense-in-depth).

## Layout impact

- `SlotId`: 8 B → 12 B (added `epoch: u32`). `Option<SlotId>` is 12 B via the existing `NonZeroU32` niche.
- `CapabilitySlot`: 56 B → 72 B (4 × 4 B more for the four `deriv_*` fields).
- `L2_SIZE`: 64 → 56 (4096 / 72). Two-level capacity: 16384 → 14336 slots.
- `MAX_CSPACES`: 65536 → 4096. Live-count bound now; ~432 KiB BSS reclaimed (4096 × 16 B registry + 16 KiB free list vs prior 65536 × 8 B).

## Acceptance (per issue #137)

- [x] `SlotId` carries an epoch / generation counter — fail-fast on stale resolution.
- [x] `dealloc_object(CSpaceObj)` performs an explicit pre-`unregister_cspace` walk that clears every external `deriv_*` reference into the dying `CSpace`, with the PR #136 aliasing hazard avoided structurally.
- [x] Root `CSpace` lifetime fixed (Phase-9 `inc_ref`) AND id 0 special-cased in the allocator (defense-in-depth).
- [x] `MAX_CSPACES` shrunk to 4096 once the namespace is bounded by live count.
- [x] Full ktest stress run passes on both arches in both debug and release profiles (see Validation below).

## Validation

Per `docs/conventions.md`:

| Arch     | Profile | ktest result        |
|----------|---------|---------------------|
| x86_64   | debug   | 168/168 PASS        |
| x86_64   | release | 168/168 PASS        |
| riscv64  | debug   | 168/168 PASS        |
| riscv64  | release | 168/168 PASS        |

New: `stress::cspace_recycle` — 10000 iterations of `cap_create_cspace` + `cap_delete` (2.4× the new `MAX_CSPACES` ceiling; a recycling regression would surface `SyscallError::OutOfMemory` at iteration ~4096 and fail the loop).

## Commit series

1. `kernel/cap: pin root CSpace refcount; fix Phase-9 self-cap inc_ref` — independent of recycling; resolves the latent transient-refcount-0 bug from issue #137's prior-art constraint #2.
2. `kernel/cap: widen SlotId with epoch; CapabilitySlot now 72 B, L2_SIZE=56` — layout-only.
3. `kernel/cap: epoch-stamped registry; lookup_cspace takes expected_epoch` — registry redesign + free-list infra; `free_cspace_id` and `push_free` carry `#[allow(dead_code)]` because they're wired in by commit 4.
4. `kernel/cap: pre-unregister derivation drain; wire free_cspace_id` — recycling becomes live.
5. `kernel/cap: shrink MAX_CSPACES 65536 -> 4096`.
6. `ktest/stress: add cspace_recycle stress test`.

## Notes

- ABI unchanged. Epoch is kernel-internal; userspace cap handles remain `(cspace_idx, slot_idx)`. Internal `SlotId`s are stamped via `SlotId::current(...)` which snapshots `crate::cap::registry_epoch`.
- The two further ktests sketched in the implementation plan (root_cspace_pinned, stale_slotid) are not added — see the commit message on `8fc41ea` for the rationale (userspace cannot reach the relevant code paths without a kernel hook).
