### PR TITLE
kernel: correct TLB shootdown module-doc trigger list (closes #188)

### DIFF
--- a/core/kernel/src/mm/tlb_shootdown.rs
+++ b/core/kernel/src/mm/tlb_shootdown.rs
@@ -5,9 +5,15 @@
 
 //! TLB shootdown protocol for cross-CPU page table invalidation.
 //!
-//! When a CPU modifies page tables (unmap, protect) for an address space
-//! active on other CPUs, those CPUs must invalidate their cached TLB entries.
-//! This module implements the synchronous shootdown protocol using IPIs.
+//! When a CPU rewrites a leaf page-table entry in a way that could strand a
+//! dangerous stale TLB entry on other CPUs sharing the address space — an
+//! unmap, a permission narrowing, or a frame replacement — those CPUs must
+//! invalidate their cached translation. Fresh maps and permission widenings
+//! issue no shootdown: any stale entry only triggers a spurious fault the
+//! page-fault handler resolves by re-walking the live PTE. The caller
+//! classifies each rewrite ([`MapOutcome`](crate::mm::paging::MapOutcome)) and
+//! enters this module only for the synchronous cases. This module implements
+//! that protocol using IPIs.
 //!
 //! # Protocol
 //!


### PR DESCRIPTION
## Summary

Final documentation pass for the TLB-shootdown scalability effort (#188). Corrects the
one remaining stale description: `tlb_shootdown.rs`'s module-doc trigger list still read
"(unmap, protect)", which predates operation-class elision and implied every such rewrite
issues a shootdown. It now states the actual rule and cross-references `MapOutcome`:

- Only **unmap**, **permission narrowing**, or **frame replacement** issue the synchronous
  cross-CPU shootdown.
- **Fresh maps** and **permission widenings** issue none — any stale entry is at worst a
  spurious fault the page-fault handler resolves by re-walking the live PTE.
- The caller classifies each rewrite via `MapOutcome` and enters the module only for the
  synchronous cases.

The other doc surfaces this effort planned to touch were already brought into line by the
implementation PRs and were re-verified clean here:

- `tlb_shootdown.rs` protocol/ordering docs (per-CPU slots, ack-bit-as-liveness) — #193.
- `address_space.rs` Concurrency + operation-class-elision sections — #193 / #196.
- `scheduling-internals.md` IPI inventory (row 250 role), riscv mailbox disambiguation,
  ordering-invariants table — #196. No lingering ack-counter or mailbox-seq reference (the
  as-built has neither).
- `memory-internals.md` SMP TLB Shootdown subsection (lock-free slots + `MapOutcome`
  elision) — #196.
- `syscalls.md` `SYS_MEM_MAP` coherence guarantee — #196; `SYS_MEM_UNMAP` correctly still
  documents an unconditional synchronous shootdown (unmap is never elided).

## Closing #188

#188 asked to characterize the bottleneck, enumerate design options, and decide a
direction (or defer with rationale). All three are delivered:

- [x] **Characterize scaling behavior with controlled measurements** — #190 added
  `bench_tlb_shootdown_concurrent` (concurrent-initiator latency) alongside the existing
  single-initiator bench on both arches, plus the static analysis separating the intrinsic
  global-serialization ceiling and slow-ack tail from the QEMU-TCG amplification.
- [x] **Enumerate design options with explicit tradeoffs** — captured in the plan and the
  per-phase PR bodies: per-CPU mailbox vs stack-descriptor+generation (chose mailbox: no
  heap, no seq, ack-bit-as-liveness); operation-class elision vs unconditional shootdown;
  spurious-fault retry as the elision prerequisite.
- [x] **Decide a direction (or defer)** — decided **and implemented**:
  - #193 — per-CPU request slots replace the global `SHOOTDOWN_LOCK`; concurrent shootdowns
    on disjoint (and same) address spaces no longer serialize. Concurrent-bench mean unmap
    latency fell to single-initiator parity.
  - #194 — spurious-fault-retry path in both page-fault handlers (prerequisite for elision).
  - #196 — operation-class elision (`MapOutcome` Fresh/Widen skip the remote shootdown;
    Replace/unmap stay synchronous). Fresh-map mean now ≈ bare syscall (this PR's run:
    x86 conc_map mean 1071 vs unmap 37440 cycles; riscv64 40346 vs 153762).

The watchdog escalation ladder (250 ms / 750 ms / 5 s) is retained unchanged — it
correctly hard-fails a genuinely non-running target; the fix reduces time-in-synchronous-
wait, not the watchdog's authority.

**Deferred with rationale** (not regressions, not in scope here):

- **Batching/coalescing same-AS multi-VA shootdowns** — the issue's cost was lock
  contention + ack tail, addressed by the mailbox + elision. Revisit only if IPI count
  becomes the residual bottleneck. File as a follow-up if revisited.
- **Code-vs-design convergence** (PCID/ASID tagging per `memory-model.md`; the `Paging`
  trait per `arch-interface.md`) — pre-existing, orthogonal to shootdown scalability (TLB
  tagging removes context-switch flushes, not cross-CPU shootdowns), and a code fix; the
  design docs stay authoritative. Tracked separately from #188.

Closes #188

## Test plan

Doc-comment-only change to a kernel source file; validated on both arches per the
repository rule (build + `cargo xtask run` ktest pass marker):

- x86_64: `ALL TESTS PASSED`, passed=170, failed=0.
- riscv64: `ALL TESTS PASSED`, passed=170, failed=0.
