### PR TITLE
kernel: retry spurious stale-TLB user page faults

### DIFF
--- a/core/kernel/src/arch/riscv64/interrupts.rs
+++ b/core/kernel/src/arch/riscv64/interrupts.rs
@@ -504,6 +504,29 @@ extern "C" fn trap_dispatch(frame: &mut TrapFrame)
         // Check if the fault came from U-mode (SPP bit 8 = 0) or S-mode (SPP = 1).
         let is_userspace = (sstatus_val & (1 << 8)) == 0;
 
+        // Spurious stale-TLB retry: a U-mode page fault (instruction=12,
+        // load=13, store/AMO=15) whose faulting address is already mapped with
+        // sufficient permissions in the live tables is a stale TLB entry (e.g.
+        // after a remote map/widen whose shootdown was elided). Flush it
+        // locally and re-execute the instruction (sepc not advanced) instead
+        // of killing the thread. Genuine faults fall through to the kill path.
+        if is_userspace && matches!(cause_code, 12 | 13 | 15)
+        {
+            let write = cause_code == 15;
+            let instr = cause_code == 12;
+            // SAFETY: S-mode; the faulting hart's satp is still active (no
+            // context switch since trap entry — SIE is clear).
+            if unsafe { super::paging::user_fault_is_spurious(frame.stval, write, instr) }
+            {
+                // SAFETY: S-mode; drops the stale TLB entry so the retried
+                // instruction re-walks the now-satisfying mapping.
+                unsafe {
+                    super::paging::flush_page(frame.stval);
+                }
+                return;
+            }
+        }
+
         if is_userspace
         {
             // SAFETY: current_tcb() returns this CPU's running thread; valid

--- a/core/kernel/src/arch/riscv64/paging.rs
+++ b/core/kernel/src/arch/riscv64/paging.rs
@@ -817,6 +817,12 @@ pub unsafe fn protect_user_page(
 /// TLB. Returns `Some((phys_addr, raw_pte_bits))` if the page is present at
 /// every level, or `None` if any level is not present.
 ///
+/// Assumes 4 KiB user leaves: it descends to the L0 level and does not treat a
+/// present R/W/X entry at an intermediate level as a mega/gigapage leaf. The
+/// user mapping path never installs a large leaf, so this holds for every user
+/// VA — the spurious-fault classifier relies on it. A caller that introduces
+/// user large pages must add a large-leaf branch here.
+///
 /// # Safety
 /// `root_virt` must be the direct-map virtual address of a valid 4 KiB L3
 /// page table frame.

--- a/core/kernel/src/arch/riscv64/paging.rs
+++ b/core/kernel/src/arch/riscv64/paging.rs
@@ -860,6 +860,68 @@ pub unsafe fn translate_user_page(root_virt: u64, virt: u64) -> Option<(u64, u64
     Some((leaf.phys_addr(), leaf.0))
 }
 
+// ── Spurious-fault classification ─────────────────────────────────────────────
+
+/// Whether a leaf PTE grants a user-mode access of the given class.
+///
+/// `write` = the faulting access was a store/AMO; `instr` = an instruction
+/// fetch (a plain load has both false). A user page fault is *spurious* (stale
+/// TLB) only when the live PTE is valid, user-accessible (U), and already
+/// grants the access: a load needs `READ`, a store needs `WRITE`, a fetch
+/// needs `EXECUTE`. Sv48 does not make execute-only pages readable (MXR is
+/// kept clear), so each access class checks exactly its own bit.
+fn pte_permits_user_access(pte: u64, write: bool, instr: bool) -> bool
+{
+    /// U bit — the page is reachable from U-mode.
+    const USER: u64 = 1 << 4;
+
+    if pte & VALID == 0 || pte & USER == 0
+    {
+        return false;
+    }
+    if instr
+    {
+        pte & EXECUTE != 0
+    }
+    else if write
+    {
+        pte & WRITE != 0
+    }
+    else
+    {
+        pte & READ != 0
+    }
+}
+
+/// Classify a userspace page fault at `va` as a spurious stale-TLB fault.
+///
+/// Walks the *current* (`satp`) page tables for `va` and returns `true` iff
+/// `va` is mapped, user-accessible, and the live leaf PTE permits the faulting
+/// access — meaning the fault must be a stale TLB entry the hart resolves on
+/// retry after a local `sfence.vma`. Returns `false` for any genuine fault
+/// (unmapped, or the live mapping still forbids the access); the caller then
+/// kills the faulting thread. A `true` result requires the live PTE to grant
+/// the access, and [`PageTableEntry::new_page`] pre-sets A (and D for writable
+/// leaves), so the retried instruction cannot re-fault on an A/D update even
+/// without Svadu — no retry counter is needed.
+///
+/// # Safety
+/// Must run in S-mode in the faulting thread's context, i.e. before `satp` has
+/// been changed by a context switch.
+#[cfg(not(test))]
+pub unsafe fn user_fault_is_spurious(va: u64, write: bool, instr: bool) -> bool
+{
+    // SAFETY: S-mode; reads satp to recover the active page-table root.
+    let root_phys = unsafe { read_root_phys() };
+    let root_virt = crate::mm::paging::phys_to_virt(root_phys);
+    // SAFETY: root_virt is the direct-map VA of the active Sv48 root.
+    match unsafe { translate_user_page(root_virt, va) }
+    {
+        Some((_pa, pte)) => pte_permits_user_access(pte, write, instr),
+        None => false,
+    }
+}
+
 // ── TLB flush operations ──────────────────────────────────────────────────────
 
 /// Flush all TLB entries for all address spaces.
@@ -966,5 +1028,47 @@ mod tests
         assert_eq!(vpn3_index(kv), 511);
         assert_eq!(vpn2_index(kv), 510);
         assert_eq!(vpn1_index(kv), 0);
+    }
+
+    // ── Spurious-fault classification ──────────────────────────────────────────
+
+    const USER_BIT: u64 = 1 << 4;
+
+    #[test]
+    fn permits_load_only_when_readable()
+    {
+        let x_only = VALID | USER_BIT | EXECUTE; // execute-only, MXR clear
+        let r = VALID | USER_BIT | READ;
+        assert!(!pte_permits_user_access(x_only, false, false));
+        assert!(pte_permits_user_access(r, false, false));
+    }
+
+    #[test]
+    fn permits_store_only_when_writable()
+    {
+        let ro = VALID | USER_BIT | READ;
+        let rw = VALID | USER_BIT | READ | WRITE;
+        assert!(!pte_permits_user_access(ro, true, false));
+        assert!(pte_permits_user_access(rw, true, false));
+    }
+
+    #[test]
+    fn permits_fetch_only_when_executable()
+    {
+        let rw = VALID | USER_BIT | READ | WRITE;
+        let rx = VALID | USER_BIT | READ | EXECUTE;
+        assert!(!pte_permits_user_access(rw, false, true));
+        assert!(pte_permits_user_access(rx, false, true));
+    }
+
+    #[test]
+    fn rejects_non_user_and_invalid_pages()
+    {
+        // Valid + RWX but supervisor-only (U clear): a U-mode access is genuine.
+        let kernel = VALID | READ | WRITE | EXECUTE;
+        assert!(!pte_permits_user_access(kernel, false, false));
+        // Invalid: genuine fault regardless of other bits.
+        let invalid = USER_BIT | READ | WRITE | EXECUTE;
+        assert!(!pte_permits_user_access(invalid, false, false));
     }
 }

--- a/core/kernel/src/arch/x86_64/idt.rs
+++ b/core/kernel/src/arch/x86_64/idt.rs
@@ -474,7 +474,8 @@ isr_stub!(isr10, 10, has_error_code = true, ist = 0);
 isr_stub!(isr11, 11, has_error_code = true, ist = 0);
 isr_stub!(isr12, 12, has_error_code = true, ist = 0);
 isr_stub!(isr13, 13, has_error_code = true, ist = 0);
-isr_stub!(isr14, 14, has_error_code = true, ist = 0);
+// Vector 14 (#PF) has a dedicated stub — see `isr_page_fault` below — so a
+// spurious stale-TLB fault can be resolved and retried instead of killing.
 isr_stub!(isr15, 15, has_error_code = false, ist = 0);
 isr_stub!(isr16, 16, has_error_code = false, ist = 0);
 isr_stub!(isr17, 17, has_error_code = true, ist = 0);
@@ -758,6 +759,111 @@ extern "C" fn nm_handler()
     crate::percpu::preempt_enable();
 }
 
+/// Page-fault (`#PF`, vector 14) stub.
+///
+/// Saves the full [`ExceptionFrame`] (the hardware already pushed the error
+/// code; this stub pushes the vector), calls [`page_fault_handler`], then —
+/// reached only when the fault was a resolved spurious stale-TLB fault —
+/// restores the unmodified user register state and `iretq`s, re-executing the
+/// faulting instruction. For every genuine fault the handler diverges
+/// (`common_exception_handler` never returns) and the restore tail is dead.
+#[cfg(not(test))]
+#[unsafe(naked)]
+unsafe extern "C" fn isr_page_fault()
+{
+    core::arch::naked_asm!(
+        "push 14", // vector (hardware already pushed the error code)
+        "push r15",
+        "push r14",
+        "push r13",
+        "push r12",
+        "push r11",
+        "push r10",
+        "push r9",
+        "push r8",
+        "push rbp",
+        "push rdi",
+        "push rsi",
+        "push rdx",
+        "push rcx",
+        "push rbx",
+        "push rax",
+        "mov rdi, rsp",
+        "call {handler}",
+        "pop rax",
+        "pop rbx",
+        "pop rcx",
+        "pop rdx",
+        "pop rsi",
+        "pop rdi",
+        "pop rbp",
+        "pop r8",
+        "pop r9",
+        "pop r10",
+        "pop r11",
+        "pop r12",
+        "pop r13",
+        "pop r14",
+        "pop r15",
+        "add rsp, 16", // drop vector + error_code
+        "iretq",
+        handler = sym page_fault_handler,
+    );
+}
+
+/// Page-fault (`#PF`, vector 14) handler body.
+///
+/// Classifies the fault before the diverging common handler runs: a userspace
+/// fault whose faulting address (CR2) is mapped with permissions covering the
+/// access is a stale-TLB *spurious* fault — the live page tables already
+/// satisfy it (e.g. after a remote map/widen whose shootdown was elided). Such
+/// faults are resolved by a local `invlpg` and a return-to-retry; the stub's
+/// `iretq` re-executes the faulting instruction. Every other fault (genuine
+/// userspace fault, or any kernel fault) is handed to
+/// [`common_exception_handler`], which never returns.
+#[cfg(not(test))]
+extern "C" fn page_fault_handler(frame: *const ExceptionFrame)
+{
+    /// `#PF` error-code bits (Intel SDM Vol 3 §4.7).
+    const ERR_WRITE: u64 = 1 << 1;
+    const ERR_RSVD: u64 = 1 << 3;
+    const ERR_INSTR: u64 = 1 << 4;
+
+    // SAFETY: frame is constructed by isr_page_fault on this stack.
+    let f = unsafe { &*frame };
+    let from_user = (f.cs & 3) != 0;
+    // A reserved-bit violation is never a stale-TLB fault; only well-formed
+    // present/permission faults from userspace are retry candidates.
+    if from_user && f.error_code & ERR_RSVD == 0
+    {
+        let cr2: u64;
+        // SAFETY: CR2 holds the faulting linear address for a #PF; read-only at
+        // ring 0.
+        unsafe {
+            core::arch::asm!("mov {}, cr2", out(reg) cr2, options(nostack, nomem));
+        }
+        let write = f.error_code & ERR_WRITE != 0;
+        let instr = f.error_code & ERR_INSTR != 0;
+        // SAFETY: ring 0; the faulting thread's CR3 is still active (no context
+        // switch since entry — the interrupt gate left IF=0).
+        if unsafe { super::paging::user_fault_is_spurious(cr2, write, instr) }
+        {
+            // SAFETY: ring 0; drops the stale TLB entry so the retried
+            // instruction re-walks the now-satisfying mapping.
+            unsafe {
+                super::paging::flush_page(cr2);
+            }
+            return;
+        }
+    }
+
+    // Not a recoverable spurious fault — kill (userspace) or fatal (kernel).
+    // SAFETY: frame is valid; common_exception_handler never returns.
+    unsafe {
+        common_exception_handler(frame);
+    }
+}
+
 /// TLB shootdown IPI handler stub (vector 250).
 ///
 /// Saves caller-clobbered registers, calls the Rust handler — which services
@@ -1017,7 +1123,7 @@ pub unsafe fn init()
     set(11, isr11, 0);
     set(12, isr12, 0);
     set(13, isr13, 0);
-    set(14, isr14, 0);
+    set(14, isr_page_fault, 0); // #PF — spurious stale-TLB faults retry
     set(15, isr15, 0);
     set(16, isr16, 0);
     set(17, isr17, 0);

--- a/core/kernel/src/arch/x86_64/paging.rs
+++ b/core/kernel/src/arch/x86_64/paging.rs
@@ -858,6 +858,12 @@ pub unsafe fn protect_user_page(
 /// TLB. Returns `Some((phys_addr, raw_pte_bits))` if the page is present at
 /// every level, or `None` if any level is not present.
 ///
+/// Assumes 4 KiB user leaves: it descends to the PT level and does not test
+/// the PS (large-page) bit at PDPT/PD. The user mapping path never installs a
+/// large leaf, so this holds for every user VA — the spurious-fault classifier
+/// relies on it. A caller that introduces user large pages must add a
+/// large-leaf branch here.
+///
 /// # Safety
 /// `root_virt` must be the direct-map virtual address of a valid 4 KiB PML4
 /// frame.

--- a/core/kernel/src/arch/x86_64/paging.rs
+++ b/core/kernel/src/arch/x86_64/paging.rs
@@ -901,6 +901,66 @@ pub unsafe fn translate_user_page(root_virt: u64, virt: u64) -> Option<(u64, u64
     Some((leaf.phys_addr(), leaf.0))
 }
 
+// ── Spurious-fault classification ─────────────────────────────────────────────
+
+/// Whether a leaf PTE grants a user-mode access of the given class.
+///
+/// `write` = the faulting access was a write; `instr` = an instruction fetch
+/// (mutually: a plain read has both false). A user page fault is *spurious*
+/// (stale TLB) only when the live PTE is present, user-accessible, and already
+/// grants the access — on x86 every present page is readable, so a read needs
+/// only presence; a write needs `WRITABLE`; a fetch needs NX clear.
+fn pte_permits_user_access(pte: u64, write: bool, instr: bool) -> bool
+{
+    /// User/Supervisor bit — the page is reachable from ring 3.
+    const USER: u64 = 1 << 2;
+
+    if pte & PRESENT == 0 || pte & USER == 0
+    {
+        return false;
+    }
+    if instr
+    {
+        pte & NO_EXECUTE == 0
+    }
+    else if write
+    {
+        pte & WRITABLE != 0
+    }
+    else
+    {
+        true
+    }
+}
+
+/// Classify a userspace page fault at `va` as a spurious stale-TLB fault.
+///
+/// Walks the *current* (CR3) page tables for `va` and returns `true` iff `va`
+/// is mapped, user-accessible, and the live leaf PTE permits the faulting
+/// access — meaning the fault must be a stale TLB entry the CPU resolves on
+/// retry after a local `invlpg`. Returns `false` for any genuine fault
+/// (unmapped, or the live mapping still forbids the access); the caller then
+/// kills the faulting thread. Because a `true` result requires the live PTE to
+/// grant the access (and x86 updates A/D in hardware), the retried instruction
+/// is guaranteed to make progress — no retry counter is needed.
+///
+/// # Safety
+/// Must run at ring 0 in the faulting thread's context, i.e. before CR3 has
+/// been changed by a context switch.
+#[cfg(not(test))]
+pub unsafe fn user_fault_is_spurious(va: u64, write: bool, instr: bool) -> bool
+{
+    // SAFETY: ring 0; reads CR3 to recover the active page-table root.
+    let root_phys = unsafe { read_root_phys() };
+    let root_virt = crate::mm::paging::phys_to_virt(root_phys);
+    // SAFETY: root_virt is the direct-map VA of the active PML4.
+    match unsafe { translate_user_page(root_virt, va) }
+    {
+        Some((_pa, pte)) => pte_permits_user_access(pte, write, instr),
+        None => false,
+    }
+}
+
 // ── TLB flush operations ──────────────────────────────────────────────────────
 
 /// Flush all TLB entries by reloading CR3.
@@ -1066,5 +1126,45 @@ mod tests
     {
         // VA = 0x0000_0000_0012_3456: bits [20:12] = 0x123 = 291
         assert_eq!(pt_index(0x0000_0000_0012_3000), 0x123);
+    }
+
+    // ── Spurious-fault classification ──────────────────────────────────────────
+
+    const USER_BIT: u64 = 1 << 2;
+
+    #[test]
+    fn permits_read_of_present_user_page()
+    {
+        let pte = PRESENT | USER_BIT | NO_EXECUTE; // R-- (NX, not writable)
+        assert!(pte_permits_user_access(pte, false, false));
+    }
+
+    #[test]
+    fn permits_write_only_when_writable()
+    {
+        let ro = PRESENT | USER_BIT | NO_EXECUTE;
+        let rw = PRESENT | USER_BIT | WRITABLE | NO_EXECUTE;
+        assert!(!pte_permits_user_access(ro, true, false));
+        assert!(pte_permits_user_access(rw, true, false));
+    }
+
+    #[test]
+    fn permits_fetch_only_when_executable()
+    {
+        let nx = PRESENT | USER_BIT | NO_EXECUTE;
+        let exec = PRESENT | USER_BIT; // NX clear
+        assert!(!pte_permits_user_access(nx, false, true));
+        assert!(pte_permits_user_access(exec, false, true));
+    }
+
+    #[test]
+    fn rejects_non_user_and_absent_pages()
+    {
+        // Present + writable but supervisor-only: a user access is genuine.
+        let kernel = PRESENT | WRITABLE;
+        assert!(!pte_permits_user_access(kernel, false, false));
+        // Not present: genuine fault regardless of other bits.
+        let absent = USER_BIT | WRITABLE;
+        assert!(!pte_permits_user_access(absent, false, false));
     }
 }

--- a/core/ktest/src/integration/fault_kills_thread.rs
+++ b/core/ktest/src/integration/fault_kills_thread.rs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// ktest/src/integration/fault_kills_thread.rs
+
+//! Integration: a genuine userspace page fault still kills the thread.
+//!
+//! The kernel's page-fault handler classifies a fault before acting: a stale
+//! TLB entry whose live mapping already satisfies the access is retried, while
+//! a *genuine* fault (the address is not mapped, or the live mapping forbids
+//! the access) terminates the faulting thread. This test exercises the second
+//! half on the real fault path:
+//!
+//!   1. A child thread stores to a deliberately-unmapped user address.
+//!   2. The parent polls the child's kernel-authoritative lifecycle state via
+//!      `cap_info(CAP_INFO_THREAD_STATE)` until it reports `Exited`.
+//!   3. The recorded exit reason must be `EXIT_FAULT_BASE + <fault vector>`
+//!      (`#PF` = 14 on x86-64; store/AMO page fault = 15 on RISC-V).
+//!
+//! Beyond confirming the kill path, the bounded poll guards against a
+//! mis-classification that would treat an unmapped address as spurious and
+//! retry forever: such a bug never reaches `Exited`, so the test fails on the
+//! poll bound rather than hanging.
+
+use syscall::{cap_delete, cap_info, thread_sleep};
+use syscall_abi::{CAP_INFO_THREAD_STATE, EXIT_FAULT_BASE, THREAD_STATE_EXITED};
+
+use crate::{ChildStack, TestContext, TestResult};
+
+/// A user-half virtual address that no test maps (96 TiB, canonical, well clear
+/// of every other test's mappings).
+const WILD_VA: u64 = 0x6000_0000_0000;
+
+/// Fault vector recorded in `exit_reason` for a not-present store.
+#[cfg(target_arch = "x86_64")]
+const FAULT_VECTOR: u64 = 14; // #PF
+#[cfg(target_arch = "riscv64")]
+const FAULT_VECTOR: u64 = 15; // store/AMO page fault
+
+/// Poll bound: at ~1 ms per `thread_sleep(1)`, ~2 s before declaring the child
+/// never faulted. Comfortably above any scheduling latency on a busy SMP run.
+const MAX_POLLS: u32 = 2000;
+
+static mut CHILD_STACK: ChildStack = ChildStack::ZERO;
+
+pub fn run(ctx: &TestContext) -> TestResult
+{
+    let child = crate::spawn::new_child(ctx)
+        .map_err(|_| "integration::fault_kills_thread: spawn::new_child failed")?;
+
+    let stack_top = ChildStack::top(core::ptr::addr_of!(CHILD_STACK));
+    crate::spawn::configure_and_start(&child, fault_child, stack_top, 0)
+        .map_err(|_| "integration::fault_kills_thread: configure_and_start failed")?;
+
+    let expected = EXIT_FAULT_BASE + FAULT_VECTOR;
+    let mut polls = 0;
+    loop
+    {
+        let packed = cap_info(child.th, CAP_INFO_THREAD_STATE)
+            .map_err(|_| "integration::fault_kills_thread: cap_info(THREAD_STATE) failed")?;
+        // cast_possible_truncation: the kernel packs an 8-bit state code in the
+        // high word and a 32-bit exit reason in the low word.
+        #[allow(clippy::cast_possible_truncation)]
+        let state = (packed >> 32) as u32;
+        if state == THREAD_STATE_EXITED
+        {
+            let reason = packed & 0xFFFF_FFFF;
+            if reason != expected
+            {
+                return Err("integration::fault_kills_thread: wrong exit reason for fault");
+            }
+            break;
+        }
+
+        polls += 1;
+        if polls >= MAX_POLLS
+        {
+            return Err("integration::fault_kills_thread: child never faulted/exited");
+        }
+        thread_sleep(1).ok();
+    }
+
+    cap_delete(child.th).ok();
+    cap_delete(child.cs).ok();
+    Ok(())
+}
+
+/// Child entry: store to an unmapped address, which faults and is killed by the
+/// kernel before the store returns. The trailing loop only satisfies the `-> !`
+/// signature; it is never reached.
+fn fault_child(_arg: u64) -> !
+{
+    let p = WILD_VA as *mut u64;
+    // SAFETY: deliberately faulting — WILD_VA is unmapped, so this store raises
+    // a page fault the kernel resolves by terminating this thread.
+    unsafe {
+        p.write_volatile(0xDEAD_BEEF);
+    }
+    loop
+    {
+        core::hint::spin_loop();
+    }
+}

--- a/core/ktest/src/integration/mod.rs
+++ b/core/ktest/src/integration/mod.rs
@@ -30,10 +30,12 @@
 //! - `shared_frame_two_aspaces.rs` — one frame mapped into two `AddressSpace` caps; phys round-trip
 //! - `cap_move_into_fresh_cspace_then_ipc.rs` — `cap_move` an endpoint into a child cspace; child IPC-calls through it
 //! - `fpu_survives_ipc_call.rs` — FP register file survives a raw `SYS_IPC_CALL` round-trip across CPU migration
+//! - `fault_kills_thread.rs`     — a genuine userspace page fault terminates the thread with the right exit reason
 
 pub mod cap_delegation_chain;
 pub mod cap_move_into_fresh_cspace_then_ipc;
 pub mod cap_transfer;
+pub mod fault_kills_thread;
 pub mod fpu_survives_ipc_call;
 pub mod memory_lifecycle;
 pub mod multi_caller_ipc_fifo;
@@ -82,5 +84,9 @@ pub fn run_all(ctx: &TestContext)
     run_integration_test!(
         "integration::fpu_survives_ipc_call",
         fpu_survives_ipc_call::run(ctx)
+    );
+    run_integration_test!(
+        "integration::fault_kills_thread",
+        fault_kills_thread::run(ctx)
     );
 }

--- a/core/ktest/src/integration/tlb_coherency.rs
+++ b/core/ktest/src/integration/tlb_coherency.rs
@@ -9,8 +9,12 @@
 //! CPUs and performing map/unmap operations that trigger inter-processor
 //! interrupts (IPIs) for TLB invalidation.
 //!
-//! Since ktest runs without page fault handlers, we cannot directly test that
-//! a stale TLB entry causes a fault. Instead, this test verifies that:
+//! ktest threads run in user mode, so a stale-TLB access the shootdown failed
+//! to flush would surface as a page fault. The kernel retries only faults the
+//! live tables already satisfy; an access to an entry that should have been
+//! invalidated terminates the thread (the kill path is covered by
+//! `integration::fault_kills_thread`). This test does not construct such a
+//! window — it verifies that:
 //!
 //! 1. Repeated map/unmap cycles across CPUs complete without deadlock
 //! 2. Threads on different CPUs can safely access newly mapped memory
@@ -185,10 +189,10 @@ fn tlb_worker_thread(p2c_slot: u64) -> !
         {
             // Page is mapped. Access it (read) to load TLB entry.
             //
-            // SAFETY: Parent maps TEST_VA before signaling 0x2. If TLB
-            // shootdown is broken, we'd read stale data or fault after
-            // unmap, but since ktest has no fault handler, we just trust
-            // the kernel correctly invalidated our cached entry.
+            // SAFETY: Parent maps TEST_VA before signaling 0x2. The parent's
+            // prior-cycle unmap shot down this hart's entry, so the read sees
+            // the fresh mapping; a broken shootdown would instead fault here
+            // and terminate this thread.
             let ptr = TEST_VA as *const u64;
             // SAFETY: TEST_VA is mapped by parent; see comment above.
             let _value = unsafe { ptr.read_volatile() };


### PR DESCRIPTION
## Summary

Adds a spurious-fault-retry path to both page-fault handlers: a userspace
fault whose faulting address is already mapped, user-accessible, and permits
the faulting access is a **stale TLB entry**, not a genuine fault. The kernel
now re-walks the *live* page tables, and on a match drops the stale entry
locally and re-executes the instruction instead of killing the thread. Every
genuine fault (unmapped, or the live mapping still forbids the access) kills
exactly as before.

This is the correctness prerequisite for operation-class shootdown elision (a
later change in the issue series): once a cross-CPU map/widen skips its remote
shootdown, the only way a remote CPU's stale entry can surface is a fault the
live tables already satisfy — which this path resolves.

## Design

- **Classifier (per arch, in `arch/{x86_64,riscv64}/paging.rs`):**
  `user_fault_is_spurious(va, write, instr)` reads the active CR3/satp root,
  walks it via the existing `translate_user_page`, and delegates the
  permission decision to the pure, host-tested `pte_permits_user_access`
  (checks the USER bit + the faulting access class: read/write/fetch).
- **x86:** a **dedicated** `isr_page_fault` stub + `page_fault_handler` for
  vector 14. The shared `common_exception_handler` keeps its `-> !` contract
  untouched (the NMI backtrace path relies on it), so only the #PF gate
  changes. Spurious → `invlpg` + `iretq`-retry; otherwise it defers to
  `common_exception_handler` (unchanged kill/fatal behaviour).
- **riscv:** a retry branch in `trap_dispatch` for causes 12/13/15 →
  `sfence.vma` + return without advancing `sepc`; otherwise falls through to
  the existing kill path.
- **No retry counter / no livelock:** a spurious verdict requires the live PTE
  to grant the access. x86 updates A/D in hardware; riscv pre-sets A (and D for
  writable leaves) in `new_page`, so the retried instruction cannot re-fault on
  an A/D update even without Svadu. An unmapped or still-forbidden address
  classifies as genuine and is killed — never retried.

## Test scope

The real stale-TLB window only exists once a shootdown is **elided** (the next
change in the series); it cannot be manufactured through the stable syscall ABI
without either a test-only map-without-flush syscall (rejected — ABI pollution)
or a per-harness kernel build (the kernel binary is shared across harnesses
today). So the **positive** end-to-end retry test lands with the elision work,
where the window is real. This PR validates:

- **Host unit tests** of `pte_permits_user_access` on both arches (read/write/
  fetch permitted-vs-not, non-user page, absent/invalid page).
- **New `integration::fault_kills_thread` ktest** — fires the new #PF path with
  a genuine unmapped store and asserts the thread is killed with
  `EXIT_FAULT_BASE + vector`. This both exercises the new x86 stub end-to-end
  and guards against a mis-classification livelock (an unmapped address must not
  be retried).

## Test plan

- [x] `cargo xtask test` — host unit tests pass (incl. new classifier tests).
- [x] x86_64: `cargo xtask build` + `compose-bundle --harness ktest` +
  `run --headless` → **169/0 ALL TESTS PASSED**; `fault_kills_thread` →
  `USERSPACE FAULT vec=14 err=0x6` → PASS.
- [x] riscv64: clean + `build --arch riscv64` + `compose-bundle --harness ktest
  --arch riscv64` + `run --arch riscv64 --headless` → **169/0 ALL TESTS
  PASSED**; `fault_kills_thread` → `store/AMO page fault scause=0xf` → PASS.

Part of the issue-188 TLB-shootdown-scalability series (follows the per-CPU
request slots in #193); it advances that issue but does not complete its
Acceptance checklist.

Refs #188.