### PR TITLE
docs, comments: present-tense sweep of pre-existing change-narration (#191)

### DIFF
--- a/core/boot/docs/boot-flow.md
+++ b/core/boot/docs/boot-flow.md
@@ -173,7 +173,6 @@ Fields are populated as follows:
 | `device_tree` | Physical address of DTB from step 5; zero if GUID absent |
 | `kernel_mmio` | Arch-specific MMIO bases extracted from firmware tables in step 5 (see `firmware-parsing.md`). Fields the extractor cannot populate stay zero and the kernel falls back to its compiled-in defaults. |
 | `mmio_apertures` | Coarse `{phys_base, size}` array from step 8 (UEFI MMIO regions merged with firmware-table seeds). Empty if no MMIO regions were reported. |
-| ~~`command_line`~~ | Removed in boot-protocol v8 — kernel command line is no longer carried |
 | `cpu_count` | Enabled LAPIC count from MADT (x86-64) or enabled RINTC / DTB hart count (RISC-V); always ≥ 1 |
 | `bsp_id` | APIC ID of the BSP (x86-64) or boot hart ID from `EFI_RISCV_BOOT_PROTOCOL` (RISC-V) |
 | `cpu_ids` | Per-CPU hardware identifiers; `cpu_ids[0] == bsp_id`; entries beyond `cpu_count` are zero |

--- a/core/boot/docs/elf-loading.md
+++ b/core/boot/docs/elf-loading.md
@@ -165,8 +165,7 @@ starting each service.
 
 ## Extensibility
 
-The bundle replaces both the per-module file enumeration and the
-configuration file that used to point at it. Adding a new boot
+The bundle is the single boot-module container. Adding a new boot
 module is a bundle-composer change in
 [`xtask/src/bundle.rs`](../../../xtask/src/bundle.rs); the bootloader
 binary needs no change. `BootInfo.modules.count` accurately reflects

--- a/core/boot/docs/uefi-environment.md
+++ b/core/boot/docs/uefi-environment.md
@@ -50,8 +50,7 @@ reading. Files are read into physical memory allocated by `AllocatePages`; see
 The bootloader carries only two ESP path constants —
 `\EFI\seraph\kernel` and `\EFI\seraph\bootstrap.bundle` — both
 hardcoded in [`boot/src/main.rs`](../src/main.rs). There is no on-disk
-boot configuration file (`boot.conf` was retired alongside the
-boot-protocol v7 → v8 bump); the bundle is the single composed artifact
+boot configuration file; the bundle is the single composed artifact
 that carries init plus every userspace module the system needs. The
 bundle format itself is specified in
 [`abi/boot-protocol/src/bundle.rs`](../../../abi/boot-protocol/src/bundle.rs).

--- a/core/boot/src/elf.rs
+++ b/core/boot/src/elf.rs
@@ -358,8 +358,6 @@ pub unsafe fn load_init(
     })
 }
 
-// Boot modules are no longer loaded as standalone allocations in the
-// bootloader. Bundle entries (excluding the `init` entry, which is ELF-
-// loaded via [`load_init`]) are exposed in place by referencing the
-// single bundle UEFI allocation in `BootModule.physical_base`. See
-// `main.rs::step4_parse_bundle`.
+// Boot modules are exposed in place by referencing the single bundle UEFI
+// allocation in `BootModule.physical_base`; only the `init` entry is ELF-
+// loaded (via [`load_init`]). See `main.rs::step4_parse_bundle`.

--- a/core/kernel/docs/ipc-internals.md
+++ b/core/kernel/docs/ipc-internals.md
@@ -464,9 +464,8 @@ When the wait set itself is dropped (last cap released), `wait_set_drop`
 clears every member's back-pointer and `dec_ref`s each source's header; any
 source whose refcount reaches zero at that point is reclaimed via the
 standard `dealloc_object` cascade. The source's dealloc arm therefore never
-runs while a wait-set member references it; the inline `waitset_remove`
-call that used to live in each source's dealloc arm has been replaced with
-a `debug_assert!(state.wait_set.is_null())` invariant check.
+runs while a wait-set member references it; each source's dealloc arm
+carries a `debug_assert!(state.wait_set.is_null())` invariant check.
 
 ### Multiple Ready Sources
 

--- a/core/kernel/docs/scheduling-internals.md
+++ b/core/kernel/docs/scheduling-internals.md
@@ -156,9 +156,9 @@ racing `sys_thread_set_priority` taking the all-CPU-locks region sees
 no scheduler claim the TCB in its locate scan; it writes the new
 priority and falls through without relocating. The pending
 `enqueue_and_wake` then reads `(*tcb).priority` under the destination
-lock — the post-fix `enqueue_and_wake` no longer takes a caller-supplied
-priority — and links the TCB at whichever value was last committed
-under lock. No desync results.
+lock — `enqueue_and_wake` takes no caller-supplied priority — and links
+the TCB at whichever value was last committed under lock. No desync
+results.
 
 `migrate_ready_thread` (`core/kernel/src/sched/mod.rs`) is the other
 known consumer of this transient. Under both source and destination
@@ -433,7 +433,7 @@ Pairing table for every load-bearing atomic in the scheduling and IPC paths. "Lo
 | `has_observer` (Signal) + `bits` Dekker pair | `ipc/signal.rs:54` (decl) | Relaxed store on `:231` (signal_wait), Relaxed load on `:118` (signal_send) | (same) | Paired SeqCst fences in `signal_send` (`:115`, between `bits.fetch_or` and `has_observer.load`) and `signal_wait` (`:234`, between `has_observer.store` and `bits.swap`) form the Dekker pattern: either `signal_send` observes `has_observer == 1` and falls through to the slow path lock acquisition, or `signal_wait`'s swap observes the OR'd bits and returns without parking. The fences are the only ordering edge; weakening to plain `Acquire`/`Release` is **insufficient** because the read-and-write sites span two distinct atomics. |
 | `RESCHEDULE_PENDING` bit (per CPU) | (same as first row) | (same) | (same) | (single entry, listed once.) |
 | `BOOT_TRANSIENT_ACTIVE` | `sched/mod.rs` (decl) | Release on `init_storage` (set true) and `sched::enter` (set false) | Acquire on every `timer_tick` entry | Single-writer (BSP). The Release/Acquire pair gates `timer_tick` against firing during Phase 4–9 when the run queue and scheduler state have not yet stabilised. |
-| `CPU_LOAD[cpu]` | `sched/run_queue.rs:35` (decl) | Relaxed on `increment_load`, `decrement_load` | Relaxed on `current_load` | Advisory: `select_target_cpu` and the periodic load balancer consult this; transient inconsistency does not violate correctness. The counter MUST track queue occupancy: every `enqueue` increments, every `dequeue_highest` / `remove_from_queue` decrements (the latter was historically a no-op — fixed in #22/#23). |
+| `CPU_LOAD[cpu]` | `sched/run_queue.rs:35` (decl) | Relaxed on `increment_load`, `decrement_load` | Relaxed on `current_load` | Advisory: `select_target_cpu` and the periodic load balancer consult this; transient inconsistency does not violate correctness. The counter MUST track queue occupancy: every `enqueue` increments, every `dequeue_highest` / `remove_from_queue` decrements. |
 | `LOAD_BALANCE_TICK` | `sched/mod.rs` (decl, balancer) | Relaxed on `fetch_add` (sole writer is the loaded-path victim selection in `try_pull_balance`) | Relaxed on the same `fetch_add` (consumes the previous value) | Advisory random-victim seed; correctness does not depend on ordering — a stale value just biases victim selection slightly. |
 | `NEXT_THREAD_ID` | `sched/mod.rs` (counter) | Relaxed on `fetch_add` | n/a | Monotonic counter; no synchronisation needed. |
 | `CPU_COUNT` | `sched/mod.rs:124` | Relaxed on store (`init_storage`) | Relaxed on every read | Single-writer at boot; the SCHEDULERS_PTR Release publishes the storage; readers establish happens-before via the pointer load, not via CPU_COUNT itself. |

--- a/core/kernel/docs/thread-lifecycle-and-sleep.md
+++ b/core/kernel/docs/thread-lifecycle-and-sleep.md
@@ -171,7 +171,7 @@ The teardown sequence binds the following ordered steps. Each step's preconditio
 
 2. **Step 3 (state = Exited) commits under all locks.** No `schedule()` on any CPU can subsequently observe this TCB as `Ready` or `Running` for purposes of re-enqueue — the protection in `schedule()` reads `state` while holding its CPU's scheduler.lock and refuses to re-enqueue if `state ∈ {Exited, Stopped}`. `enqueue_and_wake` performs the same check before enqueueing (see [scheduling-internals.md § Lock Hierarchy](scheduling-internals.md#lock-hierarchy) rule 9).
 
-3. **Step 9's `running_on` spin is bounded.** The remote CPU is mid-`schedule()`; once it sets `current = next_tcb` (which happens *before* the arch switch on both arches — `release_lock_only` runs in Rust before `switch()` on x86_64 and on RISC-V post-#144), the spin exits.
+3. **Step 9's `running_on` spin is bounded.** The remote CPU is mid-`schedule()`; once it sets `current = next_tcb` (which happens *before* the arch switch on both arches — `release_lock_only` runs in Rust before `switch()`), the spin exits.
 
 4a. **No `fpu_owner` sweep is needed after eager save (#108).** The `#NM` handler only ever installs the currently Running thread on its CPU as `fpu_owner`. `switch_out_save` clears the slot on switch-out before the thread re-enters the Ready / Blocked / Stopped / Exited states. By the time steps 9 and 10 above have completed — the thread has switched out on every CPU and `context_saved == 1` — no CPU's owner slot can name this TCB. Steps 9-10's interrupt-enabled-while-spinning discipline is still required to prevent the spin from deadlocking against a peer CPU's TLB-shootdown IPI; without it, two CPUs in mutual TLB shootdown would deadlock.
 

--- a/core/kernel/src/arch/x86_64/gdt.rs
+++ b/core/kernel/src/arch/x86_64/gdt.rs
@@ -161,9 +161,8 @@ static AP_GDT_PTR: core::sync::atomic::AtomicPtr<[u64; 7]> =
 /// from `sched::init`, before any AP startup. Each slab is page-aligned and
 /// zero-filled; `init_ap` overwrites the relevant fields per AP.
 ///
-/// The IOPB region of every TSS is then filled with `0xFF` (deny-all) to
-/// match the historic BSS-init behaviour; `init_ap` re-applies on each AP
-/// for paranoia.
+/// The IOPB region of every TSS is then filled with `0xFF` so all I/O-port
+/// access is denied; `init_ap` re-applies on each AP for paranoia.
 #[cfg(not(test))]
 pub fn init_ap_storage(cpu_count: usize, allocator: &mut crate::mm::BuddyAllocator)
 {

--- a/core/kernel/src/arch/x86_64/interrupts.rs
+++ b/core/kernel/src/arch/x86_64/interrupts.rs
@@ -406,8 +406,8 @@ unsafe fn apic_send_icr(dest: u32, cmd: u32)
 /// The bit clears within microseconds on a healthy LAPIC; 1M iterations
 /// is far beyond any architectural timing. Exhaustion indicates a
 /// hardware-level fault (stuck APIC, emulator bug) rather than a
-/// schedulable race, so we fatal rather than return a status all four
-/// callers historically ignored. x2APIC has no delivery-status bit (the ICR
+/// schedulable race, so we fatal rather than return a status no caller
+/// could act on. x2APIC has no delivery-status bit (the ICR
 /// MSR write is not pipelined), so the wait is skipped in that mode.
 #[cfg(not(test))]
 unsafe fn wait_icr_idle()
@@ -642,8 +642,7 @@ pub unsafe fn init_ap()
 {
     // Per-CPU CR4/CR0/XCR0 setup. The AP trampoline only sets CR4.PAE; SMEP,
     // SMAP, OSXSAVE, and TS are per-CPU state that must be re-established on
-    // each hart. enable_smep_smap was not previously called on APs — this
-    // closes that gap alongside the XSAVE enablement.
+    // each hart.
     // SAFETY: ring-0 AP boot; IDT loaded by caller (kernel_entry_ap); CPUID
     // gates each enable so a missing feature halts cleanly.
     unsafe {

--- a/core/kernel/src/cap/mod.rs
+++ b/core/kernel/src/cap/mod.rs
@@ -129,20 +129,17 @@ pub unsafe fn root_cspace_mut() -> Option<&'static mut CSpace>
 ///
 /// IDs are recycled via the [`CSPACE_FREE_LIST`] free list once
 /// [`free_cspace_id`] runs at the end of a `CSpace`'s `dealloc_object` pass,
-/// so this is a live-count bound — not the cumulative-ever bound it used to
-/// be under the pre-#137 monotonic allocator. Per-id generation counters in
-/// [`CSPACE_REGISTRY`] make any pre-existing stale `SlotId` resolution fail
-/// fast on epoch mismatch, so recycling cannot mis-target a recycled
-/// tenant. The pre-unregister derivation drain (`dealloc_object` for
-/// `CSpaceObj`) additionally scrubs the back-links in steady state.
+/// so this is a live-count bound, not a cumulative-ever bound. Per-id
+/// generation counters in [`CSPACE_REGISTRY`] make any stale `SlotId`
+/// resolution fail fast on epoch mismatch, so recycling cannot mis-target a
+/// recycled tenant. The pre-unregister derivation drain (`dealloc_object`
+/// for `CSpaceObj`) additionally scrubs the back-links in steady state.
 ///
-/// Live-count peaks in ktest stress today sit in the low hundreds; 4096
-/// gives 10–40× headroom while reclaiming ~432 KiB of BSS the
-/// pre-#137 65536-entry registry burned (65536 × 8 B = 512 KiB old
-/// registry vs 4096 × 16 B = 64 KiB new registry + 4096 × 4 B = 16 KiB
-/// free list = 80 KiB total; 512 − 80 = 432 KiB net). A future workload
-/// that genuinely needs more live `CSpace`s only has to bump this
-/// constant — no layout, ABI, or algorithmic change is required.
+/// Live-count peaks in ktest stress sit in the low hundreds; 4096 gives
+/// 10–40× headroom. The registry (4096 × 16 B = 64 KiB) plus the free list
+/// (4096 × 4 B = 16 KiB) cost 80 KiB of BSS. A future workload that needs
+/// more live `CSpace`s only has to bump this constant — no layout, ABI, or
+/// algorithmic change is required.
 const MAX_CSPACES: usize = 4096;
 
 /// High-water mark for the bump-allocator side of `alloc_cspace_id` — only
@@ -291,8 +288,7 @@ pub fn alloc_cspace_id() -> Option<CSpaceId>
 ///
 /// The host-side test path doesn't exercise the lock primitive or the BSS
 /// free list (no SMP, no interrupts), and tests only ever create the single
-/// root CSpace before tearing down. The simple monotonic allocator matches
-/// the pre-#137 behavior exactly.
+/// root CSpace before tearing down. A simple monotonic allocator suffices.
 #[cfg(test)]
 pub fn alloc_cspace_id() -> Option<CSpaceId>
 {
@@ -1927,9 +1923,7 @@ fn read_dtb_totalsize(phys: u64) -> Option<u64>
 ///
 /// Updates `layout.module_names` / `layout.module_name_count` and
 /// appends [`CapDescriptor`] entries for each module. Init looks
-/// modules up by name via the published `module_names` table; the
-/// older `module_frame_base` / `module_frame_count` ordinal surface
-/// was retired with the init-protocol v6→v7 bump.
+/// modules up by name via the published `module_names` table.
 fn mint_module_frame_caps(cspace: &mut CSpace, boot_info: &BootInfo, layout: &mut CSpaceLayout)
 {
     use boot_protocol::BootModule;

--- a/core/kernel/src/cap/object.rs
+++ b/core/kernel/src/cap/object.rs
@@ -273,8 +273,8 @@ pub struct FrameObject
     /// Per-Frame-cap retype allocator. Stored inline in kernel-owned memory
     /// so userspace `sys_mem_map` writes against the cap's region cannot
     /// corrupt the metadata. Zero-initialised: `bump_offset = 0` and every
-    /// free-list head = `FREE_LIST_END` give the same "fresh cap, all
-    /// bytes available" state the lazy install used to produce.
+    /// free-list head = `FREE_LIST_END` give a fresh cap with all bytes
+    /// available.
     pub allocator: crate::cap::retype::RetypeAllocator,
     /// Per-cap reader/writer lock guarding mutations of `size` (and the
     /// implicit `[base, base+size)` region they describe).

--- a/core/kernel/src/main.rs
+++ b/core/kernel/src/main.rs
@@ -490,7 +490,9 @@ unsafe fn kernel_entry_post_rebase(
         // SAFETY: SEED installed in Phase 7; single-threaded Phase 9.
         let (init_as_obj_nn, init_as_ptr) =
             unsafe { cap::boot_retype_aspace(cap::seed_frame_ref(), INIT_ASPACE_PAGES) };
-        let _ = allocator; // legacy buddy path no longer used for init's AS
+        // init's AS is built from typed memory (boot_retype_aspace), so the
+        // buddy allocator is unused here.
+        let _ = allocator;
 
         // Map each ELF LOAD segment into the init address space via
         // `map_page`, whose intermediate PT pages come from `kernel_pt_pool`

--- a/core/kernel/src/sched/mod.rs
+++ b/core/kernel/src/sched/mod.rs
@@ -816,10 +816,10 @@ fn idle_thread_entry(_cpu_id: u64) -> !
                 crate::arch::current::cpu::disable_interrupts();
             }
 
-            // Step 2: atomic check of flag + run queue. (The previous
-            // `CPU_IDLE_MASK` advisory was removed alongside the always-IPI
-            // refactor; idle-state is no longer published — the wake protocol
-            // does not consult it. See docs/scheduling-internals.md.)
+            // Step 2: atomic check of flag + run queue. Idle state is not
+            // published; the wake protocol always sends a reschedule IPI
+            // rather than consulting a per-CPU idle mask.
+            // See docs/scheduling-internals.md.
             let pending = take_reschedule_pending(cpu);
             // SAFETY: scheduler slot is initialised for this CPU.
             let has_work = unsafe { (*scheduler_ptr(cpu)).has_runnable() };
@@ -1161,8 +1161,8 @@ pub unsafe fn scheduler_for(id: usize) -> &'static mut PerCpuScheduler
 /// When `new_state` is `Stopped` or `Exited`, also scans every CPU's run
 /// queue at `tcb.priority` and removes any lingering entry. Closes the
 /// Ready→Stopped→Ready double-enqueue race (issue #117): a thread
-/// transitioning Ready→Stopped used to leave a stale entry on its source
-/// CPU's queue for the dispatch-side skip loop to drain. A subsequent
+/// transitioning Ready→Stopped would otherwise leave a stale entry on its
+/// source CPU's queue for the dispatch-side skip loop to drain. A subsequent
 /// Stopped→Ready + enqueue could race that drain and produce two list
 /// entries for the same TCB, corrupting the intrusive `run_queue_next`
 /// chain. Draining the entry here keeps the run-queue invariant

--- a/core/kernel/src/syscall/mod.rs
+++ b/core/kernel/src/syscall/mod.rs
@@ -49,8 +49,7 @@ use syscall::{
 // ── TrapFrame accessor shims ──────────────────────────────────────────────────
 // `TrapFrame::syscall_nr`, `::set_return`, and `::arg` are defined as methods
 // on `TrapFrame` in each arch's `trap_frame.rs`. Callers (ipc.rs etc.) use
-// `tf.arg(n)` directly; this comment marks where the free functions used to
-// live so the removal is easy to trace.
+// `tf.arg(n)` directly.
 
 // ── Syscall dispatch ──────────────────────────────────────────────────────────
 

--- a/core/ktest/README.md
+++ b/core/ktest/README.md
@@ -156,8 +156,8 @@ Defined in `src/main.rs`:
 
 ## Compile-time options
 
-Boot-protocol v8 removed the kernel command line; ktest's runtime
-knobs now live in `KtestConfig::DEFAULT` in
+The boot protocol carries no kernel command line; ktest's runtime
+knobs live in `KtestConfig::DEFAULT` in
 [`src/cmdline.rs`](src/cmdline.rs) and are baked in at compile time.
 Editing the constant and rebuilding ktest (`cargo xtask build -p
 ktest`) is the canonical way to flip them.

--- a/core/ktest/src/cmdline.rs
+++ b/core/ktest/src/cmdline.rs
@@ -5,7 +5,7 @@
 
 //! Compile-time ktest configuration.
 //!
-//! Boot protocol v8 removed the kernel command line, so every ktest run
+//! The boot protocol carries no kernel command line, so every ktest run
 //! uses the same [`KtestConfig::DEFAULT`] baked in at build time. The
 //! defaults are picked for CI: every tier runs, the VM auto-shuts down
 //! on completion, and shutdown is immediate. To preserve QEMU for
@@ -28,8 +28,7 @@ pub enum ShutdownPolicy
     Never,
 }
 
-/// ktest configuration. Baked in at compile time after the boot-
-/// protocol v8 cmdline removal.
+/// ktest configuration. Baked in at compile time.
 #[allow(clippy::struct_excessive_bools)]
 pub struct KtestConfig
 {
@@ -44,9 +43,8 @@ pub struct KtestConfig
 
 impl KtestConfig
 {
-    /// Compile-time configuration baked into every ktest build after
-    /// the boot-protocol v8 cmdline removal. CI-friendly: full
-    /// coverage, exit immediately on completion.
+    /// Compile-time configuration baked into every ktest build.
+    /// CI-friendly: full coverage, exit immediately on completion.
     pub const DEFAULT: KtestConfig = KtestConfig {
         shutdown_policy: ShutdownPolicy::Always,
         timeout_secs: 0,

--- a/core/ktest/src/stress/cspace_recycle.rs
+++ b/core/ktest/src/stress/cspace_recycle.rs
@@ -1,16 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0-only
 // Copyright (C) 2026 George Kottler <mail@kottlerg.com>
 
-//! Stress test: repeated `CSpace` create + delete past the old cumulative bound.
+//! Stress test: repeated `CSpace` create + delete past the live-count bound.
 //!
-//! Before #137, `CSpaceId` allocation was monotonic (`fetch_add`) and the
-//! namespace was bounded by *cumulative* creates, not live count. The
-//! pre-#137 ceiling was `MAX_CSPACES = 65536`; the ramped ktest sequence
-//! peaked at ~14k cumulative `CSpace`s, with 4× headroom.
-//!
-//! Recycling makes the namespace bounded by *live* count. To prove it, we
-//! create and immediately destroy 10000 `CSpace`s in a tight loop. With
-//! `MAX_CSPACES = 4096` (post-#137), this iteration count is 2.4× the
+//! `CSpaceId`s are recycled via a free list, so the `CSpace` namespace is
+//! bounded by *live* count, not by *cumulative* creates. To prove recycling
+//! holds, this test creates and immediately destroys 10000 `CSpace`s in a
+//! tight loop. With `MAX_CSPACES = 4096`, this iteration count is 2.4× the
 //! ceiling; if recycling were broken, `cap_create_cspace` would surface
 //! `SyscallError::OutOfMemory` at iteration ~4096 and the loop would fail
 //! its first negative return.

--- a/core/ktest/src/unit/ipc.rs
+++ b/core/ktest/src/unit/ipc.rs
@@ -616,13 +616,14 @@ fn token_caller_entry(arg: u64) -> !
 /// logging helper, or any other IPC issued before the caller consumes the
 /// received data) cannot clobber it.
 ///
-/// Historically the IPC buffer was caller-visible state across the
-/// post-recv / pre-read window; a `println!` between recv and the word
-/// read would scribble `STREAM_BYTES` over the received payload. The
-/// snapshot wrapper eliminates that window at the type level. This test
-/// locks the invariant in: receive a message with known words, scribble
-/// garbage directly over the IPC buffer (the worst case of any nested IPC
-/// activity), then verify the message's view is unchanged.
+/// Without the snapshot wrapper, the IPC buffer would be caller-visible
+/// state across the post-recv / pre-read window: a `println!` between recv
+/// and the word read would scribble `STREAM_BYTES` over the received
+/// payload. The snapshot wrapper eliminates that window at the type
+/// level. This test locks the invariant in: receive a message with known
+/// words, scribble garbage directly over the IPC buffer (the worst case
+/// of any nested IPC activity), then verify the message's view is
+/// unchanged.
 pub fn recv_snapshot_survives_buffer_clobber(ctx: &TestContext) -> TestResult
 {
     let ep = cap_create_endpoint(ctx.memory_frame_base)

--- a/core/ktest/src/unit/signal.rs
+++ b/core/ktest/src/unit/signal.rs
@@ -228,9 +228,9 @@ pub fn wait_timeout_fires(ctx: &TestContext) -> TestResult
 // ── SYS_SIGNAL_WAIT (high-bit payload) ────────────────────────────────────────
 
 /// Bitmasks with bit 63 set (and `u64::MAX`) must round-trip cleanly through
-/// `signal_send` / `signal_wait`. Regression test for the dispatcher's
-/// historical `cast_signed()` aliasing of `Ok(bits)` with negative-Err
-/// codes, which surfaced bit-63-set bitmasks to userspace as `Err(i64::MIN)`.
+/// `signal_send` / `signal_wait`. Regression test for `cast_signed()`
+/// aliasing of `Ok(bits)` with negative-Err codes, which would surface
+/// bit-63-set bitmasks to userspace as `Err(i64::MIN)`.
 pub fn wait_high_bit_roundtrip(ctx: &TestContext) -> TestResult
 {
     let sig = cap_create_signal(ctx.memory_frame_base)

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -22,11 +22,10 @@ kernel entry point. The sequence is specified in ten bootloader steps in
 [`core/boot/docs/boot-flow.md`](../core/boot/docs/boot-flow.md).
 
 Boot-time configuration on disk consists of only the three ESP files
-named above plus the EFI fallback bootloader. `BootInfo` no longer
-carries a kernel command line (`boot-protocol` v8 removed
-`command_line`); root-partition identity moved to GPT type-GUID role
-discovery, performed by vfsd, and ktest options are baked into ktest's
-compile-time defaults.
+named above plus the EFI fallback bootloader. `BootInfo` carries no
+kernel command line; root-partition identity comes from GPT type-GUID
+role discovery, performed by vfsd, and ktest options are baked into
+ktest's compile-time defaults.
 
 ---
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -107,9 +107,7 @@ or on-disk UUID. The model is:
   filesystem label or UUID consulted by vfsd. The GUID is the
   binding.
 
-The boot-protocol v8 retirement of `BootInfo.command_line` and the
-prior `mounts.conf` file completed this transition; the role-GUID
-model is the present and only mount-discovery mechanism. The wire
+The role-GUID model is the only mount-discovery mechanism. The wire
 shape vfsd uses internally (a `MountRole` byte mapped to a type GUID)
 is owned by [`services/vfsd/docs/vfs-ipc-interface.md`](../services/vfsd/docs/vfs-ipc-interface.md).
 
@@ -234,8 +232,7 @@ To prevent inference of behavior that does not exist:
   etc.) are not consulted by vfsd.
 - **No boot-time mount configuration file.** Discovery is GPT-driven
   and arch-conditional; there is no `mounts.conf`, no `/etc/fstab`,
-  and no kernel command line carrying mount config (boot-protocol
-  v8 retired `command_line` entirely).
+  and no kernel command line carrying mount config.
 - **No process-global filesystem authority.** A process delivered no
   namespace cap has no filesystem access; `std::fs` returns
   `Unsupported`. There is no fallback to a system identity.

--- a/docs/userspace-memory-model.md
+++ b/docs/userspace-memory-model.md
@@ -182,7 +182,7 @@ memmgr serves frame requests over IPC. The contract:
   to `want_pages`. The reply carries each returned cap's page count
   alongside it. memmgr prefers fewer caps over many.
 - **No fixed cap-count ceiling.** Replies may use the full IPC
-  reply-side cap-slot capacity; there is no historical 4-cap limit.
+  reply-side cap-slot capacity; there is no 4-cap limit.
 - **Caller maps.** Every returned Frame cap is mapped at a caller-
   chosen VA via `mem_map` (which already accepts a multi-page
   `page_count` argument).

--- a/runtime/ruststd/src/sys/alloc/seraph.rs
+++ b/runtime/ruststd/src/sys/alloc/seraph.rs
@@ -65,8 +65,7 @@ const GROW_MIN_PAGES: u64 = 16;
 /// Upper bound on a single `grow` call's page count. memmgr's reply is
 /// bounded by `MSG_CAP_SLOTS_MAX = 4` Frame caps per round; with
 /// best-effort allocation each cap may cover many pages, so this cap is
-/// no longer driven by per-page CSpace consumption (as it was under
-/// procmgr's one-cap-per-page ABI). Kept large enough that typical
+/// not driven by per-page CSpace consumption. It is sized so typical
 /// large `Vec` reallocations stay within a single round.
 const GROW_MAX_PAGES: u64 = 256;
 
@@ -732,7 +731,7 @@ pub fn fund_aspace_pt_budget(self_aspace: u32, region_pages: u64) -> bool {
 }
 
 /// Abort the calling thread via `SYS_THREAD_EXIT`. Used as the allocation-
-/// failure and panic terminator until P3c wires a proper abort path.
+/// failure and panic terminator.
 pub fn abort_thread() -> ! {
     syscall::thread_exit()
 }

--- a/runtime/ruststd/src/sys/fs/seraph.rs
+++ b/runtime/ruststd/src/sys/fs/seraph.rs
@@ -37,7 +37,7 @@
 //! `OpenOptions::truncate(true)` on an existing file and
 //! `File::set_len(0)` ride the new `FS_TRUNCATE` label. v1 supports
 //! `new_len == 0` only; the corresponding extend-with-zero-fill case
-//! is tracked in the post-#8 completeness-gaps Issue.
+//! is tracked in the `ruststd::fs` completeness-gaps issue.
 //!
 //! ## Metadata
 //! `std::fs::metadata` / `symlink_metadata` / `exists` walk the path
@@ -1239,7 +1239,7 @@ impl File
         if new_len != 0
         {
             // v1: only shrink-to-zero is implemented. Extend-with-
-            // zero-fill is in the post-#8 completeness-gaps Issue.
+            // zero-fill is tracked in the `ruststd::fs` completeness-gaps issue.
             return Err(io::const_error!(
                 io::ErrorKind::Unsupported,
                 "seraph fs: File::set_len(non-zero) not supported in v1",

--- a/services/fs/docs/fs-driver-protocol.md
+++ b/services/fs/docs/fs-driver-protocol.md
@@ -439,8 +439,8 @@ Set a file's length. Token = file cap with `WRITE`.
 
 v1 supports only `new_len == 0`; non-zero replies `IO_ERROR`. The
 wire shape is forward-compatible with later extend-with-zero-fill
-semantics, tracked by the post-#8 `ruststd::fs` completeness-gaps
-Issue. The truncate-to-zero path frees the entire FAT cluster chain
+semantics, tracked by the `ruststd::fs` completeness-gaps issue. The
+truncate-to-zero path frees the entire FAT cluster chain
 and patches the directory entry's first-cluster + size fields to 0.
 
 **Errors**: `INVALID_TOKEN`, `IS_A_DIRECTORY`, `PERMISSION_DENIED`,

--- a/services/init/src/bootstrap.rs
+++ b/services/init/src/bootstrap.rs
@@ -511,8 +511,7 @@ fn descriptor_for(info: &InitInfo, slot: u32) -> Option<&CapDescriptor>
 /// `creator_endpoint_cap`.
 ///
 /// The memmgr boot module is located in [`InitInfo`] by name via
-/// [`crate::find_module_by_name`] (init-protocol v7+); ordinal-based
-/// lookup is no longer used.
+/// [`crate::find_module_by_name`] (init-protocol v7+).
 ///
 /// `mm_service_ep` is the full-rights cap on memmgr's service endpoint
 /// (created in init's `CSpace`); init keeps a copy and minted SENDs from it
@@ -947,8 +946,8 @@ struct ProcmgrCaps
     thread: u32,
     creator_endpoint_slot: u32,
     /// Slot index in procmgr's `CSpace` of the tokened SEND cap on memmgr's
-    /// endpoint. Zero when memmgr is not yet wired (early-boot regression
-    /// path; never expected after P5).
+    /// endpoint. Zero when memmgr is not yet wired — an early-boot-only
+    /// condition.
     memmgr_endpoint_slot: u32,
     /// Slot in procmgr's `CSpace` holding a tokened SEND on the
     /// system log endpoint with token `LOG_TOKEN_PROCMGR`. Std reads
@@ -964,8 +963,8 @@ struct ProcmgrCaps
 
 /// Populate procmgr's `ProcessInfo` page and map it read-only into procmgr.
 ///
-/// procmgr's stdio cap slots are left zero (procmgr is std-built post-
-/// P7 but does not drive interactive stdio). The un-tokened SEND on
+/// procmgr's stdio cap slots are left zero (procmgr is std-built but
+/// does not drive interactive stdio). The un-tokened SEND on
 /// the log endpoint procmgr uses as the *source* for deriving tokened
 /// SEND caps per child arrives via procmgr's bootstrap round, not via
 /// `ProcessInfo`. The pre-installed tokened SEND cap procmgr uses for
@@ -1197,10 +1196,10 @@ pub fn bootstrap_procmgr(
     let pm_creator_slot =
         syscall::cap_copy(tokened_creator, pm_cspace, syscall::RIGHTS_SEND).ok()?;
 
-    // Procmgr no longer maintains its own frame pool (P7 routes every
-    // per-child allocation through memmgr). All remaining RAM frames
-    // get delegated to memmgr in `finalize_memmgr` after every setup
-    // path has finished consuming init's pool.
+    // Procmgr maintains no frame pool of its own; every per-child
+    // allocation routes through memmgr. All remaining RAM frames get
+    // delegated to memmgr in `finalize_memmgr` after every setup path
+    // has finished consuming init's pool.
     let _ = pm_creator_slot;
 
     // Derive an un-tokened SEND cap on the log endpoint for procmgr.

--- a/services/procmgr/docs/ipc-interface.md
+++ b/services/procmgr/docs/ipc-interface.md
@@ -282,7 +282,7 @@ teardown (Threads → AddressSpace → DONATE_FRAMES → CSpace → log).
 | [docs/process-lifecycle.md](../../../docs/process-lifecycle.md) | System-scope creation order; procmgr's role and authority boundary with memmgr |
 | [abi/process-abi](../../../abi/process-abi/README.md) | ProcessInfo handover struct |
 | [abi/syscall](../../../abi/syscall/README.md) | Syscall numbers and register conventions |
-| [services/memmgr/docs/ipc-interface.md](../../memmgr/docs/ipc-interface.md) | Frame allocation IPC (formerly procmgr's `REQUEST_FRAMES`) |
+| [services/memmgr/docs/ipc-interface.md](../../memmgr/docs/ipc-interface.md) | Frame allocation IPC |
 
 ---
 

--- a/services/svctest/src/phases/fs_ipc.rs
+++ b/services/svctest/src/phases/fs_ipc.rs
@@ -80,11 +80,10 @@ pub fn fs_open_phase(_: &Caps)
 {
     use std::io::Read;
 
-    // `boot.conf` was removed in boot-protocol v8. Read the bootstrap
-    // bundle header (the first 16 bytes carry `SRPHBNDL` magic + u32
-    // version + u32 entry count) to exercise the same vfsd/fatfs std::fs
-    // path boot.conf did without pulling tens of MiB into a userspace
-    // Vec.
+    // Read the bootstrap bundle header (the first 16 bytes carry
+    // `SRPHBNDL` magic + u32 version + u32 entry count) to exercise the
+    // vfsd/fatfs std::fs path on a small read without pulling tens of MiB
+    // into a userspace Vec.
     let mut file = match std::fs::File::open("/esp/EFI/seraph/bootstrap.bundle")
     {
         Ok(f) => f,

--- a/services/svctest/src/phases/namespace.rs
+++ b/services/svctest/src/phases/namespace.rs
@@ -298,9 +298,9 @@ pub fn ns_mount_boundary_phase(_: &Caps)
 
     // Transparent root-fs delegation: paths that are not shadowed by a
     // mount on the synthetic root must resolve through the root fs.
-    // After the mounts.conf/INGEST_CONFIG_MOUNTS removal, /config lives on
-    // the root partition and reaches `/config/svcmgr/services/logd.svc`
-    // through delegation (the only mount on the synthetic root is /esp).
+    // /config lives on the root partition and reaches
+    // `/config/svcmgr/services/logd.svc` through delegation (the only mount
+    // on the synthetic root is /esp).
     let (config_cap, kind, _size) = ns_lookup(system_root_cap, b"config", 0xFFFF, ipc_buf)
         .expect("ns_mount_boundary: NS_LOOKUP(system_root, \"config\") failed");
     assert_eq!(
@@ -485,10 +485,9 @@ pub fn ns_startup_cwd_phase(_: &Caps)
     std::os::seraph::log!("ns_startup_cwd phase passed");
 }
 
-// ns_fallthrough_attenuation_phase was retired alongside the historical
-// storage-mount fixture: it asserted that fall-through caps minted under
-// a synthetic intermediate (an outer dir that existed only because a
-// deeper mount fell within it) respect parent-cap attenuation. Without
-// a multi-component mount in the in-tree boot the scenario it exercised
-// no longer exists. Re-introducing equivalent coverage requires a
+// There is no ns_fallthrough_attenuation_phase here: the in-tree boot has
+// no multi-component mount, so the scenario it would exercise — fall-through
+// caps minted under a synthetic intermediate (an outer dir present only
+// because a deeper mount falls within it) respecting parent-cap attenuation
+// — is not reachable. Re-introducing this coverage requires a
 // multi-component mount fixture; tracked as issue #139.

--- a/services/vfsd/docs/namespace-composition.md
+++ b/services/vfsd/docs/namespace-composition.md
@@ -47,9 +47,9 @@ components, creating synthetic intermediates on demand, and setting
 `terminal_cap` on the final node. After install the caller
 (`do_mount`) walks the root mount component-by-component via
 `NS_LOOKUP` to populate each new intermediate's `fallthrough_cap`.
-The in-tree mount set after the GPT-type-GUID redesign is two
-single-component mounts (`/`, `/esp`); the multi-component install
-path remains supported but is currently unexercised in production.
+The in-tree mount set is two single-component mounts (`/`, `/esp`);
+the multi-component install path remains supported but is currently
+unexercised in production.
 
 ---
 
@@ -152,8 +152,7 @@ per-cap revocation.
 
 vfsd holds two un-tokened endpoints:
 
-- **Service endpoint** — `MOUNT` and `GET_SYSTEM_ROOT_CAP`
-  (`INGEST_CONFIG_MOUNTS` was retired alongside `mounts.conf`).
+- **Service endpoint** — `MOUNT` and `GET_SYSTEM_ROOT_CAP`.
   Multi-threaded recv (4 handlers today) so
   that a handler blocked on a worker pool order does not deadlock
   the system: `CREATE_FROM_FILE` for a fatfs respawn re-enters

--- a/services/vfsd/docs/vfs-ipc-interface.md
+++ b/services/vfsd/docs/vfs-ipc-interface.md
@@ -21,12 +21,10 @@ distribution; children of init receive a `cap_copy` of it via
 `std::os::seraph::root_dir_cap()`. Vfsd holds no namespace cap on
 procmgr's behalf — there is no boot-time push.
 
-The historic `INGEST_CONFIG_MOUNTS` IPC and the `/config/mounts.conf`
-file it consumed were retired with the GPT-type-GUID redesign (boot
-protocol v8). vfsd self-mounts the Seraph root partition at `/` and the
-EFI System Partition at `/esp` at startup; additional partitions are
-discovered by their type GUID, not by a config file. The label number
-(`12`) is reserved and MUST NOT be reused for an unrelated request.
+vfsd self-mounts the Seraph root partition at `/` and the EFI System
+Partition at `/esp` at startup; additional partitions are discovered by
+their type GUID, not by a config file. Label `12` on the service endpoint
+is reserved and MUST NOT be reused for an unrelated request.
 
 ---
 

--- a/services/vfsd/src/main.rs
+++ b/services/vfsd/src/main.rs
@@ -751,8 +751,8 @@ fn handle_mount_request(recv: &IpcMessage, ipc_buf: *mut u64, rt: &VfsdRuntime)
 
     // Auto-mount the EFI System Partition at /esp once root is up so
     // userspace can read kernel + bundle + bootloader without a separate
-    // MOUNT call (the historic role of `mounts.conf`). Best-effort —
-    // failure does not propagate into the root mount's reply.
+    // MOUNT call. Best-effort — failure does not propagate into the root
+    // mount's reply.
     if matches!(role, MountRole::Root) && reply.label == ipc::vfsd_errors::SUCCESS
     {
         auto_mount_esp(rt, ipc_buf);

--- a/shared/ipc/src/lib.rs
+++ b/shared/ipc/src/lib.rs
@@ -1759,8 +1759,8 @@ impl IpcMessage
     /// (`idx >= MSG_DATA_WORDS_MAX`). Reading past the sender's declared
     /// `word_count()` returns zero — the unused array slots are zero-init
     /// and the kernel does not write them past the declared range. This
-    /// matches the old `IpcBuf::read_word` contract so protocols that
-    /// carry optional trailing words at fixed offsets keep working.
+    /// is a deliberate contract so protocols that carry optional trailing
+    /// words at fixed offsets keep working.
     #[must_use]
     pub fn word(&self, idx: usize) -> u64
     {


### PR DESCRIPTION
Closes #191.

## What

Rewrites history-lesson prose in comments and docs to present-tense statements of the current system, per `docs/coding-standards.md` and `docs/documentation-standards.md`: comments/docs describe the current system in present tense and do not narrate change history, prior implementations, removed surfaces, or issue/PR-keyed "what changed" markers. **Comment/doc-only — no behavioral change.**

## Scope

The 10 violations #191 enumerates, plus the same-class drift a repo-wide re-grep of the banned markers surfaced (per the Completeness rule and Acceptance #2's clean-re-grep requirement):

- **kernel** — `cap/mod.rs` (×3, `pre-#137`), `cap/object.rs`, `syscall/mod.rs`, `sched/mod.rs`, `main.rs`, `gdt.rs`, `interrupts.rs`; docs `scheduling-internals.md` (×2, incl. the `#22/#23`-keyed marker), `ipc-internals.md`, `thread-lifecycle-and-sleep.md`
- **ktest** — `stress/cspace_recycle.rs`, `unit/ipc.rs`, `unit/signal.rs`, `README.md`, `cmdline.rs`
- **init / svctest** — `bootstrap.rs` (incl. `P5`/`P7` planning-label leaks), `fs_ipc.rs`, `namespace.rs`
- **boot** — `elf.rs`, `boot-flow.md` (removed-field row), `elf-loading.md`, `uefi-environment.md`
- **ruststd / service docs** — `fs/seraph.rs` (×2), `alloc/seraph.rs`; `fs-driver-protocol.md`, `procmgr/ipc-interface.md`, `vfsd/{namespace-composition,vfs-ipc-interface}.md`, `vfsd/src/main.rs`
- **system docs** — `bootstrap.md`, `storage.md`, `userspace-memory-model.md`

The scattered "boot-protocol v8 removed the command line" lines are direct siblings of the enumerated `boot.conf`/`command_line` cases and are swept the same way.

**Exempt, left intact:** the `*_PROTOCOL_VERSION` version-history changelogs (`boot-protocol`, `init-protocol`) and the deliberately-labeled "Historical naming" sections (`conventions.md`, `testing.md`) — both narrate history by design, matching #191's Non-goals. Verified present-tense runtime-state uses are also left intact (`no longer mapped` postconditions, `used to <verb>` = utilized-to, `previously acquired` ordering).

## Acceptance (#191)

- [x] Each listed comment/doc rewritten to present tense; no `previously / no longer / was removed / post-#NN / pre-#NN / P<N>` history framing remains (substituted text verified against current code/behavior).
- [x] Repo-wide re-grep for the banned markers returns only legitimate present-tense runtime-state uses and dedicated changelog / version-history / `docs/releases/` surfaces.
- [x] Lands via a feature-branch PR per `docs/conventions.md`.

## Test plan

- `cargo xtask build` + `cargo xtask compose-bundle --harness ktest` + `cargo xtask run --headless` on **x86_64** → `[ktest] ALL TESTS PASSED`
- same on **riscv64** → `[ktest] ALL TESTS PASSED`
- `cargo xtask clean` run between arch switches