### PR TITLE
kernel: replace global TLB shootdown lock with per-CPU request slots

### DIFF
--- a/core/kernel/docs/scheduling-internals.md
+++ b/core/kernel/docs/scheduling-internals.md
@@ -379,7 +379,7 @@ The kernel sends three IPIs. Each has a defined purpose and correctness role.
 
 `core/kernel/src/arch/riscv64/interrupts.rs`:
 
-The riscv64 build uses one SBI IPI extension (EID `0x735049`, FID `0`) for both TLB shootdown and wakeup. The supervisor-mode trap handler distinguishes the two by side-channel state — the shootdown path consults a per-CPU pending-shootdown bitmap; the wakeup path falls through with no work, exactly mirroring the x86_64 wakeup-vector handler.
+The riscv64 build uses one SBI IPI extension (EID `0x735049`, FID `0`) for both TLB shootdown and wakeup. The supervisor-mode trap handler distinguishes the two by side-channel state — the shootdown path scans the per-CPU TLB shootdown request slots and services any whose pending mask names this hart; a wakeup-only IPI finds no slot naming it and falls through with no work, exactly mirroring the x86_64 wakeup-vector handler.
 
 The same correctness rules apply: shootdown is required for TLB coherence; wakeup is required for the wake protocol.
 
@@ -494,11 +494,11 @@ S-mode timer) would close the latter gap; tracked as issue #33.
 participating CPU (initiator preempt-disabled in `wait_for_ack`; peers spinning
 in `pt_lock` or their own shootdown) until all remote CPUs ack. Under heavy
 oversubscription that round-trip can exceed the threshold while still making
-progress, so the detector skips firing while
-`tlb_shootdown::TLB_SHOOTDOWN.pending_cpus != 0`. The shootdown's own
+progress, so the detector skips firing while `tlb_shootdown::any_pending()`
+reports any per-CPU request slot with CPUs still to ack. The shootdown's own
 escalation ladder (NMI backtrace at 0.75 s, panic at 5 s in arch
 `wait_for_ack`) is the authoritative detector for a genuinely stuck IPI; a
-non-shootdown stall re-checks on the next tick once `pending_cpus` clears.
+non-shootdown stall re-checks on the next tick once the pending slots drain.
 
 **Why kernel-side:** when every CPU is in kernel mode, no userspace monitor
 gets dispatched. The dump is also the only path that reads per-CPU

--- a/core/kernel/src/arch/riscv64/interrupts.rs
+++ b/core/kernel/src/arch/riscv64/interrupts.rs
@@ -328,27 +328,28 @@ unsafe extern "C" fn trap_entry()
 /// Dispatch a trap to the appropriate handler.
 ///
 /// `scause` bit 63 set = interrupt; clear = exception.
-/// TLB shootdown IPI handler.
+/// TLB shootdown / wakeup IPI handler.
 ///
-/// Reads the shootdown request from `TLB_SHOOTDOWN`, flushes the TLB for the
-/// target address space, and acknowledges by clearing this hart's bit in the
-/// pending mask.
+/// Services any per-CPU shootdown request that names this hart (flush + ack),
+/// then returns. Wakeup IPIs carry no extra work beyond the SSIP clear.
 #[cfg(not(test))]
 fn handle_software_interrupt()
 {
     // On RISC-V, both TLB shootdown and wakeup IPIs arrive as supervisor
-    // software interrupts (scause=1). Distinguish by checking if our bit
-    // is set in the shootdown pending mask.
+    // software interrupts (scause=1); a wakeup-only IPI simply finds no
+    // request naming this hart below.
 
-    // Clear SSIP *before* checking pending_cpus. This is critical for
-    // correctness: if a new IPI arrives between our check and sret, the
+    // Clear SSIP *before* servicing requests. This is critical for
+    // correctness: if a new IPI arrives between our scan and sret, the
     // 0→1 transition on SSIP generates a fresh interrupt after sret.
     //
-    // Clearing SSIP *after* the check is racy: a wakeup IPI sets SSIP,
-    // we enter the handler and check pending_cpus (0 — shootdown store
-    // hasn't happened yet), then the shootdown IPI arrives (SSIP already
-    // 1, no new edge), and clear_sip_ssip wipes both signals. The
-    // shootdown is never processed.
+    // Clearing SSIP *after* the scan is racy: a wakeup IPI sets SSIP, we
+    // enter and find no request (the shootdown store hasn't happened yet),
+    // then the shootdown IPI arrives (SSIP already 1, no new edge), and
+    // clear_sip_ssip wipes both signals — the shootdown is never processed.
+    // The initiator's SeqCst fence orders its slot store before the IPI, so
+    // any IPI whose SSIP-set precedes our clear has a slot store visible to
+    // the scan; any later IPI re-triggers via a fresh SSIP edge.
     //
     // SAFETY: sip.SSIP write clears supervisor software interrupt pending.
     unsafe {
@@ -356,54 +357,18 @@ fn handle_software_interrupt()
     }
 
     let hart_id = super::cpu::current_cpu() as usize;
-
-    if crate::mm::tlb_shootdown::TLB_SHOOTDOWN
-        .pending_cpus
-        .test_cpu(hart_id, core::sync::atomic::Ordering::Acquire)
-    {
-        // TLB shootdown request: flush the requested VA and acknowledge.
-        // Per-VA sfence.vma preserves global kernel-text iTLB entries that
-        // a full sfence.vma x0, x0 would otherwise discard.
-        let va = crate::mm::tlb_shootdown::TLB_SHOOTDOWN
-            .flush_va
-            .load(core::sync::atomic::Ordering::Acquire);
-        if va == u64::MAX
-        {
-            // Full flush requested.
-            // SAFETY: sfence.vma x0, x0 flushes all TLB entries.
-            unsafe {
-                super::paging::flush_tlb_all();
-            }
-        }
-        else
-        {
-            // SAFETY: sfence.vma with a specific VA flushes only that
-            // translation. The VA is a user-range address from the
-            // shootdown initiator.
-            unsafe {
-                core::arch::asm!(
-                    "sfence.vma {}, zero",
-                    in(reg) va,
-                    options(nostack, preserves_flags),
-                );
-            }
-        }
-
-        // Clear our bit to acknowledge completion.
-        // SAFETY: Release ordering ensures TLB flush is visible before bit clear.
-        crate::mm::tlb_shootdown::TLB_SHOOTDOWN
-            .pending_cpus
-            .clear_cpu(hart_id, core::sync::atomic::Ordering::Release);
+    // SAFETY: IPI-handler context on hart_id in S-mode; issuing sfence.vma here
+    // is valid.
+    unsafe {
+        crate::mm::tlb_shootdown::service_shootdowns(hart_id);
     }
 
     // Wakeup IPIs carry no handler work beyond the hardware-mandated SSIP
-    // acknowledgement (performed by the caller via `clear_sip_ssip`). The
-    // reschedule-pending flag is set producer-side in `enqueue_and_wake`,
-    // so the handler does not need to touch it here.
-    //
-    // The IPI's purpose is purely to break the target hart out of `wfi`;
-    // correctness of the wake is provided by the producer-side flag plus
-    // the atomic check-and-halt in the idle loop. See
+    // acknowledgement (performed above via `clear_sip_ssip`). The
+    // reschedule-pending flag is set producer-side in `enqueue_and_wake`, so
+    // the handler does not need to touch it here. The IPI's purpose is purely
+    // to break the target hart out of `wfi`; correctness of the wake is the
+    // producer-side flag plus the atomic check-and-halt in the idle loop. See
     // `kernel/src/sched/mod.rs` `RESCHEDULE_PENDING` doc.
 }
 
@@ -982,9 +947,9 @@ pub fn acknowledge(irq: u32)
 /// Send a TLB shootdown IPI to a target hart via SBI IPI.
 ///
 /// Sends a supervisor software interrupt to the target hart. The
-/// `handle_tlb_shootdown_ipi` handler (scause=1) on the target reads
-/// the shootdown request, executes sfence.vma, clears its pending bit,
-/// and clears SSIP.
+/// The software-interrupt handler (scause=1) on the target services any
+/// shootdown request naming it: executes sfence.vma, clears its pending
+/// bit, and clears SSIP.
 ///
 /// Note: this uses SBI IPI (not RFENCE) because RFENCE is a blocking
 /// firmware call that performs the flush internally without generating a

--- a/core/kernel/src/arch/x86_64/idt.rs
+++ b/core/kernel/src/arch/x86_64/idt.rs
@@ -760,8 +760,9 @@ extern "C" fn nm_handler()
 
 /// TLB shootdown IPI handler stub (vector 250).
 ///
-/// Reads the shootdown request from `TLB_SHOOTDOWN`, flushes the TLB for the
-/// target address space, and acknowledges by clearing this CPU's bit.
+/// Saves caller-clobbered registers, calls the Rust handler — which services
+/// any shootdown request naming this CPU and clears its acknowledgement bit —
+/// then restores and `iretq`s.
 #[cfg(not(test))]
 #[unsafe(naked)]
 unsafe extern "C" fn ipi_tlb_shootdown_stub()
@@ -946,47 +947,22 @@ unsafe extern "C" fn ipi_wakeup_stub()
 
 /// TLB shootdown IPI handler.
 ///
-/// Reads the shootdown request, flushes the TLB for the target address space,
-/// and acknowledges by clearing this CPU's bit in the pending mask.
+/// Services every per-CPU shootdown request that names this CPU (flush the
+/// requested VA, clear this CPU's acknowledgement bit), then sends EOI. The
+/// dedicated vector means every delivery is a shootdown; a re-sent or stale IPI
+/// that finds no request naming this CPU simply does no flush.
 #[cfg(not(test))]
 extern "C" fn ipi_tlb_shootdown_handler()
 {
-    // SAFETY: Acquire ordering ensures we see the root_phys stored by initiator
-    let root_phys = crate::mm::tlb_shootdown::TLB_SHOOTDOWN
-        .root_phys
-        .load(core::sync::atomic::Ordering::Acquire);
-
-    // Flush TLB for the target page.
-    let va = crate::mm::tlb_shootdown::TLB_SHOOTDOWN
-        .flush_va
-        .load(core::sync::atomic::Ordering::Acquire);
-    if va == u64::MAX || root_phys == 0
-    {
-        // Full TLB flush.
-        // SAFETY: CR3 write invalidates all non-global TLB entries.
-        unsafe {
-            super::paging::flush_tlb_all();
-        }
-    }
-    else
-    {
-        // Per-VA flush via invlpg.
-        // SAFETY: va is a valid virtual address from the shootdown initiator.
-        unsafe {
-            super::paging::flush_page(va);
-        }
-    }
-
-    // Acknowledge by clearing our bit in pending_cpus
     let cpu_id = super::cpu::current_cpu() as usize;
+    // SAFETY: IPI-handler context on cpu_id at ring 0; issuing TLB flushes here
+    // is valid.
+    unsafe {
+        crate::mm::tlb_shootdown::service_shootdowns(cpu_id);
+    }
 
-    // SAFETY: Release ordering ensures TLB flush completes before bit clear is visible
-    crate::mm::tlb_shootdown::TLB_SHOOTDOWN
-        .pending_cpus
-        .clear_cpu(cpu_id, core::sync::atomic::Ordering::Release);
-
-    // Send EOI to local APIC
-    // SAFETY: Vector 250 is the TLB shootdown vector
+    // Send EOI to local APIC.
+    // SAFETY: Vector 250 is the TLB shootdown vector.
     super::interrupts::acknowledge(u32::from(super::interrupts::IPI_VECTOR_TLB_SHOOTDOWN));
 }
 

--- a/core/kernel/src/cpu_mask.rs
+++ b/core/kernel/src/cpu_mask.rs
@@ -184,10 +184,6 @@ impl AtomicCpuMask
     }
 
     /// Whether `cpu` is in the set.
-    // Used only by the riscv64 IPI handler, which multiplexes shootdown and
-    // wakeup on one software interrupt; the x86 handler has a dedicated
-    // shootdown vector and clears unconditionally.
-    #[allow(dead_code)]
     #[inline]
     pub fn test_cpu(&self, cpu: usize, order: Ordering) -> bool
     {

--- a/core/kernel/src/mm/address_space.rs
+++ b/core/kernel/src/mm/address_space.rs
@@ -29,8 +29,9 @@
 //! priority-inversion under load. The committed PTE plus the immutable
 //! `root_phys` are all the shootdown reads, so it runs without `pt_lock`.
 //!
-//! `pt_lock` therefore does NOT nest with `SHOOTDOWN_LOCK`. The only lock the
-//! PTE edit nests under `pt_lock` is the PT-frame source
+//! The shootdown itself is lock-free — each CPU publishes into its own request
+//! slot — so `pt_lock` nests with no shootdown lock. The only lock the PTE edit
+//! nests under `pt_lock` is the PT-frame source
 //! (`pt_lock` → `FRAME_ALLOC_LOCK` on the heap-backed path).
 //!
 //! `pt_lock` does NOT disable interrupts (shootdown needs them enabled).

--- a/core/kernel/src/mm/tlb_shootdown.rs
+++ b/core/kernel/src/mm/tlb_shootdown.rs
@@ -139,6 +139,8 @@ pub unsafe fn service_shootdowns(my_cpu: usize)
         }
         let va = req.flush_va.load(Ordering::Acquire);
         let root = req.root_phys.load(Ordering::Acquire);
+        // Both `flush_va == u64::MAX` and `root_phys == 0` are full-flush
+        // sentinels per shootdown()'s contract; either alone selects flush_tlb_all.
         // SAFETY: caller guarantees IPI-handler context; flush_page /
         // flush_tlb_all are valid TLB primitives at ring 0 / S-mode. A per-VA
         // flush preserves global kernel entries that a full flush would discard.

--- a/core/kernel/src/mm/tlb_shootdown.rs
+++ b/core/kernel/src/mm/tlb_shootdown.rs
@@ -11,109 +11,162 @@
 //!
 //! # Protocol
 //!
-//! 1. The initiating CPU stores the target address space root physical address
-//!    in `TLB_SHOOTDOWN.root_phys`.
-//! 2. It stores a bitmask of CPUs that must acknowledge in `pending_cpus`.
-//! 3. It sends TLB shootdown IPIs to all target CPUs.
-//! 4. Each target CPU receives the IPI, flushes its TLB, and clears its bit
-//!    in `pending_cpus`.
-//! 5. The initiating CPU spins until `pending_cpus` becomes zero.
+//! Each CPU owns one request slot in `TLB_REQUESTS`, indexed by its logical CPU
+//! id. A CPU blocks until its own shootdown completes, so it has at most one
+//! outstanding request — the slot is never shared between concurrent shootdowns
+//! and needs no lock.
 //!
-//! Only one shootdown can be in progress at a time (serialized by
-//! `SHOOTDOWN_LOCK`).
+//! 1. The initiating CPU writes the target root, the virtual address, and the
+//!    set of CPUs that must acknowledge into *its own* slot.
+//! 2. It sends TLB shootdown IPIs to those CPUs.
+//! 3. Each target CPU ([`service_shootdowns`]) scans every slot; for any slot
+//!    whose `pending_cpus` still contains its bit, it flushes the requested VA
+//!    and clears its bit.
+//! 4. The initiator spins until its own slot's `pending_cpus` becomes empty.
+//!
+//! There is no global serialization: initiators on different CPUs touch
+//! different slots, so concurrent shootdowns — even on the same address space —
+//! proceed in parallel.
+//!
+//! # The acknowledgement bit is the liveness token
+//!
+//! A target acts on a slot only when it observes its own bit set in that slot's
+//! `pending_cpus` (Acquire). The owning CPU sets those bits (Release) only after
+//! writing `root_phys`/`flush_va`, so a target that sees its bit also sees the
+//! matching root and VA. A slot with all bits clear is idle; a stray or re-sent
+//! IPI that finds no bit set for the receiver does nothing. Because a slot is a
+//! fixed location (not a transient descriptor) and is reused only by its owner
+//! after the previous shootdown has fully drained, a late IPI can never observe
+//! a torn or stale request.
 //!
 //! # Interrupt safety
 //!
 //! `shootdown()` temporarily enables interrupts during the spin-wait so that
-//! target CPUs executing syscalls (with IF=0/SIE=0) can receive the IPI, and
-//! so this CPU can service incoming shootdown IPIs from concurrent initiators.
-//! Preemption is prevented by the caller via `preempt_disable()`.
+//! target CPUs executing syscalls (with IF=0/SIE=0) can receive the IPI, and so
+//! this CPU can service incoming shootdown IPIs from another CPU concurrently
+//! targeting it (mutual shootdown). Preemption is prevented by the caller via
+//! `preempt_disable()`.
 //!
 //! # Memory ordering
 //!
-//! - **Release** on `root_phys` and `pending_cpus` stores ensures remote CPUs
-//!   see the correct root address before handling the IPI.
-//! - **Acquire** on `pending_cpus` loads ensures the initiator sees all bit
-//!   clears from remote CPUs.
-//! - **Release** on remote CPU bit clears ensures TLB flush completes before
-//!   the initiator proceeds.
+//! - **Release** on the `root_phys`/`flush_va`/`pending_cpus` stores, followed
+//!   by a `SeqCst` fence, ensures remote CPUs see the request before the IPI
+//!   arrives (the SBI ecall that delivers a RISC-V IPI is not itself a fence).
+//! - **Acquire** on a slot's `pending_cpus` (the handler's bit test, the
+//!   initiator's emptiness poll) pairs with that Release, so a CPU that sees its
+//!   bit also sees the matching root and VA.
+//! - **Release** on a remote CPU's bit clear ensures its TLB flush completes
+//!   before the initiator observes the acknowledgement.
 
-use core::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use core::sync::atomic::{AtomicU64, Ordering};
 
 use crate::cpu_mask::{AtomicCpuMask, CpuMask};
+use crate::sched::MAX_CPUS;
 
-/// TLB shootdown request state.
+/// Per-CPU TLB shootdown request slot.
 ///
-/// The initiating CPU stores the target address space root, the virtual address
-/// to invalidate, and the pending CPU mask, then sends IPIs and spins until all
-/// acknowledge.
-pub struct TlbShootdownRequest
+/// Written only by its owning CPU (the initiator); other CPUs only clear their
+/// own acknowledgement bit in `pending_cpus`.
+struct TlbShootdownRequest
 {
-    /// Physical address of root page table to flush (0 = flush all address spaces).
-    pub root_phys: AtomicU64,
+    /// Physical address of the root page table to flush (0 = full flush).
+    root_phys: AtomicU64,
 
     /// Virtual address to invalidate. `u64::MAX` means full flush.
-    pub flush_va: AtomicU64,
+    flush_va: AtomicU64,
 
-    /// Set of CPUs that must acknowledge before the initiator proceeds.
-    /// CPU N present = CPU N must execute invlpg/sfence.vma and clear its bit.
-    pub pending_cpus: AtomicCpuMask,
+    /// CPUs that must still acknowledge this request. A set bit is both the
+    /// "CPU N must flush" instruction and this request's per-target liveness
+    /// token (see module docs).
+    pending_cpus: AtomicCpuMask,
 }
 
-/// Global TLB shootdown request state.
-///
-/// Only one shootdown can be in progress at a time (serialized by
-/// `SHOOTDOWN_LOCK`).
-pub static TLB_SHOOTDOWN: TlbShootdownRequest = TlbShootdownRequest {
-    root_phys: AtomicU64::new(0),
-    flush_va: AtomicU64::new(u64::MAX),
-    pending_cpus: AtomicCpuMask::new(),
-};
-
-/// Serialization lock for TLB shootdown initiation.
-///
-/// Only one CPU may be setting up a shootdown (writing `root_phys`, `pending_cpus`,
-/// sending IPIs) at a time. This prevents two concurrent initiators from
-/// corrupting each other's global state.
-///
-/// This lock does NOT disable interrupts. Interrupt management is handled
-/// by `shootdown()` itself. The IPI handler never acquires this lock.
-static SHOOTDOWN_LOCK: AtomicBool = AtomicBool::new(false);
-
-/// Acquire the shootdown serialization lock.
-///
-/// Simple CAS spin. Must be called with interrupts enabled (the caller
-/// enables them before acquiring) so incoming shootdown IPIs from the
-/// current holder can be serviced, preventing mutual deadlock.
-#[inline]
-fn shootdown_lock()
+impl TlbShootdownRequest
 {
-    while SHOOTDOWN_LOCK
-        .compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed)
-        .is_err()
+    const fn new() -> Self
     {
-        while SHOOTDOWN_LOCK.load(Ordering::Relaxed)
-        {
-            core::hint::spin_loop();
+        Self {
+            root_phys: AtomicU64::new(0),
+            flush_va: AtomicU64::new(u64::MAX),
+            pending_cpus: AtomicCpuMask::new(),
         }
     }
 }
 
-/// Release the shootdown serialization lock.
-#[inline]
-fn shootdown_unlock()
+/// One request slot per logical CPU, indexed by initiator CPU id.
+///
+/// ~80 bytes per slot; sized to `MAX_CPUS` so it needs no runtime allocation
+/// and is available from the first shootdown onward (including boot-time
+/// identity-map teardown, which runs before any heap-backed per-CPU storage is
+/// guaranteed).
+static TLB_REQUESTS: [TlbShootdownRequest; MAX_CPUS] =
+    [const { TlbShootdownRequest::new() }; MAX_CPUS];
+
+/// Whether any CPU currently has a shootdown awaiting acknowledgement.
+///
+/// The softlockup watchdog uses this to defer to the shootdown's own bounded
+/// escalation (NMI backtrace / panic in `wait_for_ack`) rather than dump on a
+/// stall that is really a slow ack.
+pub fn any_pending() -> bool
 {
-    SHOOTDOWN_LOCK.store(false, Ordering::Release);
+    let n = (crate::sched::CPU_COUNT.load(Ordering::Relaxed) as usize).min(MAX_CPUS);
+    TLB_REQUESTS
+        .iter()
+        .take(n)
+        .any(|r| !r.pending_cpus.is_empty(Ordering::Acquire))
+}
+
+/// Service every shootdown request that names this CPU.
+///
+/// Called from each arch's TLB-shootdown IPI handler. Scans all live slots and,
+/// for each whose `pending_cpus` contains `my_cpu`, flushes the requested VA
+/// (or the whole TLB) and clears this CPU's bit. Idempotent: a re-sent or stray
+/// IPI that finds no matching bit does nothing.
+///
+/// # Safety
+/// Must run in IPI-handler context on the CPU identified by `my_cpu`
+/// (ring 0 / S-mode), where issuing TLB flushes is valid.
+pub unsafe fn service_shootdowns(my_cpu: usize)
+{
+    let n = (crate::sched::CPU_COUNT.load(Ordering::Relaxed) as usize).min(MAX_CPUS);
+    for req in TLB_REQUESTS.iter().take(n)
+    {
+        // Acquire: pairs with the initiator's Release store of pending_cpus, so
+        // seeing our bit also makes the matching root/va visible below.
+        if !req.pending_cpus.test_cpu(my_cpu, Ordering::Acquire)
+        {
+            continue;
+        }
+        let va = req.flush_va.load(Ordering::Acquire);
+        let root = req.root_phys.load(Ordering::Acquire);
+        // SAFETY: caller guarantees IPI-handler context; flush_page /
+        // flush_tlb_all are valid TLB primitives at ring 0 / S-mode. A per-VA
+        // flush preserves global kernel entries that a full flush would discard.
+        unsafe {
+            if va == u64::MAX || root == 0
+            {
+                crate::arch::current::paging::flush_tlb_all();
+            }
+            else
+            {
+                crate::arch::current::paging::flush_page(va);
+            }
+        }
+        // Release: the flush above is visible before the initiator observes the
+        // acknowledgement.
+        req.pending_cpus.clear_cpu(my_cpu, Ordering::Release);
+    }
 }
 
 /// Initiate a TLB shootdown for an address space on target CPUs.
 ///
-/// Spins until all target CPUs acknowledge by clearing their bit in `pending_cpus`.
+/// Spins until all target CPUs acknowledge by clearing their bit in this CPU's
+/// request slot.
 ///
 /// # Contract
 /// - Caller must have called `preempt_disable()` before this function.
 /// - `root_phys` must be a valid page table root physical address or 0 for full flush.
-/// - `cpus` must contain only online CPU indices.
+/// - `cpus` must contain only online CPU indices and exclude the current CPU.
 ///
 /// # Safety
 /// Caller must ensure `root_phys` and `cpus` are valid as described above.
@@ -131,37 +184,37 @@ pub unsafe fn shootdown(root_phys: u64, cpus: &CpuMask, virt: u64)
         "shootdown: caller must call preempt_disable() first"
     );
 
-    // Enable interrupts for the duration of shootdown. This allows:
-    // 1. Target CPUs in syscalls (IF=0/SIE=0) to receive our IPI when they
-    //    temporarily enable interrupts in their own shootdown or lock spin.
-    // 2. Us to receive incoming shootdown IPIs from another CPU that is
-    //    simultaneously initiating a shootdown targeting us (mutual shootdown).
+    // Enable interrupts for the duration of the wait. This allows:
+    // 1. Target CPUs in syscalls (IF=0/SIE=0) to receive our IPI when they next
+    //    enable interrupts.
+    // 2. Us to service incoming shootdown IPIs from another CPU simultaneously
+    //    targeting us (mutual shootdown).
     //
     // Preemption is disabled by the caller, so timer_tick() will not call
     // schedule() even though interrupts are enabled.
     //
     // SAFETY: save_and_disable_interrupts is valid at ring 0 / S-mode.
     let saved_int = unsafe { crate::arch::current::cpu::save_and_disable_interrupts() };
-    // SAFETY: IDT / trap vector is installed; enabling interrupts is safe at
-    // ring 0 / S-mode. Preemption is disabled by the caller.
+    // SAFETY: trap vectors are installed; enabling interrupts is safe at ring 0
+    // / S-mode. Preemption is disabled by the caller.
     unsafe { crate::arch::current::interrupts::enable() };
 
-    // Serialize access to the global shootdown state.
-    shootdown_lock();
+    // This CPU's own request slot. No lock: the slot is owned by this CPU and
+    // the previous shootdown drained it (pending_cpus empty) before we returned.
+    let me = crate::arch::current::cpu::current_cpu() as usize;
+    let req = &TLB_REQUESTS[me];
 
-    // SAFETY: Release ordering ensures root_phys, flush_va, and cpu_mask
-    // are visible to remote CPUs before the IPI arrives.
-    TLB_SHOOTDOWN.root_phys.store(root_phys, Ordering::Release);
-    TLB_SHOOTDOWN.flush_va.store(virt, Ordering::Release);
-    TLB_SHOOTDOWN.pending_cpus.store(cpus, Ordering::Release);
+    // Publish the request. Release ordering pairs with the Acquire bit test in
+    // service_shootdowns; the SeqCst fence below makes the stores globally
+    // visible before the IPI.
+    req.root_phys.store(root_phys, Ordering::Release);
+    req.flush_va.store(virt, Ordering::Release);
+    req.pending_cpus.store(cpus, Ordering::Release);
 
-    // Fence: ensure pending_cpus is globally visible before sending IPIs.
-    // On RISC-V (RVWMO), the Release store orders it after prior stores on
-    // this hart, but other harts may not see it until it propagates through
-    // the memory system. The SBI ecall that sends the IPI is not a memory
-    // fence, so a remote hart's handler could read stale pending_cpus = 0.
-    // The SeqCst fence drains the store buffer on real hardware. On x86-64
-    // (TSO) this is a no-op.
+    // Drain the store buffer so a remote handler cannot read a stale slot. On
+    // RISC-V (RVWMO) the Release stores order this hart's writes but do not
+    // force global visibility before the SBI ecall that sends the IPI (not a
+    // fence); the SeqCst fence does. On x86-64 (TSO) this is a no-op.
     core::sync::atomic::fence(Ordering::SeqCst);
 
     // Helper: send IPIs to every CPU in `mask`.
@@ -184,23 +237,20 @@ pub unsafe fn shootdown(root_phys: u64, cpus: &CpuMask, virt: u64)
 
     // TSC-bounded ack wait with re-send + NMI-backtrace escalation. See
     // arch::current::interrupts::wait_for_ack and the IPI Watchdog Ladder
-    // subsection in docs/scheduling-internals.md. The resend closure
-    // re-fires only to CPUs whose bit is still set at the boundary, so a
-    // dropped IPI from the initial volley recovers without retransmitting
-    // to acks-in-flight. target_cpu is the lowest-numbered CPU still
-    // pending at the start of the wait; it drives the Phase-C NMI
-    // backtrace and the Phase-D panic message.
+    // subsection in docs/scheduling-internals.md. The resend closure re-fires
+    // only to CPUs whose bit is still set in our slot, so a dropped IPI recovers
+    // without retransmitting to acks-in-flight. target_cpu is the lowest-numbered
+    // target; it drives the Phase-C NMI backtrace and Phase-D panic message only.
     let target_cpu = cpus.first().unwrap_or(0);
-    // Relaxed: a stale read here only causes a redundant IPI to a CPU
-    // that has already acked, which is idempotent. The real
-    // synchronisation edge is the Acquire load inside the cond closure
-    // below.
-    let resend = || send_ipis(&TLB_SHOOTDOWN.pending_cpus.snapshot(Ordering::Relaxed));
-    // SAFETY: caller invariants (preempt-disabled, IF=1) are upheld by
-    // the save_and_disable_interrupts + enable() sequence above.
+    // Relaxed: a stale snapshot only causes a redundant IPI to a CPU that has
+    // already acked, which is idempotent. The real synchronisation edge is the
+    // Acquire poll in the cond closure below.
+    let resend = || send_ipis(&req.pending_cpus.snapshot(Ordering::Relaxed));
+    // SAFETY: caller invariants (preempt-disabled, IF=1) are upheld by the
+    // save_and_disable_interrupts + enable() sequence above.
     unsafe {
         crate::arch::current::interrupts::wait_for_ack(
-            || TLB_SHOOTDOWN.pending_cpus.is_empty(Ordering::Acquire),
+            || req.pending_cpus.is_empty(Ordering::Acquire),
             &crate::arch::current::interrupts::IpiWaitCtx {
                 op_name: "tlb-shootdown",
                 target_cpu,
@@ -209,7 +259,8 @@ pub unsafe fn shootdown(root_phys: u64, cpus: &CpuMask, virt: u64)
         );
     }
 
-    shootdown_unlock();
+    // The slot is now drained (pending_cpus empty) and stays idle until this
+    // CPU's next shootdown reuses it — no explicit teardown is required.
 
     // Restore original interrupt state.
     // SAFETY: saved_int is from save_and_disable_interrupts on this CPU.

--- a/core/kernel/src/sched/mod.rs
+++ b/core/kernel/src/sched/mod.rs
@@ -280,10 +280,8 @@ fn watchdog_tick_and_check()
     // (NMI backtrace at 0.75 s, panic at 5 s — see arch wait_for_ack) and is
     // the authoritative detector for a genuinely stuck IPI, so defer to it
     // rather than emit a misleading softlockup dump. A non-shootdown stall
-    // re-checks on the next tick once pending_cpus clears.
-    if !crate::mm::tlb_shootdown::TLB_SHOOTDOWN
-        .pending_cpus
-        .is_empty(core::sync::atomic::Ordering::Acquire)
+    // re-checks on the next tick once the shootdown drains.
+    if crate::mm::tlb_shootdown::any_pending()
     {
         return;
     }

--- a/core/ktest/src/bench/tlb.rs
+++ b/core/ktest/src/bench/tlb.rs
@@ -263,11 +263,13 @@ fn teardown(
 // `N` passive holders — the per-shootdown *hold* cost (IPI send + ack wait),
 // which scales with target count. This variant instead makes *every* pinned
 // worker an initiator: each loops map/unmap on its own VA and times its own
-// `mem_unmap`. With `W` concurrent initiators, the global `SHOOTDOWN_LOCK`
-// serializes them, so each unmap's latency also includes the *lock-wait*. The
-// difference between this bench and `bench_tlb_shootdown` at the same CPU count
-// is the global-serialization penalty — the quantity issue #188 is about, and
-// the quantity a per-CPU-mailbox shootdown redesign would drive to zero.
+// `mem_unmap`. With `W` concurrent initiators each publishing into its own
+// per-CPU request slot, the only residual cross-initiator cost is the
+// same-address-space `pt_lock` and the ack tail, so the concurrent mean tracks
+// the single-initiator mean. This bench is the regression guard for that parity:
+// a change that reintroduced system-wide shootdown serialization (the issue #188
+// bottleneck) would show up as the concurrent mean diverging above
+// `bench_tlb_shootdown` at the same CPU count.
 //
 // Workers are pinned (CPUs `1..=W`, matching `bench_tlb_shootdown`) so each
 // `cycles_now()` bracket starts and ends on the same CPU — an unpinned worker


### PR DESCRIPTION
## What

Removes the global `SHOOTDOWN_LOCK` and the single global `TLB_SHOOTDOWN` request from the cross-CPU TLB shootdown path (`core/kernel/src/mm/tlb_shootdown.rs`), replacing them with a per-CPU request-slot array. This is the primary fix for the scalability bottleneck characterized in #188.

## Why

The old path serialized **every** shootdown system-wide: one global request struct, one global lock, one shootdown in flight at a time. Initiators on different CPUs — even mutating unrelated address spaces — queued behind each other, and a single slow target inflated the critical section all of them waited on. Throughput did not scale with core count (now up to 512).

## Design (as built)

`static TLB_REQUESTS: [TlbShootdownRequest; MAX_CPUS]`, indexed by **initiator** CPU id. Each slot = `{root_phys, flush_va, pending_cpus}` (~80 B; ~40 KB total static BSS, no heap, available from the first boot-time shootdown).

A CPU has at most one outstanding shootdown (it blocks until done), so its slot is single-writer and needs **no lock**. The acknowledgement bit in `pending_cpus` is the per-target **liveness token**:

- A target acts on a slot only when it sees its own bit set (Acquire). The owner sets those bits (Release) only after writing `root_phys`/`flush_va` + a `SeqCst` fence, so a target that sees its bit also sees a consistent root/va.
- A stray or re-sent IPI that finds no bit set does nothing. Slot reuse is safe because the slot is a fixed address, fully drained (`pending_cpus` empty) before the owner reuses it.

Consequences: **no generation counter, no `AtomicPtr`, no stack-lifetime/late-IPI deref hazard, no retire step, no lock.** (This is a deliberate simplification of the originally-planned stack-descriptor + generation-cell mailbox, which proved unnecessary once the ack bit itself carries liveness.)

Both arch handlers now share one arch-neutral `service_shootdowns(my_cpu)` (scan slots → flush via `arch::current::paging::flush_page`/`flush_tlb_all` → clear bit). The riscv handler keeps its SSIP-clear-before-scan ordering. The softlockup watchdog defers via a new `any_pending()`.

## Results (ktest concurrent bench, 4 vCPU, 3 initiators)

| arch | concurrent mean — before (#190 baseline) | after | vs single-initiator |
|---|---|---|---|
| x86_64 | 95888 | 47636 | 2.75x → 1.37x |
| riscv64 | 332986 | 154976 | 2.02x → ~0.94x (parity) |

The global-lock serialization is eliminated; riscv concurrent latency drops to single-initiator parity.

## Test plan

- `cargo xtask build` + `--arch riscv64`: pass (no new warnings).
- `cargo xtask run --headless` ktest, both arches: **ALL TESTS PASSED** (168/0), including `integration::tlb_coherency` (cross-CPU coherency) and `stress::concurrent_map_unmap`.

Part of #188 (does not close it).