### PR TITLE
init → svcmgr: migrate non-bootstrap spawns + REGISTER_SERVICE off init (#78)

### DIFF
--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -78,13 +78,16 @@ transferring the RAM frame pool to memmgr and minting procmgr's
 `memmgr_endpoint_cap` so procmgr's std heap bootstrap finds memmgr on its
 first call. Init then requests procmgr to start the remaining early services
 (devmgr, svcmgr, drivers, vfsd, optionally netd), delegates the appropriate
-subsets of its initial capability set to each service, registers services
-with svcmgr, and exits.
+subsets of its initial capability set to each service, endows svcmgr with the
+handover endowment, and exits.
 
-At the end of init's Phase 2, init spawns real `logd` and hands it
-the receive side of the master log endpoint. The kernel endpoint
-object is unchanged across the transition, so existing tokened SEND
-caps continue to work without re-derivation. See
+Init runs a second thread, init-logd, that drains the master log endpoint and
+writes lines to serial directly from early boot onward. svcmgr launches and
+supervises the real `logd` post-handover, minting its bootstrap caps from the
+reserved log-sink sources init endows; the real `logd` then takes the receive
+side of the master log endpoint and pulls init-logd's captured history. The
+kernel endpoint object is unchanged across the transition, so existing tokened
+SEND caps continue to work without re-derivation. See
 [`services/logd/docs/handover-protocol.md`](../services/logd/docs/handover-protocol.md).
 
 The system-scope userspace boot order lives in

--- a/docs/console-model.md
+++ b/docs/console-model.md
@@ -29,23 +29,38 @@ earlier ones, which remain as fallbacks.
    as the panic console. The kernel never becomes a client of the userspace
    serial or framebuffer driver.
 
-3. **init-logd direct-UART fallback** — during early userspace boot, before a
-   log daemon exists, init drains the master log endpoint and writes lines to
-   the UART directly (`services/init/src/logging.rs`). This path is
-   **permanent**, not transitional: it is the only writer before the serial
-   driver is up, and the fallback if the driver fails to come up. There is
-   no parallel init-logd direct-framebuffer path today; pre-driver
-   framebuffer writes are deferred to a future surface (see "Planned future
-   surface" in the framebuffer driver README).
+3. **init-logd direct-UART fallback** — during early userspace boot, the
+   init-logd thread (a second thread of the init process,
+   `services/init/src/logging.rs`) drains the master log endpoint and writes
+   lines to the UART directly. It owns console output from the moment init
+   spawns it through the entire init → svcmgr handover and svcmgr's reconcile,
+   until the svcmgr-launched real-logd assumes the endpoint's RECV and pulls
+   init-logd's captured history via `log_labels::HANDOVER_PULL` — at which
+   point init-logd self-terminates. This direct path is **permanent**, not
+   transitional: it is the only writer before the serial driver is up, and the
+   fallback if the driver fails to come up. There is no parallel init-logd
+   direct-framebuffer path today; pre-driver framebuffer writes are deferred
+   to a future surface (see "Planned future surface" in the framebuffer driver
+   README).
 
 4. **Serial-driver-mediated path** — once devmgr has spawned the serial driver
    (`services/drivers/serial/`), every userspace UART writer routes bytes to it
    via `serial_labels::SERIAL_WRITE_BYTES`. real-logd
-   (`services/logd/src/main.rs`) is the primary client: it resolves the
-   driver's write endpoint through devmgr's
-   `devmgr_labels::QUERY_SERIAL_DEVICE` and emits both received log lines and
-   its own diagnostics through it. No userspace process other than the serial
-   driver and init-logd holds UART hardware authority.
+   (`services/logd/src/main.rs`) is the primary client: svcmgr launches and
+   supervises it, it resolves the driver's write endpoint through devmgr's
+   `devmgr_labels::QUERY_SERIAL_DEVICE`, and it emits both received log lines
+   and its own diagnostics through it. No userspace process other than the
+   serial driver and init-logd holds UART hardware authority.
+
+   real-logd is restartable (`restart = on_failure`). svcmgr holds the
+   master-log endpoint source for the system's life, so a restarted logd
+   re-attaches a fresh RECV to the same endpoint object every sender already
+   targets; the log senders are uninterrupted across the restart and need no
+   re-derivation of their `log_send_cap`. A restarted logd re-resolves the
+   serial driver via `QUERY_SERIAL_DEVICE` and resumes serial-mediated output.
+   While logd is down, a sender's `STREAM_BYTES` queues at the kernel endpoint
+   until the restarted logd drains it; the kernel panic console remains the
+   guaranteed output path for any fault in that window.
 
 5. **Framebuffer-driver-mediated path** — once devmgr has spawned the
    framebuffer driver (`services/drivers/framebuffer/`), userspace

--- a/docs/device-management.md
+++ b/docs/device-management.md
@@ -149,12 +149,13 @@ devmgr loads driver binaries from one of two places:
   `procmgr_labels::CREATE_PROCESS` during initial enumeration.
 - **On-disk rootfs** — non-essentials (today: the per-arch RTC) live
   at `/services/drivers/<chip>` and are loaded via
-  `procmgr_labels::CREATE_FROM_FILE`. After vfsd-mount, init walks
-  `system_root_cap` to `/services/drivers/` and hands devmgr that
+  `procmgr_labels::CREATE_FROM_FILE`. Post-handover, svcmgr walks its
+  universal root to `/services/drivers/` and hands devmgr that
   subtree cap via `devmgr_labels::SET_DRIVERS_DIR` (gated by
-  `INIT_BIND_AUTHORITY`; sent at `LOOKUP | READ` rights only — devmgr
+  `DRIVERS_DIR_AUTHORITY`, minted from the devmgr-registry source init
+  endows svcmgr with; sent at `LOOKUP | READ` rights only — devmgr
   cannot reach outside the drivers subtree). Devmgr replies SUCCESS
-  before doing any spawn work so init never blocks on driver
+  before doing any spawn work so svcmgr never blocks on driver
   bring-up; the actual walk + `CREATE_FROM_FILE` + bootstrap rounds
   run after `ipc_reply` and before devmgr returns to its next
   `ipc_recv`. The spawn is at-most-once per boot; on failure

--- a/docs/process-lifecycle.md
+++ b/docs/process-lifecycle.md
@@ -112,10 +112,11 @@ mechanism — but procmgr is the chooser from that point forward (see
 ### Init → remaining services
 
 Init requests procmgr to start only the bootstrap-essential services
-— devmgr, vfsd, optionally netd, real-logd, then svcmgr — by IPC to
+— devmgr, vfsd, optionally netd, then svcmgr — by IPC to
 procmgr's `CREATE_FROM_FILE` / `CREATE_PROCESS` endpoints. The
-non-bootstrap services (`timed`, `pwrmgr`, the staged test harnesses)
-are not in this list: svcmgr launches them itself post-handover from
+non-bootstrap services (`logd`, `timed`, `pwrmgr`, the staged test
+harnesses) are not in this list: svcmgr launches them itself
+post-handover from
 their `/config/svcmgr/services/*.svc` recipes. Nor is the per-arch RTC
 chip driver: devmgr spawns it during its enumeration sweep, and timed
 resolves it via `devmgr_labels::QUERY_RTC_DEVICE` at startup. For each
@@ -146,9 +147,9 @@ all svcmgr-supervised services live on disk at
 After Phase 3 signals `svcmgr_labels::HANDOVER_COMPLETE` (svcmgr
 replies immediately, then scans `/config/svcmgr/services/`, binds the
 endowed substrate bind-only, and launches every defined-but-unparked
-service — the `timed` and `pwrmgr` providers on a normal boot, plus any
-staged test recipes such as `svctest.svc` / `usertest.svc` and the
-co-staged `crasher.svc` restart fixture), init signs over its own
+service — `logd`, the `timed` and `pwrmgr` providers on a normal boot,
+plus any staged test recipes such as `svctest.svc` / `usertest.svc` and
+the co-staged `crasher.svc` restart fixture), init signs over its own
 kernel-object caps
 (`AddressSpace`, `CSpace`, main `Thread`, init-logd `Thread`) and
 every reclaimable Frame cap it solely owns (ELF segments, user stack
@@ -163,10 +164,15 @@ it lives in a single contiguous arena Frame cap that init forwards to
 memmgr as an in-use run at bootstrap (`finalize_memmgr`), so those pages
 are already accounted in memmgr's pool and never reach the reap route.
 
-Procmgr binds a death-EQ observer on init's main thread; on the death
-event procmgr tears down init's kernel objects in order (Threads →
-AddressSpace → donate Frame caps to memmgr → CSpace cascade), leaving
-zero init residue. The implementation is in
+Procmgr binds a death-EQ observer on **both** init threads (main +
+init-logd) and reaps only once both have exited — init is threadless. The
+main thread exits at the end of Phase 3, but init-logd keeps serving the
+master log endpoint until the svcmgr-launched real-logd pulls its
+handover, so it outlives main; reclaiming init's address space while a
+thread still runs in it would fault that thread. On the last death procmgr
+tears down init's kernel objects in order (Threads → AddressSpace → donate
+Frame caps to memmgr → CSpace cascade), leaving zero init residue. The
+implementation is in
 [`services/procmgr/README.md`](../services/procmgr/README.md) §"Init
 reap".
 

--- a/docs/process-lifecycle.md
+++ b/docs/process-lifecycle.md
@@ -110,28 +110,31 @@ mechanism — but procmgr is the chooser from that point forward (see
 
 ### Init → remaining services
 
-Init requests procmgr to start the remaining boot-time services in
-order — devmgr, vfsd, optionally netd, then svcmgr, timed, and
-pwrmgr — by IPC to procmgr's `CREATE_FROM_FILE` / `CREATE_PROCESS`
-endpoints. The per-arch RTC chip driver is not in this list: devmgr
-spawns it during its enumeration sweep, and timed resolves it via
-`devmgr_labels::QUERY_RTC_DEVICE` at startup. For each service,
-init delegates the appropriate capability subset (see
+Init requests procmgr to start only the bootstrap-essential services
+— devmgr, vfsd, optionally netd, real-logd, then svcmgr — by IPC to
+procmgr's `CREATE_FROM_FILE` / `CREATE_PROCESS` endpoints. The
+non-bootstrap services (`timed`, `pwrmgr`, the staged test harnesses)
+are not in this list: svcmgr launches them itself post-handover from
+their `/config/svcmgr/services/*.svc` recipes. Nor is the per-arch RTC
+chip driver: devmgr spawns it during its enumeration sweep, and timed
+resolves it via `devmgr_labels::QUERY_RTC_DEVICE` at startup. For each
+service init starts, it delegates the appropriate capability subset (see
 [`capability-model.md`](capability-model.md) §"Initial Capability
 Distribution"). svcmgr is configured with the universal
 `system_root_cap` so it can read `/config/svcmgr/services/*.svc`
 post-handover.
 
-Init then publishes well-known caps into svcmgr's discovery
-registry (`ipc::published_names::ROOTFS_ROOT`,
-`PWRMGR_SHUTDOWN`, `PWRMGR_DENY`, `SVCMGR`) via
-`svcmgr_labels::PUBLISH_ENDPOINT` with a `PUBLISH_AUTHORITY`-tokened
-`RIGHTS_SEND_GRANT` cap, and registers every foundational service
-it bootstrapped with svcmgr via the v3 `REGISTER_SERVICE` wire
-(name + thread cap): `memmgr`, `procmgr`, `devmgr`, `vfsd`, `logd`,
-`timed`, `pwrmgr`. Recipes for all svcmgr-supervised services live
-on disk at `/config/svcmgr/services/<name>.svc`, not on the wire —
-see
+Init then publishes the well-known caps it still owns the sources for
+into svcmgr's discovery registry (`ipc::published_names::ROOTFS_ROOT`,
+`SVCMGR`, `DEVMGR_REGISTRY`) via `svcmgr_labels::PUBLISH_ENDPOINT` with
+a `PUBLISH_AUTHORITY`-tokened `RIGHTS_SEND_GRANT` cap, and registers
+every foundational substrate service it bootstrapped with svcmgr via the
+v3 `REGISTER_SERVICE` wire (name + thread cap): `memmgr`, `procmgr`,
+`devmgr`, `vfsd`, `logd`. The names of svcmgr-launched providers
+(`timed`, `pwrmgr.shutdown`, `pwrmgr.deny`) are published by svcmgr's
+own provider path, not by init. Recipes for all svcmgr-supervised
+services live on disk at `/config/svcmgr/services/<name>.svc`, not on
+the wire — see
 [`services/svcmgr/docs/service-definitions.md`](../services/svcmgr/docs/service-definitions.md).
 
 ### Init reap

--- a/docs/process-lifecycle.md
+++ b/docs/process-lifecycle.md
@@ -42,7 +42,8 @@ init                  no_std; receives the full initial CSpace
    │
    ├── delegates per-service capability subsets via IPC
    │
-   ├── registers all started services with svcmgr
+   ├── endows svcmgr (its endpoints + publish-source caps + substrate
+   │     thread caps) over the bootstrap-round handover endowment
    │
    └── exits
        │
@@ -124,27 +125,30 @@ Distribution"). svcmgr is configured with the universal
 `system_root_cap` so it can read `/config/svcmgr/services/*.svc`
 post-handover.
 
-Init then publishes the well-known caps it still owns the sources for
-into svcmgr's discovery registry (`ipc::published_names::ROOTFS_ROOT`,
-`SVCMGR`, `DEVMGR_REGISTRY`) via `svcmgr_labels::PUBLISH_ENDPOINT` with
-a `PUBLISH_AUTHORITY`-tokened `RIGHTS_SEND_GRANT` cap, and registers
-every foundational substrate service it bootstrapped with svcmgr via the
-v3 `REGISTER_SERVICE` wire (name + thread cap): `memmgr`, `procmgr`,
-`devmgr`, `vfsd`, `logd`. The names of svcmgr-launched providers
-(`timed`, `pwrmgr.shutdown`, `pwrmgr.deny`) are published by svcmgr's
-own provider path, not by init. Recipes for all svcmgr-supervised
-services live on disk at `/config/svcmgr/services/<name>.svc`, not on
-the wire — see
+Init then serves svcmgr the **handover endowment** over the
+bootstrap-round protocol: round 1 carries svcmgr's own endpoints plus the
+publish-role source caps (a `SEND` on the root filesystem namespace
+endpoint and a token-0 `SEND|GRANT` source on devmgr's registry
+endpoint); each subsequent round carries one `(name, thread_cap)` pair for
+a substrate service init bootstrapped (`memmgr`, `procmgr`, `devmgr`,
+`vfsd`, `logd`). svcmgr — not init — then publishes the well-known names
+it owns into its own registry (`ipc::published_names::ROOTFS_ROOT`,
+`SVCMGR`, `DEVMGR_REGISTRY`, minted from the endowed sources) and installs
+devmgr's `/services/drivers/` cap via `devmgr_labels::SET_DRIVERS_DIR`.
+The provider names (`timed`, `pwrmgr.shutdown`, `pwrmgr.deny`) are
+published by svcmgr's provider path on each provider's launch. Recipes for
+all svcmgr-supervised services live on disk at
+`/config/svcmgr/services/<name>.svc`, not on the wire — see
 [`services/svcmgr/docs/service-definitions.md`](../services/svcmgr/docs/service-definitions.md).
 
 ### Init reap
 
 After Phase 3 signals `svcmgr_labels::HANDOVER_COMPLETE` (svcmgr
-replies immediately, then scans `/config/svcmgr/services/` and launches any
-defined-but-unregistered service it finds — on a normal boot every default
-service is init-registered bind-only, so none launch here; the launch path
-fires only for staged test recipes such as `svctest.svc` / `usertest.svc`
-and the co-staged `crasher.svc` restart fixture), init signs over its own
+replies immediately, then scans `/config/svcmgr/services/`, binds the
+endowed substrate bind-only, and launches every defined-but-unparked
+service — the `timed` and `pwrmgr` providers on a normal boot, plus any
+staged test recipes such as `svctest.svc` / `usertest.svc` and the
+co-staged `crasher.svc` restart fixture), init signs over its own
 kernel-object caps
 (`AddressSpace`, `CSpace`, main `Thread`, init-logd `Thread`) and
 every reclaimable Frame cap it solely owns (ELF segments, user stack

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -93,11 +93,11 @@ or on-disk UUID. The model is:
   [`SERAPH_ROOT_RISCV64`](../abi/boot-protocol/src/role_guids.rs),
   and the arch-neutral [`SERAPH_DATA`](../abi/boot-protocol/src/role_guids.rs)
   in [`abi/boot-protocol/src/role_guids.rs`](../abi/boot-protocol/src/role_guids.rs).
-- **The EFI System Partition is auto-mounted at `/esp`** after the
-  root mount completes, using the standard ESP type GUID
+- **The EFI System Partition is auto-mounted at `/esp`** immediately
+  after the root self-mount, using the standard ESP type GUID
   `c12a7328-f81f-11d2-ba4b-00a0c93ec93b`. No caller issues a
-  `MOUNT` for `/esp`; vfsd does so internally as part of root-mount
-  handling. ESP mount is best-effort and failure is non-fatal.
+  `MOUNT` for `/esp`; vfsd does so internally at startup. ESP mount
+  is best-effort and failure is non-fatal.
 - **DPS-style priority tie-break.** Where multiple partitions match
   a role GUID, GPT attribute bits 48–63 are compared as an unsigned
   priority; the highest wins. Tied non-zero priorities are a fatal
@@ -119,23 +119,26 @@ is owned by [`services/vfsd/docs/vfs-ipc-interface.md`](../services/vfsd/docs/vf
 
 Three actors cooperate to bring a filesystem online:
 
-**init** holds two storage-relevant caps after vfsd is spawned: an
-untokened SEND on vfsd's service endpoint (for the un-gated `MOUNT`
-call), and a `SEED_AUTHORITY`-tokened SEND on the same endpoint
-(required by the `GET_SYSTEM_ROOT_CAP` gate). Init issues exactly
-one `MOUNT` request — the root — over the untokened SEND, then pulls
-the system root via `GET_SYSTEM_ROOT_CAP`, then distributes per-child
-copies on every spawn via `procmgr_labels::CONFIGURE_NAMESPACE`.
-Init retains no further filesystem access of its own.
+**init** holds one storage-relevant cap after vfsd is spawned: a
+`SEED_AUTHORITY`-tokened SEND on vfsd's service endpoint (required by
+the `GET_SYSTEM_ROOT_CAP` gate). Init issues no `MOUNT` — vfsd
+self-mounts root. Init pulls the system root via
+`GET_SYSTEM_ROOT_CAP` (which vfsd serves only once root is mounted, so
+the call blocks until the root filesystem is up), then distributes
+per-child copies on every spawn via
+`procmgr_labels::CONFIGURE_NAMESPACE`. Init retains no further
+filesystem access of its own.
 
-**vfsd** parses the GPT once at startup, resolves the role byte to a
-type GUID, looks the partition up in its parsed table, registers the
-partition bound with virtio-blk, spawns the fs driver, sends
-`FS_MOUNT` to validate the BPB, and captures the driver's root cap
-into the synthetic root (see
+**vfsd** parses the GPT once at startup, then self-mounts the root
+partition: it resolves the arch root GUID, looks the partition up in
+its parsed table, registers the partition bound with virtio-blk,
+spawns the fs driver, sends `FS_MOUNT` to validate the BPB, and
+captures the driver's root cap into the synthetic root (see
 [`services/vfsd/docs/namespace-composition.md`](../services/vfsd/docs/namespace-composition.md)).
-When the requested role is the rootfs, vfsd additionally auto-mounts
-the ESP at `/esp` inside the same handler before replying.
+It then auto-mounts the ESP at `/esp`. Both run before any service
+thread serves a request, so `GET_SYSTEM_ROOT_CAP` never observes an
+unmounted root. The runtime `MOUNT` label is retained for explicit /
+foreign-GUID mounts and shares this resolution path.
 
 **fs driver** runs as a separate process. After `FS_MOUNT` succeeds,
 it serves the cap-native `NS_*` protocol plus the surviving

--- a/rootfs/config/svcmgr/services/logd.svc
+++ b/rootfs/config/svcmgr/services/logd.svc
@@ -1,15 +1,22 @@
-# logd — log endpoint + arch serial-authority writer.
+# logd — the system log sink (real-logd).
 #
-# Init spawns logd at the end of Phase 2 from `/services/logd`, hands
-# over the master log endpoint RECV, the SEND for HANDOVER_PULL,
-# the DEATH_EQ_AUTHORITY-tokened SEND on procmgr, and the
-# arch-specific serial-authority cap (IoPortRange on x86-64,
-# SbiControl on RISC-V). Those caps are unreachable from svcmgr
-# post-handover, so `restart = never`. `critical = yes`: a dead
-# logd means no log destination — every subsequent log line
-# disappears, so the system is functionally blind. Graceful
-# shutdown is the right escape.
+# svcmgr launches and supervises logd post-handover, minting its bootstrap
+# round from the reserved log-sink sources init endows: the master log
+# endpoint RECV, a first-launch SEND for the HANDOVER_PULL of init-logd's
+# boot history, a DEATH_EQ_AUTHORITY SEND on procmgr (for sender slot
+# reclaim), and a devmgr.registry query cap (logd resolves the serial driver
+# via QUERY_SERIAL_DEVICE and routes output through it — it holds no UART
+# hardware). `log_sink = yes` selects this svcmgr-minted round in place of
+# seed / provides.
+#
+# `restart = on_failure`: svcmgr holds the master-log source for the system's
+# life, so a fresh logd re-attaches to the same endpoint object every log
+# sender already targets; a restart skips the one-shot history pull (no
+# init-logd remains) and serves a fresh table. `critical = yes`: a
+# permanently-down logd leaves the system blind, so graceful shutdown is the
+# right terminal escape once the restart budget is spent.
 binary    = /services/logd
-restart   = never
+restart   = on_failure
 critical  = yes
 namespace = none
+log_sink  = yes

--- a/rootfs/config/svcmgr/services/pwrmgr.svc
+++ b/rootfs/config/svcmgr/services/pwrmgr.svc
@@ -1,18 +1,28 @@
 # /services/pwrmgr — power manager (platform shutdown / reboot).
 #
-# Init spawns pwrmgr in Phase 3 with the arch-specific shutdown
-# caps (IoPortRange / SbiControl / ACPI region frames) it cannot
-# obtain post-handover; svcmgr therefore binds-only on the running
-# instance rather than launching a fresh one. Once those platform
-# caps are reachable from svcmgr a `restart = on_failure` recipe
-# can replace this.
+# svcmgr launches pwrmgr post-handover as a provider. `provides` makes
+# svcmgr create pwrmgr's service endpoint, serve its RECV as bootstrap
+# cap[0], and publish two SENDs on it:
+#   * pwrmgr.shutdown:auth — SHUTDOWN_AUTHORITY-tokened (1 << 63), for
+#     consumers permitted to power the platform off.
+#   * pwrmgr.deny:deny    — a no-authority twin (sentinel token 1) that the
+#     SHUTDOWN/REBOOT gate rejects; svctest uses it to assert the deny path.
+# `seed = devmgr.registry` delivers the REGISTRY_QUERY_AUTHORITY-tokened
+# SEND on devmgr's registry that pwrmgr uses to acquire its shutdown
+# actuator caps (QUERY_ACPI_TABLE for the FADT/DSDT it parses, and
+# QUERY_SHUTDOWN_DEVICE for the carved PM1a + 8042 ports / SbiControl).
+# pwrmgr owns no hardware caps directly — devmgr is the hardware authority.
 #
-# critical = yes: if pwrmgr dies and cannot recover, svcmgr
-# attempts a graceful shutdown via `pwrmgr.shutdown` — which is
-# unreachable because the source is gone. The death handler logs
-# the degraded state and continues; no fallback raw-shutdown path
-# exists in this architecture.
+# `restart = on_failure`: svcmgr re-creates pwrmgr from /services/pwrmgr and
+# re-serves a fresh RECV on the persistent endpoint, so a SHUTDOWN_AUTHORITY
+# cap cached against `pwrmgr.shutdown` survives a crash-restart. pwrmgr
+# re-acquires its actuator caps from devmgr on each (re)start.
+# `critical = no`: a permanently-dead pwrmgr cannot self-shutdown, so the
+# graceful-shutdown-via-pwrmgr path would be circular; the honest terminal
+# state is logged-and-continue, matching timed.
 binary    = /services/pwrmgr
-restart   = never
-critical  = yes
+restart   = on_failure
+critical  = no
 namespace = none
+provides  = pwrmgr.shutdown:auth pwrmgr.deny:deny
+seed      = devmgr.registry

--- a/rootfs/config/svcmgr/services/timed.svc
+++ b/rootfs/config/svcmgr/services/timed.svc
@@ -1,14 +1,25 @@
 # timed — wall-clock service (RTC-source-agnostic).
 #
-# Init spawns timed in Phase 3 from `/services/timed`. timed needs a
-# service-endpoint RECV plus a REGISTRY_QUERY_AUTHORITY-tokened SEND on
-# devmgr's registry endpoint (delivered together in the bootstrap
-# round) and resolves the RTC via `QUERY_RTC_DEVICE`. `restart = never`
-# matches the pre-#21 shape (no restart path preserves the bootstrap
-# handshake). `critical = no`: a dead timed leaves `SystemTime::now()`
-# returning UNIX_EPOCH but does not break the system; logged and left
-# inactive.
+# svcmgr launches timed post-handover and owns its service endpoint.
+# `provides = timed` makes svcmgr create the endpoint, serve its RECV as
+# bootstrap cap[0], and publish a SEND under the name `timed` so consumers
+# resolve `SystemTime::now()` through the discovery registry.
+# `seed = devmgr.registry` delivers the REGISTRY_QUERY_AUTHORITY-tokened
+# SEND on devmgr's registry that timed uses for `QUERY_RTC_DEVICE`. The two
+# together are timed's bootstrap round (caps[0] = own service endpoint,
+# caps[1] = devmgr registry). As a provider, timed launches ahead of pure
+# consumers during reconciliation so its name is published before any
+# consumer resolves it.
+#
+# `restart = on_failure`: svcmgr re-creates timed from `/services/timed`
+# and re-serves a fresh RECV on the persistent endpoint, so a client cap
+# cached against the published `timed` name survives a crash-restart.
+# `critical = no`: a dead timed leaves `SystemTime::now()` returning
+# UNIX_EPOCH but does not break the system; logged and left inactive once
+# the restart budget is spent.
 binary    = /services/timed
-restart   = never
+restart   = on_failure
 critical  = no
 namespace = none
+provides  = timed
+seed      = devmgr.registry

--- a/services/devmgr/README.md
+++ b/services/devmgr/README.md
@@ -78,6 +78,17 @@ responsibilities are:
   driver (`QUERY_FRAMEBUFFER_DEVICE`), timed resolves the platform RTC
   (`QUERY_RTC_DEVICE`), and netd in due course. devmgr owns each driver's
   service endpoint and mints a tokened SEND on query.
+- **Broker ACPI and shutdown hardware to pwrmgr** — devmgr is the sole
+  owner of the ACPI Frame caps and the only service that walks the ACPI
+  table tree (RSDP → XSDT). `QUERY_ACPI_TABLE` locates a table by
+  signature or physical address and serves a read-only view of it (devmgr
+  reads only the directory and table headers, never a table body).
+  `QUERY_SHUTDOWN_DEVICE` carves the shutdown-actuator caps pwrmgr asks
+  for — a narrow `IoPortRange` over the PM1a control and 8042 reset ports
+  on x86-64 (the port pwrmgr computed from the FADT), or a `cap_derive`
+  copy of `SbiControl` on RISC-V. devmgr runs no shutdown logic; it brokers
+  the hardware, pwrmgr interprets and actuates. Both are gated on
+  `REGISTRY_QUERY_AUTHORITY`.
 - **Handle hotplug** — on platforms that support it, receive hotplug
   notifications and dynamically spawn or terminate driver processes. See
   [`docs/hotplug.md`](docs/hotplug.md).
@@ -95,8 +106,9 @@ how devmgr uses them.
 |---|---|---|
 | MMIO Region (per platform resource) | Map | Map device register regions into driver address spaces |
 | Interrupt (per IRQ line) | — | Delegate to drivers for hardware interrupt delivery |
-| IoPortRange (x86-64, per range) | Use | Delegate to drivers requiring port I/O |
-| Frame (firmware tables) | Map (read-only) | Parse ACPI RSDP / Device Tree blob, including full IOMMU topology (DMAR on x86-64, `iommu` / `iommu-map` on RISC-V) |
+| IoPortRange (x86-64, root) | Use / carve | Carve narrow per-driver port caps (CMOS, COM1) and pwrmgr's PM1a + 8042 reset ports |
+| SbiControl (RISC-V, root) | Delegate | Broker a copy to pwrmgr for SBI SRST shutdown / reboot |
+| Frame (firmware tables) | Map (read-only) | Parse ACPI RSDP / Device Tree blob (incl. IOMMU topology: DMAR on x86-64, `iommu` / `iommu-map` on RISC-V); broker read-only ACPI tables to pwrmgr via `QUERY_ACPI_TABLE` |
 | SchedControl | Elevate | Assign elevated priorities to latency-sensitive drivers |
 
 IOMMU register regions are not pre-minted as distinct capabilities.

--- a/services/devmgr/src/caps.rs
+++ b/services/devmgr/src/caps.rs
@@ -157,8 +157,17 @@ pub struct DevmgrCaps
 
     // Copy of init's root `IoPortRange` cap (x86-64 only; zero on RISC-V).
     // devmgr derives per-driver narrow copies for ISA peripherals
-    // (CMOS RTC at ports 0x70-0x71; COM1 at 0x3F8-0x3FF for serial).
+    // (CMOS RTC at ports 0x70-0x71; COM1 at 0x3F8-0x3FF for serial) and,
+    // on `QUERY_SHUTDOWN_DEVICE`, the PM1a + 8042-reset ports for pwrmgr.
+    #[cfg_attr(not(target_arch = "x86_64"), allow(dead_code))]
     pub ioport_root_cap: u32,
+
+    // Copy of init's `SbiControl` cap (RISC-V only; zero on x86-64). The
+    // SBI SRST shutdown/reboot authority; devmgr serves a `cap_derive`
+    // copy to pwrmgr on `QUERY_SHUTDOWN_DEVICE`. devmgr itself never
+    // forwards an SBI call — it only brokers the cap.
+    #[cfg_attr(not(target_arch = "riscv64"), allow(dead_code))]
+    pub sbi_control_cap: u32,
 
     /// Bootloader-discovered framebuffer geometry, or `None` when no
     /// framebuffer is present. Populated from init's
@@ -190,6 +199,7 @@ impl DevmgrCaps
             driver_module_count: 0,
             svcmgr_publish_cap: 0,
             ioport_root_cap: 0,
+            sbi_control_cap: 0,
             fb_info: None,
         }
     }
@@ -407,8 +417,9 @@ fn bootstrap_rounds(creator: u32, ipc_buf: *mut u64, caps: &mut DevmgrCaps) -> O
                 // caps[0] = svcmgr publish-authority cap (always present;
                 //           a zero slot indicates init's derive failed and
                 //           is treated as a bootstrap fatal).
-                // caps[1] = root IoPortRange copy (x86 only; absent on
-                //           RISC-V — sender simply omits the cap).
+                // caps[1] = arch shutdown-authority cap: root IoPortRange
+                //           on x86-64, SbiControl on RISC-V. Same slot
+                //           either way; the receiver routes it by arch.
                 if round.cap_count < 1 || round.caps[0] == 0
                 {
                     return None;
@@ -416,7 +427,14 @@ fn bootstrap_rounds(creator: u32, ipc_buf: *mut u64, caps: &mut DevmgrCaps) -> O
                 caps.svcmgr_publish_cap = round.caps[0];
                 if round.cap_count >= 2 && round.caps[1] != 0
                 {
-                    caps.ioport_root_cap = round.caps[1];
+                    #[cfg(target_arch = "x86_64")]
+                    {
+                        caps.ioport_root_cap = round.caps[1];
+                    }
+                    #[cfg(target_arch = "riscv64")]
+                    {
+                        caps.sbi_control_cap = round.caps[1];
+                    }
                 }
             }
             _ =>

--- a/services/devmgr/src/main.rs
+++ b/services/devmgr/src/main.rs
@@ -166,8 +166,8 @@ fn main() -> !
 
     // On-disk driver state. The RTC binary lives on the rootfs at
     // `/services/drivers/<chip>`, not in the boot bundle — RTC is not
-    // bootstrap-essential. Init delivers a `LOOKUP | READ`-attenuated
-    // `/services/drivers/` subtree cap via `SET_DRIVERS_DIR` post-vfsd;
+    // bootstrap-essential. svcmgr delivers a `LOOKUP | READ`-attenuated
+    // `/services/drivers/` subtree cap via `SET_DRIVERS_DIR` at handover;
     // the walk + `CREATE_FROM_FILE` + bootstrap rounds run inside the
     // `SET_DRIVERS_DIR` handler, after its `ipc_reply` and before the
     // next `ipc_recv` (a nested ipc_call inside a request-handler
@@ -353,7 +353,7 @@ fn main() -> !
             }
             ipc::devmgr_labels::SET_DRIVERS_DIR =>
             {
-                // Init-only handshake. Reply SUCCESS *first* so init
+                // svcmgr-only handshake. Reply SUCCESS *first* so svcmgr
                 // unblocks immediately and is never in the critical
                 // path of driver work. THEN do the walk + spawn between
                 // ipc_reply and the next ipc_recv: a nested ipc_call
@@ -364,15 +364,15 @@ fn main() -> !
                 let mut should_attempt_spawn = false;
                 // Capability hygiene: every gate-fail arm below must
                 // release any cap the kernel transferred into devmgr's
-                // CSpace before replying. Even though today only init
+                // CSpace before replying. Even though today only svcmgr
                 // can plausibly send this label, leaving an authority
                 // cap dangling in a server's slot is a category of bug
                 // the rest of the codebase consistently avoids.
                 let delivered_cap = msg.caps().first().copied();
-                if token & ipc::devmgr_labels::INIT_BIND_AUTHORITY == 0
+                if token & ipc::devmgr_labels::DRIVERS_DIR_AUTHORITY == 0
                 {
                     std::os::seraph::log!(
-                        "SET_DRIVERS_DIR rejected: token lacks INIT_BIND_AUTHORITY"
+                        "SET_DRIVERS_DIR rejected: token lacks DRIVERS_DIR_AUTHORITY"
                     );
                     if let Some(c) = delivered_cap
                     {
@@ -1505,9 +1505,9 @@ fn spawn_framebuffer(
 /// Spawn the platform RTC driver — CMOS on x86-64, goldfish-RTC on
 /// RISC-V — from the on-disk rootfs. Called from inside the
 /// `SET_DRIVERS_DIR` registry-loop arm, after the handler's
-/// `ipc_reply` to init and before devmgr's next `ipc_recv`. The
+/// `ipc_reply` to svcmgr and before devmgr's next `ipc_recv`. The
 /// `drivers_dir_cap` argument is the `LOOKUP | READ`-attenuated
-/// `/services/drivers/` subtree cap init delivered in the handshake
+/// `/services/drivers/` subtree cap svcmgr delivered in the handshake
 /// (namespace-protocol rights, not kernel cap rights). Walks
 /// `drivers_dir_cap` to the per-arch chip name, carves the per-arch
 /// hardware authority, and goes through the file-cap branch of
@@ -1533,7 +1533,7 @@ fn spawn_rtc_from_disk(
     #[cfg(target_arch = "riscv64")]
     const RTC_NAME: &[u8] = b"goldfish-rtc";
 
-    // Request READ rights on the resolved file node. The cap init handed
+    // Request READ rights on the resolved file node. The cap svcmgr handed
     // us in SET_DRIVERS_DIR is already attenuated to LOOKUP|READ at the
     // /services/drivers/ subtree, so the namespace server will only ever
     // mint a file cap with at most those bits set.

--- a/services/devmgr/src/main.rs
+++ b/services/devmgr/src/main.rs
@@ -484,6 +484,14 @@ fn main() -> !
                     let _ = unsafe { ipc::ipc_reply(&reply, ipc_buf) };
                 }
             }
+            ipc::devmgr_labels::QUERY_ACPI_TABLE =>
+            {
+                handle_query_acpi_table(&caps, &msg, token, ipc_buf);
+            }
+            ipc::devmgr_labels::QUERY_SHUTDOWN_DEVICE =>
+            {
+                handle_query_shutdown_device(&caps, &msg, token, ipc_buf);
+            }
             ipc::devmgr_labels::QUERY_DEVICE_INFO =>
             {
                 let dev_idx = token.wrapping_sub(1) as usize;
@@ -590,10 +598,37 @@ fn platform_default_ecam() -> Option<firmware::EcamLocation>
 
 fn discover_ecam_acpi(caps: &caps::DevmgrCaps) -> Option<firmware::EcamLocation>
 {
+    let xsdt_phys = read_xsdt_phys(caps)?;
+
+    // Copy XSDT entry pointers into a heap vec so we can release the XSDT
+    // mapping and remap per-table — MCFG may live in a different ACPI
+    // region than the XSDT (e.g. EDK2 on RISC-V virt: many tiny regions).
+    let entries = read_xsdt_entries(caps, xsdt_phys)?;
+
+    for tbl_phys in entries
+    {
+        if let Some(loc) = read_mcfg_at(caps, tbl_phys)
+        {
+            return Some(loc);
+        }
+    }
+    None
+}
+
+/// Map the RSDP page and read the XSDT physical address out of it.
+///
+/// Shared by ECAM discovery and the [`devmgr_labels::QUERY_ACPI_TABLE`]
+/// broker so the RSDP → XSDT step exists exactly once. Returns `None` when
+/// no RSDP was delivered or the table is pre-ACPI-2.0.
+fn read_xsdt_phys(caps: &caps::DevmgrCaps) -> Option<u64>
+{
+    if caps.rsdp_frame_cap == 0
+    {
+        return None;
+    }
     // `rsdp_page_base` carries the exact RSDP physical address (see
     // init-protocol v5 docs); the backing Frame cap covers the page.
-    let rsdp_phys = caps.rsdp_page_base;
-    let rsdp_page_offset = (rsdp_phys & 0xFFF) as usize;
+    let rsdp_page_offset = (caps.rsdp_page_base & 0xFFF) as usize;
     let range = reserve_pages(1).ok()?;
     let va = range.va_start();
     if syscall::mem_map(
@@ -615,21 +650,7 @@ fn discover_ecam_acpi(caps: &caps::DevmgrCaps) -> Option<firmware::EcamLocation>
     let xsdt_phys = firmware::acpi::rsdp_xsdt_phys(rsdp_bytes);
     let _ = syscall::mem_unmap(caps.self_aspace, va, 1);
     unreserve_pages(range);
-    let xsdt_phys = xsdt_phys?;
-
-    // Copy XSDT entry pointers into a heap vec so we can release the XSDT
-    // mapping and remap per-table — MCFG may live in a different ACPI
-    // region than the XSDT (e.g. EDK2 on RISC-V virt: many tiny regions).
-    let entries = read_xsdt_entries(caps, xsdt_phys)?;
-
-    for tbl_phys in entries
-    {
-        if let Some(loc) = read_mcfg_at(caps, tbl_phys)
-        {
-            return Some(loc);
-        }
-    }
-    None
+    xsdt_phys
 }
 
 /// Map the ACPI region containing `xsdt_phys`, copy the entry pointer
@@ -761,6 +782,209 @@ fn find_region_for(caps: &caps::DevmgrCaps, phys: u64) -> Option<(caps::AcpiRegi
         }
     }
     None
+}
+
+/// Read the 4-byte signature of the ACPI table at physical address
+/// `tbl_phys` by mapping the region that contains it. Returns `None` if no
+/// region covers the address or the header is unreadable. devmgr reads
+/// only the header signature here — never a table body.
+fn read_table_sig(caps: &caps::DevmgrCaps, tbl_phys: u64) -> Option<[u8; 4]>
+{
+    let (region, off) = find_region_for(caps, tbl_phys)?;
+    let region_pages = region.size.div_ceil(PAGE_SIZE);
+    let map_pages = region_pages.min(FIRMWARE_MAP_MAX_PAGES);
+    let range = reserve_pages(map_pages).ok()?;
+    let va = range.va_start();
+    if syscall::mem_map(
+        region.slot,
+        caps.self_aspace,
+        va,
+        0,
+        map_pages,
+        syscall_abi::MAP_READONLY,
+    )
+    .is_err()
+    {
+        unreserve_pages(range);
+        return None;
+    }
+    let span = (map_pages * PAGE_SIZE) as usize;
+    let sig = if off + 4 <= span
+    {
+        // SAFETY: `span` bytes mapped read-only from `va`.
+        let bytes = unsafe { core::slice::from_raw_parts(va as *const u8, span) };
+        Some(firmware::acpi::sdt_signature(&bytes[off..]))
+    }
+    else
+    {
+        None
+    };
+    let _ = syscall::mem_unmap(caps.self_aspace, va, map_pages);
+    unreserve_pages(range);
+    sig
+}
+
+/// Locate an ACPI table by 4-byte `sig` via an XSDT walk. Returns the
+/// table's physical address. Reuses the same RSDP/XSDT directory read as
+/// ECAM discovery, so there is one XSDT walk in the whole system.
+fn locate_table_by_sig(caps: &caps::DevmgrCaps, sig: [u8; 4]) -> Option<u64>
+{
+    let xsdt_phys = read_xsdt_phys(caps)?;
+    let entries = read_xsdt_entries(caps, xsdt_phys)?;
+    entries
+        .into_iter()
+        .find(|&tbl_phys| read_table_sig(caps, tbl_phys) == Some(sig))
+}
+
+/// Resolve an ACPI-table request to `(region, table_phys)`. A non-zero
+/// `phys` is looked up directly (e.g. the DSDT, whose address the caller
+/// read from the FADT); otherwise `sig_word`'s low 32 bits are the table
+/// signature to find via the XSDT.
+fn locate_acpi_table(
+    caps: &caps::DevmgrCaps,
+    sig_word: u64,
+    phys: u64,
+) -> Option<(caps::AcpiRegion, u64)>
+{
+    let table_phys = if phys != 0
+    {
+        phys
+    }
+    else
+    {
+        locate_table_by_sig(caps, (sig_word as u32).to_le_bytes())?
+    };
+    let (region, _off) = find_region_for(caps, table_phys)?;
+    Some((region, table_phys))
+}
+
+/// Send a bodyless status reply (no caps) on the current request.
+fn reply_status(code: u64, ipc_buf: *mut u64)
+{
+    let reply = IpcMessage::new(code);
+    // SAFETY: ipc_buf is the registered IPC buffer.
+    let _ = unsafe { ipc::ipc_reply(&reply, ipc_buf) };
+}
+
+/// `QUERY_ACPI_TABLE` handler: locate the requested ACPI table and reply
+/// with a read-only Frame cap on its region plus the `(region_base,
+/// region_size, table_phys)` the caller needs to map and read it. devmgr
+/// is the sole ACPI owner; consumers hold no ACPI frames of their own.
+fn handle_query_acpi_table(caps: &caps::DevmgrCaps, msg: &IpcMessage, token: u64, ipc_buf: *mut u64)
+{
+    if token & ipc::devmgr_labels::REGISTRY_QUERY_AUTHORITY == 0
+    {
+        reply_status(ipc::devmgr_errors::UNAUTHORIZED, ipc_buf);
+        return;
+    }
+    if msg.word(0) != u64::from(ipc::DEVMGR_LABELS_VERSION)
+    {
+        reply_status(ipc::devmgr_errors::LABEL_VERSION_MISMATCH, ipc_buf);
+        return;
+    }
+    let Some((region, table_phys)) = locate_acpi_table(caps, msg.word(1), msg.word(2))
+    else
+    {
+        reply_status(ipc::devmgr_errors::NO_DEVICE, ipc_buf);
+        return;
+    };
+    let Ok(frame) = syscall::cap_derive(region.slot, syscall::RIGHTS_ALL)
+    else
+    {
+        reply_status(ipc::devmgr_errors::INVALID_REQUEST, ipc_buf);
+        return;
+    };
+    let reply = IpcMessage::builder(ipc::devmgr_errors::SUCCESS)
+        .word(0, region.base)
+        .word(1, region.size)
+        .word(2, table_phys)
+        .cap(frame)
+        .build();
+    // SAFETY: ipc_buf is the registered IPC buffer.
+    if unsafe { ipc::ipc_reply(&reply, ipc_buf) }.is_err()
+    {
+        let _ = syscall::cap_delete(frame);
+    }
+}
+
+/// `QUERY_SHUTDOWN_DEVICE` handler: serve pwrmgr the platform shutdown
+/// actuator caps. devmgr carves exactly what is asked for and runs no
+/// shutdown logic. x86-64: a narrow `IoPortRange` over the caller-supplied
+/// `PM1a` control port plus the 8042 reset port. RISC-V: a `cap_derive` copy
+/// of `SbiControl`. The caps are re-derived from the root on every call,
+/// so a pwrmgr restart re-acquires them cleanly.
+fn handle_query_shutdown_device(
+    caps: &caps::DevmgrCaps,
+    msg: &IpcMessage,
+    token: u64,
+    ipc_buf: *mut u64,
+)
+{
+    if token & ipc::devmgr_labels::REGISTRY_QUERY_AUTHORITY == 0
+    {
+        reply_status(ipc::devmgr_errors::UNAUTHORIZED, ipc_buf);
+        return;
+    }
+    if msg.word(0) != u64::from(ipc::DEVMGR_LABELS_VERSION)
+    {
+        reply_status(ipc::devmgr_errors::LABEL_VERSION_MISMATCH, ipc_buf);
+        return;
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        // 8042 KBC command port — the 1-byte reset register pwrmgr pulses
+        // for reboot. The PM1a control port is FADT-derived, so pwrmgr
+        // computes it and passes it here; devmgr only carves.
+        const KBC_COMMAND_PORT: u16 = 0x64;
+        let pm1a = msg.word(1) as u16;
+        let Some(pm1a_cap) = ioport_carve(caps.ioport_root_cap, pm1a, 2)
+        else
+        {
+            reply_status(ipc::devmgr_errors::NO_DEVICE, ipc_buf);
+            return;
+        };
+        let Some(kbc_cap) = ioport_carve(caps.ioport_root_cap, KBC_COMMAND_PORT, 1)
+        else
+        {
+            let _ = syscall::cap_delete(pm1a_cap);
+            reply_status(ipc::devmgr_errors::NO_DEVICE, ipc_buf);
+            return;
+        };
+        let reply = IpcMessage::builder(ipc::devmgr_errors::SUCCESS)
+            .cap(pm1a_cap)
+            .cap(kbc_cap)
+            .build();
+        // SAFETY: ipc_buf is the registered IPC buffer.
+        if unsafe { ipc::ipc_reply(&reply, ipc_buf) }.is_err()
+        {
+            let _ = syscall::cap_delete(pm1a_cap);
+            let _ = syscall::cap_delete(kbc_cap);
+        }
+    }
+
+    #[cfg(target_arch = "riscv64")]
+    {
+        if caps.sbi_control_cap == 0
+        {
+            reply_status(ipc::devmgr_errors::NO_DEVICE, ipc_buf);
+            return;
+        }
+        let Ok(sbi) = syscall::cap_derive(caps.sbi_control_cap, syscall::RIGHTS_ALL)
+        else
+        {
+            reply_status(ipc::devmgr_errors::INVALID_REQUEST, ipc_buf);
+            return;
+        };
+        let reply = IpcMessage::builder(ipc::devmgr_errors::SUCCESS)
+            .cap(sbi)
+            .build();
+        // SAFETY: ipc_buf is the registered IPC buffer.
+        if unsafe { ipc::ipc_reply(&reply, ipc_buf) }.is_err()
+        {
+            let _ = syscall::cap_delete(sbi);
+        }
+    }
 }
 
 // ── Aperture splitting helper ───────────────────────────────────────────────

--- a/services/init/README.md
+++ b/services/init/README.md
@@ -18,7 +18,7 @@ init/
 └── src/
     ├── main.rs                 # _start, run() orchestration across the three stages
     ├── bootstrap.rs            # Raw memmgr / procmgr ELF-load + kernel-object setup
-    ├── service.rs              # IPC-driven spawns (devmgr, vfsd, svcmgr, logd, timed, pwrmgr) and phase3_svcmgr_handover
+    ├── service.rs              # IPC-driven spawns (devmgr, vfsd, svcmgr, logd) and phase3_svcmgr_handover
     ├── mount.rs                # Root MOUNT exchange + GET_SYSTEM_ROOT_CAP pull
     ├── logging.rs              # init-logd thread (serves the log endpoint until real-logd takes over)
     ├── walk.rs                 # /services/<name> path walker over the seed system-root cap
@@ -42,15 +42,17 @@ Init runs three stages between `_start` and `sys_thread_exit`:
    the role to the arch-specific Seraph root GPT type-GUID), pull the seed
    `system_root_cap` via `GET_SYSTEM_ROOT_CAP`, then launch real-logd from
    `/services/logd` and hand off the master log endpoint via `HANDOVER_PULL`.
-3. **Handover** — spawn svcmgr, timed, and pwrmgr (the per-arch RTC
-   chip driver is devmgr-spawned during devmgr's enumeration sweep
-   and resolved by timed via `QUERY_RTC_DEVICE`); publish the
-   well-known caps (`rootfs.root`, `pwrmgr.shutdown`, `pwrmgr.deny`,
-   `svcmgr`, `timed`); register every init-bootstrapped service with svcmgr via
-   `REGISTER_SERVICE`; signal `HANDOVER_COMPLETE`; hand init's own
-   kernel objects + reclaimable Frame caps to procmgr via
+3. **Handover** — spawn svcmgr and endow it; publish the well-known caps
+   init still owns the sources for (`rootfs.root`, `svcmgr`,
+   `devmgr.registry`); register every init-bootstrapped substrate service
+   with svcmgr via `REGISTER_SERVICE`; signal `HANDOVER_COMPLETE`; hand
+   init's own kernel objects + reclaimable Frame caps to procmgr via
    `REGISTER_INIT_TEARDOWN`; call `sys_thread_exit`. Procmgr's death-EQ
-   observer then runs the reap path.
+   observer then runs the reap path. The non-bootstrap services svcmgr
+   then launches itself — `timed` and `pwrmgr` (providers), the staged
+   test harnesses — and publishes their names; the per-arch RTC chip
+   driver is devmgr-spawned during enumeration and resolved by timed via
+   `QUERY_RTC_DEVICE`.
 
 See [docs/bootstrap.md](docs/bootstrap.md) for the authoritative
 stage-by-stage enumeration, source citations, and per-stage capability
@@ -88,7 +90,7 @@ transfer table.
 | [services/procmgr/README.md](../procmgr/README.md) | Owns process creation post-bootstrap; runs init's reap path |
 | [services/svcmgr/README.md](../svcmgr/README.md) | Takes over as resident supervisor after `HANDOVER_COMPLETE` |
 | [services/logd/README.md](../logd/README.md) | Master log endpoint owner post-Phase-2-epilogue |
-| [services/pwrmgr/README.md](../pwrmgr/README.md) | Receives arch authority + ACPI Frame caps during handover |
+| [services/pwrmgr/README.md](../pwrmgr/README.md) | svcmgr-launched post-handover; acquires its shutdown caps from devmgr, not from init |
 | [docs/coding-standards.md](../../docs/coding-standards.md) | Formatting, naming, safety rules |
 | [docs/documentation-standards.md](../../docs/documentation-standards.md) | Document hierarchy, authority, backlinks |
 

--- a/services/init/README.md
+++ b/services/init/README.md
@@ -2,8 +2,8 @@
 
 Bootstrap service and first userspace process. The kernel starts init at the end
 of its initialization sequence. Init runs a three-stage bootstrap — raw memmgr /
-procmgr creation, root mount, then handover to svcmgr — and exits. It is not a
-long-lived service manager.
+procmgr creation, root acquisition, then handover to svcmgr — and exits. It is
+not a long-lived service manager.
 
 ---
 
@@ -19,7 +19,7 @@ init/
     ├── main.rs                 # _start, run() orchestration across the three stages
     ├── bootstrap.rs            # Raw memmgr / procmgr ELF-load + kernel-object setup
     ├── service.rs              # IPC-driven spawns (devmgr, vfsd, svcmgr, logd) and phase3_svcmgr_handover
-    ├── mount.rs                # Root MOUNT exchange + GET_SYSTEM_ROOT_CAP pull
+    ├── mount.rs                # GET_SYSTEM_ROOT_CAP pull (vfsd self-mounts root)
     ├── logging.rs              # init-logd thread (serves the log endpoint until real-logd takes over)
     ├── walk.rs                 # /services/<name> path walker over the seed system-root cap
     └── arch/                   # Per-arch serial init (x86-64, riscv64)
@@ -38,10 +38,12 @@ Init runs three stages between `_start` and `sys_thread_exit`:
 1. **Raw bootstrap** — version-check `InitInfo`, set up the IPC buffer, mint
    endpoints, spawn init-logd, bring up memmgr and procmgr via raw syscalls,
    then drive procmgr IPC to create devmgr and vfsd.
-2. **Root mount** — issue `MOUNT(MountRole::Root, "/")` to vfsd (vfsd resolves
-   the role to the arch-specific Seraph root GPT type-GUID), pull the seed
-   `system_root_cap` via `GET_SYSTEM_ROOT_CAP`, then launch real-logd from
-   `/services/logd` and hand off the master log endpoint via `HANDOVER_PULL`.
+2. **Root acquisition** — vfsd self-mounts the Seraph root partition at `/`
+   on its own startup; init issues no `MOUNT`. Pull the seed
+   `system_root_cap` via `GET_SYSTEM_ROOT_CAP` (which vfsd serves only once
+   root is mounted, so the call blocks until root is up), then launch
+   real-logd from `/services/logd` and hand off the master log endpoint via
+   `HANDOVER_PULL`.
 3. **Handover** — load svcmgr and serve it the handover endowment over
    the bootstrap-round protocol: its own endpoints, the publish-role
    source caps (`rootfs.root` SEND, devmgr-registry `SEND|GRANT` source),

--- a/services/init/README.md
+++ b/services/init/README.md
@@ -18,7 +18,7 @@ init/
 └── src/
     ├── main.rs                 # _start, run() orchestration across the three stages
     ├── bootstrap.rs            # Raw memmgr / procmgr ELF-load + kernel-object setup
-    ├── service.rs              # IPC-driven spawns (devmgr, vfsd, svcmgr, logd) and phase3_svcmgr_handover
+    ├── service.rs              # IPC-driven spawns (devmgr, vfsd, svcmgr) and phase3_svcmgr_handover
     ├── mount.rs                # GET_SYSTEM_ROOT_CAP pull (vfsd self-mounts root)
     ├── logging.rs              # init-logd thread (serves the log endpoint until real-logd takes over)
     ├── walk.rs                 # /services/<name> path walker over the seed system-root cap
@@ -41,16 +41,20 @@ Init runs three stages between `_start` and `sys_thread_exit`:
 2. **Root acquisition** — vfsd self-mounts the Seraph root partition at `/`
    on its own startup; init issues no `MOUNT`. Pull the seed
    `system_root_cap` via `GET_SYSTEM_ROOT_CAP` (which vfsd serves only once
-   root is mounted, so the call blocks until root is up), then launch
-   real-logd from `/services/logd` and hand off the master log endpoint via
-   `HANDOVER_PULL`.
+   root is mounted, so the call blocks until root is up). The init-logd
+   thread keeps serving the master log endpoint and writing serial directly;
+   the svcmgr-launched real-logd takes over the endpoint and pulls init-logd's
+   captured history via `HANDOVER_PULL` post-handover.
 3. **Handover** — load svcmgr and serve it the handover endowment over
    the bootstrap-round protocol: its own endpoints, the publish-role
    source caps (`rootfs.root` SEND, devmgr-registry `SEND|GRANT` source),
-   and one `(name, thread_cap)` round per init-bootstrapped substrate
-   service. Signal `HANDOVER_COMPLETE`; hand init's own kernel objects +
-   reclaimable Frame caps to procmgr via `REGISTER_INIT_TEARDOWN`; call
-   `sys_thread_exit`. Procmgr's death-EQ observer then runs the reap path.
+   one `(name, thread_cap)` round per init-bootstrapped substrate
+   service, and a terminal round carrying the reserved log-sink sources
+   (master-log endpoint + procmgr `SEND|GRANT`) svcmgr keeps to launch and
+   supervise real-logd. Signal `HANDOVER_COMPLETE`; hand init's own kernel
+   objects + reclaimable Frame caps to procmgr via `REGISTER_INIT_TEARDOWN`;
+   call `sys_thread_exit`. Procmgr binds a death-EQ on both init threads
+   (main + init-logd) and runs the reap path once both have exited.
    svcmgr publishes the well-known names it now owns (`rootfs.root`,
    `svcmgr`, `devmgr.registry`) and installs devmgr's `/services/drivers/`
    cap via `SET_DRIVERS_DIR` from the endowment; it then launches the
@@ -94,7 +98,7 @@ transfer table.
 | [services/memmgr/README.md](../memmgr/README.md) | First service init creates; receives the RAM Frame pool |
 | [services/procmgr/README.md](../procmgr/README.md) | Owns process creation post-bootstrap; runs init's reap path |
 | [services/svcmgr/README.md](../svcmgr/README.md) | Takes over as resident supervisor after `HANDOVER_COMPLETE` |
-| [services/logd/README.md](../logd/README.md) | Master log endpoint owner post-Phase-2-epilogue |
+| [services/logd/README.md](../logd/README.md) | Master log endpoint owner; svcmgr-launched, pulls init-logd's history at handover |
 | [services/pwrmgr/README.md](../pwrmgr/README.md) | svcmgr-launched post-handover; acquires its shutdown caps from devmgr, not from init |
 | [docs/coding-standards.md](../../docs/coding-standards.md) | Formatting, naming, safety rules |
 | [docs/documentation-standards.md](../../docs/documentation-standards.md) | Document hierarchy, authority, backlinks |

--- a/services/init/README.md
+++ b/services/init/README.md
@@ -42,17 +42,20 @@ Init runs three stages between `_start` and `sys_thread_exit`:
    the role to the arch-specific Seraph root GPT type-GUID), pull the seed
    `system_root_cap` via `GET_SYSTEM_ROOT_CAP`, then launch real-logd from
    `/services/logd` and hand off the master log endpoint via `HANDOVER_PULL`.
-3. **Handover** — spawn svcmgr and endow it; publish the well-known caps
-   init still owns the sources for (`rootfs.root`, `svcmgr`,
-   `devmgr.registry`); register every init-bootstrapped substrate service
-   with svcmgr via `REGISTER_SERVICE`; signal `HANDOVER_COMPLETE`; hand
-   init's own kernel objects + reclaimable Frame caps to procmgr via
-   `REGISTER_INIT_TEARDOWN`; call `sys_thread_exit`. Procmgr's death-EQ
-   observer then runs the reap path. The non-bootstrap services svcmgr
-   then launches itself — `timed` and `pwrmgr` (providers), the staged
-   test harnesses — and publishes their names; the per-arch RTC chip
-   driver is devmgr-spawned during enumeration and resolved by timed via
-   `QUERY_RTC_DEVICE`.
+3. **Handover** — load svcmgr and serve it the handover endowment over
+   the bootstrap-round protocol: its own endpoints, the publish-role
+   source caps (`rootfs.root` SEND, devmgr-registry `SEND|GRANT` source),
+   and one `(name, thread_cap)` round per init-bootstrapped substrate
+   service. Signal `HANDOVER_COMPLETE`; hand init's own kernel objects +
+   reclaimable Frame caps to procmgr via `REGISTER_INIT_TEARDOWN`; call
+   `sys_thread_exit`. Procmgr's death-EQ observer then runs the reap path.
+   svcmgr publishes the well-known names it now owns (`rootfs.root`,
+   `svcmgr`, `devmgr.registry`) and installs devmgr's `/services/drivers/`
+   cap via `SET_DRIVERS_DIR` from the endowment; it then launches the
+   non-bootstrap services itself — `timed` and `pwrmgr` (providers), the
+   staged test harnesses — and publishes their names. The per-arch RTC
+   chip driver is devmgr-spawned lazily after `SET_DRIVERS_DIR` and
+   resolved by timed via `QUERY_RTC_DEVICE`.
 
 See [docs/bootstrap.md](docs/bootstrap.md) for the authoritative
 stage-by-stage enumeration, source citations, and per-stage capability

--- a/services/init/docs/bootstrap.md
+++ b/services/init/docs/bootstrap.md
@@ -130,51 +130,40 @@ and hands init's own kernel objects to procmgr for reaping.
   (walk fails, devmgr replies non-SUCCESS) leaves the system without
   a wallclock — timed degrades to `WALL_CLOCK_UNAVAILABLE`.
   (`set_drivers_dir_on_devmgr` in `../src/service.rs`.)
-- Bring up the wallclock chain: spawn timed and resolve the per-arch
-  RTC driver through devmgr. The RTC chip driver (cmos-rtc on x86-64,
-  goldfish-rtc on RISC-V) is spawned by devmgr from the on-disk
-  rootfs (`/services/drivers/<chip>`) after the
-  `SET_DRIVERS_DIR` handshake above, not by init; timed resolves the
-  SEND at startup via `devmgr_labels::QUERY_RTC_DEVICE` on the
-  `REGISTRY_QUERY_AUTHORITY`-tokened copy of devmgr's registry
-  endpoint delivered in its bootstrap round
-  (`../src/service.rs:1379` → `bring_up_timed` at
-  `../src/service.rs:2177`, with `create_and_start_timed` at
-  `../src/service.rs:1987`).
-- Spawn pwrmgr with the arch authority cap
-  (`IoPortRange` on x86-64, `SbiControl` on RISC-V) and the
-  ACPI Frame caps; capture pwrmgr's service endpoint and main
-  thread cap (`../src/service.rs:1390` →
-  `create_and_start_pwrmgr` at `../src/service.rs:796`).
+- The wallclock chain and pwrmgr are **not** spawned by init. `timed`
+  and `pwrmgr` are svcmgr-launched providers (`timed.svc` / `pwrmgr.svc`),
+  brought up post-handover; each resolves its authority from devmgr at
+  startup (`QUERY_RTC_DEVICE` for timed; `QUERY_ACPI_TABLE` +
+  `QUERY_SHUTDOWN_DEVICE` for pwrmgr). The RTC chip driver (cmos-rtc on
+  x86-64, goldfish-rtc on RISC-V) is spawned by devmgr from
+  `/services/drivers/<chip>` after the `SET_DRIVERS_DIR` handshake above,
+  also not by init.
 - Derive a `PUBLISH_AUTHORITY`-tokened `RIGHTS_SEND_GRANT` cap on
-  svcmgr's service endpoint (`../src/service.rs:1419`) and
-  publish five well-known names via `PUBLISH_ENDPOINT`:
+  svcmgr's service endpoint and publish the three well-known names init
+  still owns the sources for, via `PUBLISH_ENDPOINT`
+  (`phase3_svcmgr_handover` in `../src/service.rs`):
   - `rootfs.root` — tokened SEND on the root filesystem's
     namespace endpoint at its root directory (FS-driver-agnostic
-    by design) (`../src/service.rs:1429`).
-  - `pwrmgr.shutdown` — `SHUTDOWN_AUTHORITY`-tokened SEND on
-    pwrmgr's service endpoint (`../src/service.rs:1450`).
-  - `pwrmgr.deny` — non-AUTHORITY SEND on pwrmgr's service
-    endpoint (negative-test twin) (`../src/service.rs:1462`).
-  - `svcmgr` — un-tokened SEND on svcmgr's own service endpoint
-    (`../src/service.rs:1482`).
+    by design).
+  - `svcmgr` — un-tokened SEND on svcmgr's own service endpoint.
   - `devmgr.registry` — `REGISTRY_QUERY_AUTHORITY`-tokened SEND
-    on devmgr's registry endpoint (`../src/service.rs:1505`).
-    Consumers needing to resolve a device driver themselves
-    (today: `programs/fb-charset` → `QUERY_FRAMEBUFFER_DEVICE`;
-    future: any non-init caller of devmgr's discovery surface)
-    seed this name. The token bit survives svcmgr's plain
-    `cap_derive` in `registry_lookup_derived`.
+    on devmgr's registry endpoint. Consumers needing to resolve a
+    device driver themselves (`programs/fb-charset` →
+    `QUERY_FRAMEBUFFER_DEVICE`; timed and pwrmgr → their devmgr
+    queries; future: any non-init caller of devmgr's discovery surface)
+    seed this name. The token bit survives svcmgr's plain `cap_derive`
+    in `registry_lookup_derived`.
 
-  Name constants are centralised in `ipc::published_names`.
-- Register each init-bootstrapped service with svcmgr via the v3
-  `REGISTER_SERVICE` wire (name + thread cap)
-  (`../src/service.rs:1528`–`../src/service.rs:1550`;
-  `register_service` helper at `../src/service.rs:1273`).
-  Registration set: `memmgr`, `procmgr`, `devmgr`, `vfsd`,
-  `logd`, `timed`, `pwrmgr`. svcmgr reconciles each against the
-  matching `<name>.svc` recipe in `/config/svcmgr/services/` and
-  binds death-notification — see
+  `pwrmgr.shutdown`, `pwrmgr.deny`, and `timed` are published by
+  svcmgr's provider path, not by init. Name constants are centralised in
+  `ipc::published_names`.
+- Register each init-bootstrapped substrate service with svcmgr via the
+  v3 `REGISTER_SERVICE` wire (name + thread cap; `register_service`
+  helper in `../src/service.rs`). Registration set: `memmgr`, `procmgr`,
+  `devmgr`, `vfsd`, `logd`. svcmgr reconciles each against the matching
+  `<name>.svc` recipe in `/config/svcmgr/services/` and binds
+  death-notification; the non-bootstrap services (`timed`, `pwrmgr`,
+  staged harnesses) it launches itself from their recipes — see
   [`../../svcmgr/docs/service-definitions.md`](../../svcmgr/docs/service-definitions.md).
 - Signal `HANDOVER_COMPLETE` (`../src/service.rs:1552`). svcmgr
   scans `/config/svcmgr/services/` and launches any
@@ -245,12 +234,11 @@ svcmgr if needed.
 |---|---|---|
 | Raw bootstrap | memmgr | RAM `Frame` pool (every Frame cap not consumed by init/procmgr setup) |
 | Raw bootstrap | procmgr | memmgr SEND cap, log endpoint SEND, svcmgr service endpoint SEND, boot-module `Frame` caps for downstream `CREATE_PROCESS` |
-| Raw bootstrap | devmgr | MMIO apertures, Interrupt range, ACPI/DTB Frame caps |
+| Raw bootstrap | devmgr | MMIO apertures, Interrupt range, ACPI/DTB Frame caps; root `IoPortRange` (x86-64) / `SbiControl` (RISC-V) via the terminal `SVCMGR_BUNDLE` round — the hardware + shutdown authority devmgr brokers to drivers and to pwrmgr |
 | Raw bootstrap | vfsd | `SEED_AUTHORITY`-tokened SEND on vfsd's own service endpoint (gates `GET_SYSTEM_ROOT_CAP`); the un-tokened service-endpoint SEND init holds is used for the un-gated MOUNT call. Init keeps no FS access of its own. |
 | Root mount | logd | RECV on the master log endpoint, one-shot SEND for `HANDOVER_PULL`, `DEATH_EQ_AUTHORITY`-tokened SEND on procmgr, arch serial authority (`IoPortRange` on x86-64, `SbiControl` on RISC-V) |
 | Handover | svcmgr | `Universal` namespace seed (full `system_root_cap`) installed via `procmgr_labels::CONFIGURE_NAMESPACE` before `START_PROCESS`; in the bootstrap round, full-rights SEND on its own service endpoint and on the local svcmgr-bootstrap endpoint |
-| Handover | pwrmgr | Remaining arch authority (`IoPortRange` / `SbiControl`) + ACPI region Frame caps |
-| Handover (publish) | svcmgr registry | `rootfs.root`, `pwrmgr.shutdown`, `pwrmgr.deny`, `svcmgr`, `devmgr.registry` named caps |
+| Handover (publish) | svcmgr registry | `rootfs.root`, `svcmgr`, `devmgr.registry` named caps (init no longer publishes `pwrmgr.*` / `timed` — svcmgr's provider path does) |
 | Reap | procmgr | Init's `AddressSpace`, `CSpace`, main `Thread`, init-logd `Thread`, every reclaimable Frame cap it solely owns (ELF segments, user stack, `InitInfo` pages, bootloader/bundle reclaim ranges, AP-trampoline frame, boot-module ELF sources) |
 
 ---

--- a/services/init/docs/bootstrap.md
+++ b/services/init/docs/bootstrap.md
@@ -4,7 +4,7 @@ Authoritative enumeration of the work init performs between kernel
 handoff (`_start`) and `sys_thread_exit`, organised into three
 stages: **Raw bootstrap**, **Root acquisition**, **Handover**. The
 names used in source `log()` strings — `"phase 1 bootstrap complete"`,
-`"phase 2: acquiring system-root cap"`, `"phase 2 epilogue"`,
+`"phase 2: acquiring system-root cap"`, `"phase 2 bootstrap complete"`,
 `"phase 3: ..."` — are the searchable equivalents and remain stable.
 
 ---
@@ -13,64 +13,71 @@ names used in source `log()` strings — `"phase 1 bootstrap complete"`,
 
 ### Raw bootstrap
 
-Init reaches `run()` (`../src/main.rs:375`) with the kernel-supplied
+Init reaches `run()` (`../src/main.rs:350`) with the kernel-supplied
 `InitInfo` populated and the initial CSpace seeded (see
 [Capability flow](#capability-flow)). It performs the work required to
 stand memmgr and procmgr up via raw syscalls, then delegates further
 process creation to procmgr IPC.
 
 - Version-check `InitInfo` against `INIT_PROTOCOL_VERSION` and exit
-  on mismatch (`../src/main.rs:382`).
+  on mismatch (`../src/main.rs:357`).
 - Initialise the per-arch serial path used for FATAL pre-IPC errors
-  (`../src/main.rs:389`).
+  (`../src/main.rs:364`).
 - Build the `FrameAlloc` bump allocator over the kernel-provided
-  memory pool (`../src/main.rs:391`).
+  memory pool (`../src/main.rs:366`).
 - Reserve a Frame to back kernel-object retypes (the endpoint slab;
   one page suffices for the eight endpoints init creates)
-  (`../src/main.rs:396`).
+  (`../src/main.rs:377`).
 - Map a fresh IPC buffer page at `INIT_IPC_BUF_VA` and register it
-  with the kernel (`../src/main.rs:404`–`../src/main.rs:427`).
+  with the kernel (`../src/main.rs:393`–`../src/main.rs:405`).
 - Mint endpoint objects: init's bootstrap endpoint, procmgr's
   service endpoint, memmgr's service endpoint, svcmgr's service
-  endpoint (`../src/main.rs:461`; minted here so procmgr can receive
+  endpoint (`../src/main.rs:439`; minted here so procmgr can receive
   an un-tokened SEND on it during procmgr's bootstrap round), and
-  the master log endpoint (`../src/main.rs:483`).
-- Spawn the init-logd thread, which serves the log endpoint until
-  real-logd takes over via `HANDOVER_PULL`
-  (`../src/main.rs:494`, with the receive loop in
+  the master log endpoint (`../src/main.rs:460`).
+- Spawn the init-logd thread — a second thread of the init process
+  that drains the master log endpoint and writes lines to the serial
+  UART directly (`../src/main.rs:472`, with the receive loop in
   `../src/logging.rs`). After this point init's own `log()` lines
-  ride IPC through init-logd to the serial UART.
+  ride IPC through init-logd to the serial UART. init-logd outlives
+  init's main thread: it covers the console across the init→svcmgr
+  handover and svcmgr's reconcile, until the svcmgr-launched
+  real-logd pulls its captured history via `HANDOVER_PULL` and
+  init-logd self-terminates (see [Handover](#handover)).
 - Bootstrap memmgr via raw `cap_create_aspace` / `cap_create_cspace`
   / `cap_create_thread`, ELF-load it from the `memmgr` bundle
   entry, prepare its `ProcessInfo` page, and configure its main
   thread but defer `thread_start`
-  (`bootstrap::bootstrap_memmgr` at `../src/bootstrap.rs:429`,
-  called from `../src/main.rs:527`).
+  (`bootstrap::bootstrap_memmgr` at `../src/bootstrap.rs:521`,
+  called from `../src/main.rs:506`).
 - Bootstrap procmgr the same way; procmgr's `ProcessInfo` receives
   the memmgr SEND cap so its std heap reaches memmgr on the first
   allocation (`bootstrap::bootstrap_procmgr` at
-  `../src/bootstrap.rs:796`, called from `../src/main.rs:537`).
-- Donate the remaining RAM Frame caps to memmgr's CSpace, serve a
-  single bootstrap-IPC round carrying the donated slot range
-  (so memmgr knows where its pool lives), then donate the
-  boot-module Frame caps that backed procmgr/devmgr/vfsd
-  (`../src/main.rs:630`, `../src/main.rs:652`).
+  `../src/bootstrap.rs:1119`, called from `../src/main.rs:515`).
+- Delegate all remaining RAM Frame caps to memmgr's CSpace via
+  `finalize_memmgr` and serve a single bootstrap-IPC round carrying
+  the pool's frame range + a read-only phys-table cap (so memmgr can
+  ingest its pool) (`../src/main.rs:543`, serve at `../src/main.rs:574`).
+  Init retains every boot-module Frame cap (its self-loaded
+  memmgr/procmgr ELFs plus the devmgr/vfsd/driver modules) as sole
+  owner; those donate to memmgr's pool on the reap-handoff route, not
+  here (`../src/main.rs:628`).
 - Start procmgr's thread and serve procmgr's bootstrap IPC, handing
   it the log endpoint SEND and svcmgr's service endpoint SEND
-  (`../src/main.rs:696`).
+  (`../src/main.rs:634`).
 - Request procmgr to create devmgr via boot-module
   `CREATE_PROCESS` and serve devmgr's multi-round bootstrap
   (hardware caps: MMIO apertures, Interrupt range, ACPI Frame caps,
   DTB Frame cap on riscv64, and a `FRAMEBUFFER_INFO` round carrying
   the bootloader-discovered `boot_protocol::FramebufferInfo` so devmgr
   can spawn the userspace framebuffer driver)
-  (`../src/main.rs:782` + `service::create_devmgr_with_caps` at
-  `../src/service.rs:371`).
+  (`../src/main.rs:720` + `service::create_devmgr_with_caps` at
+  `../src/service.rs:341`).
 - Request procmgr to create vfsd the same way and serve its
-  bootstrap (`../src/main.rs:800` +
-  `service::create_vfsd_with_caps` at `../src/service.rs:950`).
+  bootstrap (`../src/main.rs:738` +
+  `service::create_vfsd_with_caps` at `../src/service.rs:738`).
 - Closing marker: `"phase 1 bootstrap complete"`
-  (`../src/main.rs:821`).
+  (`../src/main.rs:755`).
 
 ### Root acquisition
 
@@ -88,26 +95,23 @@ init's wait-for-root barrier.
   — every later child receives a `cap_copy` of it via
   `procmgr_labels::CONFIGURE_NAMESPACE`, and svcmgr derives the
   published `rootfs.root` SEND from it.
-- **Phase 2 epilogue** — walk `/services/logd`, request procmgr to
-  create real-logd via `CREATE_FROM_FILE`, and serve its bootstrap
-  round (RECV cap on the master log endpoint, one-shot SEND for
-  `HANDOVER_PULL`, `DEATH_EQ_AUTHORITY`-tokened SEND on procmgr,
-  arch serial authority). Real-logd pulls init-logd's captured
-  state via `HANDOVER_PULL`; init-logd self-terminates on the
-  final reply. See
-  [`../../logd/docs/handover-protocol.md`](../../logd/docs/handover-protocol.md)
-  (`../src/main.rs:866` → `service::create_and_start_logd` in
-  `../src/service.rs`).
+- real-logd is a svcmgr-launched service, not an init responsibility.
+  init-logd continues to serve the master log endpoint and write
+  serial directly; svcmgr brings up real-logd post-handover from the
+  reserved log-sink sources init endows in the Handover stage (the
+  `LOGD_SOURCES` round below), and real-logd then pulls init-logd's
+  captured state via `HANDOVER_PULL`. See
+  [`../../logd/docs/handover-protocol.md`](../../logd/docs/handover-protocol.md).
 - Closing marker: `"phase 2 bootstrap complete"`
-  (`../src/main.rs:881`).
+  (`../src/main.rs:783`).
 
 ### Handover
 
 `service::phase3_svcmgr_handover` (in `../src/service.rs`, called
 from `../src/main.rs`) loads svcmgr, serves it the handover endowment,
 signals handover, and hands init's own kernel objects to procmgr for
-reaping. init no longer publishes well-known caps, registers services,
-or talks to devmgr — svcmgr does all of that from the endowment.
+reaping. svcmgr — not init — publishes the well-known caps, registers
+services, and talks to devmgr, all from the endowment.
 
 - Spawn svcmgr from `/services/svcmgr` with the `Universal` namespace
   policy (`create_svcmgr_from_file`), then serve it the handover
@@ -122,10 +126,25 @@ or talks to devmgr — svcmgr does all of that from the endowment.
     `SVCMGR_LABELS_VERSION`. An absent source rides as a zero slot.
   - **Rounds 2..N (`SUBSTRATE`)** — one `(name, thread_cap)` per
     init-bootstrapped substrate service: `memmgr`, `procmgr`, `devmgr`,
-    `vfsd`, `logd`. svcmgr parks them and binds death-notification on
+    `vfsd`. svcmgr parks them and binds death-notification on
     each at reconciliation, pairing against the matching `<name>.svc`
     recipe in `/config/svcmgr/services/` — see
     [`../../svcmgr/docs/service-definitions.md`](../../svcmgr/docs/service-definitions.md).
+    logd is not among them: it is a svcmgr-launched service (from the
+    `LOGD_SOURCES` round below), not a parked substrate.
+  - **Terminal round (`LOGD_SOURCES`)** — the two reserved log-sink
+    source caps svcmgr holds for the system's lifetime so it can
+    launch + supervise + restart real-logd any number of times:
+    `master_log_source`, a `RIGHTS_ALL` derive of init's master log
+    endpoint (svcmgr mints real-logd's master-log RECV from it on every
+    (re)launch, plus the one-shot `HANDOVER_PULL` SEND on the first
+    launch), and `procmgr_death_auth_source`, a token-0
+    `RIGHTS_SEND_GRANT` derive of procmgr's service endpoint (svcmgr
+    mints real-logd's `DEATH_EQ_AUTHORITY` SEND from it for per-sender
+    death-EQ registration). Holding `master_log_source` keeps the log
+    endpoint object alive across a logd crash, so log senders are
+    agnostic to which process holds the RECV. An absent source rides as
+    a zero slot.
 - After draining the endowment, **svcmgr** (not init) publishes the
   well-known names it owns into its own registry and installs devmgr's
   drivers dir:
@@ -231,8 +250,7 @@ svcmgr if needed.
 | Raw bootstrap | procmgr | memmgr SEND cap, log endpoint SEND, svcmgr service endpoint SEND, boot-module `Frame` caps for downstream `CREATE_PROCESS` |
 | Raw bootstrap | devmgr | MMIO apertures, Interrupt range, ACPI/DTB Frame caps; root `IoPortRange` (x86-64) / `SbiControl` (RISC-V) via the terminal `SVCMGR_BUNDLE` round — the hardware + shutdown authority devmgr brokers to drivers and to pwrmgr |
 | Raw bootstrap | vfsd | `SEED_AUTHORITY`-tokened SEND on vfsd's own service endpoint (gates `GET_SYSTEM_ROOT_CAP`). vfsd self-mounts root, so init issues no `MOUNT` and keeps no FS access of its own. |
-| Root acquisition | logd | RECV on the master log endpoint, one-shot SEND for `HANDOVER_PULL`, `DEATH_EQ_AUTHORITY`-tokened SEND on procmgr, arch serial authority (`IoPortRange` on x86-64, `SbiControl` on RISC-V) |
-| Handover | svcmgr | `Universal` namespace seed (full `system_root_cap`) installed via `procmgr_labels::CONFIGURE_NAMESPACE` before `START_PROCESS`; then the handover endowment over the bootstrap protocol — round 1 (`CAPS`): full-rights SEND on its own service + bootstrap endpoints, a `SEND` on the root filesystem namespace endpoint (svcmgr publishes as `rootfs.root`) and a token-0 `SEND\|GRANT` source on `devmgr_registry_ep` (svcmgr mints the `devmgr.registry` publish cap and the `SET_DRIVERS_DIR` cap); rounds 2..N (`SUBSTRATE`): one `(name, thread_cap)` per substrate service for death-supervision binding. svcmgr publishes all well-known names itself and sends `SET_DRIVERS_DIR` from these sources; init no longer publishes or talks to devmgr. |
+| Handover | svcmgr | `Universal` namespace seed (full `system_root_cap`) installed via `procmgr_labels::CONFIGURE_NAMESPACE` before `START_PROCESS`; then the handover endowment over the bootstrap protocol — round 1 (`CAPS`): full-rights SEND on its own service + bootstrap endpoints, a `SEND` on the root filesystem namespace endpoint (svcmgr publishes as `rootfs.root`) and a token-0 `SEND\|GRANT` source on `devmgr_registry_ep` (svcmgr mints the `devmgr.registry` publish cap and the `SET_DRIVERS_DIR` cap); rounds 2..N (`SUBSTRATE`): one `(name, thread_cap)` per substrate service for death-supervision binding; terminal round (`LOGD_SOURCES`): a `RIGHTS_ALL` master-log endpoint source and a token-0 `SEND\|GRANT` procmgr source, both reserved for the system's lifetime so svcmgr can launch + supervise + restart real-logd (minting its master-log RECV, first-launch `HANDOVER_PULL` SEND, and `DEATH_EQ_AUTHORITY` SEND per launch). svcmgr publishes all well-known names itself, sends `SET_DRIVERS_DIR` from these sources, and launches real-logd; init publishes nothing and does not talk to devmgr. |
 | Reap | procmgr | Init's `AddressSpace`, `CSpace`, main `Thread`, init-logd `Thread`, every reclaimable Frame cap it solely owns (ELF segments, user stack, `InitInfo` pages, bootloader/bundle reclaim ranges, AP-trampoline frame, boot-module ELF sources) |
 
 ---

--- a/services/init/docs/bootstrap.md
+++ b/services/init/docs/bootstrap.md
@@ -100,86 +100,85 @@ directly without init involvement.
   state via `HANDOVER_PULL`; init-logd self-terminates on the
   final reply. See
   [`../../logd/docs/handover-protocol.md`](../../logd/docs/handover-protocol.md)
-  (`../src/main.rs:866` → `service::create_and_start_logd` at
-  `../src/service.rs:1595`).
+  (`../src/main.rs:866` → `service::create_and_start_logd` in
+  `../src/service.rs`).
 - Closing marker: `"phase 2 bootstrap complete"`
   (`../src/main.rs:881`).
 
 ### Handover
 
-`service::phase3_svcmgr_handover` (`../src/service.rs:1311`, called
-from `../src/main.rs`) brings up the remaining bootstrap services,
-transfers the system-wide service registry to svcmgr, publishes the
-well-known caps, registers init-bootstrapped services with svcmgr,
-and hands init's own kernel objects to procmgr for reaping.
+`service::phase3_svcmgr_handover` (in `../src/service.rs`, called
+from `../src/main.rs`) loads svcmgr, serves it the handover endowment,
+signals handover, and hands init's own kernel objects to procmgr for
+reaping. init no longer publishes well-known caps, registers services,
+or talks to devmgr — svcmgr does all of that from the endowment.
 
 - Spawn svcmgr from `/services/svcmgr` with the `Universal` namespace
-  policy and serve its bootstrap round
-  (`../src/service.rs:1340` → `create_svcmgr_from_file` at
-  `../src/service.rs:1135`; `setup_and_start_svcmgr` at
-  `../src/service.rs:1213`).
-- Walk `system_root_cap` to `/services/drivers/` at `LOOKUP | READ`
-  rights and hand devmgr the resulting subtree cap via
-  `devmgr_labels::SET_DRIVERS_DIR`, on an
-  `INIT_BIND_AUTHORITY`-tokened copy of `devmgr_registry_ep`. Devmgr
-  replies SUCCESS *before* doing any spawn work, then walks the
-  per-arch RTC name from that subtree and spawns the driver between
-  its `ipc_reply` and next `ipc_recv` (procmgr `CREATE_FROM_FILE` —
-  the binary lives on the rootfs, not in the boot bundle).
-  Best-effort: the handshake is non-fatal, and any failure
-  (walk fails, devmgr replies non-SUCCESS) leaves the system without
-  a wallclock — timed degrades to `WALL_CLOCK_UNAVAILABLE`.
-  (`set_drivers_dir_on_devmgr` in `../src/service.rs`.)
+  policy (`create_svcmgr_from_file`), then serve it the handover
+  endowment over the bootstrap-round protocol (`endow_svcmgr`):
+  - **Round 1 (`CAPS`)** — svcmgr's service + bootstrap endpoints
+    (full rights), plus the publish-role source caps: a `SEND` on the
+    root filesystem's namespace endpoint (svcmgr publishes it as
+    `rootfs.root`) and a token-0 `SEND|GRANT` source on
+    `devmgr_registry_ep` (svcmgr mints the `REGISTRY_QUERY_AUTHORITY`
+    `devmgr.registry` publish cap and the `DRIVERS_DIR_AUTHORITY`
+    `SET_DRIVERS_DIR` cap from it). `data[1]` carries
+    `SVCMGR_LABELS_VERSION`. An absent source rides as a zero slot.
+  - **Rounds 2..N (`SUBSTRATE`)** — one `(name, thread_cap)` per
+    init-bootstrapped substrate service: `memmgr`, `procmgr`, `devmgr`,
+    `vfsd`, `logd`. svcmgr parks them and binds death-notification on
+    each at reconciliation, pairing against the matching `<name>.svc`
+    recipe in `/config/svcmgr/services/` — see
+    [`../../svcmgr/docs/service-definitions.md`](../../svcmgr/docs/service-definitions.md).
+- After draining the endowment, **svcmgr** (not init) publishes the
+  well-known names it owns into its own registry and installs devmgr's
+  drivers dir:
+  - `rootfs.root` — the endowed `SEND` on the root filesystem's
+    namespace endpoint (FS-driver-agnostic by design).
+  - `svcmgr` — un-tokened SEND on svcmgr's own service endpoint.
+  - `devmgr.registry` — `REGISTRY_QUERY_AUTHORITY`-tokened SEND minted
+    from the endowed devmgr-registry source. Consumers needing to
+    resolve a device driver themselves (`programs/fb-charset` →
+    `QUERY_FRAMEBUFFER_DEVICE`; timed and pwrmgr → their devmgr queries;
+    future: any non-init caller of devmgr's discovery surface) seed this
+    name. The token bit survives svcmgr's plain `cap_derive` in
+    `registry_lookup_derived`.
+  - `SET_DRIVERS_DIR` — svcmgr walks its universal root to
+    `/services/drivers/` at `LOOKUP | READ` and hands devmgr the subtree
+    cap on a `DRIVERS_DIR_AUTHORITY`-tokened copy of the
+    devmgr-registry source. Devmgr replies SUCCESS *before* any spawn
+    work, then walks the per-arch RTC name and spawns the driver between
+    its `ipc_reply` and next `ipc_recv` (procmgr `CREATE_FROM_FILE` —
+    the binary lives on the rootfs, not in the boot bundle). Best-effort:
+    a failure leaves the system without a wallclock — timed degrades to
+    `WALL_CLOCK_UNAVAILABLE`.
+
+  `pwrmgr.shutdown`, `pwrmgr.deny`, and `timed` are published by
+  svcmgr's provider path on each provider's launch. Name constants are
+  centralised in `ipc::published_names`.
 - The wallclock chain and pwrmgr are **not** spawned by init. `timed`
   and `pwrmgr` are svcmgr-launched providers (`timed.svc` / `pwrmgr.svc`),
   brought up post-handover; each resolves its authority from devmgr at
   startup (`QUERY_RTC_DEVICE` for timed; `QUERY_ACPI_TABLE` +
   `QUERY_SHUTDOWN_DEVICE` for pwrmgr). The RTC chip driver (cmos-rtc on
   x86-64, goldfish-rtc on RISC-V) is spawned by devmgr from
-  `/services/drivers/<chip>` after the `SET_DRIVERS_DIR` handshake above,
-  also not by init.
-- Derive a `PUBLISH_AUTHORITY`-tokened `RIGHTS_SEND_GRANT` cap on
-  svcmgr's service endpoint and publish the three well-known names init
-  still owns the sources for, via `PUBLISH_ENDPOINT`
-  (`phase3_svcmgr_handover` in `../src/service.rs`):
-  - `rootfs.root` — tokened SEND on the root filesystem's
-    namespace endpoint at its root directory (FS-driver-agnostic
-    by design).
-  - `svcmgr` — un-tokened SEND on svcmgr's own service endpoint.
-  - `devmgr.registry` — `REGISTRY_QUERY_AUTHORITY`-tokened SEND
-    on devmgr's registry endpoint. Consumers needing to resolve a
-    device driver themselves (`programs/fb-charset` →
-    `QUERY_FRAMEBUFFER_DEVICE`; timed and pwrmgr → their devmgr
-    queries; future: any non-init caller of devmgr's discovery surface)
-    seed this name. The token bit survives svcmgr's plain `cap_derive`
-    in `registry_lookup_derived`.
-
-  `pwrmgr.shutdown`, `pwrmgr.deny`, and `timed` are published by
-  svcmgr's provider path, not by init. Name constants are centralised in
-  `ipc::published_names`.
-- Register each init-bootstrapped substrate service with svcmgr via the
-  v3 `REGISTER_SERVICE` wire (name + thread cap; `register_service`
-  helper in `../src/service.rs`). Registration set: `memmgr`, `procmgr`,
-  `devmgr`, `vfsd`, `logd`. svcmgr reconciles each against the matching
-  `<name>.svc` recipe in `/config/svcmgr/services/` and binds
-  death-notification; the non-bootstrap services (`timed`, `pwrmgr`,
-  staged harnesses) it launches itself from their recipes — see
-  [`../../svcmgr/docs/service-definitions.md`](../../svcmgr/docs/service-definitions.md).
-- Signal `HANDOVER_COMPLETE` (`../src/service.rs:1552`). svcmgr
-  scans `/config/svcmgr/services/` and launches any
-  defined-but-unregistered services from disk.
+  `/services/drivers/<chip>` after svcmgr's `SET_DRIVERS_DIR` handshake.
+- Signal `HANDOVER_COMPLETE`. svcmgr scans `/config/svcmgr/services/`,
+  reconciles the parked substrate against the recipes, and launches any
+  defined-but-unparked services (`timed`, `pwrmgr`, staged harnesses)
+  from disk.
 - Hand init's kernel-object caps (`AddressSpace`, `CSpace`, main
   `Thread`, init-logd `Thread`) and every reclaimable Frame cap it
   solely owns (ELF segments, user stack pages, `InitInfo` pages, the
   bootloader/bundle reclaim ranges, the AP-trampoline frame, and the
   boot-module ELF sources) to procmgr via
-  `REGISTER_INIT_TEARDOWN` (`../src/service.rs:1565` →
-  `handoff_to_procmgr_reap` at `../src/service.rs:1586`). IPC
+  `REGISTER_INIT_TEARDOWN` (`handoff_to_procmgr_reap` in
+  `../src/service.rs`). IPC
   cap-transfer MOVES the caps, so they leave init's CSpace. The
   usable-RAM range (already memmgr's), the firmware read-only caps,
   and init's own bootstrap backing (arena-forwarded to memmgr at
   `finalize_memmgr`) are excluded.
-- Call `sys_thread_exit` (`../src/service.rs:1574`). Procmgr's
+- Call `sys_thread_exit`. Procmgr's
   death-EQ observer (bound on init's main thread with
   `INIT_REAP_CORRELATOR`) fires and runs
   [`init_reap::run_reap`](../../procmgr/src/init_reap.rs): both
@@ -237,8 +236,7 @@ svcmgr if needed.
 | Raw bootstrap | devmgr | MMIO apertures, Interrupt range, ACPI/DTB Frame caps; root `IoPortRange` (x86-64) / `SbiControl` (RISC-V) via the terminal `SVCMGR_BUNDLE` round — the hardware + shutdown authority devmgr brokers to drivers and to pwrmgr |
 | Raw bootstrap | vfsd | `SEED_AUTHORITY`-tokened SEND on vfsd's own service endpoint (gates `GET_SYSTEM_ROOT_CAP`); the un-tokened service-endpoint SEND init holds is used for the un-gated MOUNT call. Init keeps no FS access of its own. |
 | Root mount | logd | RECV on the master log endpoint, one-shot SEND for `HANDOVER_PULL`, `DEATH_EQ_AUTHORITY`-tokened SEND on procmgr, arch serial authority (`IoPortRange` on x86-64, `SbiControl` on RISC-V) |
-| Handover | svcmgr | `Universal` namespace seed (full `system_root_cap`) installed via `procmgr_labels::CONFIGURE_NAMESPACE` before `START_PROCESS`; in the bootstrap round, full-rights SEND on its own service endpoint and on the local svcmgr-bootstrap endpoint |
-| Handover (publish) | svcmgr registry | `rootfs.root`, `svcmgr`, `devmgr.registry` named caps (init no longer publishes `pwrmgr.*` / `timed` — svcmgr's provider path does) |
+| Handover | svcmgr | `Universal` namespace seed (full `system_root_cap`) installed via `procmgr_labels::CONFIGURE_NAMESPACE` before `START_PROCESS`; then the handover endowment over the bootstrap protocol — round 1 (`CAPS`): full-rights SEND on its own service + bootstrap endpoints, a `SEND` on the root filesystem namespace endpoint (svcmgr publishes as `rootfs.root`) and a token-0 `SEND\|GRANT` source on `devmgr_registry_ep` (svcmgr mints the `devmgr.registry` publish cap and the `SET_DRIVERS_DIR` cap); rounds 2..N (`SUBSTRATE`): one `(name, thread_cap)` per substrate service for death-supervision binding. svcmgr publishes all well-known names itself and sends `SET_DRIVERS_DIR` from these sources; init no longer publishes or talks to devmgr. |
 | Reap | procmgr | Init's `AddressSpace`, `CSpace`, main `Thread`, init-logd `Thread`, every reclaimable Frame cap it solely owns (ELF segments, user stack, `InitInfo` pages, bootloader/bundle reclaim ranges, AP-trampoline frame, boot-module ELF sources) |
 
 ---

--- a/services/init/docs/bootstrap.md
+++ b/services/init/docs/bootstrap.md
@@ -2,9 +2,9 @@
 
 Authoritative enumeration of the work init performs between kernel
 handoff (`_start`) and `sys_thread_exit`, organised into three
-stages: **Raw bootstrap**, **Root mount**, **Handover**. The names
-used in source `log()` strings — `"phase 1 bootstrap complete"`,
-`"phase 2: mounting root filesystem"`, `"phase 2 epilogue"`,
+stages: **Raw bootstrap**, **Root acquisition**, **Handover**. The
+names used in source `log()` strings — `"phase 1 bootstrap complete"`,
+`"phase 2: acquiring system-root cap"`, `"phase 2 epilogue"`,
 `"phase 3: ..."` — are the searchable equivalents and remain stable.
 
 ---
@@ -72,26 +72,22 @@ process creation to procmgr IPC.
 - Closing marker: `"phase 1 bootstrap complete"`
   (`../src/main.rs:821`).
 
-### Root mount
+### Root acquisition
 
-vfsd identifies the root partition by GPT type-GUID
-(`boot_protocol::role_guids::SERAPH_ROOT_<arch>`), so init names
-only the *role* and vfsd performs the partition lookup. Init's
-contribution is the MOUNT exchange and the seed-cap pull; the ESP
-and any further partitions are discovered and mounted by vfsd
-directly without init involvement.
+vfsd self-mounts the root partition at `/` (and the ESP at `/esp`) on
+its own startup, identifying partitions by GPT type-GUID
+(`boot_protocol::role_guids::SERAPH_ROOT_<arch>`). Init issues no
+`MOUNT`; its only contribution is the seed-cap pull, which doubles as
+init's wait-for-root barrier.
 
-- Send `MOUNT(MountRole::Root, "/")` to vfsd
-  (`../src/main.rs:830` → `mount::send_mount` at
-  `../src/mount.rs:63`). The wire payload is the `MountRole`
-  discriminant byte (`../src/mount.rs:30`, currently a single
-  variant `Root = 0`) plus the mount-point path.
 - Pull the seed system-root cap via `GET_SYSTEM_ROOT_CAP`
-  (`../src/main.rs:846` → `mount::request_system_root` at
-  `../src/mount.rs:100`). The reply is a tokened SEND on vfsd's
-  namespace endpoint at the synthetic root with full namespace
-  rights — every later child receives a `cap_copy` of it via
-  `procmgr_labels::CONFIGURE_NAMESPACE`.
+  (`mount::request_system_root`). vfsd replies `NO_MOUNT` until it has
+  mounted root, so the call blocks until the root filesystem is up; a
+  zero return is FATAL. The success reply is a tokened SEND on vfsd's
+  namespace endpoint at the synthetic root with full namespace rights
+  — every later child receives a `cap_copy` of it via
+  `procmgr_labels::CONFIGURE_NAMESPACE`, and svcmgr derives the
+  published `rootfs.root` SEND from it.
 - **Phase 2 epilogue** — walk `/services/logd`, request procmgr to
   create real-logd via `CREATE_FROM_FILE`, and serve its bootstrap
   round (RECV cap on the master log endpoint, one-shot SEND for
@@ -234,8 +230,8 @@ svcmgr if needed.
 | Raw bootstrap | memmgr | RAM `Frame` pool (every Frame cap not consumed by init/procmgr setup) |
 | Raw bootstrap | procmgr | memmgr SEND cap, log endpoint SEND, svcmgr service endpoint SEND, boot-module `Frame` caps for downstream `CREATE_PROCESS` |
 | Raw bootstrap | devmgr | MMIO apertures, Interrupt range, ACPI/DTB Frame caps; root `IoPortRange` (x86-64) / `SbiControl` (RISC-V) via the terminal `SVCMGR_BUNDLE` round — the hardware + shutdown authority devmgr brokers to drivers and to pwrmgr |
-| Raw bootstrap | vfsd | `SEED_AUTHORITY`-tokened SEND on vfsd's own service endpoint (gates `GET_SYSTEM_ROOT_CAP`); the un-tokened service-endpoint SEND init holds is used for the un-gated MOUNT call. Init keeps no FS access of its own. |
-| Root mount | logd | RECV on the master log endpoint, one-shot SEND for `HANDOVER_PULL`, `DEATH_EQ_AUTHORITY`-tokened SEND on procmgr, arch serial authority (`IoPortRange` on x86-64, `SbiControl` on RISC-V) |
+| Raw bootstrap | vfsd | `SEED_AUTHORITY`-tokened SEND on vfsd's own service endpoint (gates `GET_SYSTEM_ROOT_CAP`). vfsd self-mounts root, so init issues no `MOUNT` and keeps no FS access of its own. |
+| Root acquisition | logd | RECV on the master log endpoint, one-shot SEND for `HANDOVER_PULL`, `DEATH_EQ_AUTHORITY`-tokened SEND on procmgr, arch serial authority (`IoPortRange` on x86-64, `SbiControl` on RISC-V) |
 | Handover | svcmgr | `Universal` namespace seed (full `system_root_cap`) installed via `procmgr_labels::CONFIGURE_NAMESPACE` before `START_PROCESS`; then the handover endowment over the bootstrap protocol — round 1 (`CAPS`): full-rights SEND on its own service + bootstrap endpoints, a `SEND` on the root filesystem namespace endpoint (svcmgr publishes as `rootfs.root`) and a token-0 `SEND\|GRANT` source on `devmgr_registry_ep` (svcmgr mints the `devmgr.registry` publish cap and the `SET_DRIVERS_DIR` cap); rounds 2..N (`SUBSTRATE`): one `(name, thread_cap)` per substrate service for death-supervision binding. svcmgr publishes all well-known names itself and sends `SET_DRIVERS_DIR` from these sources; init no longer publishes or talks to devmgr. |
 | Reap | procmgr | Init's `AddressSpace`, `CSpace`, main `Thread`, init-logd `Thread`, every reclaimable Frame cap it solely owns (ELF segments, user stack, `InitInfo` pages, bootloader/bundle reclaim ranges, AP-trampoline frame, boot-module ELF sources) |
 

--- a/services/init/src/main.rs
+++ b/services/init/src/main.rs
@@ -451,13 +451,12 @@ fn run(info_ptr: u64) -> !
     // log_ep) are satisfied so init's own subsequent log lines ride IPC
     // through the mediator instead of direct serial.
     //
-    // Real `logd` (loaded from `/services/logd` at the end of Phase 2,
-    // post-root-mount) takes over the receive side via the
+    // Real `logd` (svcmgr-launched post-handover from the reserved log-sink
+    // sources init endows) takes over the receive side via the
     // `log_labels::HANDOVER_PULL` exchange — see
-    // `service::create_and_start_logd` and
-    // `services/logd/docs/handover-protocol.md`. The same kernel
-    // endpoint object is reused, so every existing tokened SEND cap
-    // survives the handover unchanged.
+    // `services/logd/docs/handover-protocol.md`. The same kernel endpoint
+    // object is reused, so every existing tokened SEND cap survives the
+    // handover unchanged.
     let Ok(log_ep) = syscall::cap_create_endpoint(endpoint_slab())
     else
     {
@@ -466,8 +465,9 @@ fn run(info_ptr: u64) -> !
     };
 
     // Log thread cap retained so init's reap-handoff
-    // (`procmgr.REGISTER_INIT_TEARDOWN`) can include it, letting procmgr
-    // reclaim the init-logd TCB after init's main thread exits.
+    // (`procmgr.REGISTER_INIT_TEARDOWN`) can include it: procmgr binds a
+    // death-EQ on both init threads and reclaims the init-logd TCB once init
+    // is threadless (init-logd outlives main until real-logd's handover).
     let ioport_cap = find_cap_by_type(info, init_protocol::CapType::IoPortRange).unwrap_or(0);
     let init_logd_thread_cap = logging::spawn_log_thread(info, &mut init_arena, log_ep, ioport_cap);
 
@@ -758,7 +758,7 @@ fn run(info_ptr: u64) -> !
 
     // vfsd self-mounts the root partition at `/` (and the ESP at `/esp`) on
     // its own startup, identifying partitions by GPT type-GUID; init issues
-    // no MOUNT. `/config/mounts.conf` and `INGEST_CONFIG_MOUNTS` are gone.
+    // no MOUNT and reads no mount-config file.
     //
     // Acquire init's seed system-root cap. vfsd serves this only once root
     // is mounted, so the call blocks until the root filesystem is up. The
@@ -774,32 +774,12 @@ fn run(info_ptr: u64) -> !
     }
     logging::log("phase 2: root available");
 
-    // ── Phase 2 epilogue: launch real logd ──────────────────────────────────
-    //
-    // Spawned at the end of Phase 2 (after root mount, with
-    // system_root_cap in hand) so logd can be walked from
-    // `/services/logd`. Hands over the master log endpoint via
-    // `HANDOVER_PULL` IPC inside logd's bootstrap; init-logd's
-    // receive loop self-terminates after replying the final chunk.
-    // From here on the same kernel endpoint object carries every
-    // sender's messages to real-logd's RECV — no live writer
-    // re-registers.
-    logging::log("phase 2: launching logd");
-    thread_caps.logd = service::create_and_start_logd(
-        endpoint_cap,
-        endpoint_cap,
-        init_bootstrap_ep,
-        log_ep,
-        devmgr_registry_ep,
-        system_root_cap,
-        info.cspace_cap,
-        ipc_buf,
-    )
-    .unwrap_or_else(|| {
-        logging::log("phase 2: logd launch failed; init-logd remains the receiver");
-        0
-    });
-
+    // init-logd (the serial-writer thread) serves the master log endpoint
+    // and writes serial directly until the svcmgr-launched real-logd pulls
+    // `HANDOVER_PULL`; it outlives init's main thread, so procmgr reaps init
+    // only once both init threads have exited (reap-on-threadless). svcmgr
+    // launches real-logd post-handover from the reserved log-sink sources
+    // endowed in Phase 3.
     logging::log("phase 2 bootstrap complete");
 
     // ── Phase 3: svcmgr, service registration, handover ────────────────────
@@ -817,6 +797,7 @@ fn run(info_ptr: u64) -> !
         svcmgr_service_ep,
         devmgr_registry_ep,
         system_root_cap,
+        log_ep,
         thread_caps,
         ipc_buf,
         init_logd_thread_cap,

--- a/services/init/src/main.rs
+++ b/services/init/src/main.rs
@@ -121,7 +121,7 @@ pub(crate) fn descriptors(info: &InitInfo) -> &[CapDescriptor]
 ///
 /// Returns the table entry's `CSpace` slot index, or `None` if no
 /// entry carries the requested name. This is init's only module-cap
-/// lookup; the v6 ordinal surface (`module_frame_base + N`) is gone.
+/// lookup; modules are addressed by name through the table.
 pub(crate) fn find_module_by_name(info: &InitInfo, name: &[u8]) -> Option<u32>
 {
     init_protocol::find_module_slot(info, name)
@@ -644,8 +644,7 @@ fn run(info_ptr: u64) -> !
     //       procmgr's CSpace by `bootstrap_procmgr`. Procmgr derives a
     //       tokened SEND per child for `ProcessInfo.service_registry_cap`.
     //
-    // No data words: procmgr no longer maintains a frame pool; every
-    // per-child allocation routes through memmgr.
+    // No data words: every per-child allocation routes through memmgr.
     let Ok(pm_service_cap_for_pm) = syscall::cap_derive(procmgr_service_ep, syscall::RIGHTS_ALL)
     else
     {
@@ -691,10 +690,8 @@ fn run(info_ptr: u64) -> !
     };
 
     // Derive a tokened call cap with the `SEED_AUTHORITY` bit set so vfsd's
-    // `GET_SYSTEM_ROOT_CAP` accepts the init request. `INGEST_AUTHORITY` is
-    // no longer needed (`INGEST_CONFIG_MOUNTS` was removed alongside
-    // `mounts.conf`); MOUNT is un-gated and keeps using the un-tokened
-    // service cap.
+    // `GET_SYSTEM_ROOT_CAP` accepts the init request. MOUNT is un-gated and
+    // uses the un-tokened service cap.
     let Ok(vfsd_seed_cap) = syscall::cap_derive_token(
         vfsd_service_ep,
         syscall::RIGHTS_SEND,

--- a/services/init/src/main.rs
+++ b/services/init/src/main.rs
@@ -754,35 +754,25 @@ fn run(info_ptr: u64) -> !
 
     logging::log("phase 1 bootstrap complete");
 
-    // ── Phase 2: mount root filesystem ──────────────────────────────────────
+    // ── Phase 2: acquire the system-root cap ─────────────────────────────────
 
-    // Boot protocol v8 removed the kernel command line; the root partition
-    // is identified by its GPT type-GUID (`role_guids::SERAPH_ROOT_<arch>`).
-    // vfsd resolves the role to a partition entry on its side; init just
-    // names the role.
-    logging::log("phase 2: mounting root filesystem");
-    let root_mount = mount::send_mount(vfsd_service_ep, ipc_buf, mount::MountRole::Root, b"/");
-    if !root_mount.success
-    {
-        logging::log("FATAL: root mount failed");
-        syscall::thread_exit();
-    }
-    logging::log("phase 2: root mounted at /");
-
-    // `/config/mounts.conf` and `INGEST_CONFIG_MOUNTS` are gone. Additional
-    // partitions (e.g. the ESP, mounted at `/esp`) are discovered and mounted
-    // by vfsd directly via GPT type-GUID lookup.
-
-    // Acquire init's seed system-root cap. Drives every Phase 3
-    // walk-and-spawn — children receive a `cap_copy` of this cap via
-    // `procmgr_labels::CONFIGURE_NAMESPACE`. The `SEED_AUTHORITY`
-    // tokened cap is required by vfsd's `GET_SYSTEM_ROOT_CAP` gate.
+    // vfsd self-mounts the root partition at `/` (and the ESP at `/esp`) on
+    // its own startup, identifying partitions by GPT type-GUID; init issues
+    // no MOUNT. `/config/mounts.conf` and `INGEST_CONFIG_MOUNTS` are gone.
+    //
+    // Acquire init's seed system-root cap. vfsd serves this only once root
+    // is mounted, so the call blocks until the root filesystem is up. The
+    // cap drives every Phase 3 walk-and-spawn — children receive a
+    // `cap_copy` via `procmgr_labels::CONFIGURE_NAMESPACE`. The
+    // `SEED_AUTHORITY` tokened cap is required by vfsd's gate.
+    logging::log("phase 2: acquiring system-root cap (vfsd self-mounts root)");
     let system_root_cap = mount::request_system_root(vfsd_seed_cap, ipc_buf);
     if system_root_cap == 0
     {
         logging::log("FATAL: GET_SYSTEM_ROOT_CAP from vfsd failed");
         syscall::thread_exit();
     }
+    logging::log("phase 2: root available");
 
     // ── Phase 2 epilogue: launch real logd ──────────────────────────────────
     //
@@ -827,7 +817,6 @@ fn run(info_ptr: u64) -> !
         svcmgr_service_ep,
         devmgr_registry_ep,
         system_root_cap,
-        root_mount.root_cap,
         thread_caps,
         ipc_buf,
         init_logd_thread_cap,

--- a/services/init/src/mount.rs
+++ b/services/init/src/mount.rs
@@ -3,98 +3,33 @@
 
 // init/src/mount.rs
 
-//! Init-side mount orchestration helpers.
+//! Init-side system-root acquisition.
 //!
-//! Boot protocol v8 dropped the kernel command line, removing the
-//! `root=UUID=` parser that previously selected the rootfs partition.
-//! vfsd now identifies partitions by GPT type-GUID (per-arch root via
-//! `boot_protocol::role_guids`, plus the standard EFI System Partition
-//! type for `/esp`), so init only names the *role* in the MOUNT request
-//! and vfsd does the lookup. The historic `INGEST_CONFIG_MOUNTS` IPC
-//! and `mounts.conf` ingest are likewise gone — additional partitions
-//! are discovered and mounted by vfsd directly.
+//! vfsd self-mounts the Seraph root partition at `/` (and the ESP at
+//! `/esp`) on its own startup, identifying partitions by GPT type-GUID
+//! (per-arch root via `boot_protocol::role_guids`, plus the standard
+//! EFI System Partition type). Init no longer issues a MOUNT request;
+//! the historic `INGEST_CONFIG_MOUNTS` IPC and `mounts.conf` ingest are
+//! likewise gone.
 //!
-//! After mounts complete init pulls a seed system-root cap from vfsd
-//! via `GET_SYSTEM_ROOT_CAP` (see [`request_system_root`]) and uses it
-//! both to walk binary paths for Phase 3 spawns (`crate::walk`) and to
-//! seed each child's `ProcessInfo.system_root_cap` via
-//! `procmgr_labels::CONFIGURE_NAMESPACE`.
+//! Init pulls a seed system-root cap from vfsd via `GET_SYSTEM_ROOT_CAP`
+//! (see [`request_system_root`]) and uses it both to walk binary paths
+//! for Phase 3 spawns (`crate::walk`) and to seed each child's
+//! `ProcessInfo.system_root_cap` via `procmgr_labels::CONFIGURE_NAMESPACE`.
+//! vfsd serves this only once root is mounted, so the call doubles as
+//! init's wait-for-root barrier.
 
 use ipc::vfsd_labels;
 
-// ── Mount roles ──────────────────────────────────────────────────────────────
-
-/// Which partition-role vfsd should resolve and mount. The wire payload
-/// is the discriminant byte; vfsd maps it to an arch-conditional GPT
-/// type-GUID on its side.
-#[repr(u8)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum MountRole
-{
-    /// The Seraph root partition (`SERAPH_ROOT_X86_64` or
-    /// `SERAPH_ROOT_RISCV64`, selected by the producer's compile-time
-    /// `target_arch`).
-    Root = 0,
-}
-
 // ── VFS IPC operations ──────────────────────────────────────────────────────
-
-/// Outcome of a MOUNT request: success flag plus the optional
-/// namespace-root cap minted by vfsd for this mount.
-///
-/// `root_cap` is a tokened SEND on the driver's namespace endpoint
-/// representing the mount root at full namespace rights. The system-
-/// root cap (delivered to every process via `ProcessInfo.system_root_cap`)
-/// is the authoritative cap for VFS access; this per-mount cap is
-/// retained only so the existing svctest direct-driver phase still
-/// has a fatfs root to exercise.
-pub struct MountOutcome
-{
-    pub success: bool,
-    pub root_cap: u32,
-}
-
-/// Send a MOUNT IPC request to vfsd by role.
-///
-/// MOUNT data layout (post-boot-protocol-v8): `data[0]` low byte = role
-/// discriminant, `data[1]` = `path_len`, `data[2..]` = path. Reply on
-/// success carries `caps[0]` = mount-root node cap (zero if vfsd was
-/// unable to mint one).
-pub fn send_mount(vfsd_ep: u32, ipc_buf: *mut u64, role: MountRole, path: &[u8]) -> MountOutcome
-{
-    let path_bytes = path.len().min(8 * 8);
-    let msg = ipc::IpcMessage::builder(vfsd_labels::MOUNT)
-        .word(0, u64::from(role as u8))
-        .word(1, path.len() as u64)
-        .bytes(2, &path[..path_bytes])
-        .build();
-
-    // SAFETY: ipc_buf is the caller's registered IPC buffer page.
-    let Ok(reply) = (unsafe { ipc::ipc_call(vfsd_ep, &msg, ipc_buf) })
-    else
-    {
-        return MountOutcome {
-            success: false,
-            root_cap: 0,
-        };
-    };
-    let success = reply.label == 0;
-    let root_cap = if success
-    {
-        reply.caps().first().copied().unwrap_or(0)
-    }
-    else
-    {
-        0
-    };
-    MountOutcome { success, root_cap }
-}
 
 /// Request vfsd's system-root cap via [`vfsd_labels::GET_SYSTEM_ROOT_CAP`].
 ///
 /// Returns the tokened SEND cap on vfsd's namespace endpoint addressing
-/// the synthetic root at full namespace rights, or `0` on failure. Init
-/// holds this cap as the seed from which all later tier-3 namespace-cap
+/// the synthetic root at full namespace rights, or `0` on failure. vfsd
+/// replies an error (and this returns `0`) until it has mounted root, so
+/// the call blocks until the root filesystem is available. Init holds
+/// this cap as the seed from which all later tier-3 namespace-cap
 /// distribution flows (`cap_copy` for the parent-inherit default,
 /// walk-and-attenuate for sandboxed views).
 pub fn request_system_root(vfsd_ep: u32, ipc_buf: *mut u64) -> u32

--- a/services/init/src/mount.rs
+++ b/services/init/src/mount.rs
@@ -8,9 +8,7 @@
 //! vfsd self-mounts the Seraph root partition at `/` (and the ESP at
 //! `/esp`) on its own startup, identifying partitions by GPT type-GUID
 //! (per-arch root via `boot_protocol::role_guids`, plus the standard
-//! EFI System Partition type). Init no longer issues a MOUNT request;
-//! the historic `INGEST_CONFIG_MOUNTS` IPC and `mounts.conf` ingest are
-//! likewise gone.
+//! EFI System Partition type). Init issues no MOUNT request.
 //!
 //! Init pulls a seed system-root cap from vfsd via `GET_SYSTEM_ROOT_CAP`
 //! (see [`request_system_root`]) and uses it both to walk binary paths

--- a/services/init/src/service.rs
+++ b/services/init/src/service.rs
@@ -676,16 +676,18 @@ pub fn create_devmgr_with_caps(
 
     // ── Terminal SVCMGR_BUNDLE round ────────────────────────────────────
     //
-    // caps: [svcmgr_publish_cap, ioport_root_cap (x86 only)]. The
-    // SEND-rights cap on svcmgr's service endpoint is stamped with the
-    // PUBLISH_AUTHORITY verb-bit in its token so devmgr can register
-    // service caps in svcmgr's registry on init's behalf (today's only
-    // use is reserved for future devmgr publications; the active
-    // publications — `timed`, `rootfs.root`, `pwrmgr.*`, `svcmgr`,
-    // `devmgr.registry` — are init-issued). The IoPortRange copy is
-    // delivered only on x86-64 (RISC-V has no I/O ports); devmgr
-    // derives narrow per-driver IoPort caps from it for ISA
-    // peripherals like the CMOS RTC.
+    // caps: [svcmgr_publish_cap, arch_shutdown_cap]. The SEND-rights cap
+    // on svcmgr's service endpoint is stamped with the PUBLISH_AUTHORITY
+    // verb-bit in its token so devmgr can register service caps in
+    // svcmgr's registry on init's behalf (today's only use is reserved
+    // for future devmgr publications; the active publications — `timed`,
+    // `rootfs.root`, `svcmgr`, `devmgr.registry` — are init-issued).
+    // The arch shutdown-authority cap is the root `IoPortRange` on x86-64
+    // (devmgr derives narrow per-driver IoPort caps from it for ISA
+    // peripherals like the CMOS RTC, and carves the PM1a + 8042 ports for
+    // pwrmgr) and `SbiControl` on RISC-V (devmgr serves a copy to pwrmgr
+    // for SBI SRST). devmgr is the hardware authority; pwrmgr acquires its
+    // shutdown caps from devmgr, not from init.
     // SVCMGR_BUNDLE is unconditionally the terminal round. On any
     // preparation failure init MUST still emit a `done=true` round so
     // devmgr's bootstrap_rounds loop in `services/devmgr/src/caps.rs`
@@ -735,19 +737,25 @@ pub fn create_devmgr_with_caps(
         return None;
     }
 
-    let ioport_root_cap = if cfg!(target_arch = "x86_64")
+    let arch_shutdown_cap = if cfg!(target_arch = "x86_64")
     {
         crate::find_cap_by_type(info, init_protocol::CapType::IoPortRange)
             .and_then(|root| syscall::cap_derive(root, syscall::RIGHTS_ALL).ok())
             .unwrap_or(0)
+    }
+    else if info.sbi_control_cap != 0
+    {
+        // RISC-V: SbiControl is the platform shutdown authority. devmgr
+        // serves a copy to pwrmgr on QUERY_SHUTDOWN_DEVICE for SBI SRST.
+        syscall::cap_derive(info.sbi_control_cap, syscall::RIGHTS_ALL).unwrap_or(0)
     }
     else
     {
         0
     };
 
-    let bundle_caps: [u32; 2] = [svcmgr_publish, ioport_root_cap];
-    let bundle_cap_count = if ioport_root_cap != 0 { 2 } else { 1 };
+    let bundle_caps: [u32; 2] = [svcmgr_publish, arch_shutdown_cap];
+    let bundle_cap_count = if arch_shutdown_cap != 0 { 2 } else { 1 };
 
     let _ = serve(
         bootstrap_ep,
@@ -759,258 +767,6 @@ pub fn create_devmgr_with_caps(
         "devmgr: bootstrap SVCMGR_BUNDLE round failed",
     );
     Some(thread_cap)
-}
-
-// ── pwrmgr creation ─────────────────────────────────────────────────────────
-
-/// Pwrmgr-side result of [`create_and_start_pwrmgr`].
-///
-/// `service_ep` is the un-tokened source on pwrmgr's service endpoint
-/// (init keeps it to mint tokened SENDs); `thread_cap` is pwrmgr's
-/// main thread in init's `CSpace`, registered with svcmgr so the
-/// supervisor can bind death-notification.
-pub struct PwrmgrSpawn
-{
-    pub service_ep: u32,
-    pub thread_cap: u32,
-}
-
-/// Walk `/services/pwrmgr`, create the process, transfer platform shutdown
-/// caps via bootstrap rounds, and start it.
-///
-/// Returns the service-endpoint slot init owns (the RECV side stays with
-/// pwrmgr; init keeps the source for deriving tokened SENDs to
-/// authorized consumers) plus pwrmgr's main thread cap. Returns `None`
-/// on any failure; partial state is torn down before returning.
-///
-/// Bootstrap layout (matches `services/pwrmgr/src/caps.rs`):
-/// * Round 1 (≤2 caps, 2 data words):
-///   - `caps[0]` = pwrmgr's service endpoint (derived copy).
-///   - `caps[1]` = arch authority cap (`IoPortRange` on x86-64,
-///     `SbiControl` on RISC-V). Omitted when absent.
-///   - `data[0]` = presence bitmap (bit 0 = arch cap present).
-///   - `data[1]` = `PWRMGR_LABELS_VERSION`.
-///   - `done` = true on RISC-V or when no ACPI regions follow.
-/// * Round 2..N (x86-64 only): ACPI region Frame caps, ≤4 per round.
-#[allow(clippy::too_many_lines)]
-pub fn create_and_start_pwrmgr(
-    info: &InitInfo,
-    procmgr_ep: u32,
-    bootstrap_ep: u32,
-    system_root_cap: u32,
-    init_self_cspace: u32,
-    ipc_buf: *mut u64,
-) -> Option<PwrmgrSpawn>
-{
-    let walked = walk::walk_to_file(system_root_cap, b"/services/pwrmgr", 0xFFFF, ipc_buf)?;
-
-    let (tokened_creator, child_token) = derive_tokened_creator(bootstrap_ep)?;
-
-    let msg = IpcMessage::builder(procmgr_labels::CREATE_FROM_FILE)
-        .word(0, walked.size)
-        .cap(walked.file_cap)
-        .cap(tokened_creator)
-        .build();
-
-    // SAFETY: ipc_buf is the registered IPC buffer.
-    let Ok(reply) = (unsafe { ipc::ipc_call(procmgr_ep, &msg, ipc_buf) })
-    else
-    {
-        log("pwrmgr: CREATE_FROM_FILE ipc_call failed");
-        return None;
-    };
-    if reply.label != 0
-    {
-        log("pwrmgr: CREATE_FROM_FILE error");
-        return None;
-    }
-
-    let reply_caps = reply.caps();
-    if reply_caps.is_empty()
-    {
-        log("pwrmgr: CREATE_FROM_FILE reply missing caps");
-        return None;
-    }
-    let process_handle = reply_caps[0];
-    // CREATE_FROM_FILE returns (process_handle, thread_cap). Pwrmgr is
-    // svcmgr-registered for death monitoring (post-#21); the thread
-    // cap is preserved here and returned via [`PwrmgrSpawn`] for the
-    // Phase-3 v3 `REGISTER_SERVICE` call.
-    if reply_caps.len() < 2
-    {
-        log("pwrmgr: CREATE_FROM_FILE reply missing thread cap");
-        destroy_partial_child(process_handle, ipc_buf);
-        return None;
-    }
-    let thread_cap = reply_caps[1];
-
-    // pwrmgr's only surface is the gated SHUTDOWN/REBOOT IPC; it
-    // owns IoPortRange/SbiControl/ACPI frames directly and never
-    // touches the filesystem. Spawn with no namespace cap.
-    if !configure_child_namespace(
-        process_handle,
-        system_root_cap,
-        init_self_cspace,
-        NsPolicy::None,
-        None,
-        ipc_buf,
-    )
-    {
-        let _ = syscall::cap_delete(thread_cap);
-        return None;
-    }
-
-    // Service endpoint: init owns the RECV source; pwrmgr receives a
-    // derived RECV copy. Source stays in init's CSpace for deriving
-    // tokened SENDs (SHUTDOWN_AUTHORITY) to authorized consumers.
-    let Ok(pwrmgr_service_ep) = syscall::cap_create_endpoint(crate::endpoint_slab())
-    else
-    {
-        log("pwrmgr: cannot create service endpoint");
-        destroy_partial_child(process_handle, ipc_buf);
-        let _ = syscall::cap_delete(thread_cap);
-        return None;
-    };
-    let Ok(service_copy) = syscall::cap_derive(pwrmgr_service_ep, syscall::RIGHTS_ALL)
-    else
-    {
-        log("pwrmgr: service endpoint derive failed");
-        let _ = syscall::cap_delete(pwrmgr_service_ep);
-        destroy_partial_child(process_handle, ipc_buf);
-        let _ = syscall::cap_delete(thread_cap);
-        return None;
-    };
-
-    // Arch authority cap: IoPortRange on x86_64, SbiControl on
-    // RISC-V. Both are present in InitInfo's hw caps; on the absent arch
-    // the corresponding slot is zero.
-    let arch_cap_source: u32 = {
-        #[cfg(target_arch = "x86_64")]
-        {
-            crate::find_cap_by_type(info, CapType::IoPortRange).unwrap_or(0)
-        }
-        #[cfg(target_arch = "riscv64")]
-        {
-            info.sbi_control_cap
-        }
-        #[cfg(not(any(target_arch = "x86_64", target_arch = "riscv64")))]
-        {
-            let _ = info;
-            0
-        }
-    };
-    let arch_cap_copy = if arch_cap_source != 0
-    {
-        syscall::cap_derive(arch_cap_source, syscall::RIGHTS_ALL).unwrap_or(0)
-    }
-    else
-    {
-        0
-    };
-
-    if !start_process(
-        process_handle,
-        ipc_buf,
-        "phase 3: pwrmgr started; serving bootstrap",
-        "phase 3: pwrmgr START_PROCESS failed",
-    )
-    {
-        let _ = syscall::cap_delete(pwrmgr_service_ep);
-        let _ = syscall::cap_delete(thread_cap);
-        return None;
-    }
-
-    // Round 1: service endpoint + (optionally) arch cap. The ACPI
-    // region rounds (x86_64 only) follow when present.
-    let acpi_present = info.acpi_region_frame_count > 0;
-    let mut r1_caps = [0u32; 2];
-    let mut r1_cap_count: usize = 1;
-    r1_caps[0] = service_copy;
-    let mut presence: u64 = 0;
-    if arch_cap_copy != 0
-    {
-        presence |= 1u64 << 0;
-        r1_caps[r1_cap_count] = arch_cap_copy;
-        r1_cap_count += 1;
-    }
-    let r1_done = !acpi_present;
-    if !serve(
-        bootstrap_ep,
-        child_token,
-        ipc_buf,
-        r1_done,
-        &r1_caps[..r1_cap_count],
-        &[presence, u64::from(ipc::PWRMGR_LABELS_VERSION)],
-        "pwrmgr: bootstrap round 1 failed",
-    )
-    {
-        let _ = syscall::cap_delete(pwrmgr_service_ep);
-        let _ = syscall::cap_delete(thread_cap);
-        return None;
-    }
-
-    if acpi_present
-    {
-        let ar_start = info.acpi_region_frame_base;
-        let ar_end = ar_start + info.acpi_region_frame_count;
-        // Collect ACPI region metadata from descriptor array.
-        let mut regions: [(u32, u64, u64); MAX_ACPI_REGION_CAPS] =
-            [(0, 0, 0); MAX_ACPI_REGION_CAPS];
-        let mut region_count: usize = 0;
-        for d in crate::descriptors(info)
-        {
-            if d.cap_type == CapType::Frame
-                && d.slot >= ar_start
-                && d.slot < ar_end
-                && region_count < MAX_ACPI_REGION_CAPS
-            {
-                regions[region_count] = (d.slot, d.aux0, d.aux1);
-                region_count += 1;
-            }
-        }
-
-        let mut idx = 0;
-        while idx < region_count
-        {
-            let batch_end = (idx + 4).min(region_count);
-            let batch_count = batch_end - idx;
-            let mut caps = [0u32; 4];
-            let mut data = [0u64; 2 + 4 * 2];
-            data[0] = kind::ACPI_REGION;
-            data[1] = batch_count as u64;
-            for j in 0..batch_count
-            {
-                let (slot, base, size) = regions[idx + j];
-                if let Ok(c) = syscall::cap_derive(slot, syscall::RIGHTS_ALL)
-                {
-                    caps[j] = c;
-                }
-                data[2 + j * 2] = base;
-                data[3 + j * 2] = size;
-            }
-            let is_last = batch_end == region_count;
-            if !serve(
-                bootstrap_ep,
-                child_token,
-                ipc_buf,
-                is_last,
-                &caps[..batch_count],
-                &data[..2 + batch_count * 2],
-                "pwrmgr: bootstrap ACPI region round failed",
-            )
-            {
-                let _ = syscall::cap_delete(pwrmgr_service_ep);
-                let _ = syscall::cap_delete(thread_cap);
-                return None;
-            }
-            idx = batch_end;
-        }
-    }
-
-    Some(PwrmgrSpawn {
-        service_ep: pwrmgr_service_ep,
-        thread_cap,
-    })
 }
 
 // ── vfsd creation ────────────────────────────────────────────────────────────
@@ -1372,23 +1128,10 @@ pub fn phase3_svcmgr_handover(
     // rest of Phase 3 proceeds normally.
     set_drivers_dir_on_devmgr(devmgr_registry_ep, system_root_cap, ipc_buf);
 
-    let pwrmgr_spawn = create_and_start_pwrmgr(
-        info,
-        procmgr_ep,
-        bootstrap_ep,
-        system_root_cap,
-        init_self_cspace,
-        ipc_buf,
-    );
-    let (pwrmgr_service_ep, pwrmgr_thread_cap) = if let Some(s) = pwrmgr_spawn
-    {
-        (s.service_ep, s.thread_cap)
-    }
-    else
-    {
-        log("phase 3: pwrmgr not available; naked xtask run will not exit cleanly");
-        (0, 0)
-    };
+    // pwrmgr is now a svcmgr-launched provider (`pwrmgr.svc`): it acquires
+    // its shutdown caps from devmgr (QUERY_SHUTDOWN_DEVICE) and publishes
+    // `pwrmgr.shutdown`/`pwrmgr.deny` itself via svcmgr's provider path.
+    // init no longer spawns it, holds its endpoint, or publishes its caps.
 
     // Derive a PUBLISH_AUTHORITY-tokened SEND_GRANT on svcmgr's
     // service ep so init can publish the named caps post-#21 consumers
@@ -1417,44 +1160,9 @@ pub fn phase3_svcmgr_handover(
         let _ = syscall::cap_delete(derived);
     }
 
-    // 2/3. pwrmgr.shutdown + pwrmgr.deny — derived from pwrmgr's
-    //      service endpoint with the SHUTDOWN_AUTHORITY token bit set
-    //      (or a non-AUTHORITY sentinel `1` for the negative-test
-    //      twin). Plain SEND would let consumers re-tokenize the cap
-    //      and defeat the gate; cap_derive_token rejects sources with
-    //      a non-zero token, so the AUTHORITY shape stays sealed.
-    if let Some(cap) = publish_cap
-        && pwrmgr_service_ep != 0
-    {
-        if let Ok(auth) = syscall::cap_derive_token(
-            pwrmgr_service_ep,
-            syscall::RIGHTS_SEND,
-            ipc::pwrmgr_labels::SHUTDOWN_AUTHORITY,
-        )
-        {
-            if !svcmgr_publish(cap, ipc::published_names::PWRMGR_SHUTDOWN, auth, ipc_buf)
-            {
-                log("phase 3: publish pwrmgr.shutdown failed");
-                let _ = syscall::cap_delete(auth);
-            }
-        }
-        else
-        {
-            log("phase 3: derive pwrmgr.shutdown cap failed");
-        }
-        if let Ok(deny) = syscall::cap_derive_token(pwrmgr_service_ep, syscall::RIGHTS_SEND, 1)
-        {
-            if !svcmgr_publish(cap, ipc::published_names::PWRMGR_DENY, deny, ipc_buf)
-            {
-                log("phase 3: publish pwrmgr.deny failed");
-                let _ = syscall::cap_delete(deny);
-            }
-        }
-        else
-        {
-            log("phase 3: derive pwrmgr.deny cap failed");
-        }
-    }
+    // pwrmgr.shutdown / pwrmgr.deny are published by svcmgr's provider
+    // path now (`pwrmgr.svc` `provides = pwrmgr.shutdown:auth
+    // pwrmgr.deny:deny`), not by init.
 
     // 4. svcmgr — tokened SEND on svcmgr's own service endpoint. Used
     //    by crasher.svc's `seed = svcmgr` line so the launched
@@ -1516,7 +1224,6 @@ pub fn phase3_svcmgr_handover(
         (b"devmgr", thread_caps.devmgr),
         (b"vfsd", thread_caps.vfsd),
         (b"logd", thread_caps.logd),
-        (b"pwrmgr", pwrmgr_thread_cap),
     ];
     for (name, thread_cap) in registrations
     {

--- a/services/init/src/service.rs
+++ b/services/init/src/service.rs
@@ -18,10 +18,10 @@ use crate::walk;
 use init_protocol::{CapType, InitInfo};
 use ipc::{IpcMessage, procmgr_labels, svcmgr_labels};
 
-/// Thread caps init collects across Phases 1-3 for v3
-/// `REGISTER_SERVICE` once svcmgr is up. Zero in a slot means init
-/// could not capture (or chose not to capture) that service's thread
-/// cap; the corresponding `register_service` call is then skipped.
+/// Thread caps init collects across Phases 1-3 to hand svcmgr in the
+/// handover endowment (one `SUBSTRATE` round each). Zero in a slot means
+/// init could not capture (or chose not to capture) that service's thread
+/// cap; the corresponding endowment round is then skipped.
 ///
 /// Field order matches reconciliation order in the boot log, not
 /// spawn order. memmgr / procmgr come from
@@ -958,112 +958,166 @@ pub fn create_svcmgr_from_file(
     Some((process_handle, child_token))
 }
 
-/// Endpoint set handed to svcmgr in its bootstrap round.
+/// Round kinds for the svcmgr handover endowment, tagged in `data[0]`.
+/// Mirrors the receive side in `services/svcmgr/src/service.rs::endow_kind`.
+mod endow_kind
+{
+    /// Round 1: svcmgr's own endpoints + publish-role source caps.
+    pub const CAPS: u64 = 1;
+    /// One substrate `(name, thread_cap)` registration.
+    pub const SUBSTRATE: u64 = 2;
+}
+
+/// Source + endpoint caps init endows svcmgr with at handover. The two
+/// source caps are init's own (full-rights) handles on the root filesystem
+/// namespace endpoint and devmgr's registry endpoint; svcmgr derives the
+/// shapes it publishes / sends from them.
 #[allow(clippy::struct_field_names)]
-pub struct SvcmgrHandoverCaps
+pub struct SvcmgrEndowment
 {
     pub svcmgr_service_ep: u32,
     pub svcmgr_bootstrap_ep: u32,
+    pub rootfs_root_cap: u32,
+    pub devmgr_registry_ep: u32,
 }
 
-/// Start svcmgr, then serve its bootstrap.
-pub fn setup_and_start_svcmgr(
+/// Start svcmgr, then serve the handover endowment over the bootstrap
+/// protocol.
+///
+/// Round 1 (`CAPS`, not done) delivers svcmgr's service + bootstrap
+/// endpoints (full rights) and the publish-role source caps: a `SEND` on
+/// the root filesystem namespace endpoint (svcmgr publishes it as
+/// `rootfs.root`) and a token-0 `SEND|GRANT` source on devmgr's registry
+/// endpoint (svcmgr mints the `REGISTRY_QUERY_AUTHORITY` `devmgr.registry`
+/// publish cap and the `DRIVERS_DIR_AUTHORITY` `SET_DRIVERS_DIR` cap from
+/// it). An absent source cap rides as a zero slot, which svcmgr tolerates.
+///
+/// Each subsequent `SUBSTRATE` round delivers one init-bootstrapped
+/// service's thread cap plus its name; the final substrate round is
+/// terminal. svcmgr parks the pairs for reconciliation. Best-effort: a
+/// failed round logs and aborts the endowment; svcmgr then runs with
+/// whatever it received (the system is already non-viable if a substrate
+/// thread cap cannot be delivered).
+fn endow_svcmgr(
     bootstrap_ep: u32,
     process_handle: u32,
     child_token: u64,
-    handover: &SvcmgrHandoverCaps,
+    endow: &SvcmgrEndowment,
+    thread_caps: ServiceThreadCaps,
     ipc_buf: *mut u64,
 )
 {
     if !start_process(
         process_handle,
         ipc_buf,
-        "phase 3: svcmgr started; serving bootstrap",
+        "phase 3: svcmgr started; serving endowment",
         "phase 3: svcmgr START_PROCESS failed",
     )
     {
         return;
     }
 
-    let Ok(service_copy) = syscall::cap_derive(handover.svcmgr_service_ep, syscall::RIGHTS_ALL)
+    let Ok(service_copy) = syscall::cap_derive(endow.svcmgr_service_ep, syscall::RIGHTS_ALL)
     else
     {
+        log("phase 3: svcmgr service-ep derive failed");
         return;
     };
-    let Ok(boot_copy) = syscall::cap_derive(handover.svcmgr_bootstrap_ep, syscall::RIGHTS_ALL)
+    let Ok(boot_copy) = syscall::cap_derive(endow.svcmgr_bootstrap_ep, syscall::RIGHTS_ALL)
     else
     {
+        log("phase 3: svcmgr bootstrap-ep derive failed");
         return;
+    };
+    // rootfs.root SEND — token inherited from the root fs namespace cap.
+    let rootfs_send = if endow.rootfs_root_cap != 0
+    {
+        syscall::cap_derive(endow.rootfs_root_cap, syscall::RIGHTS_SEND).unwrap_or(0)
+    }
+    else
+    {
+        0
+    };
+    // devmgr-registry source: token-0 SEND|GRANT so svcmgr can mint the
+    // tokened query + drivers-dir caps. SEND|GRANT (not RIGHTS_ALL) is the
+    // minimum — it withholds the RECV right on devmgr's registry endpoint.
+    let devmgr_registry_src = if endow.devmgr_registry_ep != 0
+    {
+        syscall::cap_derive(endow.devmgr_registry_ep, syscall::RIGHTS_SEND_GRANT).unwrap_or(0)
+    }
+    else
+    {
+        0
     };
 
-    // One round: [service, bootstrap_ep].
-    // (log + procmgr auto-delivered via ProcessInfo.)
-    let _ = serve(
+    // Substrate set; init skips a service whose thread cap it could not
+    // capture, so a missing recipe match is bind-only-absent rather than a
+    // `registered without definition` orphan in svcmgr.
+    let registrations: &[(&[u8], u32)] = &[
+        (b"memmgr", thread_caps.memmgr),
+        (b"procmgr", thread_caps.procmgr),
+        (b"devmgr", thread_caps.devmgr),
+        (b"vfsd", thread_caps.vfsd),
+        (b"logd", thread_caps.logd),
+    ];
+    let last = registrations.iter().rposition(|&(_, tc)| tc != 0);
+
+    // Round 1 (CAPS), positional: [service, bootstrap, rootfs, devmgr_reg].
+    // Terminal only in the (unreachable) all-zero-substrate case.
+    if !serve(
         bootstrap_ep,
         child_token,
         ipc_buf,
-        true,
-        &[service_copy, boot_copy],
-        &[],
-        "phase 3: svcmgr bootstrap failed",
-    );
-}
-
-/// Minimal v3 `REGISTER_SERVICE` payload: name + thread cap.
-///
-/// Post-#21 the recipe (binary, argv, env, restart policy,
-/// criticality, namespace shape, seed names) lives on disk at
-/// `/config/svcmgr/services/<name>.svc`. The wire conveys only what
-/// cannot be on disk: which named recipe this running process
-/// implements, and the thread cap svcmgr binds death-notification on.
-pub struct ServiceRegistration<'a>
-{
-    pub name: &'a [u8],
-    pub thread_cap: u32,
-}
-
-/// Register a currently-running service with svcmgr via the v3
-/// [`svcmgr_labels::REGISTER_SERVICE`] wire (`word 0` =
-/// `SVCMGR_LABELS_VERSION`, `word 1` = `name_len`, `words 2..` = name
-/// bytes, `caps[0]` = thread cap). svcmgr parks the entry and
-/// reconciles against `/config/svcmgr/services/` on `HANDOVER_COMPLETE`.
-pub fn register_service(svcmgr_ep: u32, ipc_buf: *mut u64, reg: &ServiceRegistration)
-{
-    let name_len = reg.name.len();
-    if name_len == 0 || name_len > 32 || reg.thread_cap == 0
+        last.is_none(),
+        &[service_copy, boot_copy, rootfs_send, devmgr_registry_src],
+        &[endow_kind::CAPS, u64::from(ipc::SVCMGR_LABELS_VERSION)],
+        "phase 3: svcmgr endowment CAPS round failed",
+    )
     {
-        log("phase 3: REGISTER_SERVICE caller bug (empty name or zero thread cap)");
         return;
     }
-    let name_words = name_len.div_ceil(8);
-    let data_count = 2 + name_words;
 
-    let msg = IpcMessage::builder(svcmgr_labels::REGISTER_SERVICE)
-        .word(0, u64::from(ipc::SVCMGR_LABELS_VERSION))
-        .word(1, name_len as u64)
-        .bytes(2, reg.name)
-        .word_count(data_count)
-        .cap(reg.thread_cap)
-        .build();
-
-    // SAFETY: ipc_buf is the caller's registered IPC buffer.
-    match unsafe { ipc::ipc_call(svcmgr_ep, &msg, ipc_buf) }
+    // Substrate rounds: one (name, thread_cap) each; last is terminal.
+    for (i, &(name, thread_cap)) in registrations.iter().enumerate()
     {
-        Ok(reply) if reply.label == 0 =>
-        {}
-        _ => log("phase 3: REGISTER_SERVICE failed"),
+        if thread_cap == 0
+        {
+            continue;
+        }
+        let mut name_words = [0u64; 2];
+        let nw = pack_svc_name(name, &mut name_words);
+        let mut data = [0u64; 2 + 2];
+        data[0] = endow_kind::SUBSTRATE;
+        data[1] = name.len() as u64;
+        data[2..2 + nw].copy_from_slice(&name_words[..nw]);
+        if !serve(
+            bootstrap_ep,
+            child_token,
+            ipc_buf,
+            Some(i) == last,
+            &[thread_cap],
+            &data[..2 + nw],
+            "phase 3: svcmgr endowment SUBSTRATE round failed",
+        )
+        {
+            return;
+        }
     }
 }
 
 // ── Phase 3 orchestration ───────────────────────────────────────────────────
 
-/// Phase 3: spawn svcmgr, bring up the wallclock chain, spawn pwrmgr,
-/// register pwrmgr with svcmgr (v3 wire), publish the named caps
-/// post-#21 consumers resolve from `/config/svcmgr/services/<name>.svc` `seed = ...`
-/// lines, then signal `HANDOVER_COMPLETE` so svcmgr scans
-/// `/config/svcmgr/services/`. On a normal boot the defined services there are
-/// all init-registered (bind-only); svcmgr's launch path fires only for staged
-/// test recipes (svctest / usertest, and crasher co-staged with svctest).
+/// Phase 3: load svcmgr, serve it the handover endowment (its own
+/// endpoints + publish-role source caps + one `(name, thread_cap)` round
+/// per init-bootstrapped substrate service), then signal
+/// `HANDOVER_COMPLETE` so svcmgr scans `/config/svcmgr/services/`. svcmgr
+/// publishes the well-known names it now owns and installs devmgr's
+/// drivers dir from the endowment; init no longer publishes caps,
+/// registers services, or talks to devmgr. On a normal boot the defined
+/// services are the bind-only substrate plus the svcmgr-launched providers
+/// (`timed`, `pwrmgr`); svcmgr's pure-consumer launch path fires only for
+/// staged test recipes (svctest / usertest, and crasher co-staged with
+/// svctest).
 #[allow(clippy::too_many_lines, clippy::too_many_arguments)]
 pub fn phase3_svcmgr_handover(
     info: &InitInfo,
@@ -1108,137 +1162,33 @@ pub fn phase3_svcmgr_handover(
         idle_loop();
     };
 
-    let handover = SvcmgrHandoverCaps {
+    // Serve svcmgr its handover endowment: round 1 carries svcmgr's own
+    // endpoints plus the publish-role source caps (rootfs root, devmgr
+    // registry), then one round per init-bootstrapped substrate service
+    // carries that service's (name, thread_cap) for death-supervision
+    // binding. svcmgr drains it all in `bootstrap_caps`, publishes the
+    // well-known names it now owns (`rootfs.root` / `svcmgr` /
+    // `devmgr.registry`) and installs devmgr's drivers dir itself, then
+    // reconciles the substrate against `/config/svcmgr/services/` on
+    // HANDOVER_COMPLETE.
+    //
+    // pwrmgr/timed are svcmgr-launched providers (`*.svc`) that acquire
+    // their caps from devmgr and publish their own names; init neither
+    // spawns nor publishes for them.
+    let endowment = SvcmgrEndowment {
         svcmgr_service_ep,
         svcmgr_bootstrap_ep,
+        rootfs_root_cap,
+        devmgr_registry_ep,
     };
-    setup_and_start_svcmgr(
+    endow_svcmgr(
         bootstrap_ep,
         svcmgr_handle,
         svcmgr_token,
-        &handover,
+        &endowment,
+        thread_caps,
         ipc_buf,
     );
-
-    // Hand devmgr a least-privilege `/services/drivers/` subtree cap so
-    // it can lazily walk + spawn its on-disk driver binaries (today: the
-    // per-arch RTC). Ack-only handshake; init does not block on driver
-    // work. Best-effort: a failure here means timed will see NO_DEVICE
-    // on its first QUERY_RTC_DEVICE and degrade to its no-RTC path; the
-    // rest of Phase 3 proceeds normally.
-    set_drivers_dir_on_devmgr(devmgr_registry_ep, system_root_cap, ipc_buf);
-
-    // pwrmgr is now a svcmgr-launched provider (`pwrmgr.svc`): it acquires
-    // its shutdown caps from devmgr (QUERY_SHUTDOWN_DEVICE) and publishes
-    // `pwrmgr.shutdown`/`pwrmgr.deny` itself via svcmgr's provider path.
-    // init no longer spawns it, holds its endpoint, or publishes its caps.
-
-    // Derive a PUBLISH_AUTHORITY-tokened SEND_GRANT on svcmgr's
-    // service ep so init can publish the named caps post-#21 consumers
-    // resolve through `/config/svcmgr/services/<name>.svc` `seed = ...`.
-    // `RIGHTS_SEND_GRANT` (not bare SEND): PUBLISH_ENDPOINT carries the
-    // value cap in the message, and the IPC kernel requires the GRANT
-    // bit on the caller's send-cap to transfer caps. After the four
-    // publications init drops this cap; runtime consumers use the
-    // un-tokened SEND seeded into `ProcessInfo.service_registry_cap`.
-    let publish_cap = syscall::cap_derive_token(
-        svcmgr_service_ep,
-        syscall::RIGHTS_SEND_GRANT,
-        svcmgr_labels::PUBLISH_AUTHORITY,
-    )
-    .ok();
-
-    // 1. rootfs.root — tokened SEND on the root filesystem's namespace
-    //    endpoint at its root directory. FS-driver-agnostic by design:
-    //    today fatfs, tomorrow any other FS driver, same name.
-    if let Some(cap) = publish_cap
-        && rootfs_root_cap != 0
-        && let Ok(derived) = syscall::cap_derive(rootfs_root_cap, syscall::RIGHTS_SEND)
-        && !svcmgr_publish(cap, ipc::published_names::ROOTFS_ROOT, derived, ipc_buf)
-    {
-        log("phase 3: publish rootfs.root failed");
-        let _ = syscall::cap_delete(derived);
-    }
-
-    // pwrmgr.shutdown / pwrmgr.deny are published by svcmgr's provider
-    // path now (`pwrmgr.svc` `provides = pwrmgr.shutdown:auth
-    // pwrmgr.deny:deny`), not by init.
-
-    // 4. svcmgr — tokened SEND on svcmgr's own service endpoint. Used
-    //    by crasher.svc's `seed = svcmgr` line so the launched
-    //    crasher receives the same cap shape today's hard-coded
-    //    bundle gave it. Per-publisher attenuation (so children can
-    //    only QUERY, not PUBLISH) lives in the SEND-without-AUTHORITY
-    //    shape — same as `ProcessInfo.service_registry_cap`.
-    if let Some(cap) = publish_cap
-        && let Ok(svc_send) = syscall::cap_derive(svcmgr_service_ep, syscall::RIGHTS_SEND)
-        && !svcmgr_publish(cap, ipc::published_names::SVCMGR, svc_send, ipc_buf)
-    {
-        log("phase 3: publish svcmgr failed");
-        let _ = syscall::cap_delete(svc_send);
-    }
-
-    // 5. devmgr.registry — `REGISTRY_QUERY_AUTHORITY`-tokened SEND on
-    //    devmgr's registry endpoint. Today's consumer is
-    //    `programs/fb-charset` via `seed = devmgr.registry`; future
-    //    non-init consumers of devmgr's discovery surface use the same
-    //    name. The token bit survives svcmgr's plain `cap_derive` in
-    //    `registry_lookup_derived`.
-    if let Some(cap) = publish_cap
-        && devmgr_registry_ep != 0
-    {
-        match syscall::cap_derive_token(
-            devmgr_registry_ep,
-            syscall::RIGHTS_SEND,
-            ipc::devmgr_labels::REGISTRY_QUERY_AUTHORITY,
-        )
-        {
-            Ok(derived) =>
-            {
-                if !svcmgr_publish(cap, ipc::published_names::DEVMGR_REGISTRY, derived, ipc_buf)
-                {
-                    log("phase 3: publish devmgr.registry failed");
-                    let _ = syscall::cap_delete(derived);
-                }
-            }
-            Err(_) => log("phase 3: derive devmgr.registry cap failed"),
-        }
-    }
-
-    if let Some(cap) = publish_cap
-    {
-        let _ = syscall::cap_delete(cap);
-    }
-
-    // Register every foundational service init bootstrapped with
-    // svcmgr (v3 wire: name + thread cap). svcmgr's reconciliation
-    // path pairs each name with the matching `.svc` recipe on disk
-    // and binds death-notification. Zero in a slot means init could
-    // not capture the thread cap (e.g. the spawn failed or the
-    // helper had no cap to share); the register call is then
-    // skipped and the recipe ⇒ `registered without definition`
-    // entries are absent rather than surfacing as orphans.
-    let registrations: &[(&[u8], u32)] = &[
-        (b"memmgr", thread_caps.memmgr),
-        (b"procmgr", thread_caps.procmgr),
-        (b"devmgr", thread_caps.devmgr),
-        (b"vfsd", thread_caps.vfsd),
-        (b"logd", thread_caps.logd),
-    ];
-    for (name, thread_cap) in registrations
-    {
-        if *thread_cap != 0
-        {
-            register_service(
-                svcmgr_service_ep,
-                ipc_buf,
-                &ServiceRegistration {
-                    name,
-                    thread_cap: *thread_cap,
-                },
-            );
-        }
-    }
 
     let handover_msg = IpcMessage::new(svcmgr_labels::HANDOVER_COMPLETE);
     // SAFETY: ipc_buf is caller's registered IPC buffer.
@@ -1619,10 +1569,11 @@ pub fn create_and_start_logd(
     Some(thread_cap)
 }
 
-// ── svcmgr publish + drivers-dir handshake ──────────────────────────────────
+// ── svcmgr endowment name packing ───────────────────────────────────────────
 
-/// Pack a short ASCII name into IPC data words (`pack_name` shape matches
-/// `svcmgr::read_tail_name_from_msg`). Returns the word count used.
+/// Pack a short ASCII name into IPC data words, little-endian within each
+/// word. Matches svcmgr's unpack in `service::ingest_substrate` /
+/// `read_tail_name_from_msg`. Returns the word count used.
 fn pack_svc_name(name: &[u8], out: &mut [u64; 2]) -> usize
 {
     for (i, &b) in name.iter().enumerate()
@@ -1630,123 +1581,4 @@ fn pack_svc_name(name: &[u8], out: &mut [u64; 2]) -> usize
         out[i / 8] |= u64::from(b) << ((i % 8) * 8);
     }
     name.len().div_ceil(8)
-}
-
-/// Publish `(name, send_cap)` to svcmgr via `PUBLISH_ENDPOINT`. `publish_cap`
-/// MUST carry `svcmgr_labels::PUBLISH_AUTHORITY` in its token (init mints
-/// such caps locally from the un-tokened source it owns on svcmgr's service
-/// endpoint). Returns `true` on `svcmgr_errors::SUCCESS`.
-fn svcmgr_publish(publish_cap: u32, name: &[u8], send_cap: u32, ipc_buf: *mut u64) -> bool
-{
-    if publish_cap == 0 || send_cap == 0 || name.is_empty() || name.len() > 16
-    {
-        return false;
-    }
-    let mut words = [0u64; 2];
-    let word_count = pack_svc_name(name, &mut words);
-
-    let mut builder =
-        IpcMessage::builder(svcmgr_labels::PUBLISH_ENDPOINT | ((name.len() as u64) << 16))
-            .cap(send_cap);
-    for (i, &w) in words.iter().take(word_count).enumerate()
-    {
-        builder = builder.word(i, w);
-    }
-    let request = builder.build();
-
-    // SAFETY: ipc_buf is the registered IPC buffer.
-    let reply = unsafe { ipc::ipc_call(publish_cap, &request, ipc_buf) };
-    matches!(reply, Ok(r) if r.label == ipc::svcmgr_errors::SUCCESS)
-}
-
-/// Phase 3 sub-step: hand devmgr a least-privilege
-/// `/services/drivers/` subtree cap so it can lazily walk + spawn
-/// on-disk driver binaries (today: the per-arch RTC).
-///
-/// Walks `system_root_cap` to `/services/drivers/` at `LOOKUP | READ`
-/// rights, then sends `devmgr_labels::SET_DRIVERS_DIR` on a fresh
-/// `INIT_BIND_AUTHORITY`-tokened copy of `devmgr_registry_ep` (only
-/// init holds this verb bit; the `REGISTRY_QUERY_AUTHORITY`-only copy
-/// published to svcmgr cannot send this label).
-///
-/// devmgr's handler is ack-only: it stashes the cap and replies
-/// SUCCESS immediately. No driver walk or spawn happens in the
-/// handshake's blocking window — those fire lazily on the first
-/// `QUERY_RTC_DEVICE`. Init is not in the critical path of any
-/// driver spawn.
-///
-/// Best-effort: any failure (walk fails, devmgr replies a non-SUCCESS
-/// code, transport error) is logged and Phase 3 continues. The
-/// system boots without a wallclock; timed sees `NO_DEVICE` and
-/// degrades to its no-RTC path.
-fn set_drivers_dir_on_devmgr(devmgr_registry_ep: u32, system_root_cap: u32, ipc_buf: *mut u64)
-{
-    if devmgr_registry_ep == 0 || system_root_cap == 0
-    {
-        log("phase 3: SET_DRIVERS_DIR skipped (no devmgr or no system root)");
-        return;
-    }
-
-    // Attenuated rights: only what devmgr needs to walk into a
-    // subdirectory and read file contents. Visibility-gating bits are
-    // intentionally omitted; the namespace server intersects per hop.
-    let rights = u64::from(namespace_protocol::rights::LOOKUP | namespace_protocol::rights::READ);
-    let Some(drivers_dir) =
-        walk::walk_to_dir(system_root_cap, b"/services/drivers", rights, ipc_buf)
-    else
-    {
-        log("phase 3: SET_DRIVERS_DIR walk to /services/drivers failed; RTC unavailable");
-        return;
-    };
-
-    // `ipc::ipc_call` requires SEND+GRANT on the endpoint cap when the
-    // message carries caps (`drivers_dir` here); use
-    // `RIGHTS_SEND_GRANT`. The `devmgr.registry` cap init publishes for
-    // other services to look up deliberately omits the GRANT bit so
-    // client callers cannot transfer caps in queries; init's own
-    // privileged copy includes it for this single transfer.
-    let Ok(init_bind_ep) = syscall::cap_derive_token(
-        devmgr_registry_ep,
-        syscall::RIGHTS_SEND_GRANT,
-        ipc::devmgr_labels::INIT_BIND_AUTHORITY,
-    )
-    else
-    {
-        log("phase 3: SET_DRIVERS_DIR INIT_BIND_AUTHORITY derive failed; RTC unavailable");
-        let _ = syscall::cap_delete(drivers_dir);
-        return;
-    };
-
-    let msg = IpcMessage::builder(ipc::devmgr_labels::SET_DRIVERS_DIR)
-        .word(0, u64::from(ipc::DEVMGR_LABELS_VERSION))
-        .cap(drivers_dir)
-        .build();
-    // SAFETY: ipc_buf is the registered IPC buffer.
-    let result = unsafe { ipc::ipc_call(init_bind_ep, &msg, ipc_buf) };
-    let _ = syscall::cap_delete(init_bind_ep);
-
-    match result
-    {
-        Ok(reply) if reply.label == ipc::devmgr_errors::SUCCESS =>
-        {
-            // Kernel transferred `drivers_dir` to devmgr; nothing
-            // for init to clean up.
-            log("phase 3: SET_DRIVERS_DIR handshake ok");
-        }
-        Ok(_reply) =>
-        {
-            // Devmgr replied an error after the kernel transferred
-            // the cap. Per the SET_DRIVERS_DIR contract, devmgr's
-            // error paths release the delivered cap themselves.
-            log("phase 3: SET_DRIVERS_DIR rejected; RTC unavailable");
-        }
-        Err(_) =>
-        {
-            // ipc_call returned before the kernel committed the
-            // transfer; the source slot still owns `drivers_dir`
-            // and must be released.
-            let _ = syscall::cap_delete(drivers_dir);
-            log("phase 3: SET_DRIVERS_DIR ipc_call error; RTC unavailable");
-        }
-    }
 }

--- a/services/init/src/service.rs
+++ b/services/init/src/service.rs
@@ -890,8 +890,8 @@ pub fn create_svcmgr_from_file(
         let _ = syscall::cap_delete(reply_caps[1]);
     }
 
-    // Post-#21 svcmgr is the supervisor and holds the universal
-    // root: it reads `/config/svcmgr/services/*.svc` at handover,
+    // svcmgr is the supervisor and holds the universal root: it
+    // reads `/config/svcmgr/services/*.svc` at handover,
     // walks the recipe's `binary` path (typically
     // `/services/<name>` or `/programs/<name>`) for first-launch of
     // defined-but-unregistered services, and applies per-service

--- a/services/init/src/service.rs
+++ b/services/init/src/service.rs
@@ -969,14 +969,16 @@ mod endow_kind
 }
 
 /// Source + endpoint caps init endows svcmgr with at handover. The two
-/// source caps are init's own (full-rights) handles on the root filesystem
-/// namespace endpoint and devmgr's registry endpoint; svcmgr derives the
-/// shapes it publishes / sends from them.
+/// source caps are init's seed system-root cap (a SEND on vfsd's
+/// namespace endpoint) and init's full-rights handle on devmgr's registry
+/// endpoint; svcmgr derives the shapes it publishes / sends from them.
 #[allow(clippy::struct_field_names)]
 pub struct SvcmgrEndowment
 {
     pub svcmgr_service_ep: u32,
     pub svcmgr_bootstrap_ep: u32,
+    /// Seed system-root cap (`GET_SYSTEM_ROOT_CAP` from vfsd). svcmgr
+    /// derives the published `rootfs.root` SEND from it.
     pub rootfs_root_cap: u32,
     pub devmgr_registry_ep: u32,
 }
@@ -1126,7 +1128,6 @@ pub fn phase3_svcmgr_handover(
     svcmgr_service_ep: u32,
     devmgr_registry_ep: u32,
     system_root_cap: u32,
-    rootfs_root_cap: u32,
     thread_caps: ServiceThreadCaps,
     ipc_buf: *mut u64,
     init_logd_thread_cap: u32,
@@ -1178,7 +1179,10 @@ pub fn phase3_svcmgr_handover(
     let endowment = SvcmgrEndowment {
         svcmgr_service_ep,
         svcmgr_bootstrap_ep,
-        rootfs_root_cap,
+        // vfsd self-mounts root, so init no longer holds a per-mount fatfs
+        // cap; the seed system-root cap (vfsd's synthetic root) is the
+        // publish source for `rootfs.root`.
+        rootfs_root_cap: system_root_cap,
         devmgr_registry_ep,
     };
     endow_svcmgr(

--- a/services/init/src/service.rs
+++ b/services/init/src/service.rs
@@ -36,7 +36,6 @@ pub struct ServiceThreadCaps
     pub devmgr: u32,
     pub vfsd: u32,
     pub logd: u32,
-    pub timed: u32,
 }
 
 /// Per-spawn namespace-cap policy for [`configure_child_namespace`].
@@ -1318,7 +1317,7 @@ pub fn phase3_svcmgr_handover(
     devmgr_registry_ep: u32,
     system_root_cap: u32,
     rootfs_root_cap: u32,
-    mut thread_caps: ServiceThreadCaps,
+    thread_caps: ServiceThreadCaps,
     ipc_buf: *mut u64,
     init_logd_thread_cap: u32,
     mem_frame_reap_floor: u32,
@@ -1372,23 +1371,6 @@ pub fn phase3_svcmgr_handover(
     // on its first QUERY_RTC_DEVICE and degrade to its no-RTC path; the
     // rest of Phase 3 proceeds normally.
     set_drivers_dir_on_devmgr(devmgr_registry_ep, system_root_cap, ipc_buf);
-
-    // Wallclock chain: timed (init-spawned, svcmgr-published) consumes
-    // devmgr's QUERY_RTC_DEVICE for the per-arch RTC driver, which devmgr
-    // loads lazily from disk after the SET_DRIVERS_DIR handshake above.
-    // Failures are logged but do not abort phase 3 — svctest tolerates
-    // `SystemTime::now()` returning UNIX_EPOCH and exercises the live
-    // path only when the chain came up.
-    thread_caps.timed = bring_up_timed(
-        procmgr_ep,
-        bootstrap_ep,
-        svcmgr_service_ep,
-        devmgr_registry_ep,
-        system_root_cap,
-        init_self_cspace,
-        ipc_buf,
-    )
-    .unwrap_or(0);
 
     let pwrmgr_spawn = create_and_start_pwrmgr(
         info,
@@ -1534,7 +1516,6 @@ pub fn phase3_svcmgr_handover(
         (b"devmgr", thread_caps.devmgr),
         (b"vfsd", thread_caps.vfsd),
         (b"logd", thread_caps.logd),
-        (b"timed", thread_caps.timed),
         (b"pwrmgr", pwrmgr_thread_cap),
     ];
     for (name, thread_cap) in registrations
@@ -1931,7 +1912,7 @@ pub fn create_and_start_logd(
     Some(thread_cap)
 }
 
-// ── RTC + timed spawn pipeline ──────────────────────────────────────────────
+// ── svcmgr publish + drivers-dir handshake ──────────────────────────────────
 
 /// Pack a short ASCII name into IPC data words (`pack_name` shape matches
 /// `svcmgr::read_tail_name_from_msg`). Returns the word count used.
@@ -1969,178 +1950,6 @@ fn svcmgr_publish(publish_cap: u32, name: &[u8], send_cap: u32, ipc_buf: *mut u6
     // SAFETY: ipc_buf is the registered IPC buffer.
     let reply = unsafe { ipc::ipc_call(publish_cap, &request, ipc_buf) };
     matches!(reply, Ok(r) if r.label == ipc::svcmgr_errors::SUCCESS)
-}
-
-/// Common service-endpoint + RECV-derivation setup for a timed spawn.
-/// Init keeps the source slot to mint per-publish SENDs; the child
-/// receives a RECV-rights derivation.
-fn create_service_endpoint_pair() -> Option<(u32, u32)>
-{
-    let source = syscall::cap_create_endpoint(crate::endpoint_slab()).ok()?;
-    let Ok(recv_cap) = syscall::cap_derive(source, syscall::RIGHTS_RECEIVE)
-    else
-    {
-        let _ = syscall::cap_delete(source);
-        return None;
-    };
-    Some((source, recv_cap))
-}
-
-/// Walk + `CREATE_FROM_FILE` for one binary path. Returns
-/// `(process_handle, thread_cap, child_token)`; caller owns the thread
-/// cap (e.g. for svcmgr `REGISTER_SERVICE`) and is responsible for
-/// `destroy_partial_child` on any subsequent failure.
-///
-/// `policy` and `cwd` are forwarded to `configure_child_namespace`.
-/// Service helpers that use this path (e.g. timed) pass `NsPolicy::None`
-/// because they do not touch the filesystem after `_start`.
-#[allow(clippy::too_many_arguments)]
-fn walk_and_create_from_file(
-    path: &[u8],
-    procmgr_ep: u32,
-    bootstrap_ep: u32,
-    system_root_cap: u32,
-    init_self_cspace: u32,
-    policy: NsPolicy,
-    cwd: Option<(&[u8], u64)>,
-    ipc_buf: *mut u64,
-) -> Option<(u32, u32, u64)>
-{
-    let walked = walk::walk_to_file(system_root_cap, path, 0xFFFF, ipc_buf)?;
-    let (tokened_creator, child_token) = derive_tokened_creator(bootstrap_ep)?;
-    let create_msg = IpcMessage::builder(procmgr_labels::CREATE_FROM_FILE)
-        .word(0, walked.size)
-        .cap(walked.file_cap)
-        .cap(tokened_creator)
-        .build();
-    // SAFETY: ipc_buf is the registered IPC buffer.
-    let reply = unsafe { ipc::ipc_call(procmgr_ep, &create_msg, ipc_buf) }.ok()?;
-    if reply.label != 0
-    {
-        return None;
-    }
-    let reply_caps = reply.caps();
-    if reply_caps.len() < 2
-    {
-        return None;
-    }
-    let process_handle = reply_caps[0];
-    let thread_cap = reply_caps[1];
-    if !configure_child_namespace(
-        process_handle,
-        system_root_cap,
-        init_self_cspace,
-        policy,
-        cwd,
-        ipc_buf,
-    )
-    {
-        let _ = syscall::cap_delete(thread_cap);
-        return None;
-    }
-    Some((process_handle, thread_cap, child_token))
-}
-
-/// Spawn `/services/timed` and serve its single bootstrap round. Returns
-/// the init-owned service-endpoint source cap; init derives a SEND
-/// from it for the `timed` publish.
-/// Timed-side result of [`create_and_start_timed`].
-///
-/// `service_ep` is the init-owned service-endpoint source cap (used
-/// to derive the SEND init publishes as `timed`). `thread_cap` is
-/// timed's main thread in init's `CSpace`, registered with svcmgr so
-/// the supervisor can bind death-notification.
-pub struct TimedSpawn
-{
-    pub service_ep: u32,
-    pub thread_cap: u32,
-}
-
-pub fn create_and_start_timed(
-    procmgr_ep: u32,
-    bootstrap_ep: u32,
-    devmgr_registry_ep: u32,
-    system_root_cap: u32,
-    init_self_cspace: u32,
-    ipc_buf: *mut u64,
-) -> Option<TimedSpawn>
-{
-    let (svc_source, svc_recv) = create_service_endpoint_pair()?;
-
-    // timed resolves the RTC via devmgr's QUERY_RTC_DEVICE on a
-    // REGISTRY_QUERY_AUTHORITY-tokened SEND copy of devmgr's registry
-    // endpoint, then serves GET_WALL_TIME. No filesystem access.
-    let Ok(devmgr_registry_copy) = syscall::cap_derive_token(
-        devmgr_registry_ep,
-        syscall::RIGHTS_SEND,
-        ipc::devmgr_labels::REGISTRY_QUERY_AUTHORITY,
-    )
-    else
-    {
-        let _ = syscall::cap_delete(svc_recv);
-        let _ = syscall::cap_delete(svc_source);
-        log("timed: devmgr registry token derive failed");
-        return None;
-    };
-
-    let Some((process_handle, thread_cap, child_token)) = walk_and_create_from_file(
-        b"/services/timed",
-        procmgr_ep,
-        bootstrap_ep,
-        system_root_cap,
-        init_self_cspace,
-        NsPolicy::None,
-        None,
-        ipc_buf,
-    )
-    else
-    {
-        let _ = syscall::cap_delete(devmgr_registry_copy);
-        let _ = syscall::cap_delete(svc_recv);
-        let _ = syscall::cap_delete(svc_source);
-        log("timed: walk + CREATE_FROM_FILE failed");
-        return None;
-    };
-
-    if !start_process(
-        process_handle,
-        ipc_buf,
-        "phase 3: timed started; serving bootstrap",
-        "phase 3: timed START_PROCESS failed",
-    )
-    {
-        let _ = syscall::cap_delete(devmgr_registry_copy);
-        let _ = syscall::cap_delete(svc_recv);
-        let _ = syscall::cap_delete(svc_source);
-        let _ = syscall::cap_delete(thread_cap);
-        destroy_partial_child(process_handle, ipc_buf);
-        return None;
-    }
-
-    if !serve(
-        bootstrap_ep,
-        child_token,
-        ipc_buf,
-        true,
-        &[svc_recv, devmgr_registry_copy],
-        &[],
-        "timed: bootstrap round failed",
-    )
-    {
-        // Best-effort delete: serve_round may have transferred caps before
-        // failing. Child has been started; cannot destroy safely. It will
-        // exit on the receive-side failure and procmgr will reap.
-        let _ = syscall::cap_delete(svc_recv);
-        let _ = syscall::cap_delete(devmgr_registry_copy);
-        let _ = syscall::cap_delete(svc_source);
-        let _ = syscall::cap_delete(thread_cap);
-        return None;
-    }
-
-    Some(TimedSpawn {
-        service_ep: svc_source,
-        thread_cap,
-    })
 }
 
 /// Phase 3 sub-step: hand devmgr a least-privilege
@@ -2233,77 +2042,4 @@ fn set_drivers_dir_on_devmgr(devmgr_registry_ep: u32, system_root_cap: u32, ipc_
             log("phase 3: SET_DRIVERS_DIR ipc_call error; RTC unavailable");
         }
     }
-}
-
-/// Phase 3 sub-step: spawn timed and publish it as `timed`. The RTC
-/// driver itself is loaded by devmgr from the on-disk rootfs inside
-/// the [`set_drivers_dir_on_devmgr`] handshake (above), between
-/// devmgr's `ipc_reply` and its next `ipc_recv`; by the time `timed`
-/// queries [`ipc::devmgr_labels::QUERY_RTC_DEVICE`] against the
-/// `REGISTRY_QUERY_AUTHORITY`-tokened copy of `devmgr_registry_ep`
-/// delivered in its bootstrap round, devmgr already holds `rtc_ep`
-/// (or the sticky-failure state and replies `NO_DEVICE`). Init's
-/// PUBLISH_AUTHORITY-tokened cap is derived from `svcmgr_service_ep`
-/// (the un-tokened source init already owns). All failures are
-/// logged; the function never aborts phase 3 — a degraded wall-clock
-/// leaves `SystemTime::now()` returning `UNIX_EPOCH` but the rest of
-/// svctest still runs.
-pub fn bring_up_timed(
-    procmgr_ep: u32,
-    bootstrap_ep: u32,
-    svcmgr_service_ep: u32,
-    devmgr_registry_ep: u32,
-    system_root_cap: u32,
-    init_self_cspace: u32,
-    ipc_buf: *mut u64,
-) -> Option<u32>
-{
-    // RIGHTS_SEND_GRANT (not bare SEND): PUBLISH_ENDPOINT carries the
-    // service's SEND cap in the message, and the IPC kernel requires the
-    // GRANT bit on the caller's send-cap to transfer caps.
-    let Ok(publish_cap) = syscall::cap_derive_token(
-        svcmgr_service_ep,
-        syscall::RIGHTS_SEND_GRANT,
-        svcmgr_labels::PUBLISH_AUTHORITY,
-    )
-    else
-    {
-        log("phase 3: timed PUBLISH_AUTHORITY derive failed");
-        return None;
-    };
-
-    let Some(timed_spawn) = create_and_start_timed(
-        procmgr_ep,
-        bootstrap_ep,
-        devmgr_registry_ep,
-        system_root_cap,
-        init_self_cspace,
-        ipc_buf,
-    )
-    else
-    {
-        let _ = syscall::cap_delete(publish_cap);
-        return None;
-    };
-
-    let Ok(timed_publish_send) = syscall::cap_derive(timed_spawn.service_ep, syscall::RIGHTS_SEND)
-    else
-    {
-        log("phase 3: timed publish SEND derive failed");
-        let _ = syscall::cap_delete(timed_spawn.thread_cap);
-        let _ = syscall::cap_delete(publish_cap);
-        return None;
-    };
-    if !svcmgr_publish(publish_cap, b"timed", timed_publish_send, ipc_buf)
-    {
-        log("phase 3: timed publish failed");
-        let _ = syscall::cap_delete(timed_publish_send);
-        let _ = syscall::cap_delete(timed_spawn.thread_cap);
-        let _ = syscall::cap_delete(publish_cap);
-        return None;
-    }
-    log("phase 3: timed published");
-
-    let _ = syscall::cap_delete(publish_cap);
-    Some(timed_spawn.thread_cap)
 }

--- a/services/init/src/service.rs
+++ b/services/init/src/service.rs
@@ -35,26 +35,6 @@ pub struct ServiceThreadCaps
     pub procmgr: u32,
     pub devmgr: u32,
     pub vfsd: u32,
-    pub logd: u32,
-}
-
-/// Per-spawn namespace-cap policy for [`configure_child_namespace`].
-///
-/// The variants encode the two shapes a child's `system_root_cap`
-/// can take when init still spawns the service directly: a `cap_copy`
-/// of the spawner's seed root, or nothing at all. Per-service subtree
-/// attenuation lives in svcmgr (parsed from `/config/svcmgr/services/<name>.svc`'s
-/// `namespace = subtree:<path>:<rights>` line) post-#21.
-#[derive(Clone, Copy)]
-pub enum NsPolicy
-{
-    /// Hand the child a `cap_copy` of `system_root_cap` at full
-    /// rights.
-    Universal,
-    /// Do not call `CONFIGURE_NAMESPACE` at all. The child's
-    /// `system_root_cap` stays zero; std-side absolute-path fs ops
-    /// return `Unsupported`.
-    None,
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -67,20 +47,16 @@ fn derive_tokened_creator(bootstrap_ep: u32) -> Option<(u32, u64)>
 }
 
 /// Issue `procmgr_labels::CONFIGURE_NAMESPACE` on a freshly-created
-/// (suspended) child according to `policy` and the optional `cwd`.
+/// (suspended) child, handing it a universal `cap_copy` of
+/// `system_root_cap` at full rights plus the optional `cwd`.
 ///
-/// * `policy` selects the shape of the child's `system_root_cap`:
-///   universal copy of `system_root_cap`, an attenuated subtree
-///   walked from it, or no cap at all.
-/// * `cwd`, when `Some`, walks `(path, rights)` from `system_root_cap`
-///   and delivers the resulting directory cap as `caps[1]` so the
-///   child's `current_dir_cap` is non-zero from the first instruction.
+/// `cwd`, when `Some`, walks `(path, rights)` from `system_root_cap`
+/// and delivers the resulting directory cap as `caps[1]` so the
+/// child's `current_dir_cap` is non-zero from the first instruction.
 ///
-/// `NsPolicy::None` with `cwd = None` skips the IPC entirely
-/// (procmgr's default leaves both `ProcessInfo` slots at zero).
-/// `NsPolicy::None` with `cwd = Some(_)` is rejected by procmgr
-/// (`root_cap == 0` is `INVALID_ARGUMENT`); callers MUST pair a cwd
-/// with at least `Universal` or `Subtree`.
+/// Per-service subtree attenuation lives in svcmgr (parsed from each
+/// `/config/svcmgr/services/<name>.svc`'s `namespace =` line); init
+/// hands its sole namespace consumer — svcmgr — the universal root.
 ///
 /// On any failure the partial child is destroyed (`DESTROY_PROCESS`
 /// on `process_handle`, then `cap_delete`) so a false return tells
@@ -91,37 +67,16 @@ fn configure_child_namespace(
     process_handle: u32,
     system_root_cap: u32,
     init_self_cspace: u32,
-    policy: NsPolicy,
     cwd: Option<(&[u8], u64)>,
     ipc_buf: *mut u64,
 ) -> bool
 {
-    let ns_cap = match policy
+    let Ok(ns_cap) = syscall::cap_copy(system_root_cap, init_self_cspace, syscall::RIGHTS_SEND)
+    else
     {
-        NsPolicy::None =>
-        {
-            if cwd.is_some()
-            {
-                // cwd without root is unrepresentable on the wire
-                // (procmgr enforces root_cap != 0). Treat as a
-                // caller bug.
-                log("phase 3: NsPolicy::None with cwd is invalid");
-                destroy_partial_child(process_handle, ipc_buf);
-                return false;
-            }
-            return true;
-        }
-        NsPolicy::Universal =>
-        {
-            let Ok(c) = syscall::cap_copy(system_root_cap, init_self_cspace, syscall::RIGHTS_SEND)
-            else
-            {
-                log("phase 3: cap_copy of system root for child failed");
-                destroy_partial_child(process_handle, ipc_buf);
-                return false;
-            };
-            c
-        }
+        log("phase 3: cap_copy of system root for child failed");
+        destroy_partial_child(process_handle, ipc_buf);
+        return false;
     };
 
     let cwd_cap = if let Some((path, rights)) = cwd
@@ -939,15 +894,13 @@ pub fn create_svcmgr_from_file(
     // root: it reads `/config/svcmgr/services/*.svc` at handover,
     // walks the recipe's `binary` path (typically
     // `/services/<name>` or `/programs/<name>`) for first-launch of
-    // defined-but-unregistered
-    // services, and applies per-service namespace attenuation from
-    // each `.svc` recipe when configuring the child. Init no longer
-    // pre-attenuates svcmgr to `/bin`.
+    // defined-but-unregistered services, and applies per-service
+    // namespace attenuation from each `.svc` recipe when configuring
+    // the child. svcmgr therefore holds the universal root.
     if !configure_child_namespace(
         process_handle,
         system_root_cap,
         init_self_cspace,
-        NsPolicy::Universal,
         None,
         ipc_buf,
     )
@@ -966,12 +919,15 @@ mod endow_kind
     pub const CAPS: u64 = 1;
     /// One substrate `(name, thread_cap)` registration.
     pub const SUBSTRATE: u64 = 2;
+    /// Terminal round: the reserved source caps svcmgr keeps to launch +
+    /// supervise + restart real-logd (master-log endpoint, procmgr death-auth).
+    pub const LOGD_SOURCES: u64 = 3;
 }
 
-/// Source + endpoint caps init endows svcmgr with at handover. The two
-/// source caps are init's seed system-root cap (a SEND on vfsd's
-/// namespace endpoint) and init's full-rights handle on devmgr's registry
-/// endpoint; svcmgr derives the shapes it publishes / sends from them.
+/// Source + endpoint caps init endows svcmgr with at handover. svcmgr
+/// derives the shapes it publishes / sends / launches with from these
+/// reserved sources; it keeps the log-sink sources for the system's life
+/// so it can (re)launch real-logd any number of times.
 #[allow(clippy::struct_field_names)]
 pub struct SvcmgrEndowment
 {
@@ -981,25 +937,40 @@ pub struct SvcmgrEndowment
     /// derives the published `rootfs.root` SEND from it.
     pub rootfs_root_cap: u32,
     pub devmgr_registry_ep: u32,
+    /// Reserved master-log endpoint source (`cap_derive(log_ep, RIGHTS_ALL)`).
+    /// svcmgr mints real-logd's master-log RECV from it on every (re)launch,
+    /// plus the one-shot `HANDOVER_PULL` SEND on the first launch. Holding it
+    /// keeps the endpoint object alive across a logd crash so log senders are
+    /// agnostic to which process holds the RECV.
+    pub master_log_source: u32,
+    /// Reserved token-0 `SEND|GRANT` source on procmgr's service endpoint.
+    /// svcmgr mints real-logd's `DEATH_EQ_AUTHORITY` SEND from it per launch
+    /// (used by logd to register sender death-notifications for slot reclaim).
+    pub procmgr_death_auth_source: u32,
 }
 
 /// Start svcmgr, then serve the handover endowment over the bootstrap
 /// protocol.
 ///
-/// Round 1 (`CAPS`, not done) delivers svcmgr's service + bootstrap
-/// endpoints (full rights) and the publish-role source caps: a `SEND` on
-/// the root filesystem namespace endpoint (svcmgr publishes it as
-/// `rootfs.root`) and a token-0 `SEND|GRANT` source on devmgr's registry
-/// endpoint (svcmgr mints the `REGISTRY_QUERY_AUTHORITY` `devmgr.registry`
-/// publish cap and the `DRIVERS_DIR_AUTHORITY` `SET_DRIVERS_DIR` cap from
-/// it). An absent source cap rides as a zero slot, which svcmgr tolerates.
+/// Round 1 (`CAPS`) delivers svcmgr's service + bootstrap endpoints (full
+/// rights) and the publish-role source caps: a `SEND` on the root
+/// filesystem namespace endpoint (svcmgr publishes it as `rootfs.root`) and
+/// a token-0 `SEND|GRANT` source on devmgr's registry endpoint (svcmgr mints
+/// the `REGISTRY_QUERY_AUTHORITY` `devmgr.registry` publish cap and the
+/// `DRIVERS_DIR_AUTHORITY` `SET_DRIVERS_DIR` cap from it). An absent source
+/// cap rides as a zero slot, which svcmgr tolerates.
 ///
-/// Each subsequent `SUBSTRATE` round delivers one init-bootstrapped
-/// service's thread cap plus its name; the final substrate round is
-/// terminal. svcmgr parks the pairs for reconciliation. Best-effort: a
-/// failed round logs and aborts the endowment; svcmgr then runs with
-/// whatever it received (the system is already non-viable if a substrate
-/// thread cap cannot be delivered).
+/// Each `SUBSTRATE` round then delivers one init-bootstrapped service's
+/// thread cap plus its name (memmgr/procmgr/devmgr/vfsd); svcmgr parks the
+/// pairs for death-supervision binding at reconciliation.
+///
+/// The terminal `LOGD_SOURCES` round delivers the two reserved caps svcmgr
+/// keeps to launch + supervise + restart real-logd: the master-log endpoint
+/// source and a token-0 procmgr `SEND|GRANT` source (see [`SvcmgrEndowment`]).
+///
+/// Best-effort: a failed round logs and aborts the endowment; svcmgr then
+/// runs with whatever it received (the system is already non-viable if a
+/// substrate thread cap cannot be delivered).
 fn endow_svcmgr(
     bootstrap_ep: u32,
     process_handle: u32,
@@ -1054,23 +1025,23 @@ fn endow_svcmgr(
 
     // Substrate set; init skips a service whose thread cap it could not
     // capture, so a missing recipe match is bind-only-absent rather than a
-    // `registered without definition` orphan in svcmgr.
+    // `registered without definition` orphan in svcmgr. logd is absent — it
+    // is a svcmgr-launched service (LOGD_SOURCES round), not a parked
+    // substrate.
     let registrations: &[(&[u8], u32)] = &[
         (b"memmgr", thread_caps.memmgr),
         (b"procmgr", thread_caps.procmgr),
         (b"devmgr", thread_caps.devmgr),
         (b"vfsd", thread_caps.vfsd),
-        (b"logd", thread_caps.logd),
     ];
-    let last = registrations.iter().rposition(|&(_, tc)| tc != 0);
 
     // Round 1 (CAPS), positional: [service, bootstrap, rootfs, devmgr_reg].
-    // Terminal only in the (unreachable) all-zero-substrate case.
+    // The LOGD_SOURCES round is always terminal, so no earlier round is.
     if !serve(
         bootstrap_ep,
         child_token,
         ipc_buf,
-        last.is_none(),
+        false,
         &[service_copy, boot_copy, rootfs_send, devmgr_registry_src],
         &[endow_kind::CAPS, u64::from(ipc::SVCMGR_LABELS_VERSION)],
         "phase 3: svcmgr endowment CAPS round failed",
@@ -1079,8 +1050,8 @@ fn endow_svcmgr(
         return;
     }
 
-    // Substrate rounds: one (name, thread_cap) each; last is terminal.
-    for (i, &(name, thread_cap)) in registrations.iter().enumerate()
+    // Substrate rounds: one (name, thread_cap) each.
+    for &(name, thread_cap) in registrations
     {
         if thread_cap == 0
         {
@@ -1096,7 +1067,7 @@ fn endow_svcmgr(
             bootstrap_ep,
             child_token,
             ipc_buf,
-            Some(i) == last,
+            false,
             &[thread_cap],
             &data[..2 + nw],
             "phase 3: svcmgr endowment SUBSTRATE round failed",
@@ -1105,21 +1076,35 @@ fn endow_svcmgr(
             return;
         }
     }
+
+    // Terminal round (LOGD_SOURCES): the reserved master-log endpoint source
+    // and the token-0 procmgr `SEND|GRANT` source. svcmgr mints real-logd's
+    // bootstrap caps from these on every (re)launch. A zero slot rides if a
+    // source derive failed; svcmgr degrades (logd unlaunchable) but survives.
+    let _ = serve(
+        bootstrap_ep,
+        child_token,
+        ipc_buf,
+        true,
+        &[endow.master_log_source, endow.procmgr_death_auth_source],
+        &[endow_kind::LOGD_SOURCES],
+        "phase 3: svcmgr endowment LOGD_SOURCES round failed",
+    );
 }
 
 // ── Phase 3 orchestration ───────────────────────────────────────────────────
 
 /// Phase 3: load svcmgr, serve it the handover endowment (its own
 /// endpoints + publish-role source caps + one `(name, thread_cap)` round
-/// per init-bootstrapped substrate service), then signal
-/// `HANDOVER_COMPLETE` so svcmgr scans `/config/svcmgr/services/`. svcmgr
-/// publishes the well-known names it now owns and installs devmgr's
-/// drivers dir from the endowment; init no longer publishes caps,
-/// registers services, or talks to devmgr. On a normal boot the defined
-/// services are the bind-only substrate plus the svcmgr-launched providers
-/// (`timed`, `pwrmgr`); svcmgr's pure-consumer launch path fires only for
-/// staged test recipes (svctest / usertest, and crasher co-staged with
-/// svctest).
+/// per init-bootstrapped substrate service + the reserved log-sink
+/// sources), then signal `HANDOVER_COMPLETE` so svcmgr scans
+/// `/config/svcmgr/services/`. svcmgr owns all post-handover work from the
+/// endowment: it publishes the well-known names, installs devmgr's drivers
+/// dir, and launches + supervises the non-bootstrap services. On a normal
+/// boot the defined services are the bind-only substrate plus the
+/// svcmgr-launched services (`logd`, `timed`, `pwrmgr`); svcmgr's
+/// pure-consumer launch path fires only for staged test recipes (svctest /
+/// usertest, and crasher co-staged with svctest).
 #[allow(clippy::too_many_lines, clippy::too_many_arguments)]
 pub fn phase3_svcmgr_handover(
     info: &InitInfo,
@@ -1128,6 +1113,7 @@ pub fn phase3_svcmgr_handover(
     svcmgr_service_ep: u32,
     devmgr_registry_ep: u32,
     system_root_cap: u32,
+    log_ep: u32,
     thread_caps: ServiceThreadCaps,
     ipc_buf: *mut u64,
     init_logd_thread_cap: u32,
@@ -1167,23 +1153,29 @@ pub fn phase3_svcmgr_handover(
     // endpoints plus the publish-role source caps (rootfs root, devmgr
     // registry), then one round per init-bootstrapped substrate service
     // carries that service's (name, thread_cap) for death-supervision
-    // binding. svcmgr drains it all in `bootstrap_caps`, publishes the
-    // well-known names it now owns (`rootfs.root` / `svcmgr` /
-    // `devmgr.registry`) and installs devmgr's drivers dir itself, then
-    // reconciles the substrate against `/config/svcmgr/services/` on
-    // HANDOVER_COMPLETE.
+    // binding, and the terminal round carries the reserved log-sink sources.
+    // svcmgr drains it all in `bootstrap_caps`, publishes the well-known
+    // names it owns (`rootfs.root` / `svcmgr` / `devmgr.registry`), installs
+    // devmgr's drivers dir, and reconciles `/config/svcmgr/services/` on
+    // HANDOVER_COMPLETE — launching logd/timed/pwrmgr and acquiring their
+    // caps for them.
     //
-    // pwrmgr/timed are svcmgr-launched providers (`*.svc`) that acquire
-    // their caps from devmgr and publish their own names; init neither
-    // spawns nor publishes for them.
+    // The publish source for `rootfs.root` is the seed system-root cap
+    // (vfsd's synthetic root): vfsd self-mounts root, so there is no
+    // per-mount fatfs cap to publish.
+    let master_log_source = syscall::cap_derive(log_ep, syscall::RIGHTS_ALL).unwrap_or(0);
+    // Token-0 `SEND|GRANT` source on procmgr's service endpoint; svcmgr mints
+    // logd's `DEATH_EQ_AUTHORITY` SEND from it. `GRANT` because logd's
+    // death-EQ registration transfers a cap, which the IPC kernel gates on it.
+    let procmgr_death_auth_source =
+        syscall::cap_derive(procmgr_ep, syscall::RIGHTS_SEND_GRANT).unwrap_or(0);
     let endowment = SvcmgrEndowment {
         svcmgr_service_ep,
         svcmgr_bootstrap_ep,
-        // vfsd self-mounts root, so init no longer holds a per-mount fatfs
-        // cap; the seed system-root cap (vfsd's synthetic root) is the
-        // publish source for `rootfs.root`.
         rootfs_root_cap: system_root_cap,
         devmgr_registry_ep,
+        master_log_source,
+        procmgr_death_auth_source,
     };
     endow_svcmgr(
         bootstrap_ep,
@@ -1203,10 +1195,11 @@ pub fn phase3_svcmgr_handover(
     }
 
     // Reap-handoff: move init's kernel-object caps + every reclaimable
-    // Frame cap to procmgr. Procmgr binds a death-EQ on init's main
-    // thread; when this function returns into `sys_thread_exit`
-    // immediately below, procmgr's reap path tears init's AS/CSpace
-    // /Threads down and donates the Frame caps to memmgr's pool.
+    // Frame cap to procmgr. Procmgr binds a death-EQ on both of init's
+    // threads (main + init-logd) and reaps once both have exited — init-logd
+    // outlives this main thread until the svcmgr-launched real-logd pulls
+    // `HANDOVER_PULL`. The reap tears init's AS/CSpace/Threads down and
+    // donates the Frame caps to memmgr's pool.
     handoff_to_procmgr_reap(
         info,
         procmgr_ep,
@@ -1397,180 +1390,6 @@ fn handoff_to_procmgr_reap(
         {}
         _ => log("reap-handoff: INIT_TEARDOWN_DONE IPC failed (reap may not run)"),
     }
-}
-
-// ── logd spawn ──────────────────────────────────────────────────────────────
-
-/// Spawn real-logd from `/services/logd` at the end of Phase 2, immediately
-/// after the root mount completes. Init transfers:
-///
-/// * a RECV cap on the master log endpoint (so logd becomes the
-///   receive-side; init-logd terminates as part of the handover);
-/// * a SEND cap on the same endpoint (single-use, for the
-///   `HANDOVER_PULL` IPC to init-logd);
-/// * a tokened SEND cap on procmgr carrying
-///   `procmgr_labels::DEATH_EQ_AUTHORITY` (for `REGISTER_DEATH_EQ`);
-/// * a SEND cap on devmgr's registry endpoint carrying
-///   `devmgr_labels::REGISTRY_QUERY_AUTHORITY`, with which logd resolves
-///   the serial driver (via `QUERY_SERIAL_DEVICE`) and routes its own
-///   diagnostics and the per-sender log lines it receives through the
-///   driver's `SERIAL_WRITE_BYTES`. Logd holds no UART hardware authority
-///   and cannot route diagnostics through `seraph::log!` because it IS the
-///   log receiver.
-///
-/// Returns `true` on successful spawn + bootstrap; `false` on any
-/// failure (logged at fault; init continues without real-logd, with
-/// init-logd running indefinitely until init's process is otherwise
-/// reaped).
-// too_many_lines: one transactional spawn path; splitting would push
-// most of the body into helpers and obscure the cap-flow sequencing.
-#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
-pub fn create_and_start_logd(
-    procmgr_ep: u32,
-    procmgr_service_ep_source: u32,
-    bootstrap_ep: u32,
-    log_ep: u32,
-    devmgr_registry_ep: u32,
-    system_root_cap: u32,
-    init_self_cspace: u32,
-    ipc_buf: *mut u64,
-) -> Option<u32>
-{
-    let walked = walk::walk_to_file(system_root_cap, b"/services/logd", 0xFFFF, ipc_buf)?;
-
-    let (tokened_creator, child_token) = derive_tokened_creator(bootstrap_ep)?;
-
-    let create_msg = IpcMessage::builder(procmgr_labels::CREATE_FROM_FILE)
-        .word(0, walked.size)
-        .cap(walked.file_cap)
-        .cap(tokened_creator)
-        .build();
-    // SAFETY: ipc_buf is the registered IPC buffer.
-    let Ok(reply) = (unsafe { ipc::ipc_call(procmgr_ep, &create_msg, ipc_buf) })
-    else
-    {
-        log("logd: CREATE_FROM_FILE ipc_call failed");
-        return None;
-    };
-    if reply.label != 0
-    {
-        log("logd: CREATE_FROM_FILE error");
-        return None;
-    }
-    let reply_caps = reply.caps();
-    if reply_caps.len() < 2
-    {
-        log("logd: CREATE_FROM_FILE reply missing caps");
-        return None;
-    }
-    let process_handle = reply_caps[0];
-    let thread_cap = reply_caps[1];
-
-    // logd owns the master log endpoint RECV plus a devmgr-registry query
-    // cap (to resolve the serial driver via QUERY_SERIAL_DEVICE); its
-    // serial output is driver-mediated, so it holds no UART hardware
-    // authority. It does no filesystem I/O. Spawn with no namespace cap.
-    if !configure_child_namespace(
-        process_handle,
-        system_root_cap,
-        init_self_cspace,
-        NsPolicy::None,
-        None,
-        ipc_buf,
-    )
-    {
-        return None;
-    }
-
-    // Derive the three bootstrap caps logd needs.
-    let Ok(log_recv) = syscall::cap_derive(log_ep, syscall::RIGHTS_ALL)
-    else
-    {
-        log("logd: log_ep RECV derive failed");
-        destroy_partial_child(process_handle, ipc_buf);
-        return None;
-    };
-    let Ok(log_handover_send) = syscall::cap_derive(log_ep, syscall::RIGHTS_SEND)
-    else
-    {
-        log("logd: log_ep SEND derive failed");
-        let _ = syscall::cap_delete(log_recv);
-        destroy_partial_child(process_handle, ipc_buf);
-        return None;
-    };
-    // RIGHTS_SEND_GRANT (not bare SEND): the IPC kernel requires the
-    // GRANT bit when the caller transfers any cap in the message, and
-    // logd's REGISTER_DEATH_EQ call hands over its `death_eq` cap.
-    let Ok(procmgr_death_auth) = syscall::cap_derive_token(
-        procmgr_service_ep_source,
-        syscall::RIGHTS_SEND_GRANT,
-        procmgr_labels::DEATH_EQ_AUTHORITY,
-    )
-    else
-    {
-        log("logd: procmgr DEATH_EQ_AUTHORITY derive failed");
-        let _ = syscall::cap_delete(log_recv);
-        let _ = syscall::cap_delete(log_handover_send);
-        destroy_partial_child(process_handle, ipc_buf);
-        return None;
-    };
-
-    // devmgr-registry query cap: a SEND on devmgr's registry endpoint
-    // tokened with REGISTRY_QUERY_AUTHORITY so logd can resolve the serial
-    // driver via `QUERY_SERIAL_DEVICE`. logd's serial output is mediated by
-    // that driver; it holds no UART hardware authority. A zero registry
-    // endpoint yields zero, and logd then buffers received log lines in
-    // memory until the driver becomes resolvable.
-    let devmgr_registry_query = if devmgr_registry_ep != 0
-    {
-        syscall::cap_derive_token(
-            devmgr_registry_ep,
-            syscall::RIGHTS_SEND,
-            ipc::devmgr_labels::REGISTRY_QUERY_AUTHORITY,
-        )
-        .unwrap_or(0)
-    }
-    else
-    {
-        0
-    };
-
-    if !start_process(
-        process_handle,
-        ipc_buf,
-        "phase 2: logd started; serving bootstrap",
-        "phase 2: logd START_PROCESS failed",
-    )
-    {
-        let _ = syscall::cap_delete(log_recv);
-        let _ = syscall::cap_delete(log_handover_send);
-        let _ = syscall::cap_delete(procmgr_death_auth);
-        if devmgr_registry_query != 0
-        {
-            let _ = syscall::cap_delete(devmgr_registry_query);
-        }
-        return None;
-    }
-
-    if !serve(
-        bootstrap_ep,
-        child_token,
-        ipc_buf,
-        true,
-        &[
-            log_recv,
-            log_handover_send,
-            procmgr_death_auth,
-            devmgr_registry_query,
-        ],
-        &[],
-        "logd: bootstrap round failed",
-    )
-    {
-        return None;
-    }
-
-    Some(thread_cap)
 }
 
 // ── svcmgr endowment name packing ───────────────────────────────────────────

--- a/services/logd/README.md
+++ b/services/logd/README.md
@@ -1,14 +1,18 @@
 # logd
 
-Post-mount owner of the master system log endpoint.
+Owner of the master system log endpoint.
 
-logd is spawned by init at the end of Phase 2, immediately after the
-root filesystem is mounted and before any Phase 3 service is launched.
-It assumes the receive side of the kernel endpoint that init-logd had
+svcmgr launches and supervises logd post-handover, minting its bootstrap
+round from the reserved log-sink sources init endows (see
+[`services/svcmgr/docs/service-definitions.md`](../svcmgr/docs/service-definitions.md)).
+logd assumes the receive side of the kernel endpoint that init-logd has
 been draining since boot, ingests init-logd's captured history,
-subscribes to procmgr's death-notification cascade, and from then on
-is the single owner of every log line emitted by every userspace
-process.
+subscribes to procmgr's death-notification cascade, and from then on is
+the single owner of every log line emitted by every userspace process.
+It is restartable (`restart = on_failure`): svcmgr holds the master-log
+endpoint source for the system's life, so a restarted logd re-attaches a
+fresh RECV to the same endpoint object every sender already targets; only
+the one-time init-logd history pull is skipped on restart.
 
 ## Role
 
@@ -44,8 +48,8 @@ process.
 
 * **Per-sender slot reclamation.** logd creates an `EventQueue` and
   registers it with procmgr via `procmgr_labels::REGISTER_DEATH_EQ`
-  (authorised by the `DEATH_EQ_AUTHORITY` tokened SEND cap init
-  hands to logd at bootstrap). Procmgr binds that EQ as an
+  (authorised by the `DEATH_EQ_AUTHORITY` tokened SEND cap svcmgr mints
+  into logd's bootstrap round). Procmgr binds that EQ as an
   additional death observer on every existing thread and on every
   future spawn. When a process exits, logd's EQ receives
   `(process_token << 32) | exit_reason`; logd evicts the matching
@@ -57,8 +61,6 @@ process.
 
 * Log rotation, durable-disk persistence, query API.
 * Network-syslog sink.
-* svcmgr-late-launch migration (parallel to the svctest refactor;
-  logd is launched by init for now).
 
 ## Source Layout
 
@@ -79,30 +81,35 @@ logd/
 
 ## Bootstrap caps
 
-Init's bootstrap round (one round, `done = true`) delivers four caps:
+svcmgr's bootstrap round (one round, `done = true`) delivers four caps,
+minted from the reserved log-sink sources svcmgr holds (master-log
+endpoint, procmgr `SEND|GRANT`, devmgr registry):
 
 | Index | Cap |
 |---|---|
 | 0 | RECV on the master log endpoint |
-| 1 | SEND on the master log endpoint (single-use; HANDOVER_PULL only) |
+| 1 | SEND on the master log endpoint (single-use; HANDOVER_PULL only). `0` on a restart — there is no init-logd left to pull from, so logd skips the history pull |
 | 2 | Tokened SEND on procmgr's service endpoint carrying `DEATH_EQ_AUTHORITY` |
 | 3 | Tokened SEND on devmgr's registry endpoint carrying `REGISTRY_QUERY_AUTHORITY` (to resolve the serial driver via `QUERY_SERIAL_DEVICE`) |
 
-After `HANDOVER_PULL` completes, logd deletes cap[1] (no other use
-for a SEND cap on its own endpoint). The devmgr-registry cap is kept
-for the lifetime of the process; logd uses it once to resolve and
-cache the serial driver's write endpoint.
+logd registers its death-EQ with procmgr before the handover pull (while
+init-logd still drains the endpoint and procmgr is not yet reaping init),
+then pulls cap[1] and deletes it (no other use for a SEND cap on its own
+endpoint). The devmgr-registry cap is kept for the lifetime of the
+process; logd uses it once to resolve and cache the serial driver's write
+endpoint.
 
 ## Relevant Design Documents
 
 | Document | Content |
 |---|---|
 | [docs/architecture.md](../../docs/architecture.md) | logd's role in the userspace component map |
-| [docs/bootstrap.md](../../docs/bootstrap.md) | logd's spawn timing inside init's Phase 2 |
+| [docs/bootstrap.md](../../docs/bootstrap.md) | init-logd's boot role and the init → svcmgr handover that precedes logd's launch |
 | [docs/process-lifecycle.md](../../docs/process-lifecycle.md) | Death-notification cascade logd subscribes to |
 | [docs/ipc-design.md](../../docs/ipc-design.md) | Endpoint identity, cap transfer semantics that make the init-logd handover possible |
 | [docs/console-model.md](../../docs/console-model.md) | Console output ownership; logd as the serial driver's primary client |
-| [services/init/README.md](../init/README.md) | init's Phase 2 epilogue (logd spawn) and init-logd's role + termination |
+| [services/init/README.md](../init/README.md) | init-logd's role + termination, and the reserved log-sink sources init endows svcmgr |
+| [services/svcmgr/README.md](../svcmgr/README.md) | svcmgr's launch + supervision of logd from the `log_sink` recipe |
 | [services/procmgr/README.md](../procmgr/README.md) | `REGISTER_DEATH_EQ` handler + retroactive bind |
 | [services/logd/docs/handover-protocol.md](docs/handover-protocol.md) | init-logd → logd wire format |
 | [services/logd/docs/ipc-interface.md](docs/ipc-interface.md) | IPC labels logd accepts |

--- a/services/logd/docs/handover-protocol.md
+++ b/services/logd/docs/handover-protocol.md
@@ -2,13 +2,25 @@
 
 Wire format for the one-shot init-logd → real-logd state transfer.
 
-Real-logd, on bootstrap, calls `log_labels::HANDOVER_PULL` repeatedly
-on its single-use SEND cap to the master log endpoint. Init-logd's
-receive loop, on seeing the label, replies one chunk at a time until
-its captured state is drained, then breaks its loop and calls
-`sys_thread_exit`. Real-logd's existing tokened SEND caps held by
-every other sender remain valid because the kernel endpoint object
-is unchanged across the transition.
+svcmgr launches and supervises real-logd, minting its bootstrap caps
+from the reserved log-sink sources init endows (see
+[`services/svcmgr/docs/service-definitions.md`](../../svcmgr/docs/service-definitions.md)).
+On its **first launch**, real-logd holds a single-use SEND cap on the
+master log endpoint (bootstrap `cap[1]`) and calls
+`log_labels::HANDOVER_PULL` repeatedly on it. Init-logd's receive loop,
+on seeing the label, replies one chunk at a time until its captured
+state is drained, then breaks its loop and calls `sys_thread_exit`.
+Real-logd's existing tokened SEND caps held by every other sender remain
+valid because the kernel endpoint object is unchanged across the
+transition.
+
+On a **restart**, svcmgr mints `cap[1] = 0`: init-logd exited after the
+first launch, so there is no handover source. The restarted logd skips
+the pull entirely (guarded on a non-zero `cap[1]`) and serves a fresh
+table on the same endpoint object — svcmgr holds the master-log source
+for the system's life, so the restarted logd's RECV re-attaches to the
+object every sender already targets. In-flight history from the prior
+instance is not recoverable.
 
 ## Call shape
 

--- a/services/logd/docs/ipc-interface.md
+++ b/services/logd/docs/ipc-interface.md
@@ -11,13 +11,34 @@ logd additionally calls procmgr's
 [`procmgr_labels::REGISTER_DEATH_EQ`](../../procmgr/docs/ipc-interface.md)
 once during its own startup; see that document for the wire format.
 
+## Bootstrap caps
+
+svcmgr launches and supervises real-logd, minting its bootstrap round —
+one round, `done = true`, four positional caps — from the reserved
+log-sink sources init endows it (see
+[`services/svcmgr/docs/service-definitions.md`](../../svcmgr/docs/service-definitions.md)).
+The shape mirrors the README's "Bootstrap caps" table:
+
+| Index | Cap |
+|---|---|
+| 0 | `RECV` on the master log endpoint |
+| 1 | `SEND` on the master log endpoint (single-use; `HANDOVER_PULL` only). `0` on a restart — no init-logd remains to pull from, so logd skips the history pull |
+| 2 | tokened `SEND` on procmgr's service endpoint carrying `DEATH_EQ_AUTHORITY` |
+| 3 | tokened `SEND` on devmgr's registry endpoint carrying `REGISTRY_QUERY_AUTHORITY` (resolves the serial driver via `QUERY_SERIAL_DEVICE`) |
+
+Every (re)launch mints `cap[0]` fresh from svcmgr's persistent master-log
+source, so a restarted logd re-attaches its RECV to the same endpoint
+object every sender already targets. Only `cap[1]` differs across the two
+paths: present on the first launch (one-shot history pull from init-logd),
+`0` on a restart (history pull skipped, fresh table served).
+
 ## Endpoint
 
 | Cap holder | Right | Purpose |
 |---|---|---|
 | logd's main thread | `RECV` | drains the endpoint via `ipc_recv` inside the wait-set loop |
 | every userspace sender | `SEND` (tokened) | `STREAM_BYTES`, `STREAM_REGISTER_NAME` |
-| real-logd at bootstrap | `SEND` (un-tokened) | single-use `HANDOVER_PULL` to init-logd; deleted immediately after `DONE` |
+| real-logd on its first launch | `SEND` (un-tokened) | single-use `HANDOVER_PULL` to init-logd; deleted immediately after `DONE`. Absent (`cap[1] = 0`) on a restart |
 
 ## Labels accepted
 

--- a/services/logd/src/main.rs
+++ b/services/logd/src/main.rs
@@ -6,7 +6,7 @@
 //! Seraph system log daemon — post-mount owner of the master log
 //! endpoint.
 //!
-//! Spawned by init at the end of Phase 2, real-logd:
+//! Launched and supervised by svcmgr, real-logd:
 //!
 //! 1. Receives via bootstrap protocol a RECV cap on the master log
 //!    endpoint, a SEND cap on the same endpoint (single-use, for the

--- a/services/logd/src/main.rs
+++ b/services/logd/src/main.rs
@@ -126,18 +126,40 @@ fn main() -> !
     // covered the pre-driver window) while history still accrues.
     serial_init(caps.devmgr_registry_ep, ipc_buf);
 
-    self_log("started; pulling init-logd handover state");
-
     let mut table = SlotTable::default();
-    // SAFETY: ipc_buf is the registered IPC buffer page.
-    unsafe { handover::pull_all(caps.log_ep_handover_send, ipc_buf, &mut table) };
 
-    // Handover send cap is single-use; drop it now so we don't carry a
-    // SEND cap to the log endpoint around (the only legitimate path
-    // for that cap was the handover IPC).
-    let _ = syscall::cap_delete(caps.log_ep_handover_send);
-
+    // Set up the death-notification queue + wait set and register with procmgr
+    // BEFORE pulling the handover. The pull causes init-logd to exit, which
+    // triggers procmgr's init-reap; that reap logs, and until logd reaches its
+    // draining loop there is no other reader on the log endpoint. Registering
+    // here — while init's main has already exited but init-logd is still
+    // serving, so procmgr is not yet reaping init — keeps logd from blocking on
+    // procmgr in that window, which would deadlock against procmgr blocking on
+    // the unmanned log endpoint. After the pull, logd reaches `event_loop` with
+    // no further procmgr dependency, so it drains the reap's log line itself.
+    let Some(death_eq) = create_death_eq()
+    else
     {
+        self_log("FATAL: death-EQ create failed; halting");
+        syscall::thread_exit();
+    };
+    register_with_procmgr(caps.procmgr_death_auth_send, death_eq, ipc_buf);
+    let Some(ws_cap) = create_wait_set(caps.log_ep_recv, death_eq)
+    else
+    {
+        self_log("FATAL: wait_set create failed; halting");
+        syscall::thread_exit();
+    };
+
+    if caps.log_ep_handover_send != 0
+    {
+        // First launch: pull init-logd's accrued boot history, then drop the
+        // single-use SEND so logd carries no SEND cap to its own log endpoint.
+        self_log("started; pulling init-logd handover state");
+        // SAFETY: ipc_buf is the registered IPC buffer page.
+        unsafe { handover::pull_all(caps.log_ep_handover_send, ipc_buf, &mut table) };
+        let _ = syscall::cap_delete(caps.log_ep_handover_send);
+
         let mut buf = SerialFmt::new();
         let _ = write!(
             buf,
@@ -147,22 +169,13 @@ fn main() -> !
         );
         buf.flush_self_log();
     }
-
-    let Some(death_eq) = create_death_eq()
     else
     {
-        self_log("FATAL: death-EQ create failed; halting");
-        syscall::thread_exit();
-    };
-
-    register_with_procmgr(caps.procmgr_death_auth_send, death_eq, ipc_buf);
-
-    let Some(ws_cap) = create_wait_set(caps.log_ep_recv, death_eq)
-    else
-    {
-        self_log("FATAL: wait_set create failed; halting");
-        syscall::thread_exit();
-    };
+        // A svcmgr restart: there is no handover source (init-logd exited
+        // after the first launch). Serve a fresh table; in-flight history
+        // from the prior instance is not recoverable.
+        self_log("started (restart); no handover source, serving fresh");
+    }
 
     event_loop(ws_cap, death_eq, caps.log_ep_recv, ipc_buf, &mut table);
 }

--- a/services/procmgr/src/init_reap.rs
+++ b/services/procmgr/src/init_reap.rs
@@ -2,10 +2,14 @@
 // Copyright (C) 2026 George Kottler <mail@kottlerg.com>
 
 //! Init reap-handoff: receives init's own kernel-object caps and
-//! reclaimable Frame caps in the post-Phase-3 exit IPCs, binds a
-//! death-EQ observer on init's main thread, and on the resulting
-//! death event tears down init's `AddressSpace`/`CSpace`/`Thread`
-//! objects and donates the Frame caps to memmgr.
+//! reclaimable Frame caps in the post-Phase-3 exit IPCs, binds death-EQ
+//! observers on both init threads (main + init-logd), and once both have
+//! exited — init threadless — tears down init's
+//! `AddressSpace`/`CSpace`/`Thread` objects and donates the Frame caps to
+//! memmgr. init-logd outlives the main thread until the svcmgr-launched
+//! real-logd pulls its handover, so the reap waits for the later of the two
+//! deaths; reclaiming init's aspace/cspace while a thread still runs in them
+//! would fault it.
 //!
 //! State machine (single-threaded; serialised under procmgr's
 //! `service_ep` recv loop):
@@ -20,10 +24,11 @@
 //! Collecting
 //!   │  INIT_TEARDOWN_DONE
 //!   ▼
-//! Armed   (waiting for death-EQ event with INIT_REAP_CORRELATOR)
+//! Armed   (pending_deaths = 2; waiting for both threads' INIT_REAP_CORRELATOR
+//!          death events — run_reap counts down, reaping on the last)
 //!   │
-//!   ▼  dispatch_death sees correlator == INIT_REAP_CORRELATOR
-//! Reaping (run_reap):
+//!   ▼  dispatch_death sees correlator == INIT_REAP_CORRELATOR (×2)
+//! Reaping (run_reap, last death):
 //!   1. cap_delete(logd_thread)
 //!   2. cap_delete(main_thread)
 //!   3. cap_revoke + cap_delete(aspace)        — mappings gone
@@ -62,6 +67,12 @@ pub struct InitReapState
     logd_thread: u32,
     donate_caps: Vec<u32>,
     armed: bool,
+    /// Init threads still expected to exit before the reap runs. A process is
+    /// reapable only when threadless, so the teardown waits for both init
+    /// threads (main + init-logd) — `run_reap` decrements this per death event
+    /// and reaps on the last. init-logd outlives the main thread until the
+    /// svcmgr-launched real-logd pulls its handover.
+    pending_deaths: u8,
 }
 
 /// State machine slot. `None` until init's first
@@ -74,8 +85,8 @@ static STATE: Mutex<Option<InitReapState>> = Mutex::new(None);
 ///
 /// `data[0] != 0` marks the first round (carrying the 4 kernel-object
 /// caps); subsequent rounds carry only reclaimable Frame caps. On the
-/// first round, binds the death-EQ observer on init's main thread with
-/// `INIT_REAP_CORRELATOR`.
+/// first round, binds death-EQ observers on both init threads (main +
+/// init-logd) with `INIT_REAP_CORRELATOR` and arms `pending_deaths = 2`.
 pub fn handle_register(req: &IpcMessage, ipc_buf: *mut u64, death_eq: u32)
 {
     let caps = req.caps();
@@ -118,12 +129,22 @@ pub fn handle_register(req: &IpcMessage, ipc_buf: *mut u64, death_eq: u32)
         let cspace = caps[1];
         let main_thread = caps[2];
         let logd_thread = caps[3];
+        // Bind a death-EQ observer on both init threads under the same
+        // correlator. Both are alive at this point (init's main is mid-handoff;
+        // init-logd is still serving the log endpoint), so neither bind lands
+        // on an already-exited thread. The reap waits for both.
         if syscall::thread_bind_notification(
             main_thread,
             death_eq,
             procmgr_labels::INIT_REAP_CORRELATOR,
         )
         .is_err()
+            || syscall::thread_bind_notification(
+                logd_thread,
+                death_eq,
+                procmgr_labels::INIT_REAP_CORRELATOR,
+            )
+            .is_err()
         {
             std::os::seraph::log!(
                 "init-reap: thread_bind_notification failed; refusing handoff (caps leaked in procmgr)"
@@ -138,6 +159,7 @@ pub fn handle_register(req: &IpcMessage, ipc_buf: *mut u64, death_eq: u32)
             logd_thread,
             donate_caps: Vec::with_capacity(32),
             armed: false,
+            pending_deaths: 2,
         });
         reply(ipc_buf, procmgr_errors::SUCCESS);
         return;
@@ -186,32 +208,45 @@ pub fn handle_done(ipc_buf: *mut u64)
     reply(ipc_buf, procmgr_errors::SUCCESS);
 }
 
-/// Execute the reap when the death-EQ event for init's main thread
-/// fires. Idempotent: a state-less invocation (re-fire after we
-/// already reaped) is a no-op.
+/// Execute the reap once both init threads have exited (init is
+/// threadless). Called on each death-EQ event tagged with
+/// `INIT_REAP_CORRELATOR`; it decrements the expected-death count and runs
+/// the teardown only on the last. Idempotent: a state-less invocation
+/// (re-fire after we already reaped, or before arming) is a no-op.
 pub fn run_reap(memmgr_ep: u32, ipc_buf: *mut u64)
 {
     let state = {
         let mut guard = STATE.lock().expect("init-reap state poisoned");
-        match guard.take()
+        let Some(s) = guard.as_mut()
+        else
         {
-            Some(s) if s.armed => s,
-            other =>
-            {
-                *guard = other;
-                return;
-            }
+            return;
+        };
+        if !s.armed
+        {
+            return;
         }
+        s.pending_deaths = s.pending_deaths.saturating_sub(1);
+        if s.pending_deaths > 0
+        {
+            // One init thread exited; the other still runs in init's
+            // aspace/cspace. Reclaiming now would fault it — wait.
+            std::os::seraph::log!(
+                "init-reap: an init thread exited; {} still running",
+                s.pending_deaths
+            );
+            return;
+        }
+        guard.take().expect("armed init-reap state present")
     };
 
-    // 1. Reap init-logd's TCB. Init-logd exited earlier (its
-    //    `sys_thread_exit` ran inside the `HANDOVER_PULL` reply path).
-    //    `dealloc_object` for Thread handles Exited TCBs cleanly.
+    // 1. Reap init-logd's TCB. Both init threads have exited by now (the
+    //    last death triggered this reap). `dealloc_object` for Thread
+    //    handles Exited TCBs cleanly.
     let _ = syscall::cap_delete(state.logd_thread);
 
-    // 2. Reap init's main thread TCB. The death event we're handling
-    //    proves the main thread already transitioned to Exited; the
-    //    cap_delete drives the dealloc.
+    // 2. Reap init's main thread TCB; it exited earlier in the countdown, so
+    //    the cap_delete just drives the dealloc.
     let _ = syscall::cap_delete(state.main_thread);
 
     // 3. Destroy init's AddressSpace. Revoke first to clear any

--- a/services/procmgr/src/main.rs
+++ b/services/procmgr/src/main.rs
@@ -580,9 +580,10 @@ fn dispatch_death(
         let exit_reason = payload & 0xFFFF_FFFF;
         if correlator == procmgr_labels::INIT_REAP_CORRELATOR
         {
-            // Init's main thread exited. Run the reap sequence that
-            // tears down init's AS/CSpace/Thread objects and donates
-            // its reclaimable Frame caps to memmgr's pool.
+            // An init thread exited. `run_reap` counts down the two init
+            // threads and, on the last exit, tears down init's
+            // AS/CSpace/Thread objects and donates its reclaimable Frame
+            // caps to memmgr's pool.
             init_reap::run_reap(memmgr_ep, ipc_buf);
             continue;
         }

--- a/services/pwrmgr/README.md
+++ b/services/pwrmgr/README.md
@@ -12,7 +12,7 @@ pwrmgr/
 ├── README.md
 └── src/
     ├── main.rs       # Entry, bootstrap, IPC dispatch loop, cap-gating
-    ├── caps.rs       # init → pwrmgr bootstrap protocol
+    ├── caps.rs       # svcmgr bootstrap + devmgr-query acquisition
     ├── x86_64.rs     # ACPI S5 walk + PM1a write; 8042 KBC reboot
     └── riscv64.rs    # SBI SRST shutdown + cold reboot
 ```
@@ -21,12 +21,20 @@ pwrmgr/
 
 ## Responsibilities
 
-pwrmgr is the sole holder, after Phase 3 of init's bootstrap, of the raw
-capabilities required to power off or reset the platform:
+pwrmgr owns the shutdown *interpretation* and *actuation* but holds no
+hardware caps of its own. devmgr is the hardware and ACPI authority;
+pwrmgr acquires only what it needs from devmgr at startup, "as if it were
+a device driver":
 
-- **x86-64** — the `IoPortRange` cap, plus the `AcpiReclaimable` Frame caps
-  that cover the firmware tables containing FADT and DSDT.
-- **RISC-V** — the `SbiControl` cap that authorises forwarding `system_reset`
+- **x86-64** — the FADT and DSDT it parses are served read-only by devmgr
+  via `devmgr_labels::QUERY_ACPI_TABLE` (devmgr is the sole owner of the
+  `AcpiReclaimable` Frame caps and the only service that walks the ACPI
+  table tree). pwrmgr extracts `PM1a_CNT_BLK` from the FADT and the `\_S5_`
+  sleep type from the DSDT, then requests a narrow `IoPortRange` over the
+  PM1a control port and the 8042 reset port via
+  `devmgr_labels::QUERY_SHUTDOWN_DEVICE`.
+- **RISC-V** — `QUERY_SHUTDOWN_DEVICE` serves a `cap_derive` copy of
+  devmgr's `SbiControl` cap, which authorises forwarding `system_reset`
   through the kernel to M-mode firmware.
 
 It exposes a small IPC surface (`shared/ipc/src/lib.rs::pwrmgr_labels`):
@@ -44,37 +52,42 @@ Both labels are gated by `pwrmgr_labels::SHUTDOWN_AUTHORITY` (token bit
 
 ## Cap flow
 
-1. Init holds the platform caps at boot (`InitInfo.acpi_region_frame_*`,
-   `InitInfo.sbi_control_cap`, plus the `IoPortRange` cap surfaced through
-   the descriptor array).
-2. During Phase 3, init creates pwrmgr via `procmgr_labels::CREATE_FROM_FILE`
-   from `/services/pwrmgr`, then transfers derived copies of the platform caps
-   through the bootstrap-round protocol in `caps.rs`.
-3. After pwrmgr is ready, init derives two tokened SEND caps from pwrmgr's
-   service endpoint:
-   - `pwrmgr_auth_cap` — `cap_derive_token(ep, SEND, SHUTDOWN_AUTHORITY)`.
-   - `pwrmgr_noauth_cap` — `cap_derive_token(ep, SEND, 0)`. Used by
-     svctest's `pwrmgr_cap_deny_phase` to verify the gate.
-4. Init installs both caps in svctest's bootstrap-round payload.
-5. svctest, at the end of `main()` after `ALL TESTS PASSED`, sends
+1. svcmgr launches pwrmgr post-handover from its `pwrmgr.svc` recipe. The
+   `provides = pwrmgr.shutdown:auth pwrmgr.deny:deny` directive makes svcmgr
+   create pwrmgr's service endpoint, serve its RECV as bootstrap `cap[0]`,
+   and publish two SENDs into the discovery registry: `pwrmgr.shutdown`
+   (`SHUTDOWN_AUTHORITY`-tokened) and `pwrmgr.deny` (a no-authority twin).
+   The endpoint persists across restarts.
+2. `seed = devmgr.registry` delivers a `REGISTRY_QUERY_AUTHORITY`-tokened
+   SEND on devmgr's registry as bootstrap `cap[1]`. pwrmgr uses it to
+   resolve its actuation state from devmgr (see Responsibilities). pwrmgr
+   never holds a platform cap longer than it needs — the served ACPI Frame
+   caps are mapped read-only and dropped after parsing.
+3. Consumers permitted to power the platform off seed `pwrmgr.shutdown`
+   (e.g. svctest, and svcmgr's own critical-service-death escalation); the
+   token rides through the registry lookup unchanged. svctest also seeds
+   `pwrmgr.deny` to assert the gate rejects an unauthorised cap.
+4. svctest, at the end of `main()` after `ALL TESTS PASSED`, sends
    `pwrmgr_labels::SHUTDOWN` through the authorised cap. pwrmgr executes
-   the platform shutdown sequence. QEMU exits cleanly, ending naked
+   the platform shutdown sequence. QEMU exits cleanly, ending the staged
    `cargo xtask run` without a wall-clock wait.
 
 ---
 
 ## Restart semantics
 
-pwrmgr is not registered with svcmgr. The platform caps it owns are
-unique resources; after a hypothetical crash there is no way to restart
-pwrmgr with the same authority because init has released its copies. The
-system idles in that case (the same behaviour as today's userspace when
-no caller can reach the platform reset).
+pwrmgr is a `restart = on_failure` svcmgr service. Because it holds no
+unique source caps, a crashed pwrmgr is recoverable: svcmgr re-creates it
+from `/services/pwrmgr` and re-serves a fresh RECV on the persistent
+service endpoint, so a `pwrmgr.shutdown` cap cached against the published
+name survives the restart. The restarted instance re-acquires its actuator
+caps from devmgr on startup — `QUERY_SHUTDOWN_DEVICE` re-carves the I/O
+ports from devmgr's root cap on every call, so nothing is consumed.
 
-A future revision can have init retain the source caps and re-deliver
-them to a restarted pwrmgr on svcmgr's policy; the wiring is
-straightforward but adds bootstrap state to init that is not exercised in
-v0.1.0.
+`critical = no`: a permanently-dead pwrmgr (restart budget exhausted)
+cannot power the platform off, so the graceful-shutdown-via-`pwrmgr.shutdown`
+escalation would be circular. The honest terminal state is logged and the
+system continues degraded, matching `timed`.
 
 ---
 
@@ -90,9 +103,6 @@ Out of scope for v0.1.0; deferred until concrete consumers exist:
 - **Battery and thermal monitoring** — ACPI `_BST` / `_TZ`, RISC-V
   platform sensors.
 - **Operator UX** — `shutdown` / `reboot` CLI wrappers calling pwrmgr.
-- **svcmgr-managed launch of svctest** — svctest is not
-  bootstrap-essential. Moving its spawn from init to svcmgr lets init
-  fully exit earlier once a real logd lands.
 - **Cmdline-driven test-vs-shell mode** — naked `cargo xtask run` could
   drop into an interactive userspace shell instead of running
   tests-then-shutdown.
@@ -119,8 +129,9 @@ between the two trees.
 | Document | Content |
 |---|---|
 | [docs/architecture.md](../../docs/architecture.md) | System-wide service inventory; pwrmgr's role |
-| [shared/ipc/src/lib.rs](../../shared/ipc/src/lib.rs) | Authoritative IPC label and error definitions (`pwrmgr_labels`, `pwrmgr_errors`) |
-| [services/init/README.md](../init/README.md) | Bootstrap order and cap-flow into pwrmgr |
+| [shared/ipc/src/lib.rs](../../shared/ipc/src/lib.rs) | Authoritative IPC label and error definitions (`pwrmgr_labels`, `pwrmgr_errors`, `devmgr_labels`) |
+| [services/devmgr/README.md](../devmgr/README.md) | Hardware + ACPI authority; the `QUERY_ACPI_TABLE` / `QUERY_SHUTDOWN_DEVICE` brokers pwrmgr acquires its caps through |
+| [services/svcmgr/README.md](../svcmgr/README.md) | Launcher + supervisor; the provider path that publishes `pwrmgr.shutdown` / `pwrmgr.deny` |
 
 ---
 

--- a/services/pwrmgr/src/caps.rs
+++ b/services/pwrmgr/src/caps.rs
@@ -3,192 +3,98 @@
 
 // pwrmgr/src/caps.rs
 
-//! Bootstrap cap acquisition for pwrmgr.
+//! Bootstrap and devmgr-query acquisition for pwrmgr.
 //!
-//! Pwrmgr receives the platform shutdown caps from init in a multi-round
-//! bootstrap exchange on its `creator_endpoint`. The exact shape mirrors
-//! the devmgr handshake (`services/devmgr/src/caps.rs`):
+//! pwrmgr is a svcmgr-launched provider. Its bootstrap round (served by
+//! svcmgr's provider path) delivers:
 //!
-//! * Round 1 (auth caps + presence bitmap, 2 caps + 2 data words):
-//!     - caps\[0\] = pwrmgr's service endpoint (RECV; the SHUTDOWN/REBOOT
-//!       receive end)
-//!     - caps\[1\] = arch-specific authority cap (`IoPortRange` on x86-64,
-//!       `SbiControl` on RISC-V). Zero on architectures that have no
-//!       second cap.
-//!     - data\[0\] = presence bitmap (bit 0 = arch cap present)
-//!     - data\[1\] = caller's compiled `PWRMGR_LABELS_VERSION`
-//!     - `done = true` on RISC-V (no further rounds); `done = false` on
-//!       x86-64 when ACPI region rounds follow.
+//! * `caps[0]` = pwrmgr's own service endpoint (RECV; the SHUTDOWN/REBOOT
+//!   receive end). svcmgr holds the persistent source and publishes
+//!   `pwrmgr.shutdown` / `pwrmgr.deny` SENDs against it.
+//! * `caps[1]` = `REGISTRY_QUERY_AUTHORITY`-tokened SEND on devmgr's
+//!   registry endpoint (from `pwrmgr.svc` `seed = devmgr.registry`).
 //!
-//! * Round 2..N (x86-64 only): ACPI region Frame caps, ≤4 per round.
-//!     - caps\[..\] = ACPI region Frame caps (one entry per region)
-//!     - data\[0\] = round kind (`kind::ACPI_REGION`)
-//!     - data\[1\] = batch count
-//!     - data\[2..\] = (`phys_base`, `size`) pairs per region
-//!     - terminal round has `done = true`.
+//! pwrmgr owns no hardware caps directly. It acquires its shutdown
+//! actuator caps from devmgr "as if it were a device driver": the ACPI
+//! tables it interprets come from [`devmgr_labels::QUERY_ACPI_TABLE`]
+//! (devmgr is the sole ACPI owner) and the carved I/O-port / `SbiControl`
+//! caps from [`devmgr_labels::QUERY_SHUTDOWN_DEVICE`]. The arch module
+//! ([`crate::arch`]) drives those queries and parses what it needs; devmgr
+//! runs no shutdown logic.
 
+use ipc::{IpcMessage, devmgr_errors};
 use std::os::seraph::StartupInfo;
 
-/// Maximum number of ACPI reclaimable-region Frame caps pwrmgr accepts.
-/// Matches `init/src/service.rs::MAX_ACPI_REGION_CAPS` and
-/// `devmgr/src/caps.rs::MAX_ACPI_REGIONS`. RISC-V never populates these
-/// regions but the storage stays unconditional so the bootstrap
-/// protocol shape is arch-agnostic.
-pub const MAX_ACPI_REGIONS: usize = 8;
-
-/// One ACPI region cap with its physical range. Populated only on
-/// x86-64; the fields are read by the ACPI S5 walk.
-#[derive(Clone, Copy)]
-#[cfg_attr(not(target_arch = "x86_64"), allow(dead_code))]
-pub struct AcpiRegion
+/// Caps delivered to pwrmgr by svcmgr's provider bootstrap round.
+pub struct Bootstrap
 {
-    pub slot: u32,
-    pub phys_base: u64,
-    pub size: u64,
-}
-
-impl AcpiRegion
-{
-    pub const fn empty() -> Self
-    {
-        Self {
-            slot: 0,
-            phys_base: 0,
-            size: 0,
-        }
-    }
-}
-
-/// Round-kind discriminator on post-R1 bootstrap rounds. Mirrors
-/// `init/src/service.rs::kind::ACPI_REGION`.
-pub mod kind
-{
-    pub const ACPI_REGION: u64 = 3;
-}
-
-/// Presence-bitmap bits on R1's `data[0]`. Tells pwrmgr whether the
-/// arch-specific authority cap (caps[1]) is populated.
-mod present
-{
-    pub const ARCH_CAP: u64 = 1 << 0;
-}
-
-pub struct PwrmgrCaps
-{
+    /// pwrmgr's service endpoint (RECV). Zero if the round was empty.
     pub service_ep: u32,
-    /// `IoPortRange` cap on x86-64; `SbiControl` on RISC-V; zero if the
-    /// kernel did not mint one for this platform.
-    pub arch_cap: u32,
-    /// ACPI reclaimable-region Frame caps. Populated only on x86-64.
-    #[cfg_attr(not(target_arch = "x86_64"), allow(dead_code))]
-    pub acpi_regions: [AcpiRegion; MAX_ACPI_REGIONS],
-    #[cfg_attr(not(target_arch = "x86_64"), allow(dead_code))]
-    pub acpi_region_count: usize,
-    /// Caller's own `AddressSpace` cap; the ACPI walk uses it to
-    /// `mem_map` each region read-only. Unused on RISC-V.
-    #[cfg_attr(not(target_arch = "x86_64"), allow(dead_code))]
-    pub self_aspace: u32,
+    /// `REGISTRY_QUERY_AUTHORITY`-tokened SEND on devmgr's registry
+    /// endpoint. Zero if absent — the arch module then degrades to its
+    /// no-actuator path.
+    pub devmgr_registry: u32,
 }
 
-impl PwrmgrCaps
+/// Drain the single provider bootstrap round from `creator_endpoint`.
+pub fn request_bootstrap(info: &StartupInfo, ipc_buf: *mut u64) -> Option<Bootstrap>
 {
-    pub fn new(info: &StartupInfo) -> Self
-    {
-        Self {
-            service_ep: 0,
-            arch_cap: 0,
-            acpi_regions: [AcpiRegion::empty(); MAX_ACPI_REGIONS],
-            acpi_region_count: 0,
-            self_aspace: info.self_aspace,
-        }
-    }
-}
-
-fn bootstrap_round1(creator: u32, ipc_buf: *mut u64, caps: &mut PwrmgrCaps) -> Option<bool>
-{
-    // SAFETY: `ipc_buf` is the caller-supplied kernel-registered per-thread IPC buffer page.
-    let r1 = unsafe { ipc::bootstrap::request_round(creator, ipc_buf) }.ok()?;
-    if r1.cap_count < 1
-    {
-        return None;
-    }
-    caps.service_ep = r1.caps[0];
-
-    let presence = r1.data[0];
-    if presence & present::ARCH_CAP != 0 && r1.cap_count >= 2
-    {
-        caps.arch_cap = r1.caps[1];
-    }
-
-    let caller_version = r1.data[1] as u32;
-    if caller_version != ipc::PWRMGR_LABELS_VERSION
-    {
-        std::os::seraph::log!(
-            "PWRMGR_LABELS_VERSION mismatch: caller={} expected {}",
-            u64::from(caller_version),
-            u64::from(ipc::PWRMGR_LABELS_VERSION)
-        );
-        return None;
-    }
-
-    Some(r1.done)
-}
-
-fn absorb_acpi_region_round(
-    round_caps: &[u32],
-    round_cap_count: usize,
-    round_data: &[u64; syscall_abi::MSG_DATA_WORDS_MAX],
-    caps: &mut PwrmgrCaps,
-)
-{
-    let batch_count = round_data[1] as usize;
-    let n = batch_count.min(round_cap_count).min(4);
-    for (i, &slot) in round_caps.iter().take(n).enumerate()
-    {
-        if caps.acpi_region_count >= caps.acpi_regions.len()
-        {
-            break;
-        }
-        caps.acpi_regions[caps.acpi_region_count] = AcpiRegion {
-            slot,
-            phys_base: round_data[2 + i * 2],
-            size: round_data[3 + i * 2],
-        };
-        caps.acpi_region_count += 1;
-    }
-}
-
-fn bootstrap_rounds(creator: u32, ipc_buf: *mut u64, caps: &mut PwrmgrCaps) -> Option<()>
-{
-    loop
-    {
-        // SAFETY: `ipc_buf` is the caller-supplied kernel-registered per-thread IPC buffer page.
-        let round = unsafe { ipc::bootstrap::request_round(creator, ipc_buf) }.ok()?;
-        if round.data[0] == kind::ACPI_REGION
-        {
-            absorb_acpi_region_round(&round.caps, round.cap_count, &round.data, caps);
-        }
-        if round.done
-        {
-            return Some(());
-        }
-    }
-}
-
-/// Drive the full bootstrap exchange from init.
-pub fn bootstrap_caps(info: &StartupInfo, ipc_buf: *mut u64) -> Option<PwrmgrCaps>
-{
-    let mut caps = PwrmgrCaps::new(info);
     let creator = info.creator_endpoint;
     if creator == 0
     {
         return None;
     }
-
-    let r1_done = bootstrap_round1(creator, ipc_buf, &mut caps)?;
-    if !r1_done
+    // SAFETY: `ipc_buf` is the kernel-registered per-thread IPC buffer.
+    let round = unsafe { ipc::bootstrap::request_round(creator, ipc_buf) }.ok()?;
+    let service_ep = if round.cap_count >= 1
     {
-        bootstrap_rounds(creator, ipc_buf, &mut caps)?;
+        round.caps[0]
     }
-    Some(caps)
+    else
+    {
+        0
+    };
+    let devmgr_registry = if round.cap_count >= 2
+    {
+        round.caps[1]
+    }
+    else
+    {
+        0
+    };
+    Some(Bootstrap {
+        service_ep,
+        devmgr_registry,
+    })
+}
+
+/// Issue a devmgr registry query and return the reply on a
+/// [`devmgr_errors::SUCCESS`] status. `word1` / `word2` are the
+/// label-specific request words (`data[1]` / `data[2]`); `data[0]` is
+/// always the compiled `DEVMGR_LABELS_VERSION` so devmgr can version-gate.
+/// Returns `None` on a transport error or any non-success reply.
+pub(crate) fn devmgr_call(
+    registry: u32,
+    label: u64,
+    word1: u64,
+    word2: u64,
+    ipc_buf: *mut u64,
+) -> Option<IpcMessage>
+{
+    if registry == 0
+    {
+        return None;
+    }
+    let msg = IpcMessage::builder(label)
+        .word(0, u64::from(ipc::DEVMGR_LABELS_VERSION))
+        .word(1, word1)
+        .word(2, word2)
+        .build();
+    // SAFETY: `ipc_buf` is the kernel-registered per-thread IPC buffer.
+    let reply = unsafe { ipc::ipc_call(registry, &msg, ipc_buf) }.ok()?;
+    if reply.label != devmgr_errors::SUCCESS
+    {
+        return None;
+    }
+    Some(reply)
 }

--- a/services/pwrmgr/src/main.rs
+++ b/services/pwrmgr/src/main.rs
@@ -6,13 +6,14 @@
 //! Seraph power manager — userspace authority for platform shutdown and
 //! reboot.
 //!
-//! pwrmgr owns the raw platform caps that drive a clean power-off:
-//! `AcpiReclaimable` Frame caps plus the `IoPortRange` cap on x86-64
-//! (ACPI S5), and the `SbiControl` cap on RISC-V (SBI SRST). Init
-//! transfers those caps to pwrmgr during Phase 3 bootstrap and hands a
-//! `SHUTDOWN_AUTHORITY`-tokened SEND cap on pwrmgr's service endpoint to
-//! the consumers permitted to invoke shutdown (today: svctest, plus a
-//! reserved copy held by svcmgr for future escalation policy).
+//! pwrmgr is a svcmgr-launched provider. It owns the shutdown
+//! *interpretation* and *actuation* but holds no hardware caps of its own:
+//! it acquires the ACPI tables it parses and the carved I/O-port /
+//! `SbiControl` caps it drives from devmgr (the hardware + ACPI authority)
+//! at startup, "as if it were a device driver". svcmgr publishes a
+//! `SHUTDOWN_AUTHORITY`-tokened SEND (`pwrmgr.shutdown`) and its no-auth
+//! twin (`pwrmgr.deny`) on pwrmgr's service endpoint to the consumers it
+//! seeds (today: svctest).
 //!
 //! See `services/pwrmgr/README.md` for the design and future-scope
 //! sketch.
@@ -47,31 +48,38 @@ fn main() -> !
     #[allow(clippy::cast_ptr_alignment)]
     let ipc_buf = info.ipc_buffer.cast::<u64>();
 
-    let Some(caps) = caps::bootstrap_caps(info, ipc_buf)
+    let Some(bootstrap) = caps::request_bootstrap(info, ipc_buf)
     else
     {
         std::os::seraph::log!("bootstrap failed, exiting");
         syscall::thread_exit();
     };
 
-    if caps.service_ep == 0
+    if bootstrap.service_ep == 0
     {
         std::os::seraph::log!("no service endpoint, exiting");
         syscall::thread_exit();
     }
 
-    std::os::seraph::log!(
-        "ready (arch_cap={:#x}, acpi_regions={})",
-        u64::from(caps.arch_cap),
-        caps.acpi_region_count as u64
-    );
+    // Acquire the actuation state from devmgr. `None` means the platform
+    // caps could not be resolved; pwrmgr still serves so callers get a
+    // clean error rather than a hung ipc_call.
+    let actuator = arch::resolve(bootstrap.devmgr_registry, info.self_aspace, ipc_buf);
+    if actuator.is_some()
+    {
+        std::os::seraph::log!("ready");
+    }
+    else
+    {
+        std::os::seraph::log!("ready (degraded: no shutdown actuator)");
+    }
 
     let self_thread = info.self_thread;
 
     loop
     {
         // SAFETY: ipc_buf is the registered IPC buffer.
-        let Ok(msg) = (unsafe { ipc::ipc_recv(caps.service_ep, ipc_buf) })
+        let Ok(msg) = (unsafe { ipc::ipc_recv(bootstrap.service_ep, ipc_buf) })
         else
         {
             continue;
@@ -88,9 +96,12 @@ fn main() -> !
                     continue;
                 }
                 std::os::seraph::log!("SHUTDOWN requested");
-                arch::shutdown(self_thread, &caps);
-                // Returned → shutdown failed. Reply so the caller does
-                // not hang on its ipc_call.
+                if let Some(act) = &actuator
+                {
+                    arch::shutdown(self_thread, act);
+                }
+                // Reached here → no actuator or shutdown failed. Reply so
+                // the caller does not hang on its ipc_call.
                 reject(pwrmgr_errors::INVALID_REQUEST, ipc_buf);
             }
             pwrmgr_labels::REBOOT =>
@@ -101,7 +112,10 @@ fn main() -> !
                     continue;
                 }
                 std::os::seraph::log!("REBOOT requested");
-                arch::reboot(self_thread, &caps);
+                if let Some(act) = &actuator
+                {
+                    arch::reboot(self_thread, act);
+                }
                 reject(pwrmgr_errors::INVALID_REQUEST, ipc_buf);
             }
             _ => reject(pwrmgr_errors::UNKNOWN_OPCODE, ipc_buf),

--- a/services/pwrmgr/src/riscv64.rs
+++ b/services/pwrmgr/src/riscv64.rs
@@ -5,11 +5,15 @@
 
 //! RISC-V platform shutdown and reboot via the SBI SRST extension.
 //!
-//! Forwards an SBI `system_reset` call through the kernel to M-mode
-//! firmware. The `SbiControl` capability gates kernel-side acceptance of
-//! the forwarded call; pwrmgr's cap-gating gates the userspace IPC.
+//! pwrmgr owns the actuation; devmgr owns the `SbiControl` authority. At
+//! startup pwrmgr asks devmgr for a copy of the cap via
+//! [`devmgr_labels::QUERY_SHUTDOWN_DEVICE`], then forwards an SBI
+//! `system_reset` call through the kernel to M-mode firmware. The
+//! `SbiControl` cap gates kernel-side acceptance; pwrmgr's cap-gating
+//! gates the userspace IPC.
 
-use crate::caps::PwrmgrCaps;
+use crate::caps::devmgr_call;
+use ipc::devmgr_labels;
 
 const SBI_EXT_SRST: u64 = 0x5352_5354; // "SRST" in ASCII.
 const SBI_SRST_RESET: u64 = 0; // function 0: system_reset
@@ -17,27 +21,45 @@ const SRST_TYPE_SHUTDOWN: u64 = 0;
 const SRST_TYPE_COLD_REBOOT: u64 = 2;
 const SRST_REASON_NONE: u64 = 0;
 
-/// Attempt SBI SRST shutdown. Logs and returns on failure.
-pub fn shutdown(_self_thread: u32, caps: &PwrmgrCaps)
+/// Resolved shutdown actuation state: a `cap_derive` copy of devmgr's
+/// `SbiControl` cap, acquired once at startup and held for pwrmgr's
+/// lifetime.
+pub struct Actuator
 {
-    sbi_reset(caps, SRST_TYPE_SHUTDOWN);
+    sbi_control_cap: u32,
+}
+
+/// Resolve the SBI SRST authority from devmgr. Returns `None` if the query
+/// fails or devmgr served no cap.
+pub fn resolve(devmgr_registry: u32, _self_aspace: u32, ipc_buf: *mut u64) -> Option<Actuator>
+{
+    let reply = devmgr_call(
+        devmgr_registry,
+        devmgr_labels::QUERY_SHUTDOWN_DEVICE,
+        0,
+        0,
+        ipc_buf,
+    )?;
+    let sbi_control_cap = *reply.caps().first()?;
+    Some(Actuator { sbi_control_cap })
+}
+
+/// Attempt SBI SRST shutdown. Logs and returns on failure.
+pub fn shutdown(_self_thread: u32, act: &Actuator)
+{
+    sbi_reset(act, SRST_TYPE_SHUTDOWN);
 }
 
 /// Attempt SBI SRST cold reboot. Logs and returns on failure.
-pub fn reboot(_self_thread: u32, caps: &PwrmgrCaps)
+pub fn reboot(_self_thread: u32, act: &Actuator)
 {
-    sbi_reset(caps, SRST_TYPE_COLD_REBOOT);
+    sbi_reset(act, SRST_TYPE_COLD_REBOOT);
 }
 
-fn sbi_reset(caps: &PwrmgrCaps, reset_type: u64)
+fn sbi_reset(act: &Actuator, reset_type: u64)
 {
-    if caps.arch_cap == 0
-    {
-        std::os::seraph::log!("SBI SRST failed (no SbiControl cap)");
-        return;
-    }
     let _ = syscall::sbi_call(
-        caps.arch_cap,
+        act.sbi_control_cap,
         SBI_EXT_SRST,
         SBI_SRST_RESET,
         reset_type,
@@ -48,8 +70,8 @@ fn sbi_reset(caps: &PwrmgrCaps, reset_type: u64)
     // partial output from racing the reset.
     loop
     {
-        // SAFETY: `wfi` on RISC-V is non-privileged; it merely hints
-        // the hart to enter a low-power wait state.
+        // SAFETY: `wfi` is non-privileged; it hints the hart to enter a
+        // low-power wait state.
         unsafe {
             core::arch::asm!("wfi", options(nomem, nostack));
         }

--- a/services/pwrmgr/src/x86_64.rs
+++ b/services/pwrmgr/src/x86_64.rs
@@ -5,23 +5,28 @@
 
 //! x86-64 platform shutdown and reboot.
 //!
-//! Shutdown follows ACPI S5 (soft-off):
-//! 1. Scan each `AcpiReclaimable` Frame cap for the FADT (`FACP` signature).
-//! 2. Extract `PM1a_CNT_BLK` and the `DSDT` physical address from FADT.
-//! 3. Locate the DSDT in one of the same regions and parse the `\_S5_`
-//!    AML object for `SLP_TYPa`.
-//! 4. Bind the `IoPortRange` cap, write `(SLP_TYPa << 10) | SLP_EN` to
-//!    `PM1a_CNT_BLK`.
+//! pwrmgr owns the shutdown *interpretation* and *actuation*; devmgr owns
+//! the ACPI data and the raw hardware authority. At startup pwrmgr asks
+//! devmgr for the tables it needs and the ports it computed:
 //!
-//! Reboot uses the 8042 keyboard-controller reset (port `0x64`, value
-//! `0xFE`). It is the simplest reset path that does not require parsing
-//! the ACPI `RESET_REG` and works under QEMU q35 + OVMF. A future
-//! revision can promote this to ACPI reset.
+//! 1. [`devmgr_labels::QUERY_ACPI_TABLE`] (`FACP`) → map the FADT
+//!    read-only, extract `PM1a_CNT_BLK` and the DSDT physical address.
+//! 2. [`devmgr_labels::QUERY_ACPI_TABLE`] (DSDT phys) → map the DSDT
+//!    read-only, parse the `\_S5_` AML object for `SLP_TYPa`.
+//! 3. [`devmgr_labels::QUERY_SHUTDOWN_DEVICE`] (`PM1a` port) → devmgr carves
+//!    `[PM1a, PM1a+2)` + the 8042 reset port `[0x64, 0x65)` and serves the
+//!    two `IoPortRange` caps.
 //!
-//! On any unrecoverable failure the routine falls through and the caller
-//! (`main::handle_shutdown`) replies `pwrmgr_errors::INVALID_REQUEST`.
+//! Shutdown (ACPI S5 soft-off) binds the `PM1a` cap and writes
+//! `(SLP_TYPa << 10) | SLP_EN` to `PM1a_CNT_BLK`. Reboot binds the 8042
+//! cap and pulses the keyboard-controller reset (port `0x64`, value
+//! `0xFE`) — the simplest reset path that works under QEMU q35 + OVMF.
+//!
+//! On any unrecoverable failure a routine falls through and the caller
+//! (`main`) replies `pwrmgr_errors::INVALID_REQUEST`.
 
-use crate::caps::PwrmgrCaps;
+use crate::caps::devmgr_call;
+use ipc::devmgr_labels;
 use std::os::seraph::{reserve_pages, unreserve_pages};
 use syscall_abi::MAP_READONLY;
 
@@ -33,86 +38,101 @@ const FADT_OFF_DSDT: usize = 40;
 const FADT_OFF_PM1A_CNT_BLK: usize = 64;
 const FADT_OFF_X_DSDT: usize = 140;
 
-/// 8042 keyboard-controller command port, used for the legacy CPU reset
-/// path on PC-compatible platforms.
-const KBC_COMMAND_PORT: u16 = 0x64;
-/// 8042 reset pulse (asserts INIT# to the CPU).
-const KBC_RESET_VALUE: u8 = 0xFE;
-
-/// Attempt ACPI S5 shutdown. Logs progress and does not return on
-/// success. On failure (missing caps, unparseable tables) logs a warning
-/// and returns so the caller can reply with an error.
-pub fn shutdown(self_thread: u32, caps: &PwrmgrCaps)
+/// Resolved shutdown actuation state. Acquired once at startup from
+/// devmgr; held for pwrmgr's lifetime. The two `IoPortRange` caps are
+/// narrow (the `PM1a` control pair and the single 8042 reset port).
+pub struct Actuator
 {
-    let Some((pm1a_cnt_blk, dsdt_phys)) = locate_fadt_fields(caps)
-    else
-    {
-        std::os::seraph::log!("shutdown failed (FADT not found)");
-        return;
-    };
-    if pm1a_cnt_blk == 0
-    {
-        std::os::seraph::log!("shutdown failed (PM1a_CNT_BLK is zero)");
-        return;
-    }
-    let Some(slp_typa) = locate_and_parse_dsdt(caps, dsdt_phys)
-    else
-    {
-        std::os::seraph::log!("shutdown failed (DSDT not found or \\_S5_ missing)");
-        return;
-    };
+    pm1a_port: u16,
+    slp_typa: u16,
+    pm1a_ioport_cap: u32,
+    kbc_ioport_cap: u32,
+}
 
-    if caps.arch_cap == 0
+/// Resolve the shutdown actuation state from devmgr. Returns `None` if any
+/// query or parse fails; the caller then serves SHUTDOWN/REBOOT with no
+/// actuator and replies an error to any request.
+pub fn resolve(devmgr_registry: u32, self_aspace: u32, ipc_buf: *mut u64) -> Option<Actuator>
+{
+    let facp_sig = u64::from(u32::from_le_bytes(*b"FACP"));
+    let fadt = query_acpi_table(devmgr_registry, facp_sig, 0, ipc_buf)?;
+    let (pm1a_port, dsdt_phys) = with_table_mapped(self_aspace, &fadt, |table_vaddr| {
+        Some(read_fadt_fields(table_vaddr))
+    })?;
+    if pm1a_port == 0
     {
-        std::os::seraph::log!("shutdown failed (no IoPortRange cap)");
-        return;
-    }
-    if syscall::ioport_bind(self_thread, caps.arch_cap).is_err()
-    {
-        std::os::seraph::log!("shutdown failed (ioport_bind)");
-        return;
+        std::os::seraph::log!("resolve failed (PM1a_CNT_BLK is zero)");
+        return None;
     }
 
-    let value = (slp_typa << 10) | SLP_EN;
-    // SAFETY: `PM1a_CNT_BLK` is a valid I/O port from FADT; IOPB permits
+    let dsdt = query_acpi_table(devmgr_registry, 0, dsdt_phys, ipc_buf)?;
+    let slp_typa = with_table_mapped(self_aspace, &dsdt, |dsdt_vaddr| {
+        // SAFETY: DSDT mapped read-only; offset 4 is the SDT length field.
+        let dsdt_len = unsafe { read_u32_at(dsdt_vaddr, 4) } as usize;
+        scan_dsdt_for_s5(dsdt_vaddr, dsdt_len)
+    })?;
+
+    let reply = devmgr_call(
+        devmgr_registry,
+        devmgr_labels::QUERY_SHUTDOWN_DEVICE,
+        u64::from(pm1a_port),
+        0,
+        ipc_buf,
+    )?;
+    let caps = reply.caps();
+    if caps.len() < 2
+    {
+        std::os::seraph::log!("resolve failed (QUERY_SHUTDOWN_DEVICE missing caps)");
+        return None;
+    }
+
+    Some(Actuator {
+        pm1a_port,
+        slp_typa,
+        pm1a_ioport_cap: caps[0],
+        kbc_ioport_cap: caps[1],
+    })
+}
+
+/// Attempt ACPI S5 shutdown. Logs and does not return on success; on
+/// failure logs and returns so the caller can reply with an error.
+pub fn shutdown(self_thread: u32, act: &Actuator)
+{
+    if syscall::ioport_bind(self_thread, act.pm1a_ioport_cap).is_err()
+    {
+        std::os::seraph::log!("shutdown failed (ioport_bind PM1a)");
+        return;
+    }
+    let value = (act.slp_typa << 10) | SLP_EN;
+    // SAFETY: `pm1a_port` is the FADT PM1a control port; IOPB permits
     // access after `ioport_bind`; writing `SLP_TYPa | SLP_EN` triggers
     // ACPI S5.
     unsafe {
         core::arch::asm!(
             "out dx, ax",
-            in("dx") pm1a_cnt_blk,
+            in("dx") act.pm1a_port,
             in("ax") value,
             options(nomem, nostack),
         );
     }
-    // The hardware may take a moment to power off. Halt to prevent
-    // any further output from racing the shutdown.
-    loop
-    {
-        // SAFETY: privileged HLT is rewritten by the kernel-emulation
-        // path; userspace falls back to a busy wait.
-        unsafe {
-            core::arch::asm!("pause", options(nomem, nostack));
-        }
-    }
+    halt();
 }
 
 /// Best-effort reboot via the 8042 KBC reset pulse.
-pub fn reboot(self_thread: u32, caps: &PwrmgrCaps)
+pub fn reboot(self_thread: u32, act: &Actuator)
 {
-    if caps.arch_cap == 0
+    /// 8042 keyboard-controller command port (legacy CPU reset path).
+    const KBC_COMMAND_PORT: u16 = 0x64;
+    /// 8042 reset pulse (asserts INIT# to the CPU).
+    const KBC_RESET_VALUE: u8 = 0xFE;
+
+    if syscall::ioport_bind(self_thread, act.kbc_ioport_cap).is_err()
     {
-        std::os::seraph::log!("reboot failed (no IoPortRange cap)");
+        std::os::seraph::log!("reboot failed (ioport_bind KBC)");
         return;
     }
-    if syscall::ioport_bind(self_thread, caps.arch_cap).is_err()
-    {
-        std::os::seraph::log!("reboot failed (ioport_bind)");
-        return;
-    }
-    // SAFETY: port 0x64 is the 8042 command register; writing 0xFE
-    // pulses the KBC reset line. IOPB permits access after
-    // `ioport_bind`.
+    // SAFETY: port 0x64 is the 8042 command register; writing 0xFE pulses
+    // the KBC reset line. IOPB permits access after `ioport_bind`.
     unsafe {
         core::arch::asm!(
             "out dx, al",
@@ -121,62 +141,96 @@ pub fn reboot(self_thread: u32, caps: &PwrmgrCaps)
             options(nomem, nostack),
         );
     }
+    halt();
+}
+
+/// Halt after issuing a reset/poweroff write so no further output races
+/// the platform powering off.
+fn halt() -> !
+{
     loop
     {
-        // SAFETY: same as in `shutdown`.
+        // SAFETY: `pause` is non-privileged.
         unsafe {
             core::arch::asm!("pause", options(nomem, nostack));
         }
     }
 }
 
-// ── ACPI table discovery ────────────────────────────────────────────────────
+// ── devmgr ACPI-table acquisition ───────────────────────────────────────────
 
-/// Map one ACPI region read-only, hand the (`region_vaddr`,
-/// `region_size`) pair to `f`, then unmap. Returns `f`'s output
-/// unchanged.
-fn with_region_mapped<F, R>(self_aspace: u32, region: &crate::caps::AcpiRegion, f: F) -> Option<R>
-where
-    F: FnOnce(u64, u64) -> Option<R>,
+/// A read-only ACPI table view served by devmgr's `QUERY_ACPI_TABLE`: a
+/// Frame cap on the containing region plus the geometry needed to map it
+/// and index to the table.
+struct TableView
 {
-    let pages = pages_for(region.phys_base, region.size);
+    frame_cap: u32,
+    region_base: u64,
+    region_size: u64,
+    table_phys: u64,
+}
+
+/// Query devmgr for an ACPI table by signature (`phys == 0`) or by
+/// physical address (`sig == 0`). Returns the served Frame cap + geometry.
+fn query_acpi_table(registry: u32, sig: u64, phys: u64, ipc_buf: *mut u64) -> Option<TableView>
+{
+    let reply = devmgr_call(
+        registry,
+        devmgr_labels::QUERY_ACPI_TABLE,
+        sig,
+        phys,
+        ipc_buf,
+    )?;
+    let frame_cap = *reply.caps().first()?;
+    Some(TableView {
+        frame_cap,
+        region_base: reply.word(0),
+        region_size: reply.word(1),
+        table_phys: reply.word(2),
+    })
+}
+
+/// Map the region behind a [`TableView`] read-only, hand the table's
+/// virtual address to `f`, then unmap, unreserve, and release the Frame
+/// cap. The cap is devmgr's to own; pwrmgr drops its copy after reading.
+fn with_table_mapped<F, R>(self_aspace: u32, view: &TableView, f: F) -> Option<R>
+where
+    F: FnOnce(u64) -> Option<R>,
+{
+    let pages = pages_for(view.region_base, view.region_size);
     let range = reserve_pages(pages).ok()?;
     let map_vaddr = range.va_start();
-    if syscall::mem_map(region.slot, self_aspace, map_vaddr, 0, pages, MAP_READONLY).is_err()
+    let mapped = syscall::mem_map(
+        view.frame_cap,
+        self_aspace,
+        map_vaddr,
+        0,
+        pages,
+        MAP_READONLY,
+    );
+    let out = if mapped.is_ok()
     {
-        unreserve_pages(range);
-        return None;
+        // The frame maps from the page containing `region_base`; the table
+        // sits at `table_phys` within it.
+        let table_vaddr = map_vaddr + (view.table_phys - (view.region_base & !0xFFF));
+        let r = f(table_vaddr);
+        let _ = syscall::mem_unmap(self_aspace, map_vaddr, pages);
+        r
     }
-    let region_vaddr = map_vaddr + (region.phys_base & 0xFFF);
-    let out = f(region_vaddr, region.size);
-    let _ = syscall::mem_unmap(self_aspace, map_vaddr, pages);
+    else
+    {
+        None
+    };
     unreserve_pages(range);
+    let _ = syscall::cap_delete(view.frame_cap);
     out
 }
 
-/// Scan every ACPI region for the FADT (`FACP`) signature. Returns
-/// `(pm1a_cnt_blk, dsdt_phys)` on success.
-fn locate_fadt_fields(caps: &PwrmgrCaps) -> Option<(u16, u64)>
-{
-    for region in &caps.acpi_regions[..caps.acpi_region_count]
-    {
-        let found = with_region_mapped(caps.self_aspace, region, |vaddr, size| {
-            scan_for_signature(vaddr, size, *b"FACP")
-                .map(|off| read_fadt_fields(vaddr + off as u64))
-        });
-        if let Some(pair) = found
-        {
-            return Some(pair);
-        }
-    }
-    None
-}
-
+/// Read `(PM1a_CNT_BLK, dsdt_phys)` from a mapped FADT.
 fn read_fadt_fields(table_vaddr: u64) -> (u16, u64)
 {
-    // SAFETY: `table_vaddr` is in a region just mapped read-only and
-    // sized to hold a full ACPI table header (FADT minimum size is 244
-    // bytes in ACPI 6.x).
+    // SAFETY: `table_vaddr` is in a region mapped read-only and sized to
+    // hold a full ACPI table header (FADT minimum is 244 bytes).
     let pm1a = unsafe { read_u32_at(table_vaddr, FADT_OFF_PM1A_CNT_BLK) } as u16;
     // SAFETY: same mapping.
     let dsdt32 = unsafe { read_u32_at(table_vaddr, FADT_OFF_DSDT) };
@@ -193,53 +247,9 @@ fn read_fadt_fields(table_vaddr: u64) -> (u16, u64)
     (pm1a, dsdt_phys)
 }
 
-/// Locate the DSDT by physical address and parse `\_S5_` for `SLP_TYPa`.
-fn locate_and_parse_dsdt(caps: &PwrmgrCaps, dsdt_phys: u64) -> Option<u16>
-{
-    for region in &caps.acpi_regions[..caps.acpi_region_count]
-    {
-        if dsdt_phys < region.phys_base || dsdt_phys >= region.phys_base + region.size
-        {
-            continue;
-        }
-        return with_region_mapped(caps.self_aspace, region, |region_vaddr, _size| {
-            let table_off = dsdt_phys - region.phys_base;
-            let dsdt_vaddr = region_vaddr + table_off;
-            // SAFETY: just mapped; offset 4 is the SDT length field.
-            let dsdt_len = unsafe { read_u32_at(dsdt_vaddr, 4) } as usize;
-            scan_dsdt_for_s5(dsdt_vaddr, dsdt_len)
-        });
-    }
-    None
-}
-
 fn pages_for(phys: u64, size: u64) -> u64
 {
-    ((phys & 0xFFF) + size).div_ceil(0x1000)
-}
-
-/// Scan `len` bytes starting at `vaddr` for a 4-byte ACPI signature on a
-/// 16-byte aligned offset (ACPI table header alignment per spec).
-fn scan_for_signature(vaddr: u64, len: u64, sig: [u8; 4]) -> Option<usize>
-{
-    let len = usize::try_from(len).ok()?;
-    if len < 4
-    {
-        return None;
-    }
-    // SAFETY: caller-mapped region of `len` bytes at `vaddr`.
-    let bytes = unsafe { core::slice::from_raw_parts(vaddr as *const u8, len) };
-    let last = len.saturating_sub(4);
-    let mut off = 0;
-    while off <= last
-    {
-        if bytes[off..off + 4] == sig
-        {
-            return Some(off);
-        }
-        off += 16;
-    }
-    None
+    ((phys & 0xFFF) + size).div_ceil(0x1000).max(1)
 }
 
 // ── DSDT scanning ───────────────────────────────────────────────────────────

--- a/services/svcmgr/README.md
+++ b/services/svcmgr/README.md
@@ -102,7 +102,7 @@ svcmgr/
 
 ## Namespace authority
 
-Init spawns svcmgr with the **universal** `system_root_cap` (post-#21).
+Init spawns svcmgr with the **universal** `system_root_cap`.
 svcmgr reads `/config/svcmgr/services/*.svc` directly via `std::fs`,
 walks the recipe's `binary` path for first-launch, and applies per-service
 namespace attenuation from each `.svc` `namespace = ...` line via

--- a/services/svcmgr/README.md
+++ b/services/svcmgr/README.md
@@ -5,13 +5,16 @@ init exits; runs for the lifetime of the system. svcmgr is a
 self-driven process: it spawns into an already-running system (root
 mounted; vfsd, procmgr, devmgr, fs/block drivers up), reads service
 *definitions* from `/config/svcmgr/services/`, and reconciles them
-against init's pending `REGISTER_SERVICE` announcements to either
-supervise the running instance or launch a fresh one.
+against the substrate registrations init delivers in the handover
+endowment to either supervise the running instance or launch a fresh
+one.
 
-svcmgr also owns the system-wide discovery registry: well-known names
-(`rootfs.root`, `pwrmgr.shutdown`, `pwrmgr.deny`, `svcmgr`, …) are
-published into it by init at Phase 3, and consumers resolve them via
-`QUERY_ENDPOINT` (or transparently through their `.svc` `seed = ...`
+svcmgr also owns the system-wide discovery registry: it publishes the
+well-known names it owns (`rootfs.root`, `svcmgr`, `devmgr.registry`,
+and each provider's `provides` names like `pwrmgr.shutdown` / `timed`)
+into the registry itself — from the source caps init endows it with at
+handover, and from each provider's launch — and consumers resolve them
+via `QUERY_ENDPOINT` (or transparently through their `.svc` `seed = ...`
 line at launch time).
 
 svcmgr also holds raw process-creation syscall capabilities as a
@@ -44,7 +47,7 @@ svcmgr/
 │   │   └── reconcile.rs           # PendingRegistration + reconcile_and_launch
 │   └── arch/                      # Per-arch halt() entry
 └── docs/
-    ├── ipc-interface.md           # v3 REGISTER_SERVICE, HANDOVER_COMPLETE,
+    ├── ipc-interface.md           # handover endowment, HANDOVER_COMPLETE,
     │                              # PUBLISH_ENDPOINT / QUERY_ENDPOINT
     ├── restart-protocol.md        # Death detection, restart sequencing,
     │                              # shared spawn primitives, criticality
@@ -56,17 +59,20 @@ svcmgr/
 
 ## Responsibilities
 
-- **Service registration** — accept the v3 `REGISTER_SERVICE` wire
-  (name + thread_cap) from init for services init bootstrapped
-  before svcmgr existed. Recipes (binary, argv, env, restart policy,
-  criticality, namespace shape, seed names) live on disk, not on the
-  wire — see [docs/service-definitions.md](docs/service-definitions.md).
+- **Handover endowment** — drain init's bootstrap-round endowment in
+  [`service::bootstrap_caps`](src/service.rs): svcmgr's own endpoints,
+  the publish-role source caps (`rootfs.root` SEND, devmgr-registry
+  `SEND|GRANT` source), and one `(name, thread_cap)` round per substrate
+  service init bootstrapped before svcmgr existed. Recipes (binary,
+  argv, env, restart policy, criticality, namespace shape, seed names)
+  live on disk, not on the wire — see
+  [docs/service-definitions.md](docs/service-definitions.md).
 - **Reconciliation** — at `HANDOVER_COMPLETE` scan
   `/config/svcmgr/services/`, parse each `<name>.svc`, and pair it
-  with the pending-registration table. Three outcomes: `bind only`
-  (registered AND defined), `launching` (defined only),
-  `registered without definition` (registered AND no recipe → hard
-  error).
+  with the pending-registration table (substrate pairs parked from the
+  endowment). Three outcomes: `bind only` (parked AND defined),
+  `launching` (defined only), `registered without definition`
+  (parked AND no recipe → hard error).
 - **Launch** — for `defined only` services, spawn via the shared
   primitives in [`restart.rs`](src/restart.rs)
   (`walk_and_create_from_file`, `apply_namespace_policy`,
@@ -82,9 +88,11 @@ svcmgr/
   `RestartRecipe` — so a restart reproduces the first-launch surfaces.
   Whether a service restarts is decided by its `restart` policy + budget
   alone; `critical` is orthogonal (see graceful shutdown below).
-- **Discovery registry** — `PUBLISH_ENDPOINT` (init's
-  `PUBLISH_AUTHORITY`-tokened SENDs) and `QUERY_ENDPOINT`
-  (per-process SEND seeded into `ProcessInfo.service_registry_cap`).
+- **Discovery registry** — svcmgr publishes the names it owns directly
+  (internal `registry.publish`); `PUBLISH_ENDPOINT` is the external
+  write-API (reserved for a future devmgr publisher) and `QUERY_ENDPOINT`
+  the lookup, served on the per-process SEND seeded into
+  `ProcessInfo.service_registry_cap`.
 - **Graceful shutdown** — when a `critical = yes` service is permanently
   down (restart not attempted or budget exhausted), resolve
   `ipc::published_names::PWRMGR_SHUTDOWN` from the registry and issue
@@ -136,16 +144,19 @@ Namespace forms: `none | universal | subtree:<path>:<rights>`.
 
 ## Cap publication
 
-Init publishes the following well-known names into svcmgr's registry
-during Phase 3 (post-#21). Names are FS-driver- and platform-agnostic
-by design; consumers resolve them through their `.svc` `seed = ...`
-lines or via direct `QUERY_ENDPOINT` calls.
+svcmgr publishes every well-known name into its own registry — there is
+no init-side `PUBLISH_ENDPOINT` traffic. The first three are published in
+`main()` right after the endowment is drained, from the source caps init
+endows svcmgr with at handover; the provider names are published on each
+provider's launch path. Names are FS-driver- and platform-agnostic by
+design; consumers resolve them through their `.svc` `seed = ...` lines or
+via direct `QUERY_ENDPOINT` calls.
 
 | Name | Source | Cap shape |
 |---|---|---|
-| `rootfs.root` | init Phase 3 | tokened SEND on the root filesystem's namespace endpoint at its root directory |
-| `svcmgr` | init Phase 3 | un-tokened SEND on svcmgr's own service endpoint |
-| `devmgr.registry` | init Phase 3 | `REGISTRY_QUERY_AUTHORITY`-tokened SEND on devmgr's registry endpoint |
+| `rootfs.root` | svcmgr (endowed `rootfs.root` SEND) | tokened SEND on the root filesystem's namespace endpoint at its root directory |
+| `svcmgr` | svcmgr (its own service ep) | un-tokened SEND on svcmgr's own service endpoint |
+| `devmgr.registry` | svcmgr (minted from the endowed devmgr-registry source) | `REGISTRY_QUERY_AUTHORITY`-tokened SEND on devmgr's registry endpoint |
 | `pwrmgr.shutdown` | svcmgr (`pwrmgr.svc` provider) | `SHUTDOWN_AUTHORITY`-tokened SEND on pwrmgr's service endpoint |
 | `pwrmgr.deny` | svcmgr (`pwrmgr.svc` provider) | no-authority SEND on pwrmgr's service endpoint (negative-test twin) |
 | `timed` | svcmgr (`timed.svc` provider) | SEND on timed's service endpoint |

--- a/services/svcmgr/README.md
+++ b/services/svcmgr/README.md
@@ -144,10 +144,11 @@ lines or via direct `QUERY_ENDPOINT` calls.
 | Name | Source | Cap shape |
 |---|---|---|
 | `rootfs.root` | init Phase 3 | tokened SEND on the root filesystem's namespace endpoint at its root directory |
-| `pwrmgr.shutdown` | init Phase 3 | `SHUTDOWN_AUTHORITY`-tokened SEND on pwrmgr's service endpoint |
-| `pwrmgr.deny` | init Phase 3 | no-authority SEND on pwrmgr's service endpoint (negative-test twin) |
 | `svcmgr` | init Phase 3 | un-tokened SEND on svcmgr's own service endpoint |
-| `timed` | init bring-up | SEND on timed's service endpoint |
+| `devmgr.registry` | init Phase 3 | `REGISTRY_QUERY_AUTHORITY`-tokened SEND on devmgr's registry endpoint |
+| `pwrmgr.shutdown` | svcmgr (`pwrmgr.svc` provider) | `SHUTDOWN_AUTHORITY`-tokened SEND on pwrmgr's service endpoint |
+| `pwrmgr.deny` | svcmgr (`pwrmgr.svc` provider) | no-authority SEND on pwrmgr's service endpoint (negative-test twin) |
+| `timed` | svcmgr (`timed.svc` provider) | SEND on timed's service endpoint |
 
 Centralised name constants live in `ipc::published_names`.
 

--- a/services/svcmgr/docs/ipc-interface.md
+++ b/services/svcmgr/docs/ipc-interface.md
@@ -1,6 +1,6 @@
 # svcmgr IPC Interface
 
-IPC interface specification for svcmgr: service registration (v3 wire),
+IPC interface specification for svcmgr: the init handover endowment,
 handover-driven reconciliation, and the discovery-registry publish /
 query surface.
 
@@ -9,10 +9,9 @@ query surface.
 ## Endpoint
 
 svcmgr listens on a single IPC endpoint (the svcmgr service endpoint).
-Init holds the Send-side capability and uses it to register currently-
-running services and publish well-known caps during bootstrap. svcmgr
-holds the Receive-side capability and multiplexes it with the shared
-death-notification EventQueue via a WaitSet.
+svcmgr holds the Receive-side capability (delivered in the handover
+endowment) and multiplexes it with the shared death-notification
+EventQueue via a WaitSet.
 
 A SEND on the same endpoint (without the [`PUBLISH_AUTHORITY`](#publish-authority)
 verb bit) is delivered to every process via
@@ -21,60 +20,72 @@ verb bit) is delivered to every process via
 
 ---
 
+## Handover endowment (bootstrap rounds)
+
+svcmgr's entire startup state arrives over init's bootstrap-round
+protocol (the same mechanism that delivers every service's startup caps),
+not a dedicated registration label. init serves the rounds on its
+bootstrap endpoint; svcmgr drains them in
+[`service::bootstrap_caps`](../src/service.rs). Each round is tagged by
+kind in `data[0]`:
+
+**Round 1 — `CAPS` (`data[0] = 1`, not terminal):**
+
+| Field | Value |
+|---|---|
+| caps[0] | svcmgr's service endpoint (RECV) |
+| caps[1] | svcmgr's own bootstrap endpoint (RECV — serves launched/restarted children) |
+| caps[2] | SEND on the root filesystem's namespace endpoint (published as `rootfs.root`; `0` if init could not derive it) |
+| caps[3] | `SEND\|GRANT`, token-0 source on devmgr's registry endpoint (`0` if absent) |
+| data[0] | `1` (`CAPS`) |
+| data[1] | `SVCMGR_LABELS_VERSION` (currently `4`) handshake |
+
+svcmgr mints the `devmgr.registry` publish cap
+(`REGISTRY_QUERY_AUTHORITY`) and the `SET_DRIVERS_DIR` cap
+(`DRIVERS_DIR_AUTHORITY`) from caps[3]. A version mismatch in `data[1]`
+aborts bootstrap (svcmgr exits).
+
+**Rounds 2..N — `SUBSTRATE` (`data[0] = 2`; the final round is terminal):**
+one per init-bootstrapped substrate service (memmgr, procmgr, devmgr,
+vfsd, logd).
+
+| Field | Value |
+|---|---|
+| caps[0] | the service's main thread cap (Control right) for death-notification binding |
+| data[0] | `2` (`SUBSTRATE`) |
+| data[1] | `name_len` (byte length of the service name) |
+| data[2..] | service name bytes packed LE into `u64` words (≤ 32 bytes) |
+
+svcmgr parks each pair in its pending-registration table. It does **not**
+bind death-notification at endowment time — the matching `.svc`
+definition is paired at reconciliation, on
+[`HANDOVER_COMPLETE`](#label-2-handover_complete). After draining the
+endowment svcmgr publishes the well-known names it owns (`rootfs.root`,
+`svcmgr`, `devmgr.registry`) into its own registry and installs devmgr's
+`/services/drivers/` cap via `SET_DRIVERS_DIR`, before entering the event
+loop.
+
+---
+
 ## Messages
 
 All requests use `SYS_IPC_CALL` (synchronous call/reply). The message
 label field identifies the operation.
 
-### Label 1: `REGISTER_SERVICE` (v3)
-
-Register a currently-running service for supervision.
-
-Post-#21 the recipe (binary, argv, env, restart policy, criticality,
-namespace shape, seed names) lives on disk at
-`/config/svcmgr/services/<name>.svc`. This message conveys only what
-cannot be on disk: which named recipe the running process implements,
-and the thread cap svcmgr binds death-notification on at
-reconciliation time.
-
-**Request:**
-
-| Field | Value |
-|---|---|
-| label | `1` |
-| word 0 | `SVCMGR_LABELS_VERSION` (currently `3`) handshake |
-| word 1 | `name_len` (byte length of the service name) |
-| words 2.. | service name bytes packed into `u64` words (up to 32 bytes) |
-| caps[0] | Thread capability (Control right) for death-notification binding |
-
-**Reply:**
-
-| label value | Meaning |
-|---|---|
-| `0` (`SUCCESS`) | Entry parked in svcmgr's pending-registration table |
-| `LABEL_VERSION_MISMATCH` | `word 0` does not equal svcmgr's `SVCMGR_LABELS_VERSION` |
-| `INVALID_NAME` | `name_len` is 0 or exceeds 32 |
-| `TABLE_FULL` | Pending table is full |
-| `INSUFFICIENT_CAPS` | `caps[0]` missing or zero |
-
-At register time svcmgr does **not** bind death-notification — the
-matching `.svc` definition may not yet exist; reconciliation happens
-on [`HANDOVER_COMPLETE`](#label-2-handover_complete).
-
 ### Label 2: `HANDOVER_COMPLETE`
 
-Signals that init has finished registering services and publishing
-well-known caps. svcmgr replies `SUCCESS` immediately (so init can
-proceed to teardown), then runs
+Signals that init has finished serving the handover endowment. svcmgr
+replies `SUCCESS` immediately (so init can proceed to teardown), then runs
 [`definitions::reconcile::reconcile_and_launch`](../src/definitions/reconcile.rs):
 
 1. Scan `/config/svcmgr/services/`, parse each `.svc` into a
    [`Definition`](../src/definitions/mod.rs).
-2. Reconcile against the pending-registration table:
-   * **registered AND defined** — bind death-notification, record a
+2. Reconcile against the pending-registration table (the substrate pairs
+   parked from the endowment):
+   * **parked AND defined** — bind death-notification, record a
      `ServiceEntry` with the parsed recipe.
    * **defined only** — launch via [`definitions::launch`](../src/definitions/launch.rs).
-   * **registered without definition** — log `registered without
+   * **parked without definition** — log `registered without
      definition: <name>; refusing to bind`.
 3. After reconciliation the supervision loop continues unchanged.
 
@@ -142,14 +153,18 @@ freshly-derived `RIGHTS_SEND` cap on the published endpoint.
 ## Publish authority
 
 `svcmgr_labels::PUBLISH_AUTHORITY` is a verb-bit (the top bit of the
-caller's cap token) gating `PUBLISH_ENDPOINT`. Init mints
-`PUBLISH_AUTHORITY`-tokened SENDs on svcmgr's service endpoint locally
-from the un-tokened source it owns; the SEND distributed to every
-process via `ProcessInfo.service_registry_cap` carries a per-process
-token *without* the bit, so it is accepted for `QUERY_ENDPOINT` only.
+caller's cap token) gating `PUBLISH_ENDPOINT` for *external* publishers.
+svcmgr publishes the well-known names it owns (`rootfs.root`, `svcmgr`,
+`devmgr.registry`, and each provider's `provides` names) directly into
+its own registry, so those need no token. The gate exists for a future
+external publisher — devmgr holds a `PUBLISH_AUTHORITY`-tokened SEND from
+its bootstrap bundle, reserved for driver registrations. The SEND
+distributed to every process via `ProcessInfo.service_registry_cap`
+carries a per-process token *without* the bit, so it is accepted for
+`QUERY_ENDPOINT` only.
 
-Cap derivation for the publish cap MUST use `RIGHTS_SEND_GRANT`, not
-`RIGHTS_SEND`: `PUBLISH_ENDPOINT` carries the value cap in the
+Cap derivation for an external publish cap MUST use `RIGHTS_SEND_GRANT`,
+not `RIGHTS_SEND`: `PUBLISH_ENDPOINT` carries the value cap in the
 message body, and the IPC kernel requires the GRANT bit on the
 caller's send-cap to transfer caps.
 

--- a/services/svcmgr/docs/restart-protocol.md
+++ b/services/svcmgr/docs/restart-protocol.md
@@ -44,8 +44,8 @@ permanent loss*.
    * The restart-count budget (`MAX_RESTARTS`, currently `1`) is
      enforced here; an exhausted budget reports "max restarts reached,
      marking degraded" and returns false.
-   * A missing restart source (`module_cap == 0` AND
-     `vfs_path_len == 0`) reports "no restart source" and returns false.
+   * A missing restart source (`vfs_path_len == 0`) reports
+     "no restart source" and returns false.
 2. **Restart not permitted** → mark service inactive; route to
    `permanent_death_outcome`:
    * `system_critical` (`critical = yes`) → log `critical service
@@ -131,7 +131,7 @@ at reconciliation time. The fixed-size fields live on `ServiceEntry`:
 | `ns_policy_kind` / `ns_subtree_path` / `ns_subtree_rights` | `namespace = ...` |
 | `thread_cap` | endowment thread cap (bind-only) or `Launched.thread_cap` (svcmgr-launched) |
 | `process_handle` | `Launched.process_handle` for svcmgr-launched; `0` for init-spawned (see DESTROY_PROCESS comment above) |
-| `module_cap` | `0` (no module-loaded services in the post-#21 model) |
+| `module_cap` | `0` (services restart from their `vfs_path`; no module caps are held) |
 
 The heap-backed launch surfaces that don't fit the fixed record are held
 in a parallel [`RestartRecipe`](../src/service.rs) table

--- a/services/svcmgr/docs/restart-protocol.md
+++ b/services/svcmgr/docs/restart-protocol.md
@@ -68,8 +68,8 @@ permanent loss*.
      [`apply_namespace_policy`](#shared-spawn-primitives).
    * Serve the restart bootstrap round, re-resolving the recipe's
      `seed` names from the discovery registry in declaration order (or,
-     for init-registered services with no seeds, re-deriving the
-     registration bundle caps).
+     for init-endowed services with no seeds, re-deriving the stored
+     bundle caps).
    * Rebind death-notification on the new thread cap using the same
      correlator so subsequent crashes route back to the same entry.
    * On success: increment `restart_count`, return `Restarted`.
@@ -129,7 +129,7 @@ at reconciliation time. The fixed-size fields live on `ServiceEntry`:
 | `restart_policy` | `restart = never \| on_failure \| always` |
 | `system_critical` | `critical = yes \| no` |
 | `ns_policy_kind` / `ns_subtree_path` / `ns_subtree_rights` | `namespace = ...` |
-| `thread_cap` | v3 `REGISTER_SERVICE` cap (bind-only) or `Launched.thread_cap` (svcmgr-launched) |
+| `thread_cap` | endowment thread cap (bind-only) or `Launched.thread_cap` (svcmgr-launched) |
 | `process_handle` | `Launched.process_handle` for svcmgr-launched; `0` for init-spawned (see DESTROY_PROCESS comment above) |
 | `module_cap` | `0` (no module-loaded services in the post-#21 model) |
 
@@ -157,7 +157,7 @@ back with the same surfaces first launch gave it.
 svcmgr only supervises top-level services. Drivers (cmos / virtio-rtc
 / future block / net) are supervised by devmgr. Filesystem drivers
 (fatfs / future ext / btrfs) are supervised by vfsd. None of those
-flow through `REGISTER_SERVICE`.
+flow through the handover endowment.
 
 The set of services svcmgr currently supervises (per the shipped
 `.svc` files):
@@ -172,15 +172,15 @@ every boot.
 |---|---|---|---|
 | `svctest` | svcmgr-launched (test-tier, staged) | `never` | `no` |
 | `crasher` | svcmgr-launched (test-tier, staged) | `always` | `no` |
-| `memmgr` | init-registered (bind only) | `never` | `yes` |
-| `procmgr` | init-registered (bind only) | `never` | `yes` |
-| `devmgr` | init-registered (bind only) | `never` | `yes` |
-| `vfsd` | init-registered (bind only) | `never` | `yes` |
-| `logd` | init-registered (bind only) | `never` | `yes` |
+| `memmgr` | init-endowed (bind only) | `never` | `yes` |
+| `procmgr` | init-endowed (bind only) | `never` | `yes` |
+| `devmgr` | init-endowed (bind only) | `never` | `yes` |
+| `vfsd` | init-endowed (bind only) | `never` | `yes` |
+| `logd` | init-endowed (bind only) | `never` | `yes` |
 | `timed` | svcmgr-launched (provider) | `on_failure` | `no` |
 | `pwrmgr` | svcmgr-launched (provider) | `on_failure` | `no` |
 
-Restart paths for the init-registered (bind-only) substrate set are
+Restart paths for the init-endowed (bind-only) substrate set are
 aspirational today: each was spawned with arch-/firmware-authority caps
 that init holds and svcmgr cannot re-mint (memmgr/procmgr via raw
 `cap_create_*` syscalls; devmgr/vfsd/logd with one-shot authority

--- a/services/svcmgr/docs/restart-protocol.md
+++ b/services/svcmgr/docs/restart-protocol.md
@@ -177,18 +177,24 @@ every boot.
 | `devmgr` | init-registered (bind only) | `never` | `yes` |
 | `vfsd` | init-registered (bind only) | `never` | `yes` |
 | `logd` | init-registered (bind only) | `never` | `yes` |
-| `timed` | init-registered (bind only) | `never` | `no` |
-| `pwrmgr` | init-registered (bind only) | `never` | `yes` |
+| `timed` | svcmgr-launched (provider) | `on_failure` | `no` |
+| `pwrmgr` | svcmgr-launched (provider) | `on_failure` | `no` |
 
-Restart paths for the bind-only set are aspirational today: most of
-them were spawned with arch-/firmware-authority caps that init holds
-and svcmgr cannot re-mint (memmgr/procmgr via raw `cap_create_*`
-syscalls; devmgr/vfsd/logd with one-shot authority handover; pwrmgr
-with `IoPortRange` / `SbiControl` / ACPI frames). When their
-`.svc` `restart` value moves off `never` in the future, the spawn
-path needs to gain access to those caps — either via a new
-init→svcmgr handover round, or by relocating the spawn entirely
-into svcmgr.
+Restart paths for the init-registered (bind-only) substrate set are
+aspirational today: each was spawned with arch-/firmware-authority caps
+that init holds and svcmgr cannot re-mint (memmgr/procmgr via raw
+`cap_create_*` syscalls; devmgr/vfsd/logd with one-shot authority
+handover). When their `.svc` `restart` value moves off `never` in the
+future, the spawn path needs to gain access to those caps — either via a
+new init→svcmgr handover round, or by relocating the spawn entirely into
+svcmgr.
+
+`timed` and `pwrmgr` are *not* in that set: they are svcmgr-launched
+providers and genuinely restartable. Neither holds a unique source cap —
+each re-acquires its authority on (re)start by querying devmgr
+(`QUERY_RTC_DEVICE` for timed; `QUERY_ACPI_TABLE` + `QUERY_SHUTDOWN_DEVICE`
+for pwrmgr), and svcmgr re-serves a fresh RECV on the persistent service
+endpoint so cached client caps survive the restart.
 
 ---
 

--- a/services/svcmgr/docs/service-definitions.md
+++ b/services/svcmgr/docs/service-definitions.md
@@ -57,6 +57,7 @@ seed      = rootfs.root pwrmgr.shutdown pwrmgr.deny
 | `cwd` | no | Path interpreted relative to svcmgr's universal root. Forbidden when `namespace = none`. |
 | `seed` | no | Space-separated discovery-registry names, resolved positionally (cap[i] = i-th name). |
 | `provides` | no | Space-separated `name[:auth\|:deny]` entries. svcmgr creates this service's endpoint, serves its RECV as bootstrap `cap[0]`, and publishes one tokened SEND per entry into the discovery registry. See [`provides`](#provides). |
+| `log_sink` | no | `yes` or `no` (default `no`). Marks the service as the system log sink (real-logd); svcmgr mints its bootstrap round from the reserved log-sink sources init endows. Mutually exclusive with `seed` and `provides`. See [`log_sink`](#log_sink). |
 
 ## `restart`
 
@@ -106,7 +107,7 @@ The primary lever for confining a service to only what it needs.
 | Form | Effect |
 |---|---|
 | `none` | No namespace cap delivered. The child's `ProcessInfo.system_root_cap` stays zero; std-side absolute-path filesystem operations return `Unsupported`. Default tight choice for services with no filesystem dependency. |
-| `universal` | `cap_copy` of svcmgr's own root (post-#21: the system universal root). Reserved for services that need genuine root authority (vfsd as the namespace authority, devmgr for `/dev`, procmgr for walking `/services` and `/programs`, svctest as the namespace tester). |
+| `universal` | `cap_copy` of svcmgr's own root (the system universal root). Reserved for services that need genuine root authority (vfsd as the namespace authority, devmgr for `/dev`, procmgr for walking `/services` and `/programs`, svctest as the namespace tester). |
 | `subtree:<path>:<rights>` | Walk `<path>` from svcmgr's root requesting `<rights>` per hop, hand the resulting directory cap to the child. `<rights>` is a `+`-joined list of named tokens (`LOOKUP`, `READDIR`, `STAT`, `READ`, `WRITE`, `EXEC`, `MUTATE_DIR`, `ADMIN` — see [`shared/namespace-protocol/src/rights.rs`](../../../shared/namespace-protocol/src/rights.rs)). Unknown tokens are parser errors. Empty rights list is a parser error. |
 
 Example subtree clause:
@@ -182,6 +183,43 @@ consumer's `QUERY_ENDPOINT` lookup unchanged):
 
 ```
 provides = pwrmgr.shutdown:auth pwrmgr.deny:deny
+```
+
+## `log_sink`
+
+`yes` marks the service as the system's master log sink — real-logd, the
+receive-side owner of the master log endpoint. Exactly one recipe carries
+`log_sink = yes`.
+
+A log-sink service's bootstrap round is **not** assembled from `seed` or
+`provides`. svcmgr mints it from the reserved log-sink sources init endows
+at handover (the master-log endpoint source and the procmgr `SEND|GRANT`
+death-auth source — see
+[`process-lifecycle.md`](../../../docs/process-lifecycle.md)) plus the
+`devmgr.registry` source. The round is four positional caps:
+
+| Index | Cap |
+|---|---|
+| 0 | `RECV` on the master log endpoint |
+| 1 | `SEND` on the master log endpoint (single-use; `HANDOVER_PULL` only). `0` on a restart — no init-logd remains to pull from |
+| 2 | tokened `SEND` on procmgr carrying `DEATH_EQ_AUTHORITY` (logd registers per-sender death-notifications for slot reclaim) |
+| 3 | tokened `SEND` on devmgr's registry carrying `REGISTRY_QUERY_AUTHORITY` (logd resolves the serial driver via `QUERY_SERIAL_DEVICE`) |
+
+Because these slots are svcmgr-minted, `seed` and `provides` have no
+position in the round; declaring either alongside `log_sink = yes` is a
+parser error. The same svcmgr-minted round drives both the first launch
+(`cap[1]` present, history pulled from init-logd) and every restart
+(`cap[1] = 0`, history pull skipped) — svcmgr holds the master-log source
+for the system's life, so each (re)launched logd re-attaches a fresh RECV
+to the same endpoint object every sender already targets. `restart` and
+`critical` behave exactly as for any other service.
+
+```
+binary    = /services/logd
+restart   = on_failure
+critical  = yes
+namespace = none
+log_sink  = yes
 ```
 
 ## Reconciliation

--- a/services/svcmgr/docs/service-definitions.md
+++ b/services/svcmgr/docs/service-definitions.md
@@ -1,8 +1,9 @@
 # `.svc` Service Definitions
 
 Authoritative spec for the `/config/svcmgr/services/<name>.svc` files
-svcmgr scans at `HANDOVER_COMPLETE` to reconcile init's pending
-`REGISTER_SERVICE` announcements with the on-disk service recipes.
+svcmgr scans at `HANDOVER_COMPLETE` to reconcile the substrate
+registrations init delivers in the handover endowment with the on-disk
+service recipes.
 
 ## Authority
 
@@ -15,9 +16,10 @@ recipe travels on the wire.
 
 * Directory: `/config/svcmgr/services/`
 * Filename: `<name>.svc`. The `<name>` portion is the key under which
-  the service registers with svcmgr (the `name` field of the
-  [v3 `REGISTER_SERVICE`](ipc-interface.md#label-1-register_service)
-  wire). Filenames are ASCII; case-sensitive `.svc` suffix.
+  the service is reconciled with svcmgr — for a substrate service, the
+  `name` carried in its
+  [handover-endowment `SUBSTRATE` round](ipc-interface.md#handover-endowment-bootstrap-rounds).
+  Filenames are ASCII; case-sensitive `.svc` suffix.
 * Files are shipped via `rootfs/config/svcmgr/services/` and installed
   into the sysroot by xtask's recursive `install_rootfs` copy. No
   build-system change is required to add a new recipe — drop the
@@ -185,21 +187,21 @@ provides = pwrmgr.shutdown:auth pwrmgr.deny:deny
 ## Reconciliation
 
 At `HANDOVER_COMPLETE` svcmgr scans `/config/svcmgr/services/`, parses each
-`<name>.svc`, and reconciles against init's pending-registration
-table:
+`<name>.svc`, and reconciles against the pending-registration table
+(substrate pairs parked from the handover endowment):
 
 | Definition | Pending registration | Outcome |
 |---|---|---|
-| present | present | **bind only** — bind death-notification on the registered thread cap; record a `ServiceEntry` with the parsed recipe for restart use. |
+| present | present | **bind only** — bind death-notification on the endowed thread cap; record a `ServiceEntry` with the parsed recipe for restart use. |
 | present | absent | **launching** — svcmgr launches the service via [`definitions::launch`](../src/definitions/launch.rs): walk `binary`, `CREATE_FROM_FILE` with argv/env, `CONFIGURE_NAMESPACE` with the namespace+cwd, `START_PROCESS`, serve the seed bootstrap round. If `restart != never`, bind death-notification and record a `ServiceEntry`. |
-| absent | present | **error** — `registered without definition: <name>; refusing to bind`. svcmgr has no recipe; a registration without a matching `.svc` is a configuration error. |
+| absent | present | **error** — `registered without definition: <name>; refusing to bind`. svcmgr has no recipe; an endowed name without a matching `.svc` is a configuration error. |
 
 ## Relevant Design Documents
 
 | Document | Content |
 |---|---|
 | [README.md](../README.md) | Component scope, responsibilities, restart policy |
-| [ipc-interface.md](ipc-interface.md) | v3 `REGISTER_SERVICE` wire, `HANDOVER_COMPLETE`, `PUBLISH_ENDPOINT` / `QUERY_ENDPOINT` |
+| [ipc-interface.md](ipc-interface.md) | handover endowment, `HANDOVER_COMPLETE`, `PUBLISH_ENDPOINT` / `QUERY_ENDPOINT` |
 | [restart-protocol.md](restart-protocol.md) | Restart sequencing, shared spawn primitives, criticality semantics |
 | [shared/ipc/src/lib.rs](../../../shared/ipc/src/lib.rs) | `published_names` constants, `svcmgr_labels::*`, `svcmgr_errors::*` |
 

--- a/services/svcmgr/docs/service-definitions.md
+++ b/services/svcmgr/docs/service-definitions.md
@@ -54,6 +54,7 @@ seed      = rootfs.root pwrmgr.shutdown pwrmgr.deny
 | `namespace` | yes | One of `none`, `universal`, `subtree:<path>:<rights>`. |
 | `cwd` | no | Path interpreted relative to svcmgr's universal root. Forbidden when `namespace = none`. |
 | `seed` | no | Space-separated discovery-registry names, resolved positionally (cap[i] = i-th name). |
+| `provides` | no | Space-separated `name[:auth\|:deny]` entries. svcmgr creates this service's endpoint, serves its RECV as bootstrap `cap[0]`, and publishes one tokened SEND per entry into the discovery registry. See [`provides`](#provides). |
 
 ## `restart`
 
@@ -86,13 +87,15 @@ Because the two fields are independent, any combination is valid — e.g.
 `restart = always` + `critical = no` (the `crasher` fixture: respawned on
 every fault, but its eventual permanent death is non-fatal).
 
-**pwrmgr's own death** is the edge case. If a `critical = yes`
-service that *is* `pwrmgr` dies unrecoverably, the shutdown source is
-itself gone; svcmgr logs `critical service unrecoverable: pwrmgr;
-graceful shutdown impossible; system in degraded state` and takes no
-further action. No fallback raw-shutdown path is provided — the
-same shape as today's lack of a recovery story for procmgr / memmgr
-death.
+**pwrmgr's own death** is the edge case. pwrmgr is `restart = on_failure`
++ `critical = no`: a crashed pwrmgr is recoverable (svcmgr re-creates it
+and it re-acquires its actuator caps from devmgr — see
+[services/pwrmgr/README.md](../../pwrmgr/README.md)), and its *permanent*
+death is deliberately non-fatal. It is `critical = no` precisely because
+the graceful-shutdown escalation routes through `pwrmgr.shutdown` — if
+pwrmgr is the dead service, that source is gone, so escalation would be
+circular. The honest terminal state is logged-and-continue. Setting
+`critical = yes` on pwrmgr would be self-defeating for this reason.
 
 ## `namespace`
 
@@ -149,9 +152,35 @@ Well-known names are centralised in
 | Name | Publisher (today) | Cap shape |
 |---|---|---|
 | `rootfs.root` | init Phase 3 | tokened SEND on the root filesystem's namespace endpoint at its root directory (FS-driver-agnostic) |
-| `pwrmgr.shutdown` | init Phase 3 | `SHUTDOWN_AUTHORITY`-tokened SEND on pwrmgr's service endpoint |
-| `pwrmgr.deny` | init Phase 3 | no-authority SEND on pwrmgr's service endpoint (negative-test twin) |
+| `pwrmgr.shutdown` | svcmgr (`pwrmgr.svc` provider) | `SHUTDOWN_AUTHORITY`-tokened SEND on pwrmgr's service endpoint |
+| `pwrmgr.deny` | svcmgr (`pwrmgr.svc` provider) | no-authority SEND on pwrmgr's service endpoint (negative-test twin) |
+| `timed` | svcmgr (`timed.svc` provider) | un-tokened SEND on timed's service endpoint (wall-clock) |
 | `svcmgr` | init Phase 3 | un-tokened SEND on svcmgr's own service endpoint |
+| `devmgr.registry` | init Phase 3 | `REGISTRY_QUERY_AUTHORITY`-tokened SEND on devmgr's registry endpoint |
+
+## `provides`
+
+Declares the registry names a service's own endpoint is published under.
+svcmgr creates a service endpoint, serves its RECV as bootstrap `cap[0]`
+(ahead of the `seed` caps), and publishes one SEND per entry. Providers
+launch ahead of pure consumers during reconciliation, so a provided name
+is resolvable before any consumer queries it. The endpoint persists across
+restarts (svcmgr holds the source), so a cached client cap survives a
+crash-restart and no re-publish is needed.
+
+Each space-separated entry is `name[:auth|:deny]`; the suffix selects the
+token svcmgr stamps on that name's SEND (the token rides through a
+consumer's `QUERY_ENDPOINT` lookup unchanged):
+
+| Suffix | Token | Use |
+|---|---|---|
+| *(none)* | `0` (untokened) | Plain SEND. e.g. `timed`. |
+| `:auth` | `1 << 63` | The universal verb-authority bit shared by every `*_AUTHORITY` constant — the server's `token & (1 << 63)` gate passes. e.g. `pwrmgr.shutdown:auth`. |
+| `:deny` | `1` | Present so the cap resolves, but the authority gate fails. The negative-test twin. e.g. `pwrmgr.deny:deny`. |
+
+```
+provides = pwrmgr.shutdown:auth pwrmgr.deny:deny
+```
 
 ## Reconciliation
 

--- a/services/svcmgr/src/definitions/launch.rs
+++ b/services/svcmgr/src/definitions/launch.rs
@@ -27,6 +27,10 @@ pub struct Launched
 {
     pub thread_cap: u32,
     pub process_handle: u32,
+    /// Persistent service-endpoint source for a `provides = ...` service,
+    /// stored on the `ServiceEntry` so restarts re-serve a fresh RECV on
+    /// the same object. Zero for pure-consumer services.
+    pub provided_endpoint: u32,
 }
 
 /// Build the NUL-separated, NUL-terminated wire blob procmgr's
@@ -46,6 +50,81 @@ pub(crate) fn build_blob(tokens: &[String]) -> (Vec<u8>, u32)
         blob.push(0);
     }
     (blob, tokens.len() as u32)
+}
+
+/// Delete a set of cap slots, skipping the zero sentinel. Used on the
+/// launch/restart cleanup paths where a partially-assembled cap set must
+/// be released; deleting an already-transferred slot is a kernel no-op.
+pub(crate) fn delete_caps(caps: &[u32])
+{
+    for &c in caps
+    {
+        if c != 0
+        {
+            let _ = syscall::cap_delete(c);
+        }
+    }
+}
+
+/// Assemble a child's bootstrap cap set: the provider service-endpoint
+/// RECV (`provided_recv`, cap[0]) ahead of the positional `seeds`, capped
+/// at `MSG_CAP_SLOTS_MAX`. A `provided_recv` of `0` (pure consumer) is
+/// skipped. Overflow seeds beyond the cap are deleted so they don't leak.
+/// Consumes `seeds`.
+pub(crate) fn assemble_boot_caps(provided_recv: u32, seeds: Vec<u32>) -> Vec<u32>
+{
+    let mut caps: Vec<u32> = Vec::with_capacity(syscall_abi::MSG_CAP_SLOTS_MAX);
+    if provided_recv != 0
+    {
+        caps.push(provided_recv);
+    }
+    for c in seeds
+    {
+        if caps.len() < syscall_abi::MSG_CAP_SLOTS_MAX
+        {
+            caps.push(c);
+        }
+        else if c != 0
+        {
+            let _ = syscall::cap_delete(c);
+        }
+    }
+    caps
+}
+
+/// Publish a `provides` service's endpoint under its registry name once
+/// the endpoint exists, so consumers launched after it resolve the name.
+/// The endpoint persists on the `ServiceEntry`, so the SEND stays valid
+/// across restarts. No-op for a pure consumer (`provided_endpoint == 0`)
+/// or a service with no `provides` name.
+fn publish_provided(
+    provided_endpoint: u32,
+    provides: Option<&str>,
+    registry: &mut registry::Registry<REGISTRY_CAPACITY>,
+    svc_name: &str,
+)
+{
+    let Some(name) = provides
+    else
+    {
+        return;
+    };
+    if provided_endpoint == 0
+    {
+        return;
+    }
+    if let Ok(send) = syscall::cap_derive(provided_endpoint, syscall::RIGHTS_SEND)
+    {
+        if registry.publish(name.as_bytes(), send).is_err()
+        {
+            std::os::seraph::log!("launch {svc_name}: publish {name:?} failed");
+            let _ = syscall::cap_delete(send);
+        }
+    }
+    else
+    {
+        std::os::seraph::log!("launch {svc_name}: provider SEND derive failed");
+    }
 }
 
 /// Spawn a service from its parsed `.svc` definition.
@@ -109,19 +188,61 @@ pub fn launch(
         return None;
     }
 
+    // A `provides` service serves its own service endpoint on bootstrap
+    // cap[0]. Create it now (after namespace + death bind, before seeds)
+    // so svcmgr owns the persistent source: the child receives a RECV
+    // derivation, consumers a published SEND, and a restart re-serves a
+    // fresh RECV on the same object. Created before START_PROCESS so a
+    // failure still lands on the destroyable partial child.
+    let provided_endpoint = if def.provides.is_some()
+    {
+        let Ok(ep) = syscall::cap_create_endpoint(ctx.endpoint_slab)
+        else
+        {
+            std::os::seraph::log!("launch {}: provider endpoint create failed", def.name);
+            destroy_partial_child(created.process_handle, created.thread_cap, ctx.ipc_buf);
+            return None;
+        };
+        ep
+    }
+    else
+    {
+        0
+    };
+
     // Resolve seeds AFTER namespace setup so a seed-lookup miss does
     // not leave a configured-but-orphan partial child; if the seed
     // section fails, we still tear down here before launching.
     let seed_caps = resolve_seeds(&def.seed, &def.name, registry);
 
+    // Bootstrap cap set: a provider's own service-endpoint RECV is cap[0],
+    // ahead of the positional seeds. Derive it before assembly so a derive
+    // failure tears the partial child down cleanly.
+    let provided_recv = if provided_endpoint != 0
+    {
+        let Ok(recv) = syscall::cap_derive(provided_endpoint, syscall::RIGHTS_RECEIVE)
+        else
+        {
+            std::os::seraph::log!("launch {}: provider RECV derive failed", def.name);
+            delete_caps(&seed_caps);
+            let _ = syscall::cap_delete(provided_endpoint);
+            destroy_partial_child(created.process_handle, created.thread_cap, ctx.ipc_buf);
+            return None;
+        };
+        recv
+    }
+    else
+    {
+        0
+    };
+    let boot_caps = assemble_boot_caps(provided_recv, seed_caps);
+
     if !start_process(created.process_handle, ctx.ipc_buf)
     {
-        for &c in &seed_caps
+        delete_caps(&boot_caps);
+        if provided_endpoint != 0
         {
-            if c != 0
-            {
-                let _ = syscall::cap_delete(c);
-            }
+            let _ = syscall::cap_delete(provided_endpoint);
         }
         destroy_partial_child(created.process_handle, created.thread_cap, ctx.ipc_buf);
         return None;
@@ -134,7 +255,7 @@ pub fn launch(
             created.child_token,
             ctx.ipc_buf,
             true,
-            &seed_caps,
+            &boot_caps,
             &[],
         )
     };
@@ -143,18 +264,22 @@ pub fn launch(
         std::os::seraph::log!("launch {}: bootstrap serve failed", def.name);
         // Process is already started; can't unspawn. The child will
         // observe an empty bootstrap and degrade per its own logic.
-        for &c in &seed_caps
-        {
-            if c != 0
-            {
-                let _ = syscall::cap_delete(c);
-            }
-        }
+        delete_caps(&boot_caps);
     }
+
+    // Publish the provided name now that the endpoint exists, so consumers
+    // launched after this provider resolve it.
+    publish_provided(
+        provided_endpoint,
+        def.provides.as_deref(),
+        registry,
+        &def.name,
+    );
 
     Some(Launched {
         thread_cap: created.thread_cap,
         process_handle: created.process_handle,
+        provided_endpoint,
     })
 }
 

--- a/services/svcmgr/src/definitions/launch.rs
+++ b/services/svcmgr/src/definitions/launch.rs
@@ -12,7 +12,7 @@
 //! the freshly spawned child's thread cap so the caller can bind
 //! death-notification on it.
 
-use super::{Definition, NamespaceShape};
+use super::{Definition, NamespaceShape, ProvidedName};
 use crate::REGISTRY_CAPACITY;
 use crate::registry_lookup_derived;
 use crate::restart::{
@@ -92,38 +92,49 @@ pub(crate) fn assemble_boot_caps(provided_recv: u32, seeds: Vec<u32>) -> Vec<u32
     caps
 }
 
-/// Publish a `provides` service's endpoint under its registry name once
-/// the endpoint exists, so consumers launched after it resolve the name.
-/// The endpoint persists on the `ServiceEntry`, so the SEND stays valid
-/// across restarts. No-op for a pure consumer (`provided_endpoint == 0`)
-/// or a service with no `provides` name.
+/// Publish each name in a provider's `provides` list under the discovery
+/// registry once the endpoint exists, so consumers launched after it
+/// resolve them. Each name's SEND is stamped with its
+/// [`ProvidedName::token`] (`cap_derive_token` when non-zero, plain
+/// `cap_derive` for a bare entry); the token rides through to a
+/// consumer's `QUERY_ENDPOINT` lookup unchanged. The endpoint persists on
+/// the `ServiceEntry`, so the SENDs stay valid across restarts. No-op for
+/// a pure consumer (`provided_endpoint == 0`) or an empty list.
 fn publish_provided(
     provided_endpoint: u32,
-    provides: Option<&str>,
+    provides: &[ProvidedName],
     registry: &mut registry::Registry<REGISTRY_CAPACITY>,
     svc_name: &str,
 )
 {
-    let Some(name) = provides
-    else
-    {
-        return;
-    };
     if provided_endpoint == 0
     {
         return;
     }
-    if let Ok(send) = syscall::cap_derive(provided_endpoint, syscall::RIGHTS_SEND)
+    for p in provides
     {
-        if registry.publish(name.as_bytes(), send).is_err()
+        let derived = if p.token == 0
         {
-            std::os::seraph::log!("launch {svc_name}: publish {name:?} failed");
+            syscall::cap_derive(provided_endpoint, syscall::RIGHTS_SEND)
+        }
+        else
+        {
+            syscall::cap_derive_token(provided_endpoint, syscall::RIGHTS_SEND, p.token)
+        };
+        let Ok(send) = derived
+        else
+        {
+            std::os::seraph::log!(
+                "launch {svc_name}: provider SEND derive for {:?} failed",
+                p.name
+            );
+            continue;
+        };
+        if registry.publish(p.name.as_bytes(), send).is_err()
+        {
+            std::os::seraph::log!("launch {svc_name}: publish {:?} failed", p.name);
             let _ = syscall::cap_delete(send);
         }
-    }
-    else
-    {
-        std::os::seraph::log!("launch {svc_name}: provider SEND derive failed");
     }
 }
 
@@ -194,7 +205,11 @@ pub fn launch(
     // derivation, consumers a published SEND, and a restart re-serves a
     // fresh RECV on the same object. Created before START_PROCESS so a
     // failure still lands on the destroyable partial child.
-    let provided_endpoint = if def.provides.is_some()
+    let provided_endpoint = if def.provides.is_empty()
+    {
+        0
+    }
+    else
     {
         let Ok(ep) = syscall::cap_create_endpoint(ctx.endpoint_slab)
         else
@@ -204,10 +219,6 @@ pub fn launch(
             return None;
         };
         ep
-    }
-    else
-    {
-        0
     };
 
     // Resolve seeds AFTER namespace setup so a seed-lookup miss does
@@ -269,12 +280,7 @@ pub fn launch(
 
     // Publish the provided name now that the endpoint exists, so consumers
     // launched after this provider resolve it.
-    publish_provided(
-        provided_endpoint,
-        def.provides.as_deref(),
-        registry,
-        &def.name,
-    );
+    publish_provided(provided_endpoint, &def.provides, registry, &def.name);
 
     Some(Launched {
         thread_cap: created.thread_cap,

--- a/services/svcmgr/src/definitions/launch.rs
+++ b/services/svcmgr/src/definitions/launch.rs
@@ -12,6 +12,8 @@
 //! the freshly spawned child's thread cap so the caller can bind
 //! death-notification on it.
 
+use ipc::{devmgr_labels, procmgr_labels};
+
 use super::{Definition, NamespaceShape, ProvidedName};
 use crate::REGISTRY_CAPACITY;
 use crate::registry_lookup_derived;
@@ -92,6 +94,70 @@ pub(crate) fn assemble_boot_caps(provided_recv: u32, seeds: Vec<u32>) -> Vec<u32
     caps
 }
 
+/// Mint the four bootstrap caps real-logd expects, from the reserved
+/// log-sink sources svcmgr holds for the system's life:
+///   * `[0]` master-log endpoint RECV (svcmgr's source stays valid, so a
+///     fresh RECV reattaches each (re)launched logd to the same object that
+///     every sender's `log_send_cap` targets);
+///   * `[1]` a SEND on the same endpoint for the one-shot `HANDOVER_PULL`,
+///     present only on the first launch — a restart has no init-logd to pull
+///     from, so this is `0` and logd skips the history pull;
+///   * `[2]` a `DEATH_EQ_AUTHORITY` SEND on procmgr (logd registers sender
+///     death-notifications for slot reclaim) — `SEND|GRANT` because that
+///     registration transfers a cap;
+///   * `[3]` a `REGISTRY_QUERY_AUTHORITY` SEND on devmgr's registry (logd
+///     resolves the serial driver via `QUERY_SERIAL_DEVICE`).
+///
+/// A source absent from the endowment yields `0` in its slot; logd then
+/// degrades on first use of that cap. The four slots are positional, so
+/// zeros are preserved (the round still carries `MSG_CAP_SLOTS_MAX` caps).
+pub(crate) fn mint_logd_boot_caps(ctx: &RestartCtx, first_launch: bool) -> Vec<u32>
+{
+    let recv = if ctx.master_log_source != 0
+    {
+        syscall::cap_derive(ctx.master_log_source, syscall::RIGHTS_RECEIVE).unwrap_or(0)
+    }
+    else
+    {
+        0
+    };
+    let handover_send = if first_launch && ctx.master_log_source != 0
+    {
+        syscall::cap_derive(ctx.master_log_source, syscall::RIGHTS_SEND).unwrap_or(0)
+    }
+    else
+    {
+        0
+    };
+    let death_auth = if ctx.procmgr_death_auth_source != 0
+    {
+        syscall::cap_derive_token(
+            ctx.procmgr_death_auth_source,
+            syscall::RIGHTS_SEND_GRANT,
+            procmgr_labels::DEATH_EQ_AUTHORITY,
+        )
+        .unwrap_or(0)
+    }
+    else
+    {
+        0
+    };
+    let registry_query = if ctx.devmgr_registry != 0
+    {
+        syscall::cap_derive_token(
+            ctx.devmgr_registry,
+            syscall::RIGHTS_SEND,
+            devmgr_labels::REGISTRY_QUERY_AUTHORITY,
+        )
+        .unwrap_or(0)
+    }
+    else
+    {
+        0
+    };
+    std::vec![recv, handover_send, death_auth, registry_query]
+}
+
 /// Publish each name in a provider's `provides` list under the discovery
 /// registry once the endpoint exists, so consumers launched after it
 /// resolve them. Each name's SEND is stamped with its
@@ -136,6 +202,66 @@ fn publish_provided(
             let _ = syscall::cap_delete(send);
         }
     }
+}
+
+/// Assemble the non-log-sink bootstrap cap set: create the persistent
+/// provider service endpoint (when `provides` is non-empty) so svcmgr owns the
+/// restart-stable source, resolve the `seed` caps, and lead with the provider
+/// RECV as cap[0] ahead of the positional seeds. Returns
+/// `(provided_endpoint, boot_caps)`; `provided_endpoint` is `0` for a pure
+/// consumer. Runs after namespace + death bind and before `START_PROCESS`, so
+/// any failure destroys the partial child and returns `None`.
+fn assemble_provided_boot_caps(
+    def: &Definition,
+    created: &CreatedProcess,
+    ctx: &RestartCtx,
+    registry: &mut registry::Registry<REGISTRY_CAPACITY>,
+) -> Option<(u32, Vec<u32>)>
+{
+    let provided_endpoint = if def.provides.is_empty()
+    {
+        0
+    }
+    else
+    {
+        let Ok(ep) = syscall::cap_create_endpoint(ctx.endpoint_slab)
+        else
+        {
+            std::os::seraph::log!("launch {}: provider endpoint create failed", def.name);
+            destroy_partial_child(created.process_handle, created.thread_cap, ctx.ipc_buf);
+            return None;
+        };
+        ep
+    };
+
+    // Resolve seeds AFTER namespace setup so a seed-lookup miss does not leave a
+    // configured-but-orphan partial child; on failure we still tear down here.
+    let seed_caps = resolve_seeds(&def.seed, &def.name, registry);
+
+    // A provider's own service-endpoint RECV is cap[0], ahead of the positional
+    // seeds. Derive it before assembly so a derive failure tears the partial
+    // child down cleanly.
+    let provided_recv = if provided_endpoint != 0
+    {
+        let Ok(recv) = syscall::cap_derive(provided_endpoint, syscall::RIGHTS_RECEIVE)
+        else
+        {
+            std::os::seraph::log!("launch {}: provider RECV derive failed", def.name);
+            delete_caps(&seed_caps);
+            let _ = syscall::cap_delete(provided_endpoint);
+            destroy_partial_child(created.process_handle, created.thread_cap, ctx.ipc_buf);
+            return None;
+        };
+        recv
+    }
+    else
+    {
+        0
+    };
+    Some((
+        provided_endpoint,
+        assemble_boot_caps(provided_recv, seed_caps),
+    ))
 }
 
 /// Spawn a service from its parsed `.svc` definition.
@@ -199,54 +325,18 @@ pub fn launch(
         return None;
     }
 
-    // A `provides` service serves its own service endpoint on bootstrap
-    // cap[0]. Create it now (after namespace + death bind, before seeds)
-    // so svcmgr owns the persistent source: the child receives a RECV
-    // derivation, consumers a published SEND, and a restart re-serves a
-    // fresh RECV on the same object. Created before START_PROCESS so a
-    // failure still lands on the destroyable partial child.
-    let provided_endpoint = if def.provides.is_empty()
+    // Bootstrap cap set + (for providers) the persistent service endpoint.
+    // The log-sink service (real-logd) gets a svcmgr-minted round from the
+    // reserved log-sink sources; the parser guarantees it declares neither
+    // `provides` nor `seed`, so it never enters the provider/seed path.
+    let (provided_endpoint, boot_caps) = if def.log_sink
     {
-        0
+        (0, mint_logd_boot_caps(ctx, true))
     }
     else
     {
-        let Ok(ep) = syscall::cap_create_endpoint(ctx.endpoint_slab)
-        else
-        {
-            std::os::seraph::log!("launch {}: provider endpoint create failed", def.name);
-            destroy_partial_child(created.process_handle, created.thread_cap, ctx.ipc_buf);
-            return None;
-        };
-        ep
+        assemble_provided_boot_caps(def, &created, ctx, registry)?
     };
-
-    // Resolve seeds AFTER namespace setup so a seed-lookup miss does
-    // not leave a configured-but-orphan partial child; if the seed
-    // section fails, we still tear down here before launching.
-    let seed_caps = resolve_seeds(&def.seed, &def.name, registry);
-
-    // Bootstrap cap set: a provider's own service-endpoint RECV is cap[0],
-    // ahead of the positional seeds. Derive it before assembly so a derive
-    // failure tears the partial child down cleanly.
-    let provided_recv = if provided_endpoint != 0
-    {
-        let Ok(recv) = syscall::cap_derive(provided_endpoint, syscall::RIGHTS_RECEIVE)
-        else
-        {
-            std::os::seraph::log!("launch {}: provider RECV derive failed", def.name);
-            delete_caps(&seed_caps);
-            let _ = syscall::cap_delete(provided_endpoint);
-            destroy_partial_child(created.process_handle, created.thread_cap, ctx.ipc_buf);
-            return None;
-        };
-        recv
-    }
-    else
-    {
-        0
-    };
-    let boot_caps = assemble_boot_caps(provided_recv, seed_caps);
 
     if !start_process(created.process_handle, ctx.ipc_buf)
     {

--- a/services/svcmgr/src/definitions/mod.rs
+++ b/services/svcmgr/src/definitions/mod.rs
@@ -102,16 +102,37 @@ pub struct Definition
     /// Published-registry names svcmgr resolves at launch time and
     /// injects positionally into the child's bootstrap round.
     pub seed: Vec<String>,
-    /// Registry name this service's own service endpoint is published
-    /// under. When set, svcmgr's launch path creates a service endpoint,
-    /// serves its RECV half as bootstrap cap[0] (ahead of the `seed`
-    /// caps), and publishes a SEND half under this name. The endpoint
-    /// persists across restarts (svcmgr holds the source), so a cached
-    /// client cap survives a crash-restart cycle. `None` for pure-consumer
-    /// services that only receive `seed` caps. A `provides` service also
-    /// launches ahead of pure consumers during reconciliation so its name
-    /// resolves before any consumer queries it.
-    pub provides: Option<String>,
+    /// Registry names this service's own service endpoint is published
+    /// under. When non-empty, svcmgr's launch path creates a service
+    /// endpoint, serves its RECV half as bootstrap cap[0] (ahead of the
+    /// `seed` caps), and publishes one SEND half per entry — each stamped
+    /// with that entry's [`ProvidedName::token`] — into the discovery
+    /// registry. The endpoint persists across restarts (svcmgr holds the
+    /// source), so cached client caps survive a crash-restart cycle and no
+    /// re-publish is needed. Empty for pure-consumer services that only
+    /// receive `seed` caps. A provider also launches ahead of pure
+    /// consumers during reconciliation so its names resolve before any
+    /// consumer queries them.
+    pub provides: Vec<ProvidedName>,
+}
+
+/// One published name in a service's `provides = ...` list, with the
+/// token svcmgr stamps on the SEND it publishes.
+///
+/// The token rides through publish → registry → `QUERY_ENDPOINT` lookup
+/// unchanged (`cap_derive` inherits a source cap's token), so a consumer
+/// that resolves the name receives a SEND already carrying it. The verb
+/// the server gates on is `token & (1 << 63)`, the universal
+/// verb-authority bit shared by every `*_AUTHORITY` constant.
+#[derive(Clone, Debug)]
+pub struct ProvidedName
+{
+    pub name: String,
+    /// `1 << 63` for an `:auth` entry (carries the verb-authority bit),
+    /// `1` for a `:deny` entry (present but gate-failing), `0` for a bare
+    /// entry (untokened — published via `cap_derive`, not
+    /// `cap_derive_token`).
+    pub token: u64,
 }
 
 /// Directory svcmgr scans for service definitions. Absolute path

--- a/services/svcmgr/src/definitions/mod.rs
+++ b/services/svcmgr/src/definitions/mod.rs
@@ -102,6 +102,16 @@ pub struct Definition
     /// Published-registry names svcmgr resolves at launch time and
     /// injects positionally into the child's bootstrap round.
     pub seed: Vec<String>,
+    /// Registry name this service's own service endpoint is published
+    /// under. When set, svcmgr's launch path creates a service endpoint,
+    /// serves its RECV half as bootstrap cap[0] (ahead of the `seed`
+    /// caps), and publishes a SEND half under this name. The endpoint
+    /// persists across restarts (svcmgr holds the source), so a cached
+    /// client cap survives a crash-restart cycle. `None` for pure-consumer
+    /// services that only receive `seed` caps. A `provides` service also
+    /// launches ahead of pure consumers during reconciliation so its name
+    /// resolves before any consumer queries it.
+    pub provides: Option<String>,
 }
 
 /// Directory svcmgr scans for service definitions. Absolute path

--- a/services/svcmgr/src/definitions/mod.rs
+++ b/services/svcmgr/src/definitions/mod.rs
@@ -9,9 +9,12 @@
 //! `/config/svcmgr/services/<name>.svc`. The file is the **single
 //! source of truth** for the service's recipe: binary path, argv,
 //! env, restart policy, criticality, namespace shape, optional cwd,
-//! and the named seed caps to inject into its bootstrap round. The
-//! same definition drives both first-launch (when init didn't
-//! bootstrap the service) and restart (when init did).
+//! and the named seed caps to inject into its bootstrap round. A
+//! `log_sink = yes` recipe (the master log sink, real-logd) instead
+//! takes a svcmgr-minted bootstrap round from the reserved log-sink
+//! sources and declares neither `seed` nor `provides`. The same
+//! definition drives both first-launch (when init didn't bootstrap
+//! the service) and restart (when init did).
 //!
 //! At [`crate::svcmgr_labels::HANDOVER_COMPLETE`] svcmgr calls
 //! [`reconcile_and_launch`]:
@@ -146,6 +149,6 @@ pub struct ProvidedName
 }
 
 /// Directory svcmgr scans for service definitions. Absolute path
-/// against svcmgr's `system_root_cap`; post-#21 handover that cap is
-/// universal, so absolute lookups via `std::fs` resolve normally.
+/// against svcmgr's `system_root_cap`. That cap is universal, so
+/// absolute lookups via `std::fs` resolve normally.
 pub const SERVICES_DIR: &str = "/config/svcmgr/services";

--- a/services/svcmgr/src/definitions/mod.rs
+++ b/services/svcmgr/src/definitions/mod.rs
@@ -17,14 +17,15 @@
 //! [`reconcile_and_launch`]:
 //!
 //! 1. Scan [`SERVICES_DIR`] and parse every `.svc` into a [`Definition`].
-//! 2. Reconcile against the pending-registration table init populated
-//!    via [`crate::svcmgr_labels::REGISTER_SERVICE`]:
-//!    - **Defined AND registered**: bind death-notification on the
-//!      registered thread cap and store the parsed `Definition` on
-//!      the `ServiceEntry` for restart use.
+//! 2. Reconcile against the pending-registration table
+//!    [`crate::service::bootstrap_caps`] populated from init's handover
+//!    endowment (one substrate `(name, thread_cap)` round each):
+//!    - **Defined AND parked**: bind death-notification on the endowed
+//!      thread cap and store the parsed `Definition` on the
+//!      `ServiceEntry` for restart use.
 //!    - **Defined only**: launch the service via [`launch::launch`].
-//!    - **Registered without definition**: log a hard error and
-//!      refuse to bind — svcmgr has no recipe to restart it.
+//!    - **Parked without definition**: log a hard error and refuse to
+//!      bind — svcmgr has no recipe to restart it.
 //!
 //! After reconciliation the supervision loop proceeds as today.
 

--- a/services/svcmgr/src/definitions/mod.rs
+++ b/services/svcmgr/src/definitions/mod.rs
@@ -115,6 +115,15 @@ pub struct Definition
     /// consumers during reconciliation so its names resolve before any
     /// consumer queries them.
     pub provides: Vec<ProvidedName>,
+    /// `log_sink = yes` marks the service as the system log sink (real-logd).
+    /// svcmgr mints its bootstrap round — master-log RECV, the first-launch
+    /// `HANDOVER_PULL` SEND, a `DEATH_EQ_AUTHORITY` SEND, and a
+    /// `devmgr.registry` query cap — from the reserved log-sink sources and
+    /// the `devmgr.registry` source it holds, rather than from `seed` /
+    /// `provides` (which the parser rejects in combination). Exactly one
+    /// recipe carries this; supervision/restart otherwise follow the normal
+    /// `restart`/`critical` fields.
+    pub log_sink: bool,
 }
 
 /// One published name in a service's `provides = ...` list, with the

--- a/services/svcmgr/src/definitions/parse.rs
+++ b/services/svcmgr/src/definitions/parse.rs
@@ -70,6 +70,7 @@ pub fn parse(name: &str, contents: &str) -> Result<Definition, ParseError>
     let mut cwd: Option<String> = None;
     let mut seed: Vec<String> = Vec::new();
     let mut provides: Vec<ProvidedName> = Vec::new();
+    let mut log_sink: Option<bool> = None;
 
     let mut seen_argv = false;
     let mut seen_env = false;
@@ -233,6 +234,25 @@ pub fn parse(name: &str, contents: &str) -> Result<Definition, ParseError>
                     ));
                 }
             }
+            "log_sink" =>
+            {
+                if log_sink.is_some()
+                {
+                    return Err(ParseError::DuplicateKey(lineno, "log_sink"));
+                }
+                log_sink = Some(match value
+                {
+                    "yes" => true,
+                    "no" => false,
+                    _ =>
+                    {
+                        return Err(ParseError::InvalidValue(
+                            lineno,
+                            "log_sink must be yes or no",
+                        ));
+                    }
+                });
+            }
             other => return Err(ParseError::UnknownKey(lineno, other.to_owned())),
         }
     }
@@ -250,6 +270,18 @@ pub fn parse(name: &str, contents: &str) -> Result<Definition, ParseError>
         ));
     }
 
+    let log_sink = log_sink.unwrap_or(false);
+    if log_sink && (!seed.is_empty() || !provides.is_empty())
+    {
+        // A log-sink service's bootstrap caps are minted by svcmgr from the
+        // reserved log-sink sources, so registry-resolved seeds / provided
+        // endpoints have no slot in its round.
+        return Err(ParseError::InvalidValue(
+            0,
+            "log_sink is exclusive of seed and provides",
+        ));
+    }
+
     Ok(Definition {
         name: name.to_owned(),
         binary,
@@ -261,6 +293,7 @@ pub fn parse(name: &str, contents: &str) -> Result<Definition, ParseError>
         cwd,
         seed,
         provides,
+        log_sink,
     })
 }
 

--- a/services/svcmgr/src/definitions/parse.rs
+++ b/services/svcmgr/src/definitions/parse.rs
@@ -15,7 +15,17 @@
 
 use namespace_protocol::rights as ns_rights;
 
-use super::{Definition, NamespaceShape, RestartPolicy};
+use super::{Definition, NamespaceShape, ProvidedName, RestartPolicy};
+
+/// Token stamped on an `:auth` provider SEND — the universal
+/// verb-authority bit (`1 << 63`), shared by every `*_AUTHORITY`
+/// constant the various services gate on.
+const PROVIDES_AUTH_TOKEN: u64 = 1 << 63;
+/// Token stamped on a `:deny` provider SEND — present so the cap
+/// resolves, but lacking the authority bit, so the server's
+/// `token & (1 << 63)` gate fails. Distinct from a bare (untokened)
+/// entry only in intent; both are rejected by an authority gate.
+const PROVIDES_DENY_TOKEN: u64 = 1;
 
 /// Reasons a `.svc` file is rejected. Stringified into the boot log so
 /// an operator can find the bad line at a glance.
@@ -59,12 +69,13 @@ pub fn parse(name: &str, contents: &str) -> Result<Definition, ParseError>
     let mut namespace: Option<NamespaceShape> = None;
     let mut cwd: Option<String> = None;
     let mut seed: Vec<String> = Vec::new();
-    let mut provides: Option<String> = None;
+    let mut provides: Vec<ProvidedName> = Vec::new();
 
     let mut seen_argv = false;
     let mut seen_env = false;
     let mut seen_cwd = false;
     let mut seen_seed = false;
+    let mut seen_provides = false;
 
     for (idx, raw) in contents.lines().enumerate()
     {
@@ -182,18 +193,45 @@ pub fn parse(name: &str, contents: &str) -> Result<Definition, ParseError>
             }
             "provides" =>
             {
-                if provides.is_some()
+                if seen_provides
                 {
                     return Err(ParseError::DuplicateKey(lineno, "provides"));
                 }
-                if value.is_empty() || value.len() > registry::NAME_MAX
+                seen_provides = true;
+                for tok in value.split_whitespace()
+                {
+                    let (name, token) = match tok.split_once(':')
+                    {
+                        Some((n, "auth")) => (n, PROVIDES_AUTH_TOKEN),
+                        Some((n, "deny")) => (n, PROVIDES_DENY_TOKEN),
+                        Some((_, _)) =>
+                        {
+                            return Err(ParseError::InvalidValue(
+                                lineno,
+                                "provides suffix must be :auth or :deny",
+                            ));
+                        }
+                        None => (tok, 0),
+                    };
+                    if name.is_empty() || name.len() > registry::NAME_MAX
+                    {
+                        return Err(ParseError::InvalidValue(
+                            lineno,
+                            "provides name must be non-empty and <= NAME_MAX bytes",
+                        ));
+                    }
+                    provides.push(ProvidedName {
+                        name: name.to_owned(),
+                        token,
+                    });
+                }
+                if provides.is_empty()
                 {
                     return Err(ParseError::InvalidValue(
                         lineno,
-                        "provides must be a non-empty name <= NAME_MAX bytes",
+                        "provides must list at least one name",
                     ));
                 }
-                provides = Some(value.to_owned());
             }
             other => return Err(ParseError::UnknownKey(lineno, other.to_owned())),
         }

--- a/services/svcmgr/src/definitions/parse.rs
+++ b/services/svcmgr/src/definitions/parse.rs
@@ -59,6 +59,7 @@ pub fn parse(name: &str, contents: &str) -> Result<Definition, ParseError>
     let mut namespace: Option<NamespaceShape> = None;
     let mut cwd: Option<String> = None;
     let mut seed: Vec<String> = Vec::new();
+    let mut provides: Option<String> = None;
 
     let mut seen_argv = false;
     let mut seen_env = false;
@@ -179,6 +180,21 @@ pub fn parse(name: &str, contents: &str) -> Result<Definition, ParseError>
                 seen_seed = true;
                 seed = value.split_whitespace().map(str::to_owned).collect();
             }
+            "provides" =>
+            {
+                if provides.is_some()
+                {
+                    return Err(ParseError::DuplicateKey(lineno, "provides"));
+                }
+                if value.is_empty() || value.len() > registry::NAME_MAX
+                {
+                    return Err(ParseError::InvalidValue(
+                        lineno,
+                        "provides must be a non-empty name <= NAME_MAX bytes",
+                    ));
+                }
+                provides = Some(value.to_owned());
+            }
             other => return Err(ParseError::UnknownKey(lineno, other.to_owned())),
         }
     }
@@ -206,6 +222,7 @@ pub fn parse(name: &str, contents: &str) -> Result<Definition, ParseError>
         namespace,
         cwd,
         seed,
+        provides,
     })
 }
 

--- a/services/svcmgr/src/definitions/reconcile.rs
+++ b/services/svcmgr/src/definitions/reconcile.rs
@@ -134,6 +134,12 @@ pub fn reconcile_and_launch(
     // discovery-registry lookups, not file-system ordering).
     entries.sort();
 
+    // Parse every recipe first, then order providers (services that
+    // publish their own endpoint via `provides = ...`) ahead of pure
+    // consumers, so a provided name is in the discovery registry before
+    // any consumer launched here resolves it. `sort_by_key` is stable, so
+    // alphabetical order is preserved within each group.
+    let mut defs: Vec<Definition> = Vec::with_capacity(entries.len());
     for filename in &entries
     {
         let service_name = filename.trim_end_matches(".svc");
@@ -150,18 +156,18 @@ pub fn reconcile_and_launch(
                 continue;
             }
         };
-        let def = match parse(service_name, &contents)
+        match parse(service_name, &contents)
         {
-            Ok(d) => d,
-            Err(e) =>
-            {
-                log!("svcmgr: parse {path}: {e}");
-                continue;
-            }
-        };
+            Ok(d) => defs.push(d),
+            Err(e) => log!("svcmgr: parse {path}: {e}"),
+        }
+    }
+    defs.sort_by_key(|d| d.provides.is_none());
 
+    for def in &defs
+    {
         handle_definition(
-            &def,
+            def,
             pending,
             pending_count,
             services,
@@ -233,6 +239,10 @@ fn handle_definition(
         log!("svcmgr: launched ephemeral: {}", def.name);
         let _ = syscall::cap_delete(launched.thread_cap);
         let _ = syscall::cap_delete(launched.process_handle);
+        if launched.provided_endpoint != 0
+        {
+            let _ = syscall::cap_delete(launched.provided_endpoint);
+        }
         return;
     }
 
@@ -261,7 +271,12 @@ fn handle_definition(
         return;
     };
 
-    services[idx] = build_entry(def, launched.thread_cap, launched.process_handle);
+    services[idx] = build_entry(
+        def,
+        launched.thread_cap,
+        launched.process_handle,
+        launched.provided_endpoint,
+    );
     recipes[idx] = Some(recipe_from(def));
 }
 
@@ -297,7 +312,7 @@ fn bind_only(
         let _ = syscall::cap_delete(thread_cap);
         return;
     }
-    services[idx] = build_entry(def, thread_cap, 0);
+    services[idx] = build_entry(def, thread_cap, 0, 0);
     recipes[idx] = Some(recipe_from(def));
     *service_count += 1;
 }
@@ -320,7 +335,12 @@ fn recipe_from(def: &Definition) -> RestartRecipe
 /// Maps the `.svc` `restart`/`critical`/`namespace` values onto the
 /// in-memory `ServiceEntry` representation `restart::handle_death`
 /// reads.
-fn build_entry(def: &Definition, thread_cap: u32, process_handle: u32) -> ServiceEntry
+fn build_entry(
+    def: &Definition,
+    thread_cap: u32,
+    process_handle: u32,
+    provided_endpoint: u32,
+) -> ServiceEntry
 {
     let mut entry = ServiceEntry::empty();
 
@@ -330,7 +350,7 @@ fn build_entry(def: &Definition, thread_cap: u32, process_handle: u32) -> Servic
     entry.name_len = copy_len as u8;
 
     entry.thread_cap = thread_cap;
-    entry.module_cap = 0;
+    entry.provided_endpoint = provided_endpoint;
     entry.process_handle = process_handle;
 
     let bin_bytes = def.binary.as_bytes();

--- a/services/svcmgr/src/definitions/reconcile.rs
+++ b/services/svcmgr/src/definitions/reconcile.rs
@@ -328,6 +328,7 @@ fn recipe_from(def: &Definition) -> RestartRecipe
         env: def.env.clone(),
         cwd: def.cwd.clone(),
         seed: def.seed.clone(),
+        log_sink: def.log_sink,
     }
 }
 

--- a/services/svcmgr/src/definitions/reconcile.rs
+++ b/services/svcmgr/src/definitions/reconcile.rs
@@ -206,10 +206,10 @@ fn handle_definition(
         slot.consumed = true;
         log!("svcmgr: bind only: {}", def.name);
         // init-created service: svcmgr has no process_handle (init
-        // didn't share it). First death cannot DESTROY_PROCESS; this
-        // matches the pre-#21 shape — see `restart::restart_process`.
-        // Bind happens after the fact (the thread has been running
-        // since Phase 1/2/3 spawn) — a death in that window is lost.
+        // didn't share it). First death cannot DESTROY_PROCESS — see
+        // `restart::restart_process`. Bind happens after the fact (the
+        // thread has been running since its bootstrap spawn) — a death
+        // in that window is lost.
         // Closing that race is kernel-protocol work; tracked as a
         // follow-up.
         bind_only(

--- a/services/svcmgr/src/definitions/reconcile.rs
+++ b/services/svcmgr/src/definitions/reconcile.rs
@@ -162,7 +162,7 @@ pub fn reconcile_and_launch(
             Err(e) => log!("svcmgr: parse {path}: {e}"),
         }
     }
-    defs.sort_by_key(|d| d.provides.is_none());
+    defs.sort_by_key(|d| d.provides.is_empty());
 
     for def in &defs
     {

--- a/services/svcmgr/src/definitions/reconcile.rs
+++ b/services/svcmgr/src/definitions/reconcile.rs
@@ -3,9 +3,9 @@
 
 // svcmgr/src/definitions/reconcile.rs
 
-//! Post-handover reconciliation between init's `REGISTER_SERVICE`
-//! announcements and the on-disk `/config/svcmgr/services/` recipe
-//! set.
+//! Post-handover reconciliation between the substrate registrations init
+//! delivers in the handover endowment and the on-disk
+//! `/config/svcmgr/services/` recipe set.
 //!
 //! Three outcomes per `.svc` file:
 //!
@@ -32,10 +32,10 @@ use crate::service::{
     MAX_SERVICES, POLICY_ALWAYS, POLICY_NEVER, POLICY_ON_FAILURE, RestartRecipe, ServiceEntry,
 };
 
-/// Entry in init's pending-registration table populated by
-/// `REGISTER_SERVICE`. Each entry pairs a service name with the
-/// thread cap svcmgr will bind death-notification on once the
-/// matching `.svc` definition is found.
+/// Entry in svcmgr's pending-registration table populated from init's
+/// handover endowment (one substrate `SUBSTRATE` round each). Each entry
+/// pairs a service name with the thread cap svcmgr will bind
+/// death-notification on once the matching `.svc` definition is found.
 pub struct PendingRegistration
 {
     pub name: [u8; 32],
@@ -196,8 +196,8 @@ fn handle_definition(
     registry: &mut registry::Registry<REGISTRY_CAPACITY>,
 )
 {
-    // Match against pending registrations from init's
-    // REGISTER_SERVICE pass.
+    // Match against pending registrations parked from init's
+    // handover endowment.
     if let Some(slot) = pending
         .iter_mut()
         .take(pending_count)

--- a/services/svcmgr/src/main.rs
+++ b/services/svcmgr/src/main.rs
@@ -406,6 +406,9 @@ fn event_loop(
         ipc_buf,
         deaths_eq,
         endpoint_slab,
+        master_log_source: caps.master_log_source,
+        procmgr_death_auth_source: caps.procmgr_death_auth_source,
+        devmgr_registry: caps.devmgr_registry,
     };
 
     loop

--- a/services/svcmgr/src/main.rs
+++ b/services/svcmgr/src/main.rs
@@ -48,91 +48,6 @@ const REGISTRY_CAPACITY: usize = 8;
 /// than its `ServiceEntry` table can hold.
 const MAX_PENDING_REGISTRATIONS: usize = MAX_SERVICES;
 
-// ── Registration handling ──────────────────────────────────────────────────
-
-/// Handle a `REGISTER_SERVICE` IPC message under the v3 wire (post-#21).
-///
-/// The recipe lives on disk at `/config/svcmgr/services/<name>.svc`; the
-/// wire conveys only what cannot be on disk:
-///
-/// * `word 0`: `SVCMGR_LABELS_VERSION` handshake.
-/// * `word 1`: `name_len` (byte length of the service name).
-/// * `words 2..`: `name` bytes.
-/// * `caps[0]`: thread cap for death-notification binding.
-///
-/// The thread cap is parked in `pending`; binding to the deaths event
-/// queue is deferred to [`definitions::reconcile::reconcile_and_launch`]
-/// after handover, where each pending entry is paired with its `.svc`
-/// definition (or reported as a configuration error if no recipe
-/// exists). See [`ipc::svcmgr_labels::REGISTER_SERVICE`] for the
-/// authoritative spec.
-fn handle_register(
-    msg: &IpcMessage,
-    pending: &mut [PendingRegistration],
-    pending_count: &mut usize,
-) -> u64
-{
-    // IPC delivers caps into svcmgr's CSpace before dispatch — every
-    // reject path must release the delivered thread cap, otherwise a
-    // hostile or buggy registrar can leak a cap per request over
-    // svcmgr's lifetime. The v3 wire only carries one cap; release
-    // every trailing slot the caller may have delivered defensively.
-    let recv_caps = msg.caps();
-    let delivered_cap = recv_caps.first().copied().unwrap_or(0);
-    for &extra in recv_caps.iter().skip(1)
-    {
-        if extra != 0
-        {
-            let _ = syscall::cap_delete(extra);
-        }
-    }
-    let reject = |code: u64| -> u64 {
-        if delivered_cap != 0
-        {
-            let _ = syscall::cap_delete(delivered_cap);
-        }
-        code
-    };
-
-    if msg.word(0) != u64::from(ipc::SVCMGR_LABELS_VERSION)
-    {
-        return reject(ipc::svcmgr_errors::LABEL_VERSION_MISMATCH);
-    }
-
-    let name_len = msg.word(1) as usize;
-    if name_len == 0 || name_len > 32
-    {
-        return reject(ipc::svcmgr_errors::INVALID_NAME);
-    }
-
-    if *pending_count >= MAX_PENDING_REGISTRATIONS
-    {
-        return reject(ipc::svcmgr_errors::TABLE_FULL);
-    }
-
-    if delivered_cap == 0
-    {
-        return ipc::svcmgr_errors::INSUFFICIENT_CAPS;
-    }
-
-    // delivered_cap transfers into PendingRegistration from here.
-    let mut name = [0u8; 32];
-    read_packed_bytes(msg, 2, name_len, &mut name);
-
-    let idx = *pending_count;
-    pending[idx] = PendingRegistration {
-        name,
-        name_len: name_len as u8,
-        thread_cap: delivered_cap,
-        consumed: false,
-    };
-    *pending_count += 1;
-
-    std::os::seraph::log!("registered: {}", pending[idx].name_str());
-
-    ipc::svcmgr_errors::SUCCESS
-}
-
 /// Read a short name packed into IPC data words starting at `first_word`.
 fn read_tail_name_from_msg(
     msg: &IpcMessage,
@@ -189,7 +104,19 @@ fn main() -> !
     #[allow(clippy::cast_ptr_alignment)]
     let ipc_buf = info.ipc_buffer.cast::<u64>();
 
-    let Some(caps) = bootstrap_caps(info, ipc_buf)
+    // State is created before the endowment is drained so `bootstrap_caps`
+    // can park the substrate `(name, thread_cap)` pairs directly in
+    // `state.pending`; `HANDOVER_COMPLETE` reconciles them later.
+    let mut state = SvcmgrState {
+        services: [const { ServiceEntry::empty() }; MAX_SERVICES],
+        recipes: [const { None }; MAX_SERVICES],
+        service_count: 0,
+        pending: [const { PendingRegistration::empty() }; MAX_PENDING_REGISTRATIONS],
+        pending_count: 0,
+        registry: registry::Registry::new(),
+    };
+
+    let Some(caps) = bootstrap_caps(info, ipc_buf, &mut state.pending, &mut state.pending_count)
     else
     {
         syscall::thread_exit();
@@ -261,16 +188,14 @@ fn main() -> !
         halt_loop();
     }
 
-    let mut state = SvcmgrState {
-        services: [const { ServiceEntry::empty() }; MAX_SERVICES],
-        recipes: [const { None }; MAX_SERVICES],
-        service_count: 0,
-        pending: [const { PendingRegistration::empty() }; MAX_PENDING_REGISTRATIONS],
-        pending_count: 0,
-        registry: registry::Registry::new(),
-    };
+    // Publish the well-known names svcmgr owns and hand devmgr its
+    // drivers dir — both from the handover endowment caps — before the
+    // event loop, so they are in place before `HANDOVER_COMPLETE` drives
+    // reconciliation and any launched consumer resolves them.
+    publish_well_known(&mut state.registry, &caps);
+    install_drivers_dir(&caps, ipc_buf);
 
-    std::os::seraph::log!("waiting for registrations");
+    std::os::seraph::log!("endowed; waiting for handover");
 
     event_loop(
         info,
@@ -283,6 +208,157 @@ fn main() -> !
     );
 }
 
+/// Publish the well-known names svcmgr owns into its own discovery
+/// registry, from the caps init endowed at handover. These are internal
+/// `registry.publish` calls (no `PUBLISH_AUTHORITY` token — svcmgr owns
+/// the registry). Each provider's own `provides` names are published
+/// separately on the launch path ([`definitions::launch`]).
+fn publish_well_known(
+    registry: &mut registry::Registry<REGISTRY_CAPACITY>,
+    caps: &service::SvcmgrCaps,
+)
+{
+    // rootfs.root — SEND on the root filesystem's namespace endpoint,
+    // endowed pre-derived by init. Published as-is; `registry_lookup_derived`
+    // re-derives a SEND per consumer and the token survives.
+    if caps.rootfs_root != 0
+    {
+        if registry
+            .publish(ipc::published_names::ROOTFS_ROOT, caps.rootfs_root)
+            .is_err()
+        {
+            std::os::seraph::log!("publish rootfs.root failed");
+            let _ = syscall::cap_delete(caps.rootfs_root);
+        }
+    }
+    else
+    {
+        std::os::seraph::log!("no rootfs.root source cap; not published");
+    }
+
+    // svcmgr — SEND on svcmgr's own service endpoint (crasher seeds it).
+    match syscall::cap_derive(caps.service_ep, syscall::RIGHTS_SEND)
+    {
+        Ok(send) =>
+        {
+            if registry
+                .publish(ipc::published_names::SVCMGR, send)
+                .is_err()
+            {
+                std::os::seraph::log!("publish svcmgr failed");
+                let _ = syscall::cap_delete(send);
+            }
+        }
+        Err(_) => std::os::seraph::log!("derive svcmgr SEND failed"),
+    }
+
+    // devmgr.registry — `REGISTRY_QUERY_AUTHORITY`-tokened SEND minted from
+    // the endowed token-0 `SEND|GRANT` source. The token bit rides through
+    // `registry_lookup_derived`'s plain `cap_derive` to consumers.
+    if caps.devmgr_registry != 0
+    {
+        match syscall::cap_derive_token(
+            caps.devmgr_registry,
+            syscall::RIGHTS_SEND,
+            ipc::devmgr_labels::REGISTRY_QUERY_AUTHORITY,
+        )
+        {
+            Ok(send) =>
+            {
+                if registry
+                    .publish(ipc::published_names::DEVMGR_REGISTRY, send)
+                    .is_err()
+                {
+                    std::os::seraph::log!("publish devmgr.registry failed");
+                    let _ = syscall::cap_delete(send);
+                }
+            }
+            Err(_) => std::os::seraph::log!("derive devmgr.registry cap failed"),
+        }
+    }
+    else
+    {
+        std::os::seraph::log!("no devmgr.registry source cap; not published");
+    }
+}
+
+/// Hand devmgr a `LOOKUP | READ`-attenuated `/services/drivers/` subtree
+/// cap via `SET_DRIVERS_DIR`, so devmgr can lazily walk + spawn its on-disk
+/// driver binaries (today: the per-arch RTC). svcmgr walks its universal
+/// root for the dir and mints a `DRIVERS_DIR_AUTHORITY` `SEND|GRANT` from
+/// the endowed devmgr-registry source.
+///
+/// Best-effort: any failure leaves devmgr without a drivers dir, so timed
+/// sees `NO_DEVICE` on its first `QUERY_RTC_DEVICE` and degrades to its
+/// no-RTC path; the rest of startup proceeds.
+fn install_drivers_dir(caps: &service::SvcmgrCaps, ipc_buf: *mut u64)
+{
+    if caps.devmgr_registry == 0
+    {
+        std::os::seraph::log!("SET_DRIVERS_DIR skipped: no devmgr registry source");
+        return;
+    }
+    let root_cap = std::os::seraph::root_dir_cap();
+    if root_cap == 0
+    {
+        std::os::seraph::log!("SET_DRIVERS_DIR skipped: no root_dir_cap");
+        return;
+    }
+
+    // Attenuated rights: only what devmgr needs to walk into the subtree
+    // and read driver-binary contents; the namespace server intersects
+    // per hop.
+    let rights = u64::from(namespace_protocol::rights::LOOKUP | namespace_protocol::rights::READ);
+    let drivers_dir =
+        match std::os::seraph::namespace_lookup_dir(root_cap, "/services/drivers", rights)
+        {
+            Ok(c) => c,
+            Err(e) =>
+            {
+                std::os::seraph::log!("SET_DRIVERS_DIR: walk /services/drivers failed: {e}");
+                return;
+            }
+        };
+
+    // `RIGHTS_SEND_GRANT` (not bare SEND): SET_DRIVERS_DIR transfers the
+    // dir cap, and the IPC kernel requires the GRANT bit to move caps.
+    let Ok(bind_ep) = syscall::cap_derive_token(
+        caps.devmgr_registry,
+        syscall::RIGHTS_SEND_GRANT,
+        ipc::devmgr_labels::DRIVERS_DIR_AUTHORITY,
+    )
+    else
+    {
+        std::os::seraph::log!("SET_DRIVERS_DIR: DRIVERS_DIR_AUTHORITY derive failed");
+        let _ = syscall::cap_delete(drivers_dir);
+        return;
+    };
+
+    let msg = IpcMessage::builder(ipc::devmgr_labels::SET_DRIVERS_DIR)
+        .word(0, u64::from(ipc::DEVMGR_LABELS_VERSION))
+        .cap(drivers_dir)
+        .build();
+    // SAFETY: ipc_buf is the registered IPC buffer.
+    let result = unsafe { ipc::ipc_call(bind_ep, &msg, ipc_buf) };
+    let _ = syscall::cap_delete(bind_ep);
+
+    match result
+    {
+        Ok(reply) if reply.label == ipc::devmgr_errors::SUCCESS =>
+        {
+            std::os::seraph::log!("SET_DRIVERS_DIR ok");
+        }
+        Ok(_) => std::os::seraph::log!("SET_DRIVERS_DIR rejected; RTC unavailable"),
+        Err(_) =>
+        {
+            // Transport error before the kernel committed the transfer;
+            // the source slot still owns `drivers_dir`.
+            let _ = syscall::cap_delete(drivers_dir);
+            std::os::seraph::log!("SET_DRIVERS_DIR ipc error; RTC unavailable");
+        }
+    }
+}
+
 /// `WaitSet` token for svcmgr's service endpoint.
 const WS_TOKEN_SERVICE: u64 = 0;
 /// `WaitSet` token for svcmgr's shared death event queue.
@@ -292,13 +368,14 @@ const WS_TOKEN_DEATHS: u64 = 1;
 /// registry, and handover flag. Held across the event loop for the
 /// lifetime of the process.
 ///
-/// `pending` is populated by [`handle_register`] as init announces
-/// each running service it spawned during Phase 3. On
-/// `HANDOVER_COMPLETE` [`definitions::reconcile::reconcile_and_launch`]
-/// pairs each entry with a `.svc` recipe, binds death-notification,
-/// and populates `services`. After reconciliation `pending` is
-/// effectively read-only — the unconsumed entries persist as logged
-/// configuration errors but are not re-used.
+/// `pending` is populated by [`service::bootstrap_caps`] as it drains
+/// init's handover endowment (one substrate `(name, thread_cap)` round
+/// each). On `HANDOVER_COMPLETE`
+/// [`definitions::reconcile::reconcile_and_launch`] pairs each entry with
+/// a `.svc` recipe, binds death-notification, and populates `services`.
+/// After reconciliation `pending` is effectively read-only — the
+/// unconsumed entries persist as logged configuration errors but are not
+/// re-used.
 pub struct SvcmgrState
 {
     pub services: [ServiceEntry; MAX_SERVICES],
@@ -366,13 +443,6 @@ fn dispatch_ipc(service_ep: u32, state: &mut SvcmgrState, ctx: &restart::Restart
     let opcode = msg.label & 0xFFFF;
     match opcode
     {
-        svcmgr_labels::REGISTER_SERVICE =>
-        {
-            let result = handle_register(&msg, &mut state.pending, &mut state.pending_count);
-            let reply = IpcMessage::new(result);
-            // SAFETY: ipc_buf is the registered IPC buffer.
-            let _ = unsafe { ipc::ipc_reply(&reply, ipc_buf) };
-        }
         svcmgr_labels::HANDOVER_COMPLETE =>
         {
             // Reply BEFORE reconciliation: init's call returns and it

--- a/services/svcmgr/src/main.rs
+++ b/services/svcmgr/src/main.rs
@@ -240,6 +240,16 @@ fn main() -> !
         halt_loop();
     };
 
+    // Frame slab svcmgr retypes provider service endpoints from. One page
+    // backs every `provides = ...` service (each `cap_create_endpoint`
+    // carves an endpoint object from it); the provider set is small.
+    let Some(endpoint_slab) = std::os::seraph::object_slab_acquire(syscall_abi::PAGE_SIZE)
+    else
+    {
+        std::os::seraph::log!("failed to acquire frame for provider endpoint slab");
+        halt_loop();
+    };
+
     if syscall::wait_set_add(ws_cap, caps.service_ep, WS_TOKEN_SERVICE).is_err()
     {
         std::os::seraph::log!("failed to add service endpoint to wait set");
@@ -262,7 +272,15 @@ fn main() -> !
 
     std::os::seraph::log!("waiting for registrations");
 
-    event_loop(info, &caps, ws_cap, deaths_eq, ipc_buf, &mut state);
+    event_loop(
+        info,
+        &caps,
+        ws_cap,
+        deaths_eq,
+        endpoint_slab,
+        ipc_buf,
+        &mut state,
+    );
 }
 
 /// `WaitSet` token for svcmgr's service endpoint.
@@ -300,6 +318,7 @@ fn event_loop(
     caps: &service::SvcmgrCaps,
     ws_cap: u32,
     deaths_eq: u32,
+    endpoint_slab: u32,
     ipc_buf: *mut u64,
     state: &mut SvcmgrState,
 ) -> !
@@ -309,6 +328,7 @@ fn event_loop(
         bootstrap_ep: caps.bootstrap_ep,
         ipc_buf,
         deaths_eq,
+        endpoint_slab,
     };
 
     loop

--- a/services/svcmgr/src/restart.rs
+++ b/services/svcmgr/src/restart.rs
@@ -86,7 +86,7 @@ pub struct StartupBlobs<'a>
 /// `START_PROCESS`.
 ///
 /// `path` is interpreted relative to svcmgr's own `root_dir_cap`
-/// (universal post-#21 init handover), so callers pass paths exactly
+/// (universal), so callers pass paths exactly
 /// as they appear in `.svc` files — e.g. `"/services/logd"`.
 ///
 /// `blobs` carries argv/env for the child. Both paths build them from

--- a/services/svcmgr/src/restart.rs
+++ b/services/svcmgr/src/restart.rs
@@ -18,7 +18,9 @@
 //! restart cap set.
 
 use crate::REGISTRY_CAPACITY;
-use crate::definitions::launch::{assemble_boot_caps, build_blob, delete_caps, resolve_seeds};
+use crate::definitions::launch::{
+    assemble_boot_caps, build_blob, delete_caps, mint_logd_boot_caps, resolve_seeds,
+};
 use crate::service::{MAX_RESTARTS, POLICY_ALWAYS, POLICY_ON_FAILURE, RestartRecipe, ServiceEntry};
 use ipc::{IpcMessage, procmgr_labels};
 
@@ -204,6 +206,15 @@ pub struct RestartCtx
     /// (`cap_create_endpoint`). One slab backs every `provides = ...`
     /// service's endpoint; sized for the handful of provider services.
     pub endpoint_slab: u32,
+    /// Reserved master-log endpoint source. svcmgr mints real-logd's RECV (and
+    /// the first-launch `HANDOVER_PULL` SEND) from it on every (re)launch.
+    pub master_log_source: u32,
+    /// Token-0 `SEND|GRANT` source on procmgr's service endpoint. svcmgr mints
+    /// real-logd's `DEATH_EQ_AUTHORITY` SEND from it.
+    pub procmgr_death_auth_source: u32,
+    /// Token-0 `SEND|GRANT` source on devmgr's registry endpoint. svcmgr mints
+    /// real-logd's `REGISTRY_QUERY_AUTHORITY` query cap from it.
+    pub devmgr_registry: u32,
 }
 
 /// Handle a service death detected via event queue notification.
@@ -355,74 +366,82 @@ fn restart_process(
         return false;
     }
 
-    // Assemble the restart bootstrap cap set. A service whose recipe
-    // declares `seed = ...` gets those seeds re-resolved from the registry
-    // by name, in declaration order — byte-for-byte the positional set
-    // first launch delivered (see `definitions::launch::launch`). Otherwise
-    // fall back to the stored bundle caps. In practice the fallback is
-    // empty: recipe-launched services carry seeds and no bundle, and the
-    // init-endowed substrate is delivered with only a thread cap (no
-    // bundle) — so this arm yields nothing for them. Each cap is freshly
-    // derived so the child owns its own copy.
-    let restart_caps: Vec<u32> = match recipe
+    // Assemble the restart bootstrap cap set. The log-sink service (real-logd)
+    // gets a freshly-minted round from the reserved log-sink sources, with no
+    // `HANDOVER_PULL` SEND — init-logd is long gone by any restart, so the
+    // restarted logd skips the history pull and takes over the log endpoint
+    // directly. Senders are unaffected: their SENDs target the endpoint
+    // object, and svcmgr's reserved source kept it alive across the crash.
+    //
+    // Otherwise: a recipe declaring `seed = ...` re-resolves those seeds from
+    // the registry by name, in declaration order — byte-for-byte the
+    // positional set first launch delivered. The fallback to stored bundle
+    // caps is empty in practice (recipe-launched services carry seeds and no
+    // bundle; the init-endowed substrate carries only a thread cap). A
+    // `provides` service's own service-endpoint RECV leads as cap[0]; the
+    // endpoint persists on the entry, so a fresh RECV reattaches the restarted
+    // instance to the same object consumers already hold a SEND on.
+    let boot_caps: Vec<u32> = if matches!(recipe, Some(r) if r.log_sink)
     {
-        Some(r) if !r.seed.is_empty() => resolve_seeds(&r.seed, svc.name_str(), registry),
-        _ =>
-        {
-            let mut caps: Vec<u32> = Vec::new();
-            for i in 0..(svc.bundle_count as usize)
-            {
-                if caps.len() >= syscall_abi::MSG_CAP_SLOTS_MAX
-                {
-                    break;
-                }
-                let entry = &svc.bundle[i];
-                if entry.cap == 0
-                {
-                    continue;
-                }
-                let Ok(c) = syscall::cap_derive(entry.cap, syscall::RIGHTS_SEND)
-                else
-                {
-                    std::os::seraph::log!("cannot derive bundle cap for restart");
-                    for &derived in &caps
-                    {
-                        if derived != 0
-                        {
-                            let _ = syscall::cap_delete(derived);
-                        }
-                    }
-                    let _ = syscall::cap_delete(new_thread_cap);
-                    return false;
-                };
-                caps.push(c);
-            }
-            caps
-        }
-    };
-
-    // A `provides` service's own service endpoint is bootstrap cap[0],
-    // ahead of its seeds — the same positional shape `launch::launch`
-    // delivers on first launch. The endpoint persists on the entry, so a
-    // fresh RECV derivation re-attaches the restarted instance to the same
-    // object consumers already hold a SEND on.
-    let provided_recv = if svc.provided_endpoint != 0
-    {
-        if let Ok(recv) = syscall::cap_derive(svc.provided_endpoint, syscall::RIGHTS_RECEIVE)
-        {
-            recv
-        }
-        else
-        {
-            std::os::seraph::log!("restart: provider RECV derive failed");
-            0
-        }
+        mint_logd_boot_caps(ctx, false)
     }
     else
     {
-        0
+        let restart_caps: Vec<u32> = match recipe
+        {
+            Some(r) if !r.seed.is_empty() => resolve_seeds(&r.seed, svc.name_str(), registry),
+            _ =>
+            {
+                let mut caps: Vec<u32> = Vec::new();
+                for i in 0..(svc.bundle_count as usize)
+                {
+                    if caps.len() >= syscall_abi::MSG_CAP_SLOTS_MAX
+                    {
+                        break;
+                    }
+                    let entry = &svc.bundle[i];
+                    if entry.cap == 0
+                    {
+                        continue;
+                    }
+                    let Ok(c) = syscall::cap_derive(entry.cap, syscall::RIGHTS_SEND)
+                    else
+                    {
+                        std::os::seraph::log!("cannot derive bundle cap for restart");
+                        for &derived in &caps
+                        {
+                            if derived != 0
+                            {
+                                let _ = syscall::cap_delete(derived);
+                            }
+                        }
+                        let _ = syscall::cap_delete(new_thread_cap);
+                        return false;
+                    };
+                    caps.push(c);
+                }
+                caps
+            }
+        };
+
+        let provided_recv = if svc.provided_endpoint != 0
+        {
+            if let Ok(recv) = syscall::cap_derive(svc.provided_endpoint, syscall::RIGHTS_RECEIVE)
+            {
+                recv
+            }
+            else
+            {
+                std::os::seraph::log!("restart: provider RECV derive failed");
+                0
+            }
+        }
+        else
+        {
+            0
+        };
+        assemble_boot_caps(provided_recv, restart_caps)
     };
-    let boot_caps = assemble_boot_caps(provided_recv, restart_caps);
 
     // SAFETY: ctx.ipc_buf is the registered IPC buffer.
     if unsafe {

--- a/services/svcmgr/src/restart.rs
+++ b/services/svcmgr/src/restart.rs
@@ -359,11 +359,11 @@ fn restart_process(
     // declares `seed = ...` gets those seeds re-resolved from the registry
     // by name, in declaration order — byte-for-byte the positional set
     // first launch delivered (see `definitions::launch::launch`). Otherwise
-    // fall back to the registration-time bundle caps (init-bootstrapped
-    // services that registered caps over `REGISTER_SERVICE`). The two
-    // sources are disjoint in practice: recipe-launched services carry
-    // seeds and no bundle; init-registered services carry a bundle and no
-    // seeds. Each cap is freshly derived so the child owns its own copy.
+    // fall back to the stored bundle caps. In practice the fallback is
+    // empty: recipe-launched services carry seeds and no bundle, and the
+    // init-endowed substrate is delivered with only a thread cap (no
+    // bundle) — so this arm yields nothing for them. Each cap is freshly
+    // derived so the child owns its own copy.
     let restart_caps: Vec<u32> = match recipe
     {
         Some(r) if !r.seed.is_empty() => resolve_seeds(&r.seed, svc.name_str(), registry),

--- a/services/svcmgr/src/restart.rs
+++ b/services/svcmgr/src/restart.rs
@@ -18,7 +18,7 @@
 //! restart cap set.
 
 use crate::REGISTRY_CAPACITY;
-use crate::definitions::launch::{build_blob, resolve_seeds};
+use crate::definitions::launch::{assemble_boot_caps, build_blob, delete_caps, resolve_seeds};
 use crate::service::{MAX_RESTARTS, POLICY_ALWAYS, POLICY_ON_FAILURE, RestartRecipe, ServiceEntry};
 use ipc::{IpcMessage, procmgr_labels};
 
@@ -200,6 +200,10 @@ pub struct RestartCtx
     /// the routing in `dispatch_deaths` continues to land on the
     /// correct `ServiceEntry`.
     pub deaths_eq: u32,
+    /// Frame slab svcmgr retypes provider service endpoints from
+    /// (`cap_create_endpoint`). One slab backs every `provides = ...`
+    /// service's endpoint; sized for the handful of provider services.
+    pub endpoint_slab: u32,
 }
 
 /// Handle a service death detected via event queue notification.
@@ -302,9 +306,9 @@ fn should_restart(svc: &ServiceEntry, exit_reason: u64) -> bool
         return false;
     }
 
-    if svc.module_cap == 0 && svc.vfs_path_len == 0
+    if svc.vfs_path_len == 0
     {
-        std::os::seraph::log!("no restart source (module or vfs_path), cannot restart");
+        std::os::seraph::log!("no restart source (vfs_path), cannot restart");
         return false;
     }
 
@@ -397,6 +401,29 @@ fn restart_process(
         }
     };
 
+    // A `provides` service's own service endpoint is bootstrap cap[0],
+    // ahead of its seeds — the same positional shape `launch::launch`
+    // delivers on first launch. The endpoint persists on the entry, so a
+    // fresh RECV derivation re-attaches the restarted instance to the same
+    // object consumers already hold a SEND on.
+    let provided_recv = if svc.provided_endpoint != 0
+    {
+        if let Ok(recv) = syscall::cap_derive(svc.provided_endpoint, syscall::RIGHTS_RECEIVE)
+        {
+            recv
+        }
+        else
+        {
+            std::os::seraph::log!("restart: provider RECV derive failed");
+            0
+        }
+    }
+    else
+    {
+        0
+    };
+    let boot_caps = assemble_boot_caps(provided_recv, restart_caps);
+
     // SAFETY: ctx.ipc_buf is the registered IPC buffer.
     if unsafe {
         ipc::bootstrap::serve_round(
@@ -404,7 +431,7 @@ fn restart_process(
             child_token,
             ctx.ipc_buf,
             true,
-            &restart_caps,
+            &boot_caps,
             &[],
         )
     }
@@ -416,13 +443,7 @@ fn restart_process(
         // (delete of an already-transferred slot is a no-op). Child
         // is started; cannot destroy from here — it will exit on the
         // receive-side failure and procmgr will reap.
-        for &derived in &restart_caps
-        {
-            if derived != 0
-            {
-                let _ = syscall::cap_delete(derived);
-            }
-        }
+        delete_caps(&boot_caps);
         let _ = syscall::cap_delete(new_thread_cap);
         return false;
     }
@@ -432,10 +453,9 @@ fn restart_process(
     rebind_death_notification(svc, ctx.deaths_eq, new_thread_cap, correlator)
 }
 
-/// Spawn a fresh instance of `svc` via procmgr. Branches on the recorded
-/// restart source: VFS path → [`walk_and_create_from_file`]; module
-/// cap → `CREATE_PROCESS`. After create, applies the per-service
-/// namespace policy recorded at registration via
+/// Spawn a fresh instance of `svc` via procmgr from its recorded
+/// `vfs_path` ([`walk_and_create_from_file`]). After create, applies the
+/// per-service namespace policy recorded at registration via
 /// `CONFIGURE_NAMESPACE`. Returns `(process_handle, thread, child_token)`.
 fn create_process(
     svc: &ServiceEntry,
@@ -443,72 +463,31 @@ fn create_process(
     ctx: &RestartCtx,
 ) -> Option<(u32, u32, u64)>
 {
-    let created = if svc.vfs_path_len > 0
+    if svc.vfs_path_len == 0
     {
-        let path_bytes = &svc.vfs_path[..svc.vfs_path_len as usize];
-        let path_str = core::str::from_utf8(path_bytes).ok()?;
-        // Replay argv/env from the stored recipe so the respawned child
-        // gets the same startup surfaces first launch built. The blobs
-        // must outlive the create call — `StartupBlobs` borrows them.
-        let (argv_blob, argv_count) =
-            recipe.map_or_else(|| (Vec::new(), 0), |r| build_blob(&r.argv));
-        let (env_blob, env_count) = recipe.map_or_else(|| (Vec::new(), 0), |r| build_blob(&r.env));
-        let blobs = StartupBlobs {
-            argv: &argv_blob,
-            argv_count,
-            env: &env_blob,
-            env_count,
-        };
-        walk_and_create_from_file(
-            path_str,
-            blobs,
-            ctx.procmgr_ep,
-            ctx.bootstrap_ep,
-            ctx.ipc_buf,
-        )?
+        std::os::seraph::log!("restart: no vfs_path source for {}", svc.name_str());
+        return None;
     }
-    else
-    {
-        // TODO(#78): this module-cap restart branch is unreachable today —
-        // `ServiceEntry::module_cap` is never populated (REGISTER_SERVICE
-        // delivers only a thread cap; the restart source is set from
-        // `vfs_path` by the reconcile pass), so `create_process` always takes
-        // the `vfs_path` arm above. Deferred to #78, which decides whether
-        // svcmgr must restart boot-substrate services from an in-memory ELF
-        // before the filesystem is reachable. If so, init endows svcmgr with
-        // those module source caps (excluding them from its reap donation)
-        // and this branch goes live; otherwise drop `module_cap` and this
-        // branch and restart everything from `vfs_path`.
-        let (child_token, tokened_creator) = mint_child_creator(ctx.bootstrap_ep)?;
-        let Ok(module_copy) = syscall::cap_derive(svc.module_cap, syscall::RIGHTS_ALL)
-        else
-        {
-            let _ = syscall::cap_delete(tokened_creator);
-            return None;
-        };
-        let create_msg = IpcMessage::builder(procmgr_labels::CREATE_PROCESS)
-            .cap(module_copy)
-            .cap(tokened_creator)
-            .build();
-        // SAFETY: `ctx.ipc_buf` is the registered IPC buffer.
-        let reply = unsafe { ipc::ipc_call(ctx.procmgr_ep, &create_msg, ctx.ipc_buf) }.ok()?;
-        if reply.label != 0
-        {
-            std::os::seraph::log!("restart create failed");
-            return None;
-        }
-        let reply_caps = reply.caps();
-        if reply_caps.len() < 2
-        {
-            std::os::seraph::log!("restart reply missing caps");
-            return None;
-        }
-        CreatedProcess {
-            process_handle: reply_caps[0],
-            thread_cap: reply_caps[1],
-            child_token,
-        }
+    let path_bytes = &svc.vfs_path[..svc.vfs_path_len as usize];
+    let path_str = core::str::from_utf8(path_bytes).ok()?;
+    // Replay argv/env from the stored recipe so the respawned child gets the
+    // same startup surfaces first launch built. The blobs must outlive the
+    // create call — `StartupBlobs` borrows them.
+    let (argv_blob, argv_count) = recipe.map_or_else(|| (Vec::new(), 0), |r| build_blob(&r.argv));
+    let (env_blob, env_count) = recipe.map_or_else(|| (Vec::new(), 0), |r| build_blob(&r.env));
+    let blobs = StartupBlobs {
+        argv: &argv_blob,
+        argv_count,
+        env: &env_blob,
+        env_count,
     };
+    let created = walk_and_create_from_file(
+        path_str,
+        blobs,
+        ctx.procmgr_ep,
+        ctx.bootstrap_ep,
+        ctx.ipc_buf,
+    )?;
 
     let cwd = recipe.and_then(|r| r.cwd.as_deref());
     if !apply_namespace_policy(svc, cwd, created.process_handle, created.thread_cap, ctx)

--- a/services/svcmgr/src/service.rs
+++ b/services/svcmgr/src/service.rs
@@ -161,6 +161,10 @@ pub struct RestartRecipe
     pub env: Vec<String>,
     pub cwd: Option<String>,
     pub seed: Vec<String>,
+    /// The log-sink service: its restart bootstrap round is minted from the
+    /// reserved log-sink sources (with no `HANDOVER_PULL` SEND), not from
+    /// `seed`/provider caps. See `definitions::launch::mint_logd_boot_caps`.
+    pub log_sink: bool,
 }
 
 // ── Bootstrap (init → svcmgr handover endowment) ────────────────────────────
@@ -183,10 +187,17 @@ pub struct RestartRecipe
 //              `DRIVERS_DIR_AUTHORITY` SET_DRIVERS_DIR cap (0 if absent)
 //     data[1]: `SVCMGR_LABELS_VERSION` handshake
 //
-//   SUBSTRATE (one per init-bootstrapped service; last round is done):
+//   SUBSTRATE (one per init-bootstrapped service):
 //     caps[0]: the service's main thread cap (svcmgr binds death-
 //              notification on it at reconciliation)
 //     data[1]: name_len; data[2..]: name bytes (LE-packed)
+//
+//   LOGD_SOURCES (terminal round, done):
+//     caps[0]: reserved master-log endpoint source (svcmgr mints real-logd's
+//              RECV from it per launch, and the first-launch HANDOVER_PULL
+//              SEND); held for the system's life so it can relaunch logd
+//     caps[1]: token-0 `SEND|GRANT` source on procmgr's service endpoint
+//              (svcmgr mints real-logd's `DEATH_EQ_AUTHORITY` SEND from it)
 //
 // The substrate pairs land in `pending`; `HANDOVER_COMPLETE` later
 // reconciles them against `/config/svcmgr/services/`. log and procmgr
@@ -199,6 +210,9 @@ mod endow_kind
     pub const CAPS: u64 = 1;
     /// One substrate `(name, thread_cap)` registration.
     pub const SUBSTRATE: u64 = 2;
+    /// Terminal round: the reserved log-sink sources svcmgr mints real-logd's
+    /// bootstrap caps from on every (re)launch.
+    pub const LOGD_SOURCES: u64 = 3;
 }
 
 /// Well-known capability slots acquired from the handover endowment.
@@ -218,6 +232,14 @@ pub struct SvcmgrCaps
     /// and the `SET_DRIVERS_DIR` cap (`DRIVERS_DIR_AUTHORITY`) from it.
     /// Zero if absent.
     pub devmgr_registry: u32,
+    /// Reserved master-log endpoint source (`RIGHTS_ALL`). svcmgr mints
+    /// real-logd's master-log RECV from it on every (re)launch, and the
+    /// one-shot `HANDOVER_PULL` SEND on the first launch. Holding it keeps the
+    /// log endpoint object alive across a logd crash. Zero if absent.
+    pub master_log_source: u32,
+    /// Token-0 `SEND|GRANT` source on procmgr's service endpoint. svcmgr mints
+    /// real-logd's `DEATH_EQ_AUTHORITY` SEND from it per launch. Zero if absent.
+    pub procmgr_death_auth_source: u32,
 }
 
 /// Acquire svcmgr's initial cap set and substrate registrations from its
@@ -275,9 +297,28 @@ pub fn bootstrap_caps(
                     {
                         0
                     },
+                    master_log_source: 0,
+                    procmgr_death_auth_source: 0,
                 });
             }
             endow_kind::SUBSTRATE => ingest_substrate(&round, pending, pending_count),
+            endow_kind::LOGD_SOURCES =>
+            {
+                // Terminal round (arrives after CAPS). Record the reserved
+                // log-sink sources on the already-built cap set.
+                if let Some(c) = caps.as_mut()
+                {
+                    c.master_log_source = round.caps[0];
+                    c.procmgr_death_auth_source = if round.cap_count > 1
+                    {
+                        round.caps[1]
+                    }
+                    else
+                    {
+                        0
+                    };
+                }
+            }
             other => std::os::seraph::log!("bootstrap: unknown endowment kind {other}"),
         }
         if round.done

--- a/services/svcmgr/src/service.rs
+++ b/services/svcmgr/src/service.rs
@@ -11,14 +11,18 @@
 
 use std::os::seraph::StartupInfo;
 
+use crate::definitions::reconcile::PendingRegistration;
+
 /// Maximum number of monitored services.
 pub const MAX_SERVICES: usize = 16;
 
 /// Maximum number of extra named caps stored per service for restart.
 ///
-/// Constrained by the 4-cap IPC message limit: a single `REGISTER_SERVICE`
-/// delivers `thread + module + log + 1 extra`. Larger bundles would need
-/// multi-round registration; defer until a concrete consumer appears.
+/// Vestigial: the substrate services are endowed with only a thread cap
+/// (no extra bundle caps), and recipe-launched services replay their caps
+/// from `seed = ...` rather than a stored bundle. Kept as the restart
+/// path's no-recipe fallback slot; bounded at 1 until a concrete consumer
+/// appears.
 pub const MAX_BUNDLE_CAPS: usize = 1;
 
 /// Maximum restart attempts before marking degraded.
@@ -86,9 +90,10 @@ pub struct ServiceEntry
     /// Zero for the initial instance (which svcmgr never created — init
     /// did), so the first death cannot destroy; subsequent deaths can.
     pub process_handle: u32,
-    /// Namespace-policy kind init recorded at registration; one of
-    /// `ipc::svcmgr_labels::NS_POLICY_*`. svcmgr re-applies this
-    /// shape on every restart so attenuation survives a crash cycle.
+    /// Namespace-policy kind reconciliation recorded from the `.svc`
+    /// `namespace = ...` line; one of `ipc::svcmgr_labels::NS_POLICY_*`.
+    /// svcmgr re-applies this shape on every restart so attenuation
+    /// survives a crash cycle.
     pub ns_policy_kind: u8,
     /// Length of `ns_subtree_path` in bytes (0 for non-`Subtree`).
     pub ns_subtree_path_len: u8,
@@ -128,9 +133,9 @@ impl ServiceEntry
             // Fail-safe default: an empty slot has no installed
             // policy yet, so `None` (no namespace cap delivered) is
             // the correct shape if any code path were to inspect it
-            // before `handle_register` overwrites every field.
-            // Universal would silently grant the most permissive cap
-            // on a programmer error.
+            // before reconciliation's `build_entry` overwrites every
+            // field. Universal would silently grant the most permissive
+            // cap on a programmer error.
             ns_policy_kind: ipc::svcmgr_labels::NS_POLICY_NONE,
             ns_subtree_path_len: 0,
             ns_subtree_path: [0; ipc::MAX_PATH_LEN],
@@ -158,17 +163,45 @@ pub struct RestartRecipe
     pub seed: Vec<String>,
 }
 
-// ── Bootstrap ───────────────────────────────────────────────────────────────
+// ── Bootstrap (init → svcmgr handover endowment) ────────────────────────────
 //
-// init → svcmgr bootstrap plan (one round, 2 caps):
-//   caps[0]: service endpoint (svcmgr receives on this for registrations)
-//   caps[1]: svcmgr's own bootstrap endpoint (svcmgr receives on this when
-//            serving bootstrap requests from restarted children)
+// init hands svcmgr its entire startup state over the bootstrap-round
+// protocol — there is no separate post-bootstrap registration label.
+// Round kinds are tagged in `data[0]`:
 //
-// log and procmgr endpoints arrive via `ProcessInfo` / `StartupInfo` and are
-// not part of this round.
+//   CAPS (round 1, not done):
+//     caps[0]: svcmgr's service endpoint (RECV — the discovery-registry
+//              + handover endpoint)
+//     caps[1]: svcmgr's own bootstrap endpoint (RECV — serves bootstrap
+//              requests from launched / restarted children)
+//     caps[2]: SEND on the root filesystem's namespace endpoint, which
+//              svcmgr publishes as `rootfs.root` (0 if init could not
+//              derive it)
+//     caps[3]: SEND|GRANT (token 0) source on devmgr's registry endpoint,
+//              from which svcmgr mints the `REGISTRY_QUERY_AUTHORITY`
+//              `devmgr.registry` publish cap and the
+//              `DRIVERS_DIR_AUTHORITY` SET_DRIVERS_DIR cap (0 if absent)
+//     data[1]: `SVCMGR_LABELS_VERSION` handshake
+//
+//   SUBSTRATE (one per init-bootstrapped service; last round is done):
+//     caps[0]: the service's main thread cap (svcmgr binds death-
+//              notification on it at reconciliation)
+//     data[1]: name_len; data[2..]: name bytes (LE-packed)
+//
+// The substrate pairs land in `pending`; `HANDOVER_COMPLETE` later
+// reconciles them against `/config/svcmgr/services/`. log and procmgr
+// endpoints arrive via `ProcessInfo` / `StartupInfo`, not these rounds.
+//
+// Mirrors the serve side in `services/init/src/service.rs::endow_kind`.
+mod endow_kind
+{
+    /// Round 1: svcmgr's own endpoints + publish-role source caps.
+    pub const CAPS: u64 = 1;
+    /// One substrate `(name, thread_cap)` registration.
+    pub const SUBSTRATE: u64 = 2;
+}
 
-/// Well-known capability slots acquired from the bootstrap protocol.
+/// Well-known capability slots acquired from the handover endowment.
 #[allow(clippy::struct_field_names)]
 pub struct SvcmgrCaps
 {
@@ -177,23 +210,139 @@ pub struct SvcmgrCaps
     /// svcmgr's own bootstrap endpoint (receives bootstrap requests from
     /// restarted children).
     pub bootstrap_ep: u32,
+    /// SEND on the root filesystem's namespace endpoint, published as
+    /// `rootfs.root`. Zero if init could not derive it.
+    pub rootfs_root: u32,
+    /// `SEND|GRANT`, token-0 source on devmgr's registry endpoint. svcmgr
+    /// mints the `devmgr.registry` publish cap (`REGISTRY_QUERY_AUTHORITY`)
+    /// and the `SET_DRIVERS_DIR` cap (`DRIVERS_DIR_AUTHORITY`) from it.
+    /// Zero if absent.
+    pub devmgr_registry: u32,
 }
 
-/// Acquire svcmgr's initial cap set from its creator (init) via bootstrap IPC.
-pub fn bootstrap_caps(info: &StartupInfo, ipc_buf: *mut u64) -> Option<SvcmgrCaps>
+/// Acquire svcmgr's initial cap set and substrate registrations from its
+/// creator (init) by draining the handover endowment rounds. Substrate
+/// `(name, thread_cap)` pairs are parked in `pending`; the returned
+/// `SvcmgrCaps` carries the endpoint + publish-source caps. Returns `None`
+/// on a missing creator endpoint, a version mismatch, or a malformed CAPS
+/// round.
+pub fn bootstrap_caps(
+    info: &StartupInfo,
+    ipc_buf: *mut u64,
+    pending: &mut [PendingRegistration],
+    pending_count: &mut usize,
+) -> Option<SvcmgrCaps>
 {
     if info.creator_endpoint == 0
     {
         return None;
     }
-    // SAFETY: ipc_buf is the registered IPC buffer page.
-    let round = unsafe { ipc::bootstrap::request_round(info.creator_endpoint, ipc_buf) }.ok()?;
-    if round.cap_count < 2 || !round.done
+    let mut caps: Option<SvcmgrCaps> = None;
+    loop
     {
-        return None;
+        // SAFETY: ipc_buf is the registered IPC buffer page.
+        let round =
+            unsafe { ipc::bootstrap::request_round(info.creator_endpoint, ipc_buf) }.ok()?;
+        match round.data[0]
+        {
+            endow_kind::CAPS =>
+            {
+                if round.cap_count < 2
+                {
+                    return None;
+                }
+                if round.data_words < 2 || round.data[1] != u64::from(ipc::SVCMGR_LABELS_VERSION)
+                {
+                    std::os::seraph::log!("bootstrap: endowment version mismatch");
+                    return None;
+                }
+                caps = Some(SvcmgrCaps {
+                    service_ep: round.caps[0],
+                    bootstrap_ep: round.caps[1],
+                    rootfs_root: if round.cap_count > 2
+                    {
+                        round.caps[2]
+                    }
+                    else
+                    {
+                        0
+                    },
+                    devmgr_registry: if round.cap_count > 3
+                    {
+                        round.caps[3]
+                    }
+                    else
+                    {
+                        0
+                    },
+                });
+            }
+            endow_kind::SUBSTRATE => ingest_substrate(&round, pending, pending_count),
+            other => std::os::seraph::log!("bootstrap: unknown endowment kind {other}"),
+        }
+        if round.done
+        {
+            break;
+        }
     }
-    Some(SvcmgrCaps {
-        service_ep: round.caps[0],
-        bootstrap_ep: round.caps[1],
-    })
+    caps
+}
+
+/// Park one substrate `(name, thread_cap)` round in `pending`. Releases the
+/// delivered thread cap on any reject (invalid name, full table) so a
+/// malformed round cannot leak a cap.
+fn ingest_substrate(
+    round: &ipc::bootstrap::BootstrapRound,
+    pending: &mut [PendingRegistration],
+    pending_count: &mut usize,
+)
+{
+    if round.cap_count < 1
+    {
+        return;
+    }
+    let thread_cap = round.caps[0];
+    if thread_cap == 0
+    {
+        return;
+    }
+    let reject = |cap: u32| {
+        let _ = syscall::cap_delete(cap);
+    };
+    let name_len = round.data[1] as usize;
+    if name_len == 0 || name_len > 32
+    {
+        std::os::seraph::log!("bootstrap: substrate name_len invalid");
+        reject(thread_cap);
+        return;
+    }
+    if *pending_count >= pending.len()
+    {
+        std::os::seraph::log!("bootstrap: pending table full; dropping substrate");
+        reject(thread_cap);
+        return;
+    }
+    let mut name = [0u8; 32];
+    let words = name_len.div_ceil(8);
+    for w in 0..words
+    {
+        let word = round.data[2 + w];
+        for b in 0..8
+        {
+            let idx = w * 8 + b;
+            if idx < name_len && idx < name.len()
+            {
+                name[idx] = (word >> (b * 8)) as u8;
+            }
+        }
+    }
+    let idx = *pending_count;
+    pending[idx] = PendingRegistration {
+        name,
+        name_len: name_len as u8,
+        thread_cap,
+        consumed: false,
+    };
+    *pending_count += 1;
+    std::os::seraph::log!("endowed: {}", pending[idx].name_str());
 }

--- a/services/svcmgr/src/service.rs
+++ b/services/svcmgr/src/service.rs
@@ -45,15 +45,16 @@ pub struct ServiceEntry
     pub name_len: u8,
     /// Capability slot for the service's thread.
     pub thread_cap: u32,
-    /// Capability slot for an in-memory boot-module source, used to respawn
-    /// via `CREATE_PROCESS`. Always zero today: no registration path
-    /// populates it, so every restart uses `vfs_path` + `CREATE_FROM_FILE`.
-    /// Reserved for the #78 init→svcmgr substrate endowment — see the dead
-    /// branch in [`crate::restart`]'s `create_process`.
-    pub module_cap: u32,
+    /// Persistent service endpoint svcmgr created for a `provides = ...`
+    /// service: the source half (the child holds a RECV derivation,
+    /// consumers a published SEND). Zero for pure-consumer services. The
+    /// endpoint outlives any single instance — on restart svcmgr derives a
+    /// fresh RECV from this slot and re-serves it, so the published SEND
+    /// stays valid across the crash and cached client caps keep resolving.
+    pub provided_endpoint: u32,
     /// VFS path used to respawn this service via svcmgr-side walk +
-    /// `CREATE_FROM_FILE`. The sole restart source today; `module_cap` is its
-    /// reserved alternative.
+    /// `CREATE_FROM_FILE`. The sole restart source: every restartable
+    /// service is reloaded from the filesystem.
     pub vfs_path: [u8; ipc::MAX_PATH_LEN],
     /// Length of `vfs_path` in bytes (0 = module-loaded).
     pub vfs_path_len: u8,
@@ -109,7 +110,7 @@ impl ServiceEntry
             name: [0; 32],
             name_len: 0,
             thread_cap: 0,
-            module_cap: 0,
+            provided_endpoint: 0,
             vfs_path: [0; ipc::MAX_PATH_LEN],
             vfs_path_len: 0,
             bundle: [registry::Entry {

--- a/services/svctest/src/bootstrap.rs
+++ b/services/svctest/src/bootstrap.rs
@@ -4,10 +4,12 @@
 //! Decode the creator-endpoint bootstrap round into a typed [`Caps`].
 //!
 //! Slot layout (set by whichever launcher minted the round):
-//!   * `caps[0]`: tokened SEND on the **root-filesystem's** namespace
-//!     endpoint at its root directory (zero when the launcher could
-//!     not mint one). The driver behind this cap (fatfs today, any
-//!     FS driver tomorrow) is opaque to svctest.
+//!   * `caps[0]`: tokened SEND on the unified **root-filesystem**
+//!     namespace at its root directory (`rootfs.root`; zero when the
+//!     launcher could not mint one). This is vfsd's synthetic system
+//!     root — `NS_LOOKUP` walks it, and vfsd transparently delegates
+//!     to the underlying fs driver (fatfs today), which stays opaque
+//!     to svctest.
 //!   * `caps[1]`: `SHUTDOWN_AUTHORITY`-tokened SEND on pwrmgr's
 //!     service endpoint (zero when pwrmgr is absent)
 //!   * `caps[2]`: SEND on pwrmgr's service endpoint without the
@@ -23,8 +25,9 @@ use std::os::seraph::startup_info;
 #[derive(Default)]
 pub struct Caps
 {
-    /// Tokened SEND on the root filesystem's namespace endpoint at
-    /// its root directory. FS driver behind it is opaque.
+    /// Tokened SEND on the unified root-filesystem namespace at its
+    /// root directory (vfsd's synthetic root). The fs driver behind
+    /// vfsd's delegation is opaque.
     pub root_fs: u32,
     pub pwrmgr_auth: u32,
     pub pwrmgr_noauth: u32,

--- a/services/vfsd/README.md
+++ b/services/vfsd/README.md
@@ -4,7 +4,8 @@ Virtual filesystem daemon. vfsd is a namespace server with no on-disk
 storage: it composes a synthetic system root from per-mount tokened
 SEND caps on filesystem drivers, mints the root cap that every
 process receives in `ProcessInfo.system_root_cap`, and stays out of
-the I/O path after the walk.
+the I/O path after the walk. vfsd self-mounts the Seraph root partition
+(and the ESP) at startup; init issues no `MOUNT`.
 
 ---
 
@@ -15,7 +16,7 @@ vfsd/
 ├── Cargo.toml
 ├── README.md
 ├── src/
-│   ├── main.rs              # Entry, service + namespace loops, MOUNT handler
+│   ├── main.rs              # Entry, root self-mount, service + namespace loops, MOUNT handler
 │   ├── driver.rs            # Spawning fatfs driver instances
 │   ├── gpt.rs               # GPT partition table parsing
 │   ├── role_guids.rs        # Compile-time arch-conditional root + ESP GUIDs
@@ -36,38 +37,47 @@ vfsd/
   entries on the synthetic system root, and forwards unmatched
   lookups to the root mount via transparent delegation. See
   [`docs/namespace-composition.md`](docs/namespace-composition.md).
+- **Root self-mount** — at startup, after parsing the GPT, vfsd mounts
+  the Seraph root partition at `/` and the ESP at `/esp` on its own
+  initiative, before any service thread begins serving. The namespace
+  dispatcher is spawned first because the `/esp` mount re-enters vfsd's
+  namespace endpoint to resolve `/services/fs/fatfs`; service threads
+  are spawned only after the mount, so `GET_SYSTEM_ROOT_CAP` is never
+  served against an unmounted root.
 - **Service endpoint** — handles `MOUNT` and `GET_SYSTEM_ROOT_CAP` on
   its un-tokened service endpoint, with multi-threaded recv so a
   worker-driven `CREATE_FROM_FILE` re-entry cannot deadlock an in-
-  flight reply. See
+  flight reply. `MOUNT` is the runtime explicit-mount surface
+  (foreign-GUID disks, user-invoked mounts); no in-tree caller issues
+  it, since root and `/esp` are self-mounted. See
   [`docs/vfs-ipc-interface.md`](docs/vfs-ipc-interface.md).
 - **System-root cap delivery** — vfsd does not push a system-root
   cap anywhere at boot. Init pulls one via
-  `vfsd_labels::GET_SYSTEM_ROOT_CAP` after issuing the role-driven
-  root `MOUNT`; init then distributes per-child copies via
+  `vfsd_labels::GET_SYSTEM_ROOT_CAP`; vfsd replies `NO_MOUNT` until
+  root is mounted, so the pull blocks until the root filesystem is up.
+  Init then distributes per-child copies via
   `procmgr_labels::CONFIGURE_NAMESPACE` on every spawn. Procmgr
   itself holds no namespace cap — children spawned without an
   explicit `CONFIGURE_NAMESPACE` cap see
   `ProcessInfo.system_root_cap == 0`.
 - **Filesystem driver lifecycle** — vfsd is the dispatcher for fs
-  driver processes. The first `MOUNT` (the role-driven root)
-  spawns fatfs from a boot module cap; subsequent mounts walk
-  vfsd's own held system-root cap to `/services/fs/fatfs` and pass the
-  resulting file cap to procmgr via `CREATE_FROM_FILE`. The
-  first-mount path is permanent and structural — `/services/fs/fatfs` is
-  unreachable until root mounts, so spawning the fatfs that brings
-  the root online cannot be moved elsewhere. vfsd supplies each
-  driver with a partition-scoped block device endpoint and the
-  receive side of its own service endpoint.
-- **GPT enumeration + role-driven mount discovery** — parses the GPT
-  partition table from a single scratch frame at startup. The
-  `MOUNT` handler decodes a `MountRole` byte from the wire payload
-  and resolves it to a partition entry via
-  `gpt::lookup_partition_by_type_guid` against the arch-conditional
-  root GUID in `src/role_guids.rs`. The EFI System Partition (matched
-  by its standard type GUID) auto-mounts at `/esp` immediately after
-  the root mount completes; there is no `mounts.conf` and no
-  `INGEST_CONFIG_MOUNTS` IPC. See
+  driver processes. The root self-mount spawns fatfs from a boot
+  module cap; subsequent mounts walk vfsd's own held system-root cap
+  to `/services/fs/fatfs` and pass the resulting file cap to procmgr
+  via `CREATE_FROM_FILE`. The boot-module path is permanent and
+  structural — `/services/fs/fatfs` is unreachable until root mounts,
+  so spawning the fatfs that brings the root online cannot be moved
+  elsewhere. vfsd supplies each driver with a partition-scoped block
+  device endpoint and the receive side of its own service endpoint.
+- **GPT enumeration + mount discovery** — parses the GPT partition
+  table from a single scratch frame at startup, then resolves the
+  arch-conditional root GUID in `src/role_guids.rs` via
+  `gpt::lookup_partition_by_type_guid` for the self-mount. The EFI
+  System Partition (matched by its standard type GUID) auto-mounts at
+  `/esp` immediately after root; there is no `mounts.conf` and no
+  `INGEST_CONFIG_MOUNTS` IPC. The runtime `MOUNT` handler decodes a
+  `MountRole` byte from the wire payload and reuses the same
+  resolution path. See
   [`docs/namespace-composition.md`](docs/namespace-composition.md).
 
 vfsd does not touch hardware directly. All storage I/O is mediated

--- a/services/vfsd/docs/vfs-ipc-interface.md
+++ b/services/vfsd/docs/vfs-ipc-interface.md
@@ -9,19 +9,22 @@ the synthetic-root composition that backs it is described in
 [`namespace-composition.md`](namespace-composition.md).
 
 The system-root cap is requested by init via
-[`vfsd_labels::GET_SYSTEM_ROOT_CAP`] once the role-driven root mount
-completes. Vfsd derives a fresh tokened SEND on its own namespace
-endpoint addressing `NodeId::ROOT` at full namespace rights and
-replies with it. Init holds the cap as the seed for all later tier-3
-namespace-cap distribution; children of init receive a `cap_copy` of
-it via `procmgr_labels::CONFIGURE_NAMESPACE`. Clients consume it via
+[`vfsd_labels::GET_SYSTEM_ROOT_CAP`]. vfsd self-mounts root before any
+service thread starts, and replies `NO_MOUNT` to this request until
+root is mounted, so the pull blocks until the root filesystem is up
+(and fails fast — letting init FATAL — if the self-mount failed).
+Vfsd derives a fresh tokened SEND on its own namespace endpoint
+addressing `NodeId::ROOT` at full namespace rights and replies with
+it. Init holds the cap as the seed for all later tier-3 namespace-cap
+distribution; children of init receive a `cap_copy` of it via
+`procmgr_labels::CONFIGURE_NAMESPACE`. Clients consume it via
 `std::os::seraph::root_dir_cap()`. Vfsd holds no namespace cap on
 procmgr's behalf — there is no boot-time push.
 
 The historic `INGEST_CONFIG_MOUNTS` IPC and the `/config/mounts.conf`
 file it consumed were retired with the GPT-type-GUID redesign (boot
-protocol v8). vfsd now auto-mounts the EFI System Partition at `/esp`
-after the role-driven root mount succeeds; additional partitions are
+protocol v8). vfsd self-mounts the Seraph root partition at `/` and the
+EFI System Partition at `/esp` at startup; additional partitions are
 discovered by their type GUID, not by a config file. The label number
 (`12`) is reserved and MUST NOT be reused for an unrelated request.
 
@@ -31,8 +34,8 @@ discovered by their type GUID, not by a config file. The label number
 
 vfsd holds the receive side of one un-tokened service endpoint,
 created and delivered by init at vfsd's bootstrap (round 1, `caps[0]`).
-Init holds a SEND copy for the role-driven root `MOUNT` and a tokened
-`SEED_AUTHORITY` SEND for `GET_SYSTEM_ROOT_CAP` during boot.
+Init holds a tokened `SEED_AUTHORITY` SEND for `GET_SYSTEM_ROOT_CAP`
+during boot; it issues no `MOUNT`, since vfsd self-mounts root.
 
 All requests use `SYS_IPC_CALL` (synchronous call/reply). Numeric
 labels live in [`ipc::vfsd_labels`] in `shared/ipc`.
@@ -40,6 +43,11 @@ labels live in [`ipc::vfsd_labels`] in `shared/ipc`.
 ---
 
 ## Label 10: `MOUNT`
+
+Runtime explicit-mount surface (foreign-GUID disks, user-invoked
+mounts). vfsd self-mounts root and `/esp` at startup through the same
+resolution path, so no in-tree caller currently issues `MOUNT`; the
+label is retained for runtime mounts.
 
 Mount the partition identified by a Seraph-minted GPT type GUID at the
 given path. vfsd resolves the role byte to an arch-conditional type
@@ -50,15 +58,16 @@ priority tie-break on attribute bits 48-63; tied priorities are
 fatal), registers the partition bound with virtio-blk, spawns a fatfs
 driver, sends `FS_MOUNT` to validate the BPB, captures the driver's
 root cap into [`VfsdRootBackend`], and replies with a tokened SEND on
-the new filesystem's namespace endpoint addressing its root.
+the new filesystem's namespace endpoint addressing its root. A mount
+on `/` is rejected (`NO_MOUNT`) once root is already mounted.
 
 When the requested role is the rootfs (`MountRole::Root`, byte `0`),
 vfsd additionally auto-mounts the EFI System Partition at `/esp`
-inside the same handler before replying. The ESP mount is best-effort:
-failure logs a diagnostic but does not propagate into the root mount
-reply. The ESP is identified by the standard EFI System Partition
-type GUID (`c12a7328-f81f-11d2-ba4b-00a0c93ec93b`); init never has to
-issue a separate MOUNT for `/esp`.
+inside the same handler before replying — the same logic the startup
+self-mount uses. The ESP mount is best-effort: failure logs a
+diagnostic but does not propagate into the root mount reply. The ESP
+is identified by the standard EFI System Partition type GUID
+(`c12a7328-f81f-11d2-ba4b-00a0c93ec93b`).
 
 **Request**
 
@@ -78,8 +87,9 @@ issue a separate MOUNT for `/esp`.
 
 **Reply (error)**: `label = vfsd_errors::*` (`NOT_FOUND` for an
 unknown role byte or invalid path length, `NO_MOUNT` if no partition
-matches the role GUID or if duplicate-priority partitions are
-detected, `SPAWN_FAILED`, `IO_ERROR`, `TABLE_FULL`).
+matches the role GUID, if duplicate-priority partitions are detected,
+or if root is already mounted, `SPAWN_FAILED`, `IO_ERROR`,
+`TABLE_FULL`).
 
 Single-component mount paths only (`/`, `/<name>`). Multi-component
 paths are not surfaced through `NS_LOOKUP` and remain reachable only

--- a/services/vfsd/src/main.rs
+++ b/services/vfsd/src/main.rs
@@ -6,12 +6,16 @@
 //! Seraph virtual filesystem daemon.
 //!
 //! vfsd presents a unified virtual filesystem namespace to all other
-//! processes via a synthetic system-root cap. Each MOUNT installs a
+//! processes via a synthetic system-root cap. A mount installs a
 //! tokened SEND on the underlying driver's namespace endpoint into
 //! `VfsdRootBackend`; clients walk that root via `NS_LOOKUP` and reach
 //! per-file node caps directly on the driver. After the walk vfsd is
 //! out of the path: file reads, frame requests, and closes go straight
 //! from client to driver.
+//!
+//! vfsd self-mounts the Seraph root partition at `/` (and the ESP at
+//! `/esp`) during startup, before serving any request; the runtime
+//! `MOUNT` IPC remains for explicit/foreign-GUID mounts.
 //!
 //! See `vfsd/README.md` for the design and `fs/docs/fs-driver-protocol.md`
 //! for the driver-side protocol.
@@ -256,7 +260,9 @@ fn main() -> !
         root_backend: Mutex::new(VfsdRootBackend::new()),
     }));
 
-    // Spawn the namespace dispatcher.
+    // Spawn the namespace dispatcher first: the `/esp` self-mount below
+    // takes the VFS spawn path, which re-enters vfsd's namespace endpoint
+    // to resolve `/services/fs/fatfs`.
     if std::thread::Builder::new()
         .name("vfsd-namespace".into())
         .spawn(move || namespace_loop(runtime))
@@ -264,6 +270,16 @@ fn main() -> !
     {
         std::os::seraph::log!("FATAL: namespace thread spawn failed");
         idle_loop();
+    }
+
+    // Self-mount the root filesystem (and the ESP) before any service
+    // thread can serve `GET_SYSTEM_ROOT_CAP`, so the seed system-root cap
+    // is never handed out against an unmounted root. On failure vfsd still
+    // serves: `GET_SYSTEM_ROOT_CAP` replies `NO_MOUNT` so init FATALs
+    // promptly rather than blocking forever.
+    if !self_mount(runtime, ipc_buf)
+    {
+        std::os::seraph::log!("root unavailable; system-root requests will fail");
     }
 
     // Spawn N-1 helper service threads; main becomes the Nth handler. Each
@@ -567,8 +583,28 @@ fn try_forward_lookup_fallthrough(
 /// service-endpoint token: holding the bit is equivalent to holding
 /// the system-root cap, so only consumers explicitly entrusted with
 /// seed authority reach this handler.
+///
+/// Replies [`vfsd_errors::NO_MOUNT`] when the root filesystem is not
+/// mounted. vfsd self-mounts root before any service thread starts, so
+/// this fires only when the self-mount failed (no `SERAPH_ROOT`
+/// partition, or fatfs bring-up failed); init then FATALs instead of
+/// receiving a system-root cap that resolves against an empty root.
 fn handle_get_system_root_cap(ipc_buf: *mut u64, rt: &VfsdRuntime)
 {
+    if rt
+        .root_backend
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+        .root_mount_cap()
+        == 0
+    {
+        std::os::seraph::log!("GET_SYSTEM_ROOT_CAP rejected: root not mounted");
+        let err = IpcMessage::new(ipc::vfsd_errors::NO_MOUNT);
+        // SAFETY: ipc_buf is the thread-registered IPC buffer page.
+        let _ = unsafe { ipc::ipc_reply(&err, ipc_buf) };
+        return;
+    }
+
     let token = namespace_protocol::pack(
         namespace_protocol::NodeId::ROOT,
         namespace_protocol::NamespaceRights::ALL,
@@ -622,7 +658,43 @@ impl MountRole
     }
 }
 
-/// Handle a MOUNT request from init (or any authorized client).
+/// Mount the Seraph root partition at `/`, then auto-mount the ESP at
+/// `/esp`, during vfsd startup.
+///
+/// Runs on the main thread before any service handler exists, so a
+/// `GET_SYSTEM_ROOT_CAP` request can never observe an unmounted root.
+/// The namespace dispatcher must already be running: the `/esp` mount
+/// takes the VFS spawn path, which re-enters vfsd's namespace endpoint
+/// to resolve `/services/fs/fatfs`. Returns whether the root mount
+/// succeeded; `/esp` is best-effort and never gates the return value.
+fn self_mount(rt: &VfsdRuntime, ipc_buf: *mut u64) -> bool
+{
+    match do_mount_internal(rt, ipc_buf, &role_guids::SERAPH_ROOT, b"/")
+    {
+        Ok(caller_root_cap) =>
+        {
+            // The per-mount caller cap rides back to an IPC caller; the
+            // self-mount has none, and vfsd reaches root through the
+            // synthetic backend, so drop it.
+            log_cap_delete("self-mount caller_root_cap", caller_root_cap);
+            std::os::seraph::log!("root self-mounted at /");
+        }
+        Err(code) =>
+        {
+            std::os::seraph::log!("FATAL: root self-mount failed: code={code:#x}");
+            return false;
+        }
+    }
+
+    auto_mount_esp(rt, ipc_buf);
+    true
+}
+
+/// Handle a runtime MOUNT request from an authorized client.
+///
+/// vfsd self-mounts root and `/esp` at startup ([`self_mount`]), so no
+/// in-tree caller currently issues MOUNT; it remains the explicit /
+/// runtime-mount surface (foreign-GUID disks, user-invoked mounts).
 ///
 /// IPC data layout (boot protocol v8+):
 /// - `data[0]` low byte: [`MountRole`] discriminant
@@ -631,9 +703,7 @@ impl MountRole
 ///
 /// Decodes the wire payload and delegates to [`do_mount`] for the
 /// real work. When the requested role is [`MountRole::Root`], vfsd
-/// additionally auto-mounts the EFI System Partition at `/esp` so
-/// userspace (svctest namespace tests, future userspace) can read it
-/// without a separate IPC call.
+/// additionally auto-mounts the EFI System Partition at `/esp`.
 #[allow(clippy::cast_possible_truncation)]
 fn handle_mount_request(recv: &IpcMessage, ipc_buf: *mut u64, rt: &VfsdRuntime)
 {

--- a/services/vfsd/src/root_backend.rs
+++ b/services/vfsd/src/root_backend.rs
@@ -162,7 +162,7 @@ impl VfsdRootBackend
     /// Walks `path`'s components, creating synthetic intermediates on
     /// demand, and sets `terminal_cap` on the final node. The empty
     /// path (`/`) installs `cap` as the synthetic root's
-    /// `fallthrough_cap`.
+    /// `fallthrough_cap` (the root mount).
     ///
     /// Returns `Some(InstallResult)` listing newly-created
     /// intermediate indices on success; the caller is expected to
@@ -170,13 +170,19 @@ impl VfsdRootBackend
     /// [`Self::set_fallthrough_cap`].
     ///
     /// Returns `None` on tree exhaustion, oversize component
-    /// (`> MAX_ENTRY_NAME`), or attempting to mount on top of an
-    /// already-terminal node.
+    /// (`> MAX_ENTRY_NAME`), attempting to mount on top of an
+    /// already-terminal node, or re-installing the root mount.
     pub fn install(&mut self, path: &[u8], cap: u32) -> Option<InstallResult>
     {
         let stripped = path.strip_prefix(b"/").unwrap_or(path);
         if stripped.is_empty()
         {
+            if self.nodes[0].fallthrough_cap != 0
+            {
+                // Root is already mounted; reject rather than overwrite
+                // the cap and leak the running root fs driver.
+                return None;
+            }
             self.nodes[0].fallthrough_cap = cap;
             return Some(InstallResult::empty());
         }
@@ -199,6 +205,10 @@ impl VfsdRootBackend
         if total == 0
         {
             // Path was something like `///` — treat as root.
+            if self.nodes[0].fallthrough_cap != 0
+            {
+                return None;
+            }
             self.nodes[0].fallthrough_cap = cap;
             return Some(InstallResult::empty());
         }

--- a/shared/ipc/src/lib.rs
+++ b/shared/ipc/src/lib.rs
@@ -255,9 +255,10 @@ pub mod procmgr_labels
     ///                  via IPC cap-transfer; procmgr accumulates them
     ///                  for the eventual `memmgr.DONATE_FRAMES` chunk.
     ///
-    /// Procmgr binds the death-EQ on init's main thread with correlator
-    /// `INIT_REAP_CORRELATOR` as part of the first round. Each round
-    /// replies `procmgr_errors::SUCCESS`.
+    /// Procmgr binds the death-EQ on both init threads (main and
+    /// init-logd) with correlator `INIT_REAP_CORRELATOR` as part of the
+    /// first round, and reaps once both have exited. Each round replies
+    /// `procmgr_errors::SUCCESS`.
     pub const REGISTER_INIT_TEARDOWN: u64 = 15;
 
     /// Signal end of init's reap-handoff cap stream. After this call
@@ -1642,8 +1643,8 @@ pub mod svcmgr_errors
     /// Discovery registry publish: table full or duplicate name.
     pub const REGISTER_REJECTED: u64 = 6;
     /// Caller's compiled `SVCMGR_LABELS_VERSION` does not match the receiver's.
-    /// `REGISTER_SERVICE` is the handshake entry point and carries the
-    /// caller's version as `data[0]` (with all other words shifted by +1);
+    /// The handover-endowment `CAPS` round carries the caller's version
+    /// in `data[1]` (after the `endow_kind` discriminant in `data[0]`);
     /// mismatch here means the caller was built against a different
     /// revision of `shared/ipc`.
     pub const LABEL_VERSION_MISMATCH: u64 = 7;

--- a/shared/ipc/src/lib.rs
+++ b/shared/ipc/src/lib.rs
@@ -1021,7 +1021,7 @@ pub mod fs_labels
     pub const FS_TRUNCATE: u64 = 17;
 }
 
-pub const DEVMGR_LABELS_VERSION: u32 = 5;
+pub const DEVMGR_LABELS_VERSION: u32 = 6;
 /// IPC labels for the device manager (`devmgr`).
 pub mod devmgr_labels
 {
@@ -1108,6 +1108,58 @@ pub mod devmgr_labels
     /// and replies [`super::devmgr_errors::NO_DEVICE`] on subsequent
     /// queries; clients MUST NOT retry-loop.
     pub const SET_DRIVERS_DIR: u64 = 6;
+
+    /// Locate an ACPI table and serve a read-only view of it.
+    ///
+    /// devmgr is the sole owner of ACPI data and the only service that
+    /// navigates the table tree (RSDP → XSDT). Callers that need a table
+    /// (today: `pwrmgr`, for the FADT + DSDT it interprets for S5
+    /// shutdown) request it here rather than holding ACPI frames of
+    /// their own.
+    ///
+    /// Request: `data[0]` = caller's compiled [`super::DEVMGR_LABELS_VERSION`];
+    /// `data[1]` = 4-byte table signature packed little-endian (e.g.
+    /// `FACP`), or `0` to look up by physical address; `data[2]` =
+    /// table physical address (used when `data[1] == 0`, e.g. the DSDT,
+    /// whose address the caller reads from the FADT). Caller's token MUST
+    /// carry [`REGISTRY_QUERY_AUTHORITY`]; the handler replies
+    /// [`super::devmgr_errors::UNAUTHORIZED`] otherwise.
+    ///
+    /// Reply ([`super::devmgr_errors::SUCCESS`]): `caps[0]` = a derived
+    /// **read-only-intended** Frame cap on the ACPI region containing the
+    /// table (the caller maps it `MAP_READONLY`); `data[0]` = region
+    /// physical base, `data[1]` = region size in bytes, `data[2]` = the
+    /// table's physical address. The caller maps the region and reads the
+    /// table at `table_phys - region_base`. devmgr reads only the
+    /// directory (RSDP/XSDT) and table headers (signatures) to locate the
+    /// table — never a table body. Replies
+    /// [`super::devmgr_errors::NO_DEVICE`] when the table is not found.
+    pub const QUERY_ACPI_TABLE: u64 = 7;
+
+    /// Carve and serve the platform shutdown-actuator hardware caps.
+    ///
+    /// devmgr is the hardware authority; it carves the exact ports the
+    /// power manager asks for and performs no shutdown logic. The caller
+    /// (`pwrmgr`) has already parsed the ACPI tables (served via
+    /// [`QUERY_ACPI_TABLE`]) and computed the `PM1a` control port it needs.
+    ///
+    /// Request: `data[0]` = caller's compiled [`super::DEVMGR_LABELS_VERSION`];
+    /// `data[1]` = the `PM1a` control port (x86-64; ignored on RISC-V).
+    /// Caller's token MUST carry [`REGISTRY_QUERY_AUTHORITY`]; the handler
+    /// replies [`super::devmgr_errors::UNAUTHORIZED`] otherwise.
+    ///
+    /// Reply ([`super::devmgr_errors::SUCCESS`]):
+    /// - x86-64: `caps[0]` = a narrow `IoPortRange` over `[pm1a, pm1a+2)`
+    ///   carved from devmgr's root `IoPortRange`; `caps[1]` = a narrow
+    ///   `IoPortRange` over `[0x64, 0x65)` (8042 KBC reset, for reboot).
+    ///   Both are re-derived from the root on every call, so a pwrmgr
+    ///   restart re-acquires them cleanly.
+    /// - RISC-V: `caps[0]` = a `cap_derive` copy of devmgr's `SbiControl`
+    ///   cap (SBI SRST authority).
+    ///
+    /// Replies [`super::devmgr_errors::NO_DEVICE`] when the carve fails or
+    /// the platform authority cap is absent.
+    pub const QUERY_SHUTDOWN_DEVICE: u64 = 8;
 
     /// Authority bit in the devmgr-registry-endpoint token's high
     /// u64 bit. Set on caps minted for consumers permitted to call

--- a/shared/ipc/src/lib.rs
+++ b/shared/ipc/src/lib.rs
@@ -50,7 +50,7 @@ use syscall_abi::{MSG_CAP_SLOTS_MAX, MSG_DATA_WORDS_MAX};
 //     BLK_LABELS_VERSION    — blk_labels::REGISTER_PARTITION   (vfsd ↔ virtio-blk)
 //     DEVMGR_LABELS_VERSION — devmgr_labels::QUERY_BLOCK_DEVICE (vfsd ↔ devmgr)
 //     MEMMGR_LABELS_VERSION — memmgr_labels::REGISTER_PROCESS   (procmgr ↔ memmgr)
-//     SVCMGR_LABELS_VERSION — svcmgr_labels::REGISTER_SERVICE   (init ↔ svcmgr)
+//     SVCMGR_LABELS_VERSION — svcmgr handover endowment round 1   (init ↔ svcmgr)
 //     LOG_LABELS_VERSION    — log_labels::GET_LOG_CAP            (std process ↔ logd)
 //
 //   Implicitly covered by parent-channel handshake — the channel was opened
@@ -481,41 +481,30 @@ pub mod procmgr_process_state
     pub const EXITED: u64 = 3;
 }
 
-pub const SVCMGR_LABELS_VERSION: u32 = 3;
+pub const SVCMGR_LABELS_VERSION: u32 = 4;
 /// IPC labels for the service manager (`svcmgr`).
 pub mod svcmgr_labels
 {
-    /// Register a currently-running service for supervision.
-    ///
-    /// The recipe (binary, argv, env, restart policy, criticality,
-    /// namespace shape, seed names) lives on disk at
-    /// `/config/svcmgr/services/<name>.svc`, not on the wire. This
-    /// message carries only what cannot be on disk: which named
-    /// recipe the running process implements, and the thread cap
-    /// svcmgr binds death-notification on.
-    ///
-    /// Wire format:
-    /// * word 0: `SVCMGR_LABELS_VERSION` handshake.
-    /// * word 1: `name_len` (byte length of the service name).
-    /// * words 2..: `name` bytes (the `.svc` filename without
-    ///   the `.svc` suffix).
-    /// * `caps[0]`: thread cap for death-notification binding.
-    ///
-    /// On [`HANDOVER_COMPLETE`] svcmgr reconciles every registered
-    /// name against `/config/svcmgr/services/`: a registered name with a
-    /// definition is bound and supervised using the on-disk recipe;
-    /// a defined name not registered is launched by svcmgr itself;
-    /// a registered name with no definition is a hard error (svcmgr
-    /// has no recipe to restart it). See
-    /// `services/svcmgr/docs/service-definitions.md` and
-    /// `services/svcmgr/docs/ipc-interface.md` for the
-    /// authoritative spec.
-    pub const REGISTER_SERVICE: u64 = 1;
+    // The substrate services init bootstrapped before svcmgr existed
+    // (memmgr, procmgr, devmgr, vfsd, logd) are handed to svcmgr over
+    // init's bootstrap-round endowment, not a dedicated label: round 1
+    // carries svcmgr's own endpoints plus the source caps it needs for
+    // its publish role (`rootfs.root` SEND, devmgr-registry `SEND|GRANT`
+    // source) and `SVCMGR_LABELS_VERSION` in `data[1]`; each subsequent
+    // round carries one `(name, thread_cap)` pair svcmgr parks in its
+    // pending-registration table. On `HANDOVER_COMPLETE` svcmgr
+    // reconciles every parked name against `/config/svcmgr/services/`:
+    // a parked name with a definition is bound and supervised using the
+    // on-disk recipe; a defined name not parked is launched by svcmgr
+    // itself; a parked name with no definition is a hard error (svcmgr
+    // has no recipe to restart it). The endowment layout lives in
+    // `services/init/src/service.rs` and `services/svcmgr/src/service.rs`;
+    // see `services/svcmgr/docs/ipc-interface.md` and
+    // `services/svcmgr/docs/service-definitions.md` for the spec.
 
     /// Internal namespace-policy descriptor stored on `ServiceEntry`
     /// (one of the values below). Parsed by svcmgr from each
-    /// service's `namespace = ...` line in `/config/svcmgr/services/<name>.svc`;
-    /// no longer carried on the [`REGISTER_SERVICE`] wire.
+    /// service's `namespace = ...` line in `/config/svcmgr/services/<name>.svc`.
     ///
     /// Namespace-policy descriptor: hand the child a `cap_copy` of
     /// svcmgr's own root cap at full rights. Reserved for the small
@@ -551,12 +540,14 @@ pub mod svcmgr_labels
     pub const QUERY_ENDPOINT: u64 = 4;
 
     /// Verb-bit carried by the caller's token to authorise
-    /// [`PUBLISH_ENDPOINT`]. Init mints SEND caps on svcmgr's service
-    /// endpoint whose token is exactly `PUBLISH_AUTHORITY` (no
-    /// per-publisher identity in the low bits today — server-side
-    /// auth is binary: have the bit, or don't). Holders trusted to
-    /// add names: init itself, devmgr for driver registrations,
-    /// svcmgr's own future post-init service launcher.
+    /// [`PUBLISH_ENDPOINT`] by an *external* publisher (no per-publisher
+    /// identity in the low bits today — server-side auth is binary: have
+    /// the bit, or don't). svcmgr publishes the well-known names it owns
+    /// (`rootfs.root`, `svcmgr`, `devmgr.registry`, and each provider's
+    /// `provides` names) directly into its own registry, so those need no
+    /// token. The gate exists for a future external publisher — devmgr
+    /// holds a `PUBLISH_AUTHORITY`-tokened SEND from its bootstrap bundle,
+    /// reserved for driver registrations.
     ///
     /// The SEND distributed to every process via
     /// `ProcessInfo.service_registry_cap` carries the child's
@@ -577,10 +568,12 @@ pub mod svcmgr_labels
 
 /// Well-known names published into svcmgr's discovery registry.
 ///
-/// Centralised so publishers (today: `init` during Phase 3 handover)
-/// and consumers (today: `svcmgr` resolving each `.svc`'s `seed = ...`
-/// list during launch) share the exact spelling. A typo on either
-/// side leaks out as `svcmgr_errors::UNKNOWN_NAME` rather than
+/// Centralised so the publisher (`svcmgr`, post-handover — from source
+/// caps init endows it in the handover endowment, plus each provider's
+/// `provides` names) and consumers (`svcmgr` resolving each `.svc`'s
+/// `seed = ...` list during launch, and any process via
+/// `QUERY_ENDPOINT`) share the exact spelling. A typo on either side
+/// leaks out as `svcmgr_errors::UNKNOWN_NAME` rather than
 /// `INSUFFICIENT_CAPS`.
 ///
 /// Names are FS-driver- and platform-agnostic by design: swapping the
@@ -616,10 +609,10 @@ pub mod published_names
     /// endpoint. Consumers needing to resolve a device driver
     /// themselves (today: `programs/fb-charset` →
     /// `QUERY_FRAMEBUFFER_DEVICE`; future: any non-init caller of
-    /// devmgr's discovery surface) seed this name. Init publishes it
-    /// at Phase 3 handover; the `REGISTRY_QUERY_AUTHORITY` token bit
-    /// is preserved through svcmgr's plain `cap_derive` in
-    /// `registry_lookup_derived`.
+    /// devmgr's discovery surface) seed this name. svcmgr publishes it
+    /// post-handover from the devmgr-registry source cap init endows it
+    /// with; the `REGISTRY_QUERY_AUTHORITY` token bit is preserved
+    /// through svcmgr's plain `cap_derive` in `registry_lookup_derived`.
     pub const DEVMGR_REGISTRY: &[u8] = b"devmgr.registry";
 }
 
@@ -746,12 +739,14 @@ pub mod timed_errors
 pub const PWRMGR_LABELS_VERSION: u32 = 1;
 /// IPC labels for the power manager (`pwrmgr`).
 ///
-/// pwrmgr owns the platform shutdown surface: ACPI S5 on x86-64 (via
-/// `AcpiReclaimable` Frame caps plus the `IoPortRange` cap) and SBI SRST
-/// on RISC-V (via the `SbiControl` cap). Init transfers those raw caps to
-/// pwrmgr during Phase 3 bootstrap; callers that may invoke shutdown
-/// receive a tokened SEND on pwrmgr's service endpoint with the
-/// [`pwrmgr_labels::SHUTDOWN_AUTHORITY`] verb bit set.
+/// pwrmgr owns the platform shutdown surface: ACPI S5 on x86-64 (the
+/// `PM1a` `IoPortRange` carved from the FADT/DSDT it interprets) and SBI
+/// SRST on RISC-V (the `SbiControl` cap). It acquires those caps from
+/// devmgr — the hardware/ACPI authority — at startup via
+/// [`devmgr_labels::QUERY_ACPI_TABLE`] and
+/// [`devmgr_labels::QUERY_SHUTDOWN_DEVICE`], not from init. Callers that
+/// may invoke shutdown receive a tokened SEND on pwrmgr's service
+/// endpoint with the [`pwrmgr_labels::SHUTDOWN_AUTHORITY`] verb bit set.
 ///
 /// See `services/pwrmgr/README.md` for the authoritative description.
 pub mod pwrmgr_labels
@@ -1074,21 +1069,21 @@ pub mod devmgr_labels
     /// `RTC_GET_EPOCH_TIME` round-trip and serves `GET_WALL_TIME`
     /// thereafter.
     pub const QUERY_RTC_DEVICE: u64 = 5;
-    /// Init-only handshake: install the
+    /// svcmgr-only handshake: install the
     /// `LOOKUP | READ`-attenuated `/services/drivers/` namespace cap from
     /// which devmgr walks its on-disk driver binaries.
     ///
     /// Request: `data[0]` = caller's compiled
     /// [`super::DEVMGR_LABELS_VERSION`]; `caps[0]` = tokened SEND on a
     /// vfsd directory node rooted at the system's `/services/drivers/`
-    /// path, derived by init via
-    /// `ns_client::walk_to_dir(system_root_cap, …, LOOKUP | READ)`.
-    /// Caller's token MUST carry [`INIT_BIND_AUTHORITY`]; the handler
+    /// path, derived by svcmgr via
+    /// `namespace_lookup_dir(root_dir_cap, …, LOOKUP | READ)`.
+    /// Caller's token MUST carry [`DRIVERS_DIR_AUTHORITY`]; the handler
     /// replies [`super::devmgr_errors::UNAUTHORIZED`] otherwise.
     ///
     /// Devmgr stashes the cap and replies
     /// [`super::devmgr_errors::SUCCESS`] **before** doing any spawn
-    /// work, so init never blocks on driver bring-up. The actual walk,
+    /// work, so svcmgr never blocks on driver bring-up. The actual walk,
     /// the [`super::procmgr_labels::CREATE_FROM_FILE`] call, and the
     /// bootstrap-round delivery for any on-disk driver (today: the
     /// per-arch RTC; #165 will generalize) runs after the reply but
@@ -1168,13 +1163,14 @@ pub mod devmgr_labels
     /// virtio-blk closes the minter-side surface: `MOUNT_AUTHORITY`
     /// caps are never issued to consumers devmgr did not authorise.
     pub const REGISTRY_QUERY_AUTHORITY: u64 = 1u64 << 63;
-    /// Authority bit gating [`SET_DRIVERS_DIR`]. Set only on the cap
-    /// init derives for its own use from `devmgr_registry_ep`; the
-    /// `REGISTRY_QUERY_AUTHORITY`-only copy init publishes to svcmgr
-    /// (which other services then look up) lacks this bit, so no
-    /// service other than init can call `SET_DRIVERS_DIR`. Disjoint
-    /// position from [`REGISTRY_QUERY_AUTHORITY`].
-    pub const INIT_BIND_AUTHORITY: u64 = 1u64 << 62;
+    /// Authority bit gating [`SET_DRIVERS_DIR`]. svcmgr mints a SEND
+    /// cap carrying this bit from the devmgr-registry source cap init
+    /// endows it with at handover; the `REGISTRY_QUERY_AUTHORITY`-only
+    /// copy svcmgr publishes as `devmgr.registry` (which other services
+    /// then look up) lacks this bit, so no looked-up consumer can call
+    /// `SET_DRIVERS_DIR`. Disjoint position from
+    /// [`REGISTRY_QUERY_AUTHORITY`].
+    pub const DRIVERS_DIR_AUTHORITY: u64 = 1u64 << 62;
 }
 
 /// Device-info kind discriminants for [`devmgr_labels::QUERY_DEVICE_INFO`]


### PR DESCRIPTION
## Summary

Collapses init's runtime surface to the genuine first-userspace-process
minimum and moves every post-bootstrap responsibility to its proper
owner: **svcmgr owns all post-`HANDOVER_COMPLETE` launch; devmgr owns all
hardware authority.** Guiding principle: *init must be clueless about the
post-bootstrap service graph.*

Closes #78. Also resolves #47 (logd respawn policy — pulled in per the
design discussion below).

## Stages (one self-contained, separately-validated commit each)

1. **`07926d0` — timed → svcmgr provider.** New `provides = <name>` recipe
   directive + provider launch path (svcmgr creates the endpoint, serves
   RECV as bootstrap cap[0], publishes SEND under the name; providers
   launch before consumers; restart re-serves a fresh RECV). `timed` moves
   off init.
2. **`0eeeb8b` — devmgr as ACPI/shutdown broker; pwrmgr → svcmgr.** devmgr
   becomes sole ACPI owner + hardware/shutdown broker (`QUERY_ACPI_TABLE`,
   `QUERY_SHUTDOWN_DEVICE`); pwrmgr moves off init to a svcmgr-launched
   provider acquiring its caps from devmgr "as if a device driver".
   `provides` generalized to tokened `name[:auth|:deny]`.
3. **`4fdc275` — REGISTER_SERVICE + publishes + SET_DRIVERS_DIR → svcmgr.**
   The N-per-service `REGISTER_SERVICE` loop, the well-known publishes, and
   the `SET_DRIVERS_DIR` handshake fold into a single multi-round handover
   **endowment** (kind in `data[0]`: CAPS / SUBSTRATE). svcmgr publishes
   `rootfs.root` / `svcmgr` / `devmgr.registry` and sends `SET_DRIVERS_DIR`
   itself.
4. **`dadbf24` — vfsd self-mounts root; init drops MOUNT.** vfsd self-mounts
   the Seraph root (+ ESP) by GPT type-GUID on its own startup; init issues
   no `MOUNT` and keeps `GET_SYSTEM_ROOT_CAP` as its wait-for-root barrier.
5. **`b99acfa` — real-logd → svcmgr-launched + restartable; reap-on-threadless.**
   svcmgr launches and supervises real-logd, minting its bootstrap round
   from reserved log-sink sources init endows (new `LOGD_SOURCES` round).
   logd is restartable (`restart = on_failure`, `critical = yes`): svcmgr
   holds the master-log endpoint source for the system's life and mints a
   fresh RECV per (re)launch, so senders are agnostic to which process
   holds it. procmgr's init-reap moves to **reap-on-threadless** (binds a
   death-EQ on both init threads; reaps only once init-logd has also
   exited) so init-logd outlives init's main thread until the handover.
6. **`086bf27` — docs + present-tense comment sweep.** Completes the
   Stage-5 documentation and rewrites change-narration in the touched
   comments/docs to present tense.

## #78 Acceptance

- [x] `services/init/src/service.rs` no longer contains
      `create_and_start_pwrmgr` / `create_and_start_rtc_driver` /
      `create_and_start_timed` / `bring_up_wallclock`, nor a pwrmgr spawn
      call site in `phase3_svcmgr_handover`. *(verified: no matches)*
- [x] No `REGISTER_SERVICE` loop for init-bootstrapped services; replaced
      by the single handover endowment.
- [x] svcmgr spawns pwrmgr, the per-arch RTC driver, and timed after
      `HANDOVER_COMPLETE` from `.svc` recipes. *(RTC driver is devmgr
      lazy-loaded via `SET_DRIVERS_DIR`, which svcmgr now drives — #164.)*
- [x] Wallclock comes up before any svctest phase depending on
      `SystemTime::now()` (`svctest/phases/timed.rs` asserts a real value
      ≥ UNIX_EPOCH; validated on both arches).
- [x] Fault-injection: a crashing service produces a death event and
      drives the supervised path. The CI-staged `crasher` fixture
      (`restart = always`) exercises death-event + restart + restart-
      surface preservation. The `critical = yes` → graceful-shutdown
      branch is implemented (`svcmgr/src/restart.rs::permanent_death_outcome` →
      `Unrecoverable` → `pwrmgr_labels::SHUTDOWN`); it is not driven by a
      dedicated integration test because asserting it would power the
      system off (the terminal `pwrmgr_shutdown` test covers the graceful-
      shutdown actuation itself). **Auditor note:** flagging this as the
      one acceptance item whose second half is logic-complete but not
      separately fault-injected.

## Authorized scope expansions beyond #78's literal text

Both were pulled in explicitly during the work (not silent):

- **Stage 4 (init drops `MOUNT`).** #78 lists "removing init's `MOUNT` /
  `GET_SYSTEM_ROOT_CAP` exchange" as out-of-scope. We removed only the
  `MOUNT` *call* (vfsd self-mounts now) and **kept** `GET_SYSTEM_ROOT_CAP`
  (init still pulls the root cap to load svcmgr). Net: init's vfsd surface
  shrinks to the genuine wait-for-root barrier.
- **Stage 5 (real-logd migration).** #78 lists logd migration as a
  follow-up; pulled in here as an essential part of collapsing init's
  surface (init keeps only the bootstrap serial-writer thread). Resolves
  #47.

## Deferrals (tracked)

- **#191** — pre-existing change-narration in comments/docs outside this
  PR's surface (kernel, ktest, init bootstrap, svctest). Surfaced by the
  Stage-6 sweep; deferred to keep this PR's review surface scoped.
- devmgr full hardware-broker generalization / data-driven enumeration
  remains **#165** (the per-class `QUERY_*_DEVICE` queries here are the
  pre-generalization shape).

## Test plan

Per-stage, on **x86_64 and riscv64**: `cargo xtask build` + staged
`svctest` boot → `ALL TESTS PASSED` (pwrmgr_cap_deny UNAUTHORIZED via
`pwrmgr.deny`; real wall clock through `timed`; ns phase; residual=0),
clean terminal poweroff (exit 0). Stage 5 additionally proves
reap-on-threadless ordering: `[logd] handover complete` precedes
`init reaped: …` on both arches. 68 host tests pass.

