### PR TITLE
kernel: elide TLB shootdown for fresh maps and permission widens

### DIFF
--- a/core/kernel/docs/memory-internals.md
+++ b/core/kernel/docs/memory-internals.md
@@ -353,29 +353,40 @@ Threads in the same address space switching on the same CPU require no TLB opera
 ### SMP TLB Shootdown
 
 When a mapping is modified in an address space that has active threads on other CPUs,
-TLB entries on those CPUs must be invalidated. The protocol:
+stale TLB entries on those CPUs may need invalidation. The leaf PTE is edited under
+the per-address-space `pt_lock`, which is then **released before** any cross-CPU
+work: holding it across the IPI ack-wait would serialize every concurrent map/unmap
+on the address space behind cross-CPU latency.
+
+The shootdown itself is lock-free — there is no global shootdown lock and no IPI
+payload. Each CPU owns a request slot. The initiator publishes `(root, virt)` into
+its own slot, sets the pending bit of each target CPU, then sends the IPI:
 
 ```
-1. Acquire table_lock on the address space
-2. Modify the page table (map/unmap/protect)
-3. Read active_cpu_mask to determine which remote CPUs are affected
-4. For each affected remote CPU: send an IPI (Inter-Processor Interrupt)
-   with the address space pointer and virtual address to invalidate
-5. Wait for all targeted CPUs to acknowledge (spin on a per-CPU counter)
-6. Release table_lock
+1. Edit the leaf PTE under pt_lock; release pt_lock.
+2. Read active_cpu_mask; exclude the current CPU.
+3. Publish (root, virt) into this CPU's request slot and set each target's
+   pending bit (the bit doubles as the per-target liveness/ack token).
+4. Send the shootdown IPI to the targets and wait for every pending bit to clear.
 ```
 
-The IPI handler on each remote CPU:
+A target services the slot only once it observes its own pending bit set, so it never
+reads a half-published request; it flushes the named VA and clears its bit. Preemption
+stays disabled across the whole edit-then-shootdown sequence.
 
-```
-1. Receive the (address_space, virt_addr) from the IPI payload
-2. If the current address space matches: call Paging::flush_page(virt_addr)
-3. Increment the acknowledgement counter
-```
+The shootdown is **not** issued unconditionally. Each rewrite is classified as it
+commits (`MapOutcome`):
 
-If a CPU switches away from the affected address space between step 3 and step 5, its
-TLB entries for that space are irrelevant (a context switch performs the appropriate
-flush). The kernel checks for this case and skips the IPI for CPUs that have switched.
+- **Fresh** (no prior mapping) and **Widen** (same frame, strictly broader rights)
+  skip the remote shootdown. No remote CPU can hold an entry granting more than the
+  live PTE, so the worst case is a spurious fault the page-fault handler resolves by
+  re-walking the live PTE and retrying.
+- **Replace** (different frame, or a permission narrowing) issues the synchronous
+  shootdown above: a stale entry would alias a freed/reused frame or cache revoked
+  rights, which no retry can recover. `unmap` is always synchronous.
+
+A CPU that switches away from the address space before acking is harmless: a context
+switch reloads the page-table root and flushes that space's user entries.
 
 ### Direct Physical Map Access
 

--- a/core/kernel/docs/scheduling-internals.md
+++ b/core/kernel/docs/scheduling-internals.md
@@ -372,7 +372,7 @@ The kernel sends three IPIs. Each has a defined purpose and correctness role.
 
 | Vector | Constant | Purpose | Handler | Correctness role |
 |---|---|---|---|---|
-| 250 | `IPI_VECTOR_TLB_SHOOTDOWN` | TLB invalidation cascade | Flushes per-CPU TLB entries staged by the issuer. | Required: a writer that modifies a page-table entry MUST shoot down peer CPUs' TLBs before guaranteeing the change is observable. |
+| 250 | `IPI_VECTOR_TLB_SHOOTDOWN` | TLB invalidation cascade | Flushes per-CPU TLB entries staged by the issuer. | Required for rewrites that could strand a dangerous stale entry — unmap, permission narrowing, or frame replacement — where the stale entry would alias a freed/reused frame or grant revoked rights. Fresh maps and permission widenings skip the IPI and rely instead on the page-fault handler's spurious-fault retry (the live PTE already permits the access). |
 | 251 | `IPI_VECTOR_WAKEUP` | Wake target CPU from `hlt` | EOI only (no work). | Required for the wake protocol's "always-IPI" invariant. The handler does no real work; the IPI's value is the trap entry itself, which exits `hlt` and re-enters the idle loop's check. |
 
 ### riscv64

--- a/core/kernel/docs/syscalls.md
+++ b/core/kernel/docs/syscalls.md
@@ -1371,8 +1371,13 @@ all its descendants (including C2) but leaves C and any other children of C inta
   in other processes completes before `SYS_CAP_REVOKE` returns.
 
 - **Memory mapping operations are atomic with respect to the address space.** After
-  `SYS_MEM_MAP` or `SYS_MEM_UNMAP` returns, all CPUs see the updated mapping (TLB
-  shootdowns complete before return).
+  `SYS_MEM_MAP` or `SYS_MEM_UNMAP` returns, every CPU observes the updated mapping on
+  its next access. Rewrites that could leave a dangerous stale entry (unmap,
+  permission narrowing, frame replacement) complete a synchronous cross-CPU TLB
+  shootdown before returning; fresh maps and permission widenings instead rely on the
+  page-fault handler's spurious-fault retry, which re-walks the live page table on
+  first remote access. Either way the end state is coherent before the access
+  completes.
 
 - **Syscalls may be preempted.** Long-running operations (revocation traversal, SMP
   TLB shootdowns) may be interrupted by a higher-priority runnable thread. The kernel

--- a/core/kernel/src/arch/riscv64/paging.rs
+++ b/core/kernel/src/arch/riscv64/paging.rs
@@ -398,7 +398,7 @@ pub unsafe fn map_user_page(
     virt: u64,
     phys: u64,
     flags: crate::mm::paging::PageFlags,
-) -> Result<(), ()>
+) -> Result<crate::mm::paging::MapOutcome, ()>
 {
     use crate::mm::paging::phys_to_virt;
     // U bit (bit 4) allows user-mode access.
@@ -420,9 +420,10 @@ pub unsafe fn map_user_page(
     let l0 = unsafe { table_at(phys_to_virt(l0_pa)) };
     let mut pte = PageTableEntry::new_page(phys, flags);
     pte.0 |= USER;
+    let prior = l0[vpn0_index(virt)].0;
     l0[vpn0_index(virt)] = pte;
 
-    Ok(())
+    Ok(classify_user_map(prior, pte.0))
 }
 
 /// Walk an existing Sv48 page table entry or allocate a new child frame
@@ -455,7 +456,7 @@ pub unsafe fn map_user_page_pooled(
     phys: u64,
     flags: crate::mm::paging::PageFlags,
     aso: &crate::cap::object::AddressSpaceObject,
-) -> Result<(), ()>
+) -> Result<crate::mm::paging::MapOutcome, ()>
 {
     use crate::mm::paging::phys_to_virt;
     const USER: u64 = 1 << 4;
@@ -477,9 +478,10 @@ pub unsafe fn map_user_page_pooled(
 
     let mut pte = PageTableEntry::new_page(phys, flags);
     pte.0 |= USER;
+    let prior = l0[vpn0_index(virt)].0;
     l0[vpn0_index(virt)] = pte;
 
-    Ok(())
+    Ok(classify_user_map(prior, pte.0))
 }
 
 /// Pooled equivalent of [`rv_walk_or_alloc`]: pulls a freshly-zeroed PT
@@ -753,7 +755,9 @@ pub unsafe fn unmap_identity_page(pa: u64)
 ///
 /// Returns `Err(PagingError::NotMapped)` if any level is not present. On
 /// success, rewrites the leaf PTE with the new `flags` (preserving physical
-/// address and USER bit) and calls `flush_page`.
+/// address and USER bit), calls `flush_page`, and returns the
+/// [`MapOutcome`](crate::mm::paging::MapOutcome) classifying the rights change
+/// (a same-frame rewrite, so never `Fresh`).
 ///
 /// # Safety
 /// `root_virt` must be the direct-map virtual address of a valid 4 KiB Sv48
@@ -763,7 +767,7 @@ pub unsafe fn protect_user_page(
     root_virt: u64,
     virt: u64,
     flags: crate::mm::paging::PageFlags,
-) -> Result<(), crate::mm::paging::PagingError>
+) -> Result<crate::mm::paging::MapOutcome, crate::mm::paging::PagingError>
 {
     use crate::mm::paging::{PagingError, phys_to_virt};
     // Set USER (U) bit (bit 4) to preserve user accessibility.
@@ -801,6 +805,7 @@ pub unsafe fn protect_user_page(
         return Err(PagingError::NotMapped);
     }
 
+    let prior = leaf.0;
     let phys = leaf.phys_addr();
     let mut new_pte = PageTableEntry::new_page(phys, flags);
     new_pte.0 |= USER;
@@ -808,7 +813,7 @@ pub unsafe fn protect_user_page(
 
     // SAFETY: virt is mapped; flush_page is safe for any VA.
     unsafe { flush_page(virt) };
-    Ok(())
+    Ok(classify_user_map(prior, new_pte.0))
 }
 
 /// Translate a user virtual address to its mapped physical address and raw PTE.
@@ -864,6 +869,46 @@ pub unsafe fn translate_user_page(root_virt: u64, virt: u64) -> Option<(u64, u64
     }
 
     Some((leaf.phys_addr(), leaf.0))
+}
+
+// ── Shootdown-elision classification ──────────────────────────────────────────
+
+/// Classify a leaf-PTE rewrite (`prior` → `new`) into a
+/// [`MapOutcome`](crate::mm::paging::MapOutcome) for shootdown elision.
+///
+/// `prior`/`new` are raw Sv48 leaf PTE bits (`new` is presumed valid). A not-
+/// valid `prior` is a fresh map; a same-frame rights *widening* needs only the
+/// spurious-fault retry; any frame change or rights *narrowing* strands a
+/// dangerous stale entry and must shoot down. See [`MapOutcome`] for the full
+/// argument.
+fn classify_user_map(prior: u64, new: u64) -> crate::mm::paging::MapOutcome
+{
+    use crate::mm::paging::MapOutcome;
+
+    if prior & VALID == 0
+    {
+        return MapOutcome::Fresh;
+    }
+    if PageTableEntry(prior).phys_addr() == PageTableEntry(new).phys_addr()
+        && map_rights_superset(new, prior)
+    {
+        MapOutcome::Widen
+    }
+    else
+    {
+        MapOutcome::Replace
+    }
+}
+
+/// Whether `new` grants every user access `prior` granted (Sv48 leaf bits).
+///
+/// Each access class checks its own bit: R (load), W (store), X (fetch).
+fn map_rights_superset(new: u64, prior: u64) -> bool
+{
+    let r_ok = prior & READ == 0 || new & READ != 0;
+    let w_ok = prior & WRITE == 0 || new & WRITE != 0;
+    let x_ok = prior & EXECUTE == 0 || new & EXECUTE != 0;
+    r_ok && w_ok && x_ok
 }
 
 // ── Spurious-fault classification ─────────────────────────────────────────────
@@ -1076,5 +1121,87 @@ mod tests
         // Invalid: genuine fault regardless of other bits.
         let invalid = USER_BIT | READ | WRITE | EXECUTE;
         assert!(!pte_permits_user_access(invalid, false, false));
+    }
+
+    // ── Shootdown-elision classification ───────────────────────────────────────
+
+    use crate::mm::paging::MapOutcome;
+
+    const FRAME_A: u64 = 0x10_000;
+    const FRAME_B: u64 = 0x20_000;
+
+    /// Raw Sv48 leaf PTE bits: valid user page on `frame` with the given rights.
+    fn leaf(frame: u64, r: bool, w: bool, x: bool) -> u64
+    {
+        let mut pte = VALID | USER_BIT | ((frame >> 12) << 10);
+        if r
+        {
+            pte |= READ;
+        }
+        if w
+        {
+            pte |= WRITE;
+        }
+        if x
+        {
+            pte |= EXECUTE;
+        }
+        pte
+    }
+
+    #[test]
+    fn classify_fresh_when_prior_invalid()
+    {
+        assert_eq!(
+            classify_user_map(0, leaf(FRAME_A, true, true, false)),
+            MapOutcome::Fresh
+        );
+    }
+
+    #[test]
+    fn classify_widen_when_adding_write_same_frame()
+    {
+        let prior = leaf(FRAME_A, true, false, false); // R--
+        let new = leaf(FRAME_A, true, true, false); // RW-
+        assert_eq!(classify_user_map(prior, new), MapOutcome::Widen);
+    }
+
+    #[test]
+    fn classify_widen_when_adding_exec_same_frame()
+    {
+        let prior = leaf(FRAME_A, true, false, false); // R--
+        let new = leaf(FRAME_A, true, false, true); // R-X
+        assert_eq!(classify_user_map(prior, new), MapOutcome::Widen);
+    }
+
+    #[test]
+    fn classify_widen_when_identical()
+    {
+        let pte = leaf(FRAME_A, true, true, false);
+        assert_eq!(classify_user_map(pte, pte), MapOutcome::Widen);
+    }
+
+    #[test]
+    fn classify_replace_when_narrowing_write()
+    {
+        let prior = leaf(FRAME_A, true, true, false); // RW-
+        let new = leaf(FRAME_A, true, false, false); // R--
+        assert_eq!(classify_user_map(prior, new), MapOutcome::Replace);
+    }
+
+    #[test]
+    fn classify_replace_when_narrowing_exec()
+    {
+        let prior = leaf(FRAME_A, true, false, true); // R-X
+        let new = leaf(FRAME_A, true, false, false); // R--
+        assert_eq!(classify_user_map(prior, new), MapOutcome::Replace);
+    }
+
+    #[test]
+    fn classify_replace_when_frame_changes()
+    {
+        let prior = leaf(FRAME_A, true, true, false);
+        let new = leaf(FRAME_B, true, true, false);
+        assert_eq!(classify_user_map(prior, new), MapOutcome::Replace);
     }
 }

--- a/core/kernel/src/arch/x86_64/paging.rs
+++ b/core/kernel/src/arch/x86_64/paging.rs
@@ -413,6 +413,9 @@ pub unsafe fn read_root_phys() -> u64
 /// `root_virt`, drawing missing intermediate frames from
 /// `crate::mm::kernel_pt_pool`.
 ///
+/// Returns the [`MapOutcome`](crate::mm::paging::MapOutcome) classifying the
+/// rewrite so the caller can decide whether a remote shootdown is required.
+///
 /// # Errors
 /// Returns `Err(())` if the kernel PT pool is exhausted.
 ///
@@ -425,7 +428,7 @@ pub unsafe fn map_user_page(
     virt: u64,
     phys: u64,
     flags: crate::mm::paging::PageFlags,
-) -> Result<(), ()>
+) -> Result<crate::mm::paging::MapOutcome, ()>
 {
     use crate::mm::paging::phys_to_virt;
 
@@ -449,9 +452,10 @@ pub unsafe fn map_user_page(
 
     let mut pte = PageTableEntry::new_page(phys, flags);
     pte.0 |= USER;
+    let prior = pt[pt_index(virt)].0;
     pt[pt_index(virt)] = pte;
 
-    Ok(())
+    Ok(classify_user_map(prior, pte.0))
 }
 
 /// Walk an existing page table entry or allocate a new child frame from the
@@ -495,7 +499,7 @@ pub unsafe fn map_user_page_pooled(
     phys: u64,
     flags: crate::mm::paging::PageFlags,
     aso: &crate::cap::object::AddressSpaceObject,
-) -> Result<(), ()>
+) -> Result<crate::mm::paging::MapOutcome, ()>
 {
     use crate::mm::paging::phys_to_virt;
     const USER: u64 = 1 << 2;
@@ -517,9 +521,10 @@ pub unsafe fn map_user_page_pooled(
 
     let mut pte = PageTableEntry::new_page(phys, flags);
     pte.0 |= USER;
+    let prior = pt[pt_index(virt)].0;
     pt[pt_index(virt)] = pte;
 
-    Ok(())
+    Ok(classify_user_map(prior, pte.0))
 }
 
 /// Pooled equivalent of [`user_walk_or_alloc`]: pulls a freshly-zeroed PT
@@ -792,8 +797,9 @@ pub unsafe fn unmap_identity_page(pa: u64)
 ///
 /// Walks PML4 → PDPT → PD → PT. Returns `Err(PagingError::NotMapped)` if
 /// the page is not present at any level. On success, rewrites the leaf PTE
-/// with the new `flags` (preserving the physical address and USER bit) and
-/// calls `flush_page`.
+/// with the new `flags` (preserving the physical address and USER bit), calls
+/// `flush_page`, and returns the [`MapOutcome`](crate::mm::paging::MapOutcome)
+/// classifying the rights change (a same-frame rewrite, so never `Fresh`).
 ///
 /// # Safety
 /// `root_virt` must be the direct-map virtual address of a valid 4 KiB PML4
@@ -803,7 +809,7 @@ pub unsafe fn protect_user_page(
     root_virt: u64,
     virt: u64,
     flags: crate::mm::paging::PageFlags,
-) -> Result<(), crate::mm::paging::PagingError>
+) -> Result<crate::mm::paging::MapOutcome, crate::mm::paging::PagingError>
 {
     use crate::mm::paging::{PagingError, phys_to_virt};
 
@@ -842,6 +848,7 @@ pub unsafe fn protect_user_page(
         return Err(PagingError::NotMapped);
     }
 
+    let prior = leaf.0;
     let phys = leaf.phys_addr();
     let mut new_pte = PageTableEntry::new_page(phys, flags);
     new_pte.0 |= USER;
@@ -849,7 +856,7 @@ pub unsafe fn protect_user_page(
 
     // SAFETY: invlpg flushes TLB entry for specified VA; architecture primitive.
     unsafe { flush_page(virt) };
-    Ok(())
+    Ok(classify_user_map(prior, new_pte.0))
 }
 
 /// Translate a user virtual address to its mapped physical address and raw PTE.
@@ -905,6 +912,48 @@ pub unsafe fn translate_user_page(root_virt: u64, virt: u64) -> Option<(u64, u64
     }
 
     Some((leaf.phys_addr(), leaf.0))
+}
+
+// ── Shootdown-elision classification ──────────────────────────────────────────
+
+/// Classify a leaf-PTE rewrite (`prior` → `new`) into a
+/// [`MapOutcome`](crate::mm::paging::MapOutcome) for shootdown elision.
+///
+/// `prior`/`new` are raw x86-64 leaf PTE bits (`new` is presumed present). A
+/// not-present `prior` is a fresh map; a same-frame rights *widening* needs only
+/// the spurious-fault retry; any frame change or rights *narrowing* strands a
+/// dangerous stale entry and must shoot down. See [`MapOutcome`] for the full
+/// argument.
+fn classify_user_map(prior: u64, new: u64) -> crate::mm::paging::MapOutcome
+{
+    use crate::mm::paging::MapOutcome;
+
+    if prior & PRESENT == 0
+    {
+        return MapOutcome::Fresh;
+    }
+    if PageTableEntry(prior).phys_addr() == PageTableEntry(new).phys_addr()
+        && map_rights_superset(new, prior)
+    {
+        MapOutcome::Widen
+    }
+    else
+    {
+        MapOutcome::Replace
+    }
+}
+
+/// Whether `new` grants every user access `prior` granted (x86-64 leaf bits).
+///
+/// On x86-64 every present user page is readable, so only W (WRITABLE) and X
+/// (NX clear) can narrow.
+fn map_rights_superset(new: u64, prior: u64) -> bool
+{
+    // W: if prior was writable, new must be writable.
+    let w_ok = prior & WRITABLE == 0 || new & WRITABLE != 0;
+    // X: if prior was executable (NX clear), new must be executable (NX clear).
+    let x_ok = prior & NO_EXECUTE != 0 || new & NO_EXECUTE == 0;
+    w_ok && x_ok
 }
 
 // ── Spurious-fault classification ─────────────────────────────────────────────
@@ -1172,5 +1221,84 @@ mod tests
         // Not present: genuine fault regardless of other bits.
         let absent = USER_BIT | WRITABLE;
         assert!(!pte_permits_user_access(absent, false, false));
+    }
+
+    // ── Shootdown-elision classification ───────────────────────────────────────
+
+    use crate::mm::paging::MapOutcome;
+
+    const FRAME_A: u64 = 0x10_000;
+    const FRAME_B: u64 = 0x20_000;
+
+    /// Raw leaf PTE bits: present user page on `frame` with the given rights.
+    fn leaf(frame: u64, writable: bool, executable: bool) -> u64
+    {
+        let mut pte = PRESENT | USER_BIT | (frame & PHYS_MASK);
+        if writable
+        {
+            pte |= WRITABLE;
+        }
+        if !executable
+        {
+            pte |= NO_EXECUTE;
+        }
+        pte
+    }
+
+    #[test]
+    fn classify_fresh_when_prior_absent()
+    {
+        assert_eq!(
+            classify_user_map(0, leaf(FRAME_A, true, false)),
+            MapOutcome::Fresh
+        );
+    }
+
+    #[test]
+    fn classify_widen_when_adding_write_same_frame()
+    {
+        let prior = leaf(FRAME_A, false, false); // R--
+        let new = leaf(FRAME_A, true, false); // RW-
+        assert_eq!(classify_user_map(prior, new), MapOutcome::Widen);
+    }
+
+    #[test]
+    fn classify_widen_when_adding_exec_same_frame()
+    {
+        let prior = leaf(FRAME_A, false, false); // R-- (NX)
+        let new = leaf(FRAME_A, false, true); // R-X
+        assert_eq!(classify_user_map(prior, new), MapOutcome::Widen);
+    }
+
+    #[test]
+    fn classify_widen_when_identical()
+    {
+        let pte = leaf(FRAME_A, true, false);
+        assert_eq!(classify_user_map(pte, pte), MapOutcome::Widen);
+    }
+
+    #[test]
+    fn classify_replace_when_narrowing_write()
+    {
+        let prior = leaf(FRAME_A, true, false); // RW-
+        let new = leaf(FRAME_A, false, false); // R--
+        assert_eq!(classify_user_map(prior, new), MapOutcome::Replace);
+    }
+
+    #[test]
+    fn classify_replace_when_narrowing_exec()
+    {
+        let prior = leaf(FRAME_A, false, true); // R-X
+        let new = leaf(FRAME_A, false, false); // R-- (NX)
+        assert_eq!(classify_user_map(prior, new), MapOutcome::Replace);
+    }
+
+    #[test]
+    fn classify_replace_when_frame_changes()
+    {
+        // Same rights but a different frame is a dangerous stale entry.
+        let prior = leaf(FRAME_A, true, false);
+        let new = leaf(FRAME_B, true, false);
+        assert_eq!(classify_user_map(prior, new), MapOutcome::Replace);
     }
 }

--- a/core/kernel/src/mm/address_space.rs
+++ b/core/kernel/src/mm/address_space.rs
@@ -34,6 +34,23 @@
 //! nests under `pt_lock` is the PT-frame source
 //! (`pt_lock` → `FRAME_ALLOC_LOCK` on the heap-backed path).
 //!
+//! ## Operation-class shootdown elision
+//!
+//! The remote shootdown is issued only when the leaf-PTE rewrite can strand a
+//! *dangerous* stale entry on another CPU. The arch mapping primitives classify
+//! each rewrite as a [`MapOutcome`](crate::mm::paging::MapOutcome):
+//!
+//! - **Fresh map** (no prior mapping) and **permission widen** (same frame, new
+//!   rights ⊇ prior) skip the remote shootdown. No remote CPU can hold a stale
+//!   entry that grants more than the live PTE, so the worst case is a spurious
+//!   fault the page-fault handler resolves against the live PTE and retries.
+//! - **Replace** (different frame, or a permission *narrow*) keeps the
+//!   synchronous shootdown: a stale entry would alias a freed/reused frame or
+//!   cache over-broad rights — a correctness violation the retry cannot mask.
+//!
+//! `unmap_page` is always a Replace-equivalent and stays synchronous. The local
+//! flush runs unconditionally regardless of class.
+//!
 //! `pt_lock` does NOT disable interrupts (shootdown needs them enabled).
 //! `preempt_disable()` is held across the whole edit-then-shootdown sequence:
 //! it satisfies the shootdown protocol's same-CPU invariant and ensures the
@@ -296,8 +313,10 @@ impl AddressSpace
     /// Map `virt` → `phys` as a 4 KiB page with the given permission flags.
     ///
     /// Acquires `pt_lock`, draws missing intermediate page-table frames
-    /// from [`crate::mm::kernel_pt_pool`] (seeded at Phase 7), and sends
-    /// TLB shootdown IPIs if this address space is active on other CPUs.
+    /// from [`crate::mm::kernel_pt_pool`] (seeded at Phase 7), flushes the local
+    /// TLB, and sends remote TLB shootdown IPIs only when the rewrite can strand
+    /// a dangerous stale entry (see the module's elision note). A fresh map into
+    /// a previously-unmapped VA skips the remote shootdown.
     ///
     /// Used by:
     /// - [`map_segment`](Self::map_segment) and direct kernel callers
@@ -328,14 +347,13 @@ impl AddressSpace
         // shootdown below is the only inter-CPU synchronisation cost.
         // SAFETY: contract passed to caller; root_virt is valid; virt is
         // in user range; phys is a valid 4 KiB-aligned physical address.
-        let result = unsafe { map_user_page(self.root_virt, virt, phys, flags) };
-
-        if result.is_err()
+        let Ok(outcome) = (unsafe { map_user_page(self.root_virt, virt, phys, flags) })
+        else
         {
             self.pt_unlock();
             crate::percpu::preempt_enable();
             return Err(());
-        }
+        };
 
         // Local TLB invalidation for the mapped page, under pt_lock. The
         // current CPU does not IPI itself.
@@ -344,12 +362,18 @@ impl AddressSpace
             flush_page(virt);
         }
 
-        // Drop pt_lock BEFORE the synchronous remote shootdown so concurrent
-        // map/unmap on this address space need not wait behind our IPI
-        // ack-wait. preempt stays disabled, so the shootdown completes (full
-        // TLB coherence) before this returns. See `shootdown_remote`.
+        // Drop pt_lock BEFORE the (conditional) synchronous remote shootdown so
+        // concurrent map/unmap on this address space need not wait behind our
+        // IPI ack-wait. preempt stays disabled, so any shootdown completes (full
+        // TLB coherence) before this returns. A fresh map or a permission widen
+        // strands no dangerous stale entry, so it skips the remote shootdown and
+        // relies on the spurious-fault retry path. See `shootdown_remote` and
+        // [`MapOutcome`](crate::mm::paging::MapOutcome).
         self.pt_unlock();
-        self.shootdown_remote(virt);
+        if outcome.needs_remote_shootdown()
+        {
+            self.shootdown_remote(virt);
+        }
         crate::percpu::preempt_enable();
 
         Ok(())
@@ -379,23 +403,26 @@ impl AddressSpace
         self.pt_lock();
 
         // SAFETY: caller's contract; aso pairs with this AS.
-        let result = unsafe { map_user_page_pooled(self.root_virt, virt, phys, flags, aso) };
-
-        if result.is_err()
+        let Ok(outcome) = (unsafe { map_user_page_pooled(self.root_virt, virt, phys, flags, aso) })
+        else
         {
             self.pt_unlock();
             crate::percpu::preempt_enable();
             return Err(());
-        }
+        };
 
-        // Local TLB invalidation under pt_lock; remote shootdown after unlock.
+        // Local TLB invalidation under pt_lock; conditional remote shootdown
+        // after unlock (fresh map / widen elide it — see `map_page`).
         // SAFETY: virt is a valid user virtual address.
         unsafe {
             flush_page(virt);
         }
 
         self.pt_unlock();
-        self.shootdown_remote(virt);
+        if outcome.needs_remote_shootdown()
+        {
+            self.shootdown_remote(virt);
+        }
         crate::percpu::preempt_enable();
 
         Ok(())
@@ -527,14 +554,16 @@ impl AddressSpace
 
         // Change protection bits via arch-specific page table walk.
         // SAFETY: root_virt is valid; virt is in user range (caller's contract).
-        let result = unsafe { protect_user_page(self.root_virt, virt, flags) };
-
-        if let Err(e) = result
+        let outcome = match unsafe { protect_user_page(self.root_virt, virt, flags) }
         {
-            self.pt_unlock();
-            crate::percpu::preempt_enable();
-            return Err(e);
-        }
+            Ok(outcome) => outcome,
+            Err(e) =>
+            {
+                self.pt_unlock();
+                crate::percpu::preempt_enable();
+                return Err(e);
+            }
+        };
 
         // Local TLB invalidation for the protected page, under pt_lock. The
         // current CPU does not IPI itself.
@@ -543,12 +572,18 @@ impl AddressSpace
             flush_page(virt);
         }
 
-        // Drop pt_lock BEFORE the synchronous remote shootdown so concurrent
-        // map/unmap on this address space need not wait behind our IPI
-        // ack-wait. preempt stays disabled, so the permission change is fully
-        // TLB-coherent before this returns. See `shootdown_remote`.
+        // Drop pt_lock BEFORE the (conditional) synchronous remote shootdown so
+        // concurrent map/unmap on this address space need not wait behind our
+        // IPI ack-wait. preempt stays disabled, so any shootdown is fully
+        // TLB-coherent before this returns. A permission *widen* strands only a
+        // re-walkable stale entry and skips the remote shootdown; a *narrow*
+        // leaves over-broad rights cached and stays synchronous. See
+        // `shootdown_remote` and [`MapOutcome`](crate::mm::paging::MapOutcome).
         self.pt_unlock();
-        self.shootdown_remote(virt);
+        if outcome.needs_remote_shootdown()
+        {
+            self.shootdown_remote(virt);
+        }
         crate::percpu::preempt_enable();
 
         Ok(())

--- a/core/kernel/src/mm/address_space.rs
+++ b/core/kernel/src/mm/address_space.rs
@@ -51,6 +51,10 @@
 //! `unmap_page` is always a Replace-equivalent and stays synchronous. The local
 //! flush runs unconditionally regardless of class.
 //!
+//! Fresh/Widen safety rests on the spurious-fault retry (Widen) and on x86-64 not
+//! caching not-present entries (Fresh) — not on the context-switch TLB flush — so
+//! it is unaffected by a future PCID/ASID-tagged regime.
+//!
 //! `pt_lock` does NOT disable interrupts (shootdown needs them enabled).
 //! `preempt_disable()` is held across the whole edit-then-shootdown sequence:
 //! it satisfies the shootdown protocol's same-CPU invariant and ensures the

--- a/core/kernel/src/mm/paging.rs
+++ b/core/kernel/src/mm/paging.rs
@@ -144,6 +144,51 @@ pub struct PageFlags
     pub uncacheable: bool,
 }
 
+/// How a leaf-PTE rewrite changed an existing mapping, used to decide whether a
+/// cross-CPU TLB shootdown is required once the new PTE is committed.
+///
+/// A remote CPU may hold a cached translation for the affected VA. Whether that
+/// stale entry can cause a *correctness* violation — versus at worst a
+/// re-walkable spurious fault the page-fault handler resolves against the live
+/// PTE — decides whether the synchronous shootdown can be elided. The arch
+/// mapping primitives classify the rewrite; `mm::address_space` acts on it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MapOutcome
+{
+    /// No prior mapping existed at this VA (the leaf was not-present).
+    ///
+    /// x86-64 does not cache not-present translations (Intel SDM 4.10.2.3), so
+    /// no remote CPU holds a stale entry. RISC-V may cache an invalid PTE, but
+    /// an access through it is a spurious fault the handler resolves against the
+    /// now-present live PTE. Either way, no remote shootdown is required.
+    Fresh,
+    /// A prior mapping existed; the rewrite keeps the same frame and only
+    /// *widens* permissions (new rights ⊇ prior).
+    ///
+    /// A remote CPU's stale, narrower entry can at worst raise a spurious fault
+    /// on the newly-granted access; the handler re-walks the live PTE, sees the
+    /// access is now permitted, and retries. No remote shootdown is required;
+    /// the local flush still runs so the initiating CPU sees the new rights.
+    Widen,
+    /// A prior mapping existed and the rewrite can leave a *dangerous* stale
+    /// entry on a remote CPU — a different frame (use-after-free / stale data)
+    /// or a permission *narrowing* (stale, over-broad rights). Requires a
+    /// synchronous remote shootdown before the operation returns.
+    Replace,
+}
+
+impl MapOutcome
+{
+    /// Whether committing this rewrite requires a synchronous cross-CPU TLB
+    /// shootdown. Only [`MapOutcome::Replace`] can strand a dangerous stale
+    /// entry; `Fresh` and `Widen` rely on the spurious-fault retry path.
+    #[must_use]
+    pub fn needs_remote_shootdown(self) -> bool
+    {
+        matches!(self, MapOutcome::Replace)
+    }
+}
+
 // ── Static boot table pool ────────────────────────────────────────────────────
 
 /// Number of 4 KiB frames in the static boot table pool.

--- a/core/ktest/src/bench/tlb.rs
+++ b/core/ktest/src/bench/tlb.rs
@@ -263,8 +263,9 @@ fn teardown(
 // `N` passive holders — the per-shootdown *hold* cost (IPI send + ack wait),
 // which scales with target count. This variant instead makes *every* pinned
 // worker an initiator: each loops map/unmap on its own VA and times both its
-// own `mem_map` (a fresh map, whose remote shootdown Phase 4 elides) and its
-// own `mem_unmap` (synchronous shootdown). With `W` concurrent initiators each publishing into its own
+// own `mem_map` (a fresh map, whose remote shootdown the operation-class
+// elision skips) and its own `mem_unmap` (synchronous shootdown). With `W`
+// concurrent initiators each publishing into its own
 // per-CPU request slot, the only residual cross-initiator cost is the
 // same-address-space `pt_lock` and the ack tail, so the concurrent mean tracks
 // the single-initiator mean. This bench is the regression guard for that parity:
@@ -306,9 +307,9 @@ static CONC_LAT_SUM: AtomicU64 = AtomicU64::new(0);
 static CONC_LAT_CNT: AtomicU64 = AtomicU64::new(0);
 
 /// Shared per-map latency accumulators (cycles). Each loop map is a *fresh* map
-/// (the VA was just unmapped), which Phase 4 elides the remote shootdown for —
-/// so this mean drops to ~bare-syscall cost while the unmap mean above still
-/// carries the synchronous shootdown. The gap is the elision win.
+/// (the VA was just unmapped), whose remote shootdown the operation-class
+/// elision skips — so this mean drops to ~bare-syscall cost while the unmap mean
+/// above still carries the synchronous shootdown. The gap is the elision win.
 static CONC_MAP_MIN: AtomicU64 = AtomicU64::new(u64::MAX);
 static CONC_MAP_MAX: AtomicU64 = AtomicU64::new(0);
 static CONC_MAP_SUM: AtomicU64 = AtomicU64::new(0);
@@ -366,8 +367,8 @@ fn conc_worker_entry(arg: u64) -> !
 
     for _ in 0..iters
     {
-        // Time the map — a fresh map (the VA is unmapped at loop top), the path
-        // Phase 4 elides the remote shootdown for.
+        // Time the map — a fresh map (the VA is unmapped at loop top), whose
+        // remote shootdown the operation-class elision skips.
         let m0 = cycles_now();
         let mr = syscall::mem_map(frame, aspace, va, 0, 1, syscall::MAP_WRITABLE);
         let m1 = cycles_now();
@@ -550,8 +551,8 @@ pub(super) fn bench_tlb_shootdown_concurrent(ctx: &crate::TestContext, iters: u3
     let map_cnt = CONC_MAP_CNT.load(Ordering::Acquire);
     if let Some(map_mean) = CONC_MAP_SUM.load(Ordering::Acquire).checked_div(map_cnt)
     {
-        // Fresh-map latency: with Phase 4 elision this is ~bare syscall, well
-        // below the unmap (shootdown) mean below.
+        // Fresh-map latency: with the shootdown elided this is ~bare syscall,
+        // well below the unmap (shootdown) mean below.
         crate::log_u64(
             "ktest: bench  conc_map_cycles_min=",
             CONC_MAP_MIN.load(Ordering::Acquire),

--- a/core/ktest/src/bench/tlb.rs
+++ b/core/ktest/src/bench/tlb.rs
@@ -262,8 +262,9 @@ fn teardown(
 // `bench_tlb_shootdown` above measures a single initiator (CPU 0) shooting down
 // `N` passive holders — the per-shootdown *hold* cost (IPI send + ack wait),
 // which scales with target count. This variant instead makes *every* pinned
-// worker an initiator: each loops map/unmap on its own VA and times its own
-// `mem_unmap`. With `W` concurrent initiators each publishing into its own
+// worker an initiator: each loops map/unmap on its own VA and times both its
+// own `mem_map` (a fresh map, whose remote shootdown Phase 4 elides) and its
+// own `mem_unmap` (synchronous shootdown). With `W` concurrent initiators each publishing into its own
 // per-CPU request slot, the only residual cross-initiator cost is the
 // same-address-space `pt_lock` and the ack tail, so the concurrent mean tracks
 // the single-initiator mean. This bench is the regression guard for that parity:
@@ -304,7 +305,16 @@ static CONC_LAT_MAX: AtomicU64 = AtomicU64::new(0);
 static CONC_LAT_SUM: AtomicU64 = AtomicU64::new(0);
 static CONC_LAT_CNT: AtomicU64 = AtomicU64::new(0);
 
-/// Fold one latency sample into the shared min/max/sum/count accumulators.
+/// Shared per-map latency accumulators (cycles). Each loop map is a *fresh* map
+/// (the VA was just unmapped), which Phase 4 elides the remote shootdown for —
+/// so this mean drops to ~bare-syscall cost while the unmap mean above still
+/// carries the synchronous shootdown. The gap is the elision win.
+static CONC_MAP_MIN: AtomicU64 = AtomicU64::new(u64::MAX);
+static CONC_MAP_MAX: AtomicU64 = AtomicU64::new(0);
+static CONC_MAP_SUM: AtomicU64 = AtomicU64::new(0);
+static CONC_MAP_CNT: AtomicU64 = AtomicU64::new(0);
+
+/// Fold one unmap-latency sample into the shared min/max/sum/count accumulators.
 ///
 /// Relaxed is sufficient: the parent reads these only after every worker's
 /// `done`-bit handshake, and the `signal_send`/`signal_wait` round-trip
@@ -315,6 +325,15 @@ fn conc_fold(d: u64)
     CONC_LAT_CNT.fetch_add(1, Ordering::Relaxed);
     CONC_LAT_MIN.fetch_min(d, Ordering::Relaxed);
     CONC_LAT_MAX.fetch_max(d, Ordering::Relaxed);
+}
+
+/// Fold one map-latency sample; see [`conc_fold`] for the ordering rationale.
+fn conc_map_fold(d: u64)
+{
+    CONC_MAP_SUM.fetch_add(d, Ordering::Relaxed);
+    CONC_MAP_CNT.fetch_add(1, Ordering::Relaxed);
+    CONC_MAP_MIN.fetch_min(d, Ordering::Relaxed);
+    CONC_MAP_MAX.fetch_max(d, Ordering::Relaxed);
 }
 
 /// Concurrent-initiator worker. `arg` packs
@@ -347,11 +366,17 @@ fn conc_worker_entry(arg: u64) -> !
 
     for _ in 0..iters
     {
-        if syscall::mem_map(frame, aspace, va, 0, 1, syscall::MAP_WRITABLE).is_err()
+        // Time the map — a fresh map (the VA is unmapped at loop top), the path
+        // Phase 4 elides the remote shootdown for.
+        let m0 = cycles_now();
+        let mr = syscall::mem_map(frame, aspace, va, 0, 1, syscall::MAP_WRITABLE);
+        let m1 = cycles_now();
+        if mr.is_err()
         {
             signal_send(done_slot, bit).ok();
             thread_exit();
         }
+        conc_map_fold(m1.saturating_sub(m0));
         // Time the unmap — the path that issues the shootdown IPI volley.
         let t0 = cycles_now();
         let r = syscall::mem_unmap(aspace, va, 1);
@@ -392,6 +417,10 @@ pub(super) fn bench_tlb_shootdown_concurrent(ctx: &crate::TestContext, iters: u3
     CONC_LAT_MAX.store(0, Ordering::Release);
     CONC_LAT_SUM.store(0, Ordering::Release);
     CONC_LAT_CNT.store(0, Ordering::Release);
+    CONC_MAP_MIN.store(u64::MAX, Ordering::Release);
+    CONC_MAP_MAX.store(0, Ordering::Release);
+    CONC_MAP_SUM.store(0, Ordering::Release);
+    CONC_MAP_CNT.store(0, Ordering::Release);
 
     let Ok(ready) = cap_create_signal(ctx.memory_frame_base)
     else
@@ -516,6 +545,22 @@ pub(super) fn bench_tlb_shootdown_concurrent(ctx: &crate::TestContext, iters: u3
         let _ = syscall::mem_unmap(ctx.aspace_cap, va, 1);
         // SAFETY: frame is from the pool and now unmapped (above).
         unsafe { crate::frame_pool::free(*fr) };
+    }
+
+    let map_cnt = CONC_MAP_CNT.load(Ordering::Acquire);
+    if let Some(map_mean) = CONC_MAP_SUM.load(Ordering::Acquire).checked_div(map_cnt)
+    {
+        // Fresh-map latency: with Phase 4 elision this is ~bare syscall, well
+        // below the unmap (shootdown) mean below.
+        crate::log_u64(
+            "ktest: bench  conc_map_cycles_min=",
+            CONC_MAP_MIN.load(Ordering::Acquire),
+        );
+        crate::log_u64("ktest: bench  conc_map_cycles_mean=", map_mean);
+        crate::log_u64(
+            "ktest: bench  conc_map_cycles_max=",
+            CONC_MAP_MAX.load(Ordering::Acquire),
+        );
     }
 
     let cnt = CONC_LAT_CNT.load(Ordering::Acquire);

--- a/core/ktest/src/integration/mod.rs
+++ b/core/ktest/src/integration/mod.rs
@@ -31,6 +31,7 @@
 //! - `cap_move_into_fresh_cspace_then_ipc.rs` — `cap_move` an endpoint into a child cspace; child IPC-calls through it
 //! - `fpu_survives_ipc_call.rs` — FP register file survives a raw `SYS_IPC_CALL` round-trip across CPU migration
 //! - `fault_kills_thread.rs`     — a genuine userspace page fault terminates the thread with the right exit reason
+//! - `tlb_widen_retry.rs`        — a permission-widen elides its shootdown; a remote stale-TLB write still completes via spurious-fault retry
 
 pub mod cap_delegation_chain;
 pub mod cap_move_into_fresh_cspace_then_ipc;
@@ -44,6 +45,7 @@ pub mod retype_reclaim;
 pub mod shared_frame_two_aspaces;
 pub mod thread_lifecycle;
 pub mod tlb_coherency;
+pub mod tlb_widen_retry;
 pub mod wait_concurrency;
 
 use crate::TestContext;
@@ -89,4 +91,5 @@ pub fn run_all(ctx: &TestContext)
         "integration::fault_kills_thread",
         fault_kills_thread::run(ctx)
     );
+    run_integration_test!("integration::tlb_widen_retry", tlb_widen_retry::run(ctx));
 }

--- a/core/ktest/src/integration/tlb_widen_retry.rs
+++ b/core/ktest/src/integration/tlb_widen_retry.rs
@@ -6,9 +6,9 @@
 //! Integration: a permission-widen that elides its TLB shootdown still lets a
 //! remote CPU's stale-TLB write complete via the spurious-fault retry path.
 //!
-//! Phase 4 elides the cross-CPU shootdown when a `mem_protect` only *widens*
-//! permissions — a stale, narrower remote TLB entry can at worst raise a
-//! re-walkable spurious fault. This test drives exactly that window:
+//! Operation-class elision skips the cross-CPU shootdown when a `mem_protect`
+//! only *widens* permissions — a stale, narrower remote TLB entry can at worst
+//! raise a re-walkable spurious fault. This test drives exactly that window:
 //!
 //!   1. Parent maps a page read-only at `WIDEN_VA`.
 //!   2. A child pinned to CPU 1 reads the page, caching a read-only TLB entry,

--- a/core/ktest/src/integration/tlb_widen_retry.rs
+++ b/core/ktest/src/integration/tlb_widen_retry.rs
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// ktest/src/integration/tlb_widen_retry.rs
+
+//! Integration: a permission-widen that elides its TLB shootdown still lets a
+//! remote CPU's stale-TLB write complete via the spurious-fault retry path.
+//!
+//! Phase 4 elides the cross-CPU shootdown when a `mem_protect` only *widens*
+//! permissions — a stale, narrower remote TLB entry can at worst raise a
+//! re-walkable spurious fault. This test drives exactly that window:
+//!
+//!   1. Parent maps a page read-only at `WIDEN_VA`.
+//!   2. A child pinned to CPU 1 reads the page, caching a read-only TLB entry,
+//!      then busy-spins — never yielding, so a context switch cannot flush the
+//!      entry (the scheduler re-selects the same thread without reloading the
+//!      page-table root).
+//!   3. Parent widens the page to read-write via `mem_protect`. The widen elides
+//!      the remote shootdown, so CPU 1 keeps its stale read-only entry.
+//!   4. Child writes the page. On a hardware TLB (KVM / real CPU) the stale
+//!      read-only entry raises a store page fault; the kernel re-walks the live
+//!      PTE, sees the write is now permitted, flushes locally, and retries — the
+//!      store completes and the child is *not* killed.
+//!
+//! The assertion is on the observable outcome (the store lands, the child stays
+//! alive), not that a fault occurred: under QEMU TCG the softmmu re-walks the
+//! live page table on the permission-class miss and never raises the fault, so
+//! the same assertion holds without exercising the retry. The retry path is
+//! physically exercised only under a hardware-TLB backend (x86-64 KVM, real
+//! hardware), where a broken spurious-fault classifier kills the child and fails
+//! the test. The companion `fault_kills_thread` test covers the genuine-fault
+//! kill side.
+
+use core::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+
+use syscall::{
+    MAP_READ, MAP_WRITABLE, cap_delete, cap_info, mem_map, mem_protect, mem_unmap, system_info,
+    thread_sleep,
+};
+use syscall_abi::{CAP_INFO_THREAD_STATE, SystemInfoType, THREAD_STATE_EXITED};
+
+use crate::{ChildStack, TestContext, TestResult};
+
+/// User-half VA used only by this test (1.375 GiB), clear of other tests.
+const WIDEN_VA: u64 = 0x5800_0000;
+
+/// Sentinel the child stores through the widened mapping.
+const SENTINEL: u64 = 0xCAFE_F00D;
+
+// Handshake phases. Parent and child advance this in lockstep through shared
+// memory; both busy-spin (the child must not yield, or its remote TLB entry is
+// flushed by the context switch).
+const PHASE_MAPPED: u32 = 1; // parent: page mapped read-only
+const PHASE_CACHED: u32 = 2; // child: read the page, TLB entry now cached
+const PHASE_WIDENED: u32 = 3; // parent: widened to read-write (shootdown elided)
+const PHASE_WROTE: u32 = 4; // child: store completed (retry succeeded)
+
+static PHASE: AtomicU32 = AtomicU32::new(0);
+static RESULT: AtomicU64 = AtomicU64::new(0);
+
+static mut CHILD_STACK: ChildStack = ChildStack::ZERO;
+
+/// Child busy-spin bound per wait (~1e9 iterations): seconds of headroom over
+/// the parent's sub-millisecond handshake, but finite so a dead parent cannot
+/// hang the child past harness teardown.
+const SPIN_BOUND: u64 = 1_000_000_000;
+
+/// Parent poll bound: at ~1 ms per `thread_sleep(1)`, ~2 s before declaring the
+/// child stuck. Comfortably above any scheduling latency on a busy SMP run.
+const MAX_POLLS: u32 = 2000;
+
+pub fn run(ctx: &TestContext) -> TestResult
+{
+    let cpus = system_info(SystemInfoType::CpuCount as u64)
+        .map_err(|_| "integration::tlb_widen_retry: system_info(CpuCount) failed")?;
+    if cpus < 2
+    {
+        crate::log("ktest: integration::tlb_widen_retry SKIP (need 2+ CPUs)");
+        return Ok(());
+    }
+
+    PHASE.store(0, Ordering::Release);
+    RESULT.store(0, Ordering::Release);
+
+    let frame =
+        crate::frame_pool::alloc().ok_or("integration::tlb_widen_retry: frame pool exhausted")?;
+
+    // Map the page read-only. MAP_READ forces R-- regardless of the frame cap's
+    // rights, so the child caches a narrow entry the widen can later broaden.
+    if mem_map(frame, ctx.aspace_cap, WIDEN_VA, 0, 1, MAP_READ).is_err()
+    {
+        // SAFETY: frame is from the pool and was never mapped.
+        unsafe { crate::frame_pool::free(frame) };
+        return Err("integration::tlb_widen_retry: mem_map read-only failed");
+    }
+
+    let Ok(child) = crate::spawn::new_child(ctx)
+    else
+    {
+        cleanup(ctx, None, frame);
+        return Err("integration::tlb_widen_retry: spawn::new_child failed");
+    };
+
+    let stack_top = ChildStack::top(core::ptr::addr_of!(CHILD_STACK));
+    if crate::spawn::configure_and_start_pinned(&child, widen_child, stack_top, 0, 1).is_err()
+    {
+        cleanup(ctx, Some(&child), frame);
+        return Err("integration::tlb_widen_retry: configure_and_start_pinned failed");
+    }
+
+    PHASE.store(PHASE_MAPPED, Ordering::Release);
+
+    // Wait for the child to cache the read-only entry on CPU 1.
+    if !parent_wait_phase(PHASE_CACHED, &child)
+    {
+        cleanup(ctx, Some(&child), frame);
+        return Err("integration::tlb_widen_retry: child never cached the mapping");
+    }
+
+    // Widen R-- → RW-. Same frame, strictly broader rights ⇒ MapOutcome::Widen ⇒
+    // the kernel elides the remote shootdown, leaving CPU 1's stale entry live.
+    if mem_protect(frame, ctx.aspace_cap, WIDEN_VA, 1, MAP_READ | MAP_WRITABLE).is_err()
+    {
+        cleanup(ctx, Some(&child), frame);
+        return Err("integration::tlb_widen_retry: mem_protect widen failed");
+    }
+    PHASE.store(PHASE_WIDENED, Ordering::Release);
+
+    // Wait for the child's store to complete via the retry path — or catch a
+    // kill (the child exiting before PHASE_WROTE means the widened write faulted
+    // and was mis-classified as genuine).
+    let mut polls = 0;
+    loop
+    {
+        if PHASE.load(Ordering::Acquire) >= PHASE_WROTE
+        {
+            break;
+        }
+        if child_exited(&child)? && PHASE.load(Ordering::Acquire) < PHASE_WROTE
+        {
+            cleanup(ctx, Some(&child), frame);
+            return Err("integration::tlb_widen_retry: child killed writing widened mapping");
+        }
+        polls += 1;
+        if polls >= MAX_POLLS
+        {
+            cleanup(ctx, Some(&child), frame);
+            return Err("integration::tlb_widen_retry: child never completed the write");
+        }
+        thread_sleep(1).ok();
+    }
+
+    if RESULT.load(Ordering::Acquire) != SENTINEL
+    {
+        cleanup(ctx, Some(&child), frame);
+        return Err("integration::tlb_widen_retry: widened write produced the wrong value");
+    }
+
+    cleanup(ctx, Some(&child), frame);
+    Ok(())
+}
+
+/// Spin (no yield) until `PHASE` reaches `target`, polling the child's liveness
+/// so a child that died before signalling does not spin to the bound. Returns
+/// `false` on timeout or an early child exit.
+fn parent_wait_phase(target: u32, child: &crate::spawn::SpawnedChild) -> bool
+{
+    let mut polls = 0;
+    while PHASE.load(Ordering::Acquire) < target
+    {
+        if child_exited(child).unwrap_or(true) && PHASE.load(Ordering::Acquire) < target
+        {
+            return false;
+        }
+        polls += 1;
+        if polls >= MAX_POLLS
+        {
+            return false;
+        }
+        thread_sleep(1).ok();
+    }
+    true
+}
+
+/// Whether the child thread has reached the `Exited` state.
+fn child_exited(child: &crate::spawn::SpawnedChild) -> Result<bool, &'static str>
+{
+    let packed = cap_info(child.th, CAP_INFO_THREAD_STATE)
+        .map_err(|_| "integration::tlb_widen_retry: cap_info(THREAD_STATE) failed")?;
+    // cast_possible_truncation: the kernel packs an 8-bit state code in the high
+    // word and a 32-bit exit reason in the low word.
+    #[allow(clippy::cast_possible_truncation)]
+    let state = (packed >> 32) as u32;
+    Ok(state == THREAD_STATE_EXITED)
+}
+
+/// Wait for the child to exit cooperatively, then delete its caps, unmap the
+/// page, and return the frame to the pool. Safe to call on any error path.
+fn cleanup(ctx: &TestContext, child: Option<&crate::spawn::SpawnedChild>, frame: u32)
+{
+    if let Some(child) = child
+    {
+        // The child sets PHASE_WROTE then thread_exit()s; wait for Exited so
+        // cap_delete never races a still-running pinned thread (which can hang
+        // the harness on a CPU with no other ready thread).
+        let mut polls = 0;
+        while !child_exited(child).unwrap_or(true)
+        {
+            polls += 1;
+            if polls >= MAX_POLLS
+            {
+                break;
+            }
+            thread_sleep(1).ok();
+        }
+        cap_delete(child.th).ok();
+        cap_delete(child.cs).ok();
+    }
+    mem_unmap(ctx.aspace_cap, WIDEN_VA, 1).ok();
+    // SAFETY: the page is now unmapped, so the frame is free to return.
+    unsafe { crate::frame_pool::free(frame) };
+}
+
+/// Child entry: cache a read-only TLB entry, wait for the parent's widen, then
+/// store through it. The store completes via the kernel's spurious-fault retry
+/// when a hardware TLB faults on the stale read-only entry.
+fn widen_child(_arg: u64) -> !
+{
+    let p = WIDEN_VA as *mut u64;
+
+    if !child_spin_until(PHASE_MAPPED)
+    {
+        syscall::thread_exit();
+    }
+    // Read to cache a read-only TLB entry for WIDEN_VA on this CPU.
+    // SAFETY: the parent mapped WIDEN_VA read-only before signalling.
+    let _ = unsafe { p.read_volatile() };
+    PHASE.store(PHASE_CACHED, Ordering::Release);
+
+    if !child_spin_until(PHASE_WIDENED)
+    {
+        syscall::thread_exit();
+    }
+    // Store through the now-widened mapping. A stale read-only TLB entry faults;
+    // the kernel re-walks the live RW PTE and retries, so the store completes.
+    // SAFETY: WIDEN_VA is mapped read-write; any fault is resolved by the kernel.
+    unsafe {
+        p.write_volatile(SENTINEL);
+    }
+    // SAFETY: read back the value just written through the same mapping.
+    let got = unsafe { p.read_volatile() };
+    RESULT.store(got, Ordering::Release);
+    PHASE.store(PHASE_WROTE, Ordering::Release);
+
+    syscall::thread_exit()
+}
+
+/// Busy-wait (no syscall, so no context switch) until `PHASE` reaches `target`.
+/// Returns `false` if the bound is hit first.
+fn child_spin_until(target: u32) -> bool
+{
+    let mut spins = 0u64;
+    while PHASE.load(Ordering::Acquire) < target
+    {
+        core::hint::spin_loop();
+        spins += 1;
+        if spins >= SPIN_BOUND
+        {
+            return false;
+        }
+    }
+    true
+}


### PR DESCRIPTION
## Summary

Operation-class TLB-shootdown elision (issue #188, the plan's Phase 4). The
per-CPU mailbox (#193) and spurious-fault retry path (#194) combine here into the
actual scalability win: a cross-CPU shootdown is now issued only when a leaf-PTE
rewrite can strand a *dangerous* stale entry on another CPU.

Each user mapping primitive (`map_user_page`, `map_user_page_pooled`,
`protect_user_page`) now classifies its rewrite, under `pt_lock`, as a
`MapOutcome`:

- **Fresh** — no prior mapping. No remote CPU holds a stale entry (x86: no
  not-present caching, SDM 4.10.2.3; RISC-V: a cached invalid PTE only yields a
  spurious fault). → skip remote shootdown.
- **Widen** — same frame, new rights ⊇ prior. A stale narrower entry yields at
  worst a re-walkable spurious fault. → skip remote shootdown, keep local flush.
- **Replace** — different frame, or a permission *narrow*. A stale entry would
  alias a freed/reused frame or cache over-broad rights. → synchronous shootdown.

`unmap_page` stays fully synchronous. The local flush is unconditional. The
`AddressSpace::{map_page,map_page_pooled,protect_page}` public signatures are
unchanged — the classification is internal.

## Why it is safe

Fresh/Widen elision depends on the Phase 3 retry path (#194): any stale remote
entry that survives the elision can only produce a fault the live PTE already
permits, which the page-fault handler re-walks, flushes locally, and retries.
Replace cases (use-after-free, stale over-broad rights) cannot be masked by a
retry and stay synchronous.

## Validation (both arches, `cargo xtask run` ktest → ALL TESTS PASSED)

- Regression: `tlb_coherency`, `concurrent_map_unmap`, `memory_lifecycle`,
  `fault_kills_thread` all pass on x86_64 and riscv64.
- **New** `integration::tlb_widen_retry`: parent maps a page read-only; a child
  pinned to a second CPU caches the entry and busy-spins; parent widens to RW
  (shootdown elided); child's store completes via the retry path **without being
  killed**, and the written value is verified.
- New concurrent-bench map timing demonstrates the win (3 initiators):
  fresh-map mean drops to ~bare syscall while the synchronous unmap mean is
  unchanged — **x86_64 1116 vs 36633 cycles; riscv64 38656 vs 147688**.
- Host unit tests cover the `MapOutcome` classifier on both arches.

## Test-scope note (refines the plan)

The spurious-fault retry is *physically* taken only under a hardware-TLB backend
(x86_64 KVM / real hardware). Under QEMU TCG the softmmu re-walks the live page
table on a permission-class TLB miss and never raises a live-permitted fault, so
`tlb_widen_retry` asserts the **outcome** (store lands, thread survives, value
correct) rather than that a fault occurred. It therefore genuinely exercises the
retry under KVM and is a correct trivial pass under TCG (CI x86 without
`/dev/kvm`, all riscv64). A broken classifier kills the child and fails the test
on KVM.

This advances #188 but does not complete its Acceptance checklist (Phase 5,
descriptive docs, remains). Refs #188.