### PR TITLE
kernel: implement PCID/ASID-tagged TLBs to elide context-switch flushes

### DIFF
--- a/abi/syscall/src/lib.rs
+++ b/abi/syscall/src/lib.rs
@@ -267,6 +267,17 @@ pub const THREAD_STATE_ALIVE: u32 = 1;
 /// State code for `CAP_INFO_THREAD_STATE`: thread has exited or faulted.
 pub const THREAD_STATE_EXITED: u32 = 2;
 
+/// `cap_info` selector: total context-switch activations across all CPUs that
+/// loaded a tagged address space **without** flushing (the tagged-TLB
+/// optimization firing). System-wide diagnostic; the slot argument is ignored
+/// beyond requiring a live capability. Zero when tagging is disabled.
+pub const CAP_INFO_TLB_ELIDED: u64 = 10;
+
+/// `cap_info` selector: total context-switch activations across all CPUs that
+/// performed a TLB flush (tag reissue, switched-away unmap catch-up, or
+/// pool-exhaustion fallback). Pairs with [`CAP_INFO_TLB_ELIDED`].
+pub const CAP_INFO_TLB_PERFORMED: u64 = 11;
+
 // ── CapTag discriminants ─────────────────────────────────────────────────────
 //
 // Userspace constants matching the kernel `CapTag` enum, for callers that

--- a/core/kernel/docs/arch-interface.md
+++ b/core/kernel/docs/arch-interface.md
@@ -74,22 +74,24 @@ Manages hardware page tables. A page table is referenced by its physical root fr
 intermediate frames are allocated from and returned to the kernel page-table pool.
 
 ```rust
-/// Install `root_phys` as the active page table for the current CPU.
-///
-/// Performs a full TLB flush: x86-64 writes CR3 (with CR4.PCIDE clear, so the
-/// write flushes all non-global entries); RISC-V writes `satp` (ASID 0) and
-/// executes `sfence.vma`. The kernel does not use hardware address-space tags;
-/// see docs/memory-model.md (tagged TLBs are tracked in #198).
+/// Install `root_phys` as the active page table for the current CPU with a full
+/// TLB flush: x86-64 writes CR3 with PCID 0 (flushing PCID 0's entries); RISC-V
+/// writes `satp` with ASID 0 and executes `sfence.vma`. This is the untagged
+/// fallback path, used when hardware tagging is unavailable or the tag pool is
+/// exhausted; the tagged context-switch path uses `activate_tagged` (below),
+/// driven by `AddressSpace::activate`. See docs/memory-model.md.
 ///
 /// # Safety
 /// `root_phys` must be a valid page-table root mapping current code, stack, and
 /// the direct map.
 pub unsafe fn activate(root_phys: u64);
 
-/// Write the page-table root without an explicit flush. On RISC-V this writes
-/// `satp` without `sfence.vma` (idle-thread transitions, where stale user
-/// entries are harmless). On x86-64 a CR3 write always flushes, so this is a
-/// compatibility shim equivalent to `activate`.
+/// Write the page-table root without an explicit flush (idle / kernel
+/// transitions, where the outgoing space's stale user entries are harmless).
+/// RISC-V writes `satp` (ASID 0) without `sfence.vma`. On x86-64 this loads the
+/// kernel root under PCID 0 with CR3 bit 63 (no invalidation) when `CR4.PCIDE`
+/// is set; without PCID a CR3 write necessarily flushes, so it degrades to
+/// `activate`.
 pub unsafe fn write_satp_no_fence(root_phys: u64);
 
 /// Read the active page-table root physical address (CR3 on x86-64 with the low

--- a/core/kernel/docs/arch-interface.md
+++ b/core/kernel/docs/arch-interface.md
@@ -160,6 +160,13 @@ pub unsafe fn flush_page_tagged(virt: u64, tag: u16);
 /// switched-away space accrued unmaps.
 pub unsafe fn flush_tag(tag: u16);
 
+/// Per-CPU enable of tagged TLBs; returns the number of hardware tags available
+/// (`0` when unsupported). x86-64 sets `CR4.PCIDE` and returns 4096; RISC-V
+/// probes the `satp` ASID width and returns `1 << width`. Called on the BSP
+/// (whose return seeds the tag pool) and on every AP (which must set its own
+/// `CR4.PCIDE` before any tagged CR3 load).
+pub unsafe fn enable_tagged_tlb() -> usize;
+
 /// Classify a user page fault as spurious (the live PTE already permits the
 /// access — a stale entry the handler resolves by retrying) versus a real fault.
 pub unsafe fn user_fault_is_spurious(va: u64, write: bool, instr: bool) -> bool;

--- a/core/kernel/docs/arch-interface.md
+++ b/core/kernel/docs/arch-interface.md
@@ -142,6 +142,24 @@ pub unsafe fn flush_page(virt: u64);
 /// (x86-64 CR3 reload; RISC-V `sfence.vma zero, zero`).
 pub unsafe fn flush_tlb_all();
 
+/// Install `root_phys` as the active page table under hardware address-space
+/// tag `tag` (x86-64 PCID / RISC-V ASID) **without** flushing the TLB, so the
+/// outgoing space's cached translations survive (x86-64 sets CR3 bit 63 with
+/// `CR4.PCIDE`; RISC-V writes `satp` with the ASID and no `sfence.vma`). Only
+/// valid when tagging is enabled; the caller performs any required tag
+/// invalidation (the generation check in `AddressSpace::activate`).
+pub unsafe fn activate_tagged(root_phys: u64, tag: u16);
+
+/// Invalidate the current-CPU TLB entry for `virt` tagged with `tag`,
+/// independent of the tag currently loaded (x86-64 INVPCID type 0;
+/// RISC-V `sfence.vma virt, asid`).
+pub unsafe fn flush_page_tagged(virt: u64, tag: u16);
+
+/// Invalidate all current-CPU entries tagged with `tag` (x86-64 INVPCID type 1;
+/// RISC-V `sfence.vma zero, asid`). Used when a tag is reassigned or a
+/// switched-away space accrued unmaps.
+pub unsafe fn flush_tag(tag: u16);
+
 /// Classify a user page fault as spurious (the live PTE already permits the
 /// access — a stale entry the handler resolves by retrying) versus a real fault.
 pub unsafe fn user_fault_is_spurious(va: u64, write: bool, instr: bool) -> bool;

--- a/core/kernel/docs/memory-internals.md
+++ b/core/kernel/docs/memory-internals.md
@@ -334,10 +334,13 @@ generation check then flushes only that tag if it was reissued to a different sp
 (`tag_gen` mismatch) or accrued unmaps while this CPU was switched away (`tlb_gen` lag). A
 `SeqCst` fence between the scheduler's `mark_active` and the generation reads is the
 load-bearing barrier (paired with fences in the unmap and eviction paths) that closes the
-switch-away races. Where tagging is unavailable, or the tag pool is momentarily exhausted,
-`activate` falls back to `arch::current::paging::activate(root_phys)`, a full flush (CR3
-write with `CR4.PCIDE` clear / `satp` ASID 0 + `sfence.vma`). Threads sharing an address
-space require no TLB operation on switch. The per-CPU elided/performed flush counts are
+switch-away races. Where tagging is unavailable — no hardware tags, or a tag field too
+narrow to provide more usable tags than CPUs — `activate` uses the full-flush path
+`arch::current::paging::activate(root_phys)` (CR3 write with `CR4.PCIDE` clear / `satp`
+ASID 0 + `sfence.vma`) on every switch. When tagging is enabled the pool can never be
+exhausted (the allocator keeps more usable tags than CPUs, and at most one space per CPU is
+active), so a claim always succeeds and no user space ever runs untagged. Threads sharing an
+address space require no TLB operation on switch. The per-CPU elided/performed flush counts are
 summed by the `CAP_INFO_TLB_*` `cap_info` selectors.
 
 ### SMP TLB Shootdown

--- a/core/kernel/docs/memory-internals.md
+++ b/core/kernel/docs/memory-internals.md
@@ -316,18 +316,29 @@ is established by mapping the same frame capability into multiple address spaces
 Local invalidation primitives live in the per-architecture paging modules:
 `arch::current::paging::flush_page` invalidates a single VA on the current CPU
 (`invlpg` / `sfence.vma <va>`), and `flush_tlb_all` invalidates all non-global entries
-(CR3 reload / `sfence.vma zero, zero`). Cross-CPU invalidation is the shootdown protocol
-in `mm/tlb_shootdown.rs`. The kernel uses no hardware address-space tags (PCID/ASID); see
-[docs/memory-model.md](../../../docs/memory-model.md). Tagged TLBs are tracked as future
-work in [#198](https://github.com/kottlerg/seraph/issues/198).
+(CR3 reload / `sfence.vma zero, zero`). When tagging is active, `flush_page_tagged` and
+`flush_tag` invalidate a single VA or a whole tag for an arbitrary PCID/ASID (`invpcid` /
+`sfence.vma <va>, <asid>` and `sfence.vma zero, <asid>`), independent of the tag currently
+loaded. Cross-CPU invalidation is the shootdown protocol in `mm/tlb_shootdown.rs`. The tag
+allocator and per-address-space tag state live in `mm/tag_allocator.rs`; see
+[docs/memory-model.md](../../../docs/memory-model.md) for the model.
 
 ### Context Switch TLB Handling
 
-A switch between threads in different address spaces calls
-`arch::current::paging::activate(root_phys)`, which performs a full TLB flush: x86-64
-writes CR3 with `CR4.PCIDE` clear (flushing all non-global entries); RISC-V writes `satp`
-with ASID 0 and executes `sfence.vma`. Threads sharing an address space require no TLB
-operation on switch.
+When tagging is enabled, a switch to a different address space calls
+`AddressSpace::activate`, which claims a hardware tag for the space (lazily, on first
+activation) and loads the root under that tag **without** flushing
+(`arch::current::paging::activate_tagged`): x86-64 writes CR3 with the PCID and bit 63 set
+(`CR4.PCIDE` is on); RISC-V writes `satp` with the ASID and no `sfence.vma`. A per-CPU
+generation check then flushes only that tag if it was reissued to a different space
+(`tag_gen` mismatch) or accrued unmaps while this CPU was switched away (`tlb_gen` lag). A
+`SeqCst` fence between the scheduler's `mark_active` and the generation reads is the
+load-bearing barrier (paired with fences in the unmap and eviction paths) that closes the
+switch-away races. Where tagging is unavailable, or the tag pool is momentarily exhausted,
+`activate` falls back to `arch::current::paging::activate(root_phys)`, a full flush (CR3
+write with `CR4.PCIDE` clear / `satp` ASID 0 + `sfence.vma`). Threads sharing an address
+space require no TLB operation on switch. The per-CPU elided/performed flush counts are
+summed by the `CAP_INFO_TLB_*` `cap_info` selectors.
 
 ### SMP TLB Shootdown
 
@@ -338,20 +349,22 @@ work: holding it across the IPI ack-wait would serialize every concurrent map/un
 on the address space behind cross-CPU latency.
 
 The shootdown itself is lock-free — there is no global shootdown lock and no IPI
-payload. Each CPU owns a request slot. The initiator publishes `(root, virt)` into
+payload. Each CPU owns a request slot. The initiator publishes `(root, virt, tag)` into
 its own slot, sets the pending bit of each target CPU, then sends the IPI:
 
 ```
 1. Edit the leaf PTE under pt_lock; release pt_lock.
-2. Read active_cpus; exclude the current CPU.
-3. Publish (root, virt) into this CPU's request slot and set each target's
+2. Bump the space's tlb_gen and fence (so a switched-away CPU flushes on
+   reactivation); read active_cpus; exclude the current CPU.
+3. Publish (root, virt, tag) into this CPU's request slot and set each target's
    pending bit (the bit doubles as the per-target liveness/ack token).
 4. Send the shootdown IPI to the targets and wait for every pending bit to clear.
 ```
 
 A target services the slot only once it observes its own pending bit set, so it never
-reads a half-published request; it flushes the named VA and clears its bit. Preemption
-stays disabled across the whole edit-then-shootdown sequence.
+reads a half-published request; it invalidates the named VA for `tag` (so a CPU that has
+since switched to another space still flushes the right translation) and clears its bit.
+Preemption stays disabled across the whole edit-then-shootdown sequence.
 
 The shootdown is **not** issued unconditionally. Each rewrite is classified as it
 commits (`MapOutcome`):
@@ -364,8 +377,14 @@ commits (`MapOutcome`):
   shootdown above: a stale entry would alias a freed/reused frame or cache revoked
   rights, which no retry can recover. `unmap` is always synchronous.
 
-A CPU that switches away from the address space before acking is harmless: a context
-switch reloads the page-table root and flushes that space's user entries.
+The shootdown targets only CPUs currently running the space (`active_cpus`). A CPU that
+switched away still holds the space's tagged entries (the switch did not flush them), so it
+is reached not by the IPI but by the per-CPU generation check on its next reactivation: step
+2 bumped the space's `tlb_gen` before snapshotting `active_cpus`, and a `SeqCst` fence on
+each side guarantees that for every CPU either the initiator sees it active (and IPIs it) or
+it observes the bumped `tlb_gen` on reactivation (and flushes the tag). Never neither. On
+the full-flush fallback (no tagging) the request carries `tag == 0` and the switch already
+flushed the outgoing space's entries, so a switched-away CPU has nothing stale.
 
 ### Direct Physical Map Access
 

--- a/core/kernel/docs/memory-internals.md
+++ b/core/kernel/docs/memory-internals.md
@@ -11,7 +11,7 @@ The memory subsystem comprises five components:
 2. **Slab allocator** — fixed-size kernel object allocation
 3. **Size-class allocator** — general variable-size kernel heap
 4. **Address space management** — per-process virtual address space objects
-5. **TLB management** — local invalidation, full-flush context switch, and SMP shootdown
+5. **TLB management** — local invalidation, tagged (PCID/ASID) no-flush context switch with a full-flush fallback, and SMP shootdown
 
 ---
 

--- a/core/kernel/docs/scheduling-internals.md
+++ b/core/kernel/docs/scheduling-internals.md
@@ -387,7 +387,7 @@ There is no FPU flush IPI on either arch. x86-64 uses eager XSAVE on switch-out 
 
 ### Future IPIs (out of scope)
 
-Process-stop ("kill process across all CPUs"), tagged-TLB shootdown variants (see [#198](https://github.com/kottlerg/seraph/issues/198)), and scheduler-quiesce IPIs are not in the current kernel. If added, they MUST be documented in this section before landing.
+Process-stop ("kill process across all CPUs") and scheduler-quiesce IPIs are not in the current kernel. If added, they MUST be documented in this section before landing. (Tagged-TLB invalidation does not add an IPI: it reuses the existing TLB-shootdown IPI, whose request slot now carries the target PCID/ASID — see [memory-internals.md](memory-internals.md).)
 
 ---
 

--- a/core/kernel/src/arch/riscv64/cpu.rs
+++ b/core/kernel/src/arch/riscv64/cpu.rs
@@ -77,9 +77,7 @@ pub fn current_id() -> u32
 /// Must execute in S-mode with `satp` already holding a valid root (Phase 5
 /// onward). Transiently changes the active ASID; the restore + fence makes the
 /// change invisible to translation.
-// Wired into Phase 5 / AP init by the tagged-TLB boot-enablement path.
 #[cfg(not(test))]
-#[allow(dead_code)]
 pub unsafe fn probe_asid_bits() -> u32
 {
     /// ASID field starts at bit 44 of `satp` on RV64.

--- a/core/kernel/src/arch/riscv64/cpu.rs
+++ b/core/kernel/src/arch/riscv64/cpu.rs
@@ -61,6 +61,62 @@ pub fn current_id() -> u32
     0
 }
 
+// ── ASID width probe ──────────────────────────────────────────────────────────
+
+/// Probe the number of implemented ASID bits in `satp[59:44]`.
+///
+/// Per RISC-V Privileged ISA §4.1.11, software discovers the ASID width by
+/// writing ones to every ASID bit and reading back which ones stick. This
+/// writes a test `satp` with all ASID bits set (preserving MODE and PPN), reads
+/// it back, restores the original `satp`, and issues `sfence.vma` to discard
+/// any translation cached under the transient ASID. Returns the count of
+/// implemented ASID bits; `0` means ASIDs are unsupported and the kernel falls
+/// back to full-flush context switches.
+///
+/// # Safety
+/// Must execute in S-mode with `satp` already holding a valid root (Phase 5
+/// onward). Transiently changes the active ASID; the restore + fence makes the
+/// change invisible to translation.
+// Wired into Phase 5 / AP init by the tagged-TLB boot-enablement path.
+#[cfg(not(test))]
+#[allow(dead_code)]
+pub unsafe fn probe_asid_bits() -> u32
+{
+    /// ASID field starts at bit 44 of `satp` on RV64.
+    const ASID_SHIFT: u64 = 44;
+    /// 16 ASID bits maximum on RV64 (`satp[59:44]`).
+    const ASID_MASK: u64 = 0xFFFF << ASID_SHIFT;
+
+    let orig: u64;
+    // SAFETY: reading satp is always safe in S-mode.
+    unsafe {
+        core::arch::asm!("csrr {}, satp", out(reg) orig, options(nostack, nomem));
+    }
+
+    let probe = orig | ASID_MASK;
+    let readback: u64;
+    // SAFETY: the probe value keeps the original MODE and PPN, so the active
+    // translation root is unchanged; only the (unused) ASID field differs. satp
+    // is restored to `orig` and the TLB fenced before this returns.
+    unsafe {
+        core::arch::asm!(
+            "csrw satp, {probe}",
+            "csrr {back}, satp",
+            "csrw satp, {orig}",
+            "sfence.vma zero, zero",
+            probe = in(reg) probe,
+            back = out(reg) readback,
+            orig = in(reg) orig,
+            options(nostack),
+        );
+    }
+
+    // Implemented ASID bits are the contiguous low-order bits of the field that
+    // read back as 1.
+    let implemented = (readback & ASID_MASK) >> ASID_SHIFT;
+    implemented.count_ones()
+}
+
 // ── Per-CPU tp register ───────────────────────────────────────────────────────
 
 /// Install `addr` as the per-CPU data pointer for the current hart.

--- a/core/kernel/src/arch/riscv64/paging.rs
+++ b/core/kernel/src/arch/riscv64/paging.rs
@@ -314,7 +314,6 @@ pub unsafe fn activate(root_phys: u64)
 /// `root_phys` must be a valid Sv48 root mapping the currently executing code,
 /// the active stack, and the direct map.
 #[cfg(not(test))]
-#[allow(dead_code)]
 pub unsafe fn activate_tagged(root_phys: u64, tag: u16)
 {
     let satp = (9u64 << 60) | (u64::from(tag) << 44) | (root_phys >> 12);
@@ -643,7 +642,6 @@ pub unsafe fn flush_page(virt: u64)
 /// # Safety
 /// Must execute in S-mode. `virt` need not be mapped.
 #[cfg(not(test))]
-#[allow(dead_code)]
 pub unsafe fn flush_page_tagged(virt: u64, tag: u16)
 {
     // SAFETY: sfence.vma with a VA and a non-zero ASID invalidates that leaf
@@ -666,7 +664,6 @@ pub unsafe fn flush_page_tagged(virt: u64, tag: u16)
 /// # Safety
 /// Must execute in S-mode.
 #[cfg(not(test))]
-#[allow(dead_code)]
 pub unsafe fn flush_tag(tag: u16)
 {
     // SAFETY: sfence.vma with x0 VA and a non-zero ASID invalidates all leaves
@@ -822,8 +819,10 @@ pub unsafe fn unmap_identity_page(pa: u64)
     {
         crate::percpu::preempt_disable();
         // SAFETY: root_pa is the active kernel Sv48 root; remote covers
-        // only online harts; preemption disabled around the shootdown.
-        unsafe { crate::mm::tlb_shootdown::shootdown(root_pa, &remote, virt) };
+        // only online harts; preemption disabled around the shootdown. Tag 0:
+        // this is a kernel identity mapping torn down at boot, not a tagged
+        // user space.
+        unsafe { crate::mm::tlb_shootdown::shootdown(root_pa, &remote, virt, 0) };
         crate::percpu::preempt_enable();
     }
 }

--- a/core/kernel/src/arch/riscv64/paging.rs
+++ b/core/kernel/src/arch/riscv64/paging.rs
@@ -329,6 +329,24 @@ pub unsafe fn activate_tagged(root_phys: u64, tag: u16)
     }
 }
 
+/// Per-CPU enable of ASID-tagged TLBs: report the number of hardware tags
+/// (ASIDs) this hart implements, or `0` when the `satp` ASID field is
+/// zero-width.
+///
+/// Called on the BSP and every AP. RISC-V needs no per-hart enable bit — the
+/// ASID is written directly into `satp` — so this only probes the implemented
+/// width. The BSP uses the returned count to seed the tag pool.
+///
+/// # Safety
+/// Must execute in S-mode with `satp` holding a valid root (Phase 5 onward).
+#[cfg(not(test))]
+pub unsafe fn enable_tagged_tlb() -> usize
+{
+    // SAFETY: caller's contract (S-mode, valid satp).
+    let bits = unsafe { super::cpu::probe_asid_bits() };
+    if bits == 0 { 0 } else { 1usize << bits }
+}
+
 /// No-op on RISC-V: the XN/NX mechanism is always available via PTE X bit.
 #[cfg(not(test))]
 pub unsafe fn enable_nx() {}
@@ -405,8 +423,10 @@ pub unsafe fn read_root_phys() -> u64
     unsafe {
         core::arch::asm!("csrr {}, satp", out(reg) satp, options(nostack, nomem));
     }
-    // PPN is satp[43:0]; physical address = PPN << 12.
-    (satp & 0x000F_FFFF_FFFF_FFFF) << 12
+    // PPN is satp[43:0] (44 bits); physical address = PPN << 12. The mask must
+    // exclude the ASID field (satp[59:44]) — a non-zero ASID under tagged TLBs
+    // would otherwise leak into the returned address.
+    (satp & 0x0000_0FFF_FFFF_FFFF) << 12
 }
 
 /// Map a single 4 KiB user page `virt` → `phys` in the Sv48 page table

--- a/core/kernel/src/arch/riscv64/paging.rs
+++ b/core/kernel/src/arch/riscv64/paging.rs
@@ -301,6 +301,35 @@ pub unsafe fn activate(root_phys: u64)
     }
 }
 
+/// Activate the Sv48 tables rooted at `root_phys` under ASID `tag` **without**
+/// issuing `sfence.vma`.
+///
+/// Encodes `tag` into `satp[59:44]` and the root PPN into `satp[43:0]`; cached
+/// translations for `tag` and every other ASID survive (the context-switch fast
+/// path). The caller is responsible for any ASID invalidation required for
+/// correctness (the generation check in `AddressSpace::activate`).
+///
+/// # Safety
+/// Must execute in S-mode on a hart with a non-zero implemented ASID width.
+/// `root_phys` must be a valid Sv48 root mapping the currently executing code,
+/// the active stack, and the direct map.
+#[cfg(not(test))]
+#[allow(dead_code)]
+pub unsafe fn activate_tagged(root_phys: u64, tag: u16)
+{
+    let satp = (9u64 << 60) | (u64::from(tag) << 44) | (root_phys >> 12);
+    // SAFETY: satp write switches the active Sv48 root and ASID; the deliberate
+    // absence of sfence.vma retains cached translations; caller guarantees the
+    // tables map current code, stack, and the direct map.
+    unsafe {
+        core::arch::asm!(
+            "csrw satp, {}",
+            in(reg) satp,
+            options(nostack),
+        );
+    }
+}
+
 /// No-op on RISC-V: the XN/NX mechanism is always available via PTE X bit.
 #[cfg(not(test))]
 pub unsafe fn enable_nx() {}
@@ -598,6 +627,54 @@ pub unsafe fn flush_page(virt: u64)
         core::arch::asm!(
             "sfence.vma {}, zero",
             in(reg) virt,
+            options(nostack),
+        );
+    }
+}
+
+// ── Tagged (ASID) invalidation ────────────────────────────────────────────────
+// `sfence.vma` with a non-zero ASID operand invalidates only that ASID's
+// translations, independent of the ASID currently loaded in `satp`. Used by the
+// tagged-TLB path for per-VA remote shootdown and whole-tag flush.
+
+/// Invalidate the TLB entry for `virt` tagged with ASID `tag` on the current
+/// hart (`sfence.vma virt, asid`), regardless of the ASID in `satp`.
+///
+/// # Safety
+/// Must execute in S-mode. `virt` need not be mapped.
+#[cfg(not(test))]
+#[allow(dead_code)]
+pub unsafe fn flush_page_tagged(virt: u64, tag: u16)
+{
+    // SAFETY: sfence.vma with a VA and a non-zero ASID invalidates that leaf
+    // within that ASID; S-mode primitive, safe for any VA.
+    unsafe {
+        core::arch::asm!(
+            "sfence.vma {va}, {asid}",
+            va = in(reg) virt,
+            asid = in(reg) u64::from(tag),
+            options(nostack),
+        );
+    }
+}
+
+/// Invalidate all entries tagged with ASID `tag` on the current hart
+/// (`sfence.vma zero, asid`). Used when an ASID is (re)assigned to a new address
+/// space or when a switched-away space accrued unmaps while this hart was
+/// elsewhere.
+///
+/// # Safety
+/// Must execute in S-mode.
+#[cfg(not(test))]
+#[allow(dead_code)]
+pub unsafe fn flush_tag(tag: u16)
+{
+    // SAFETY: sfence.vma with x0 VA and a non-zero ASID invalidates all leaves
+    // within that ASID; S-mode primitive.
+    unsafe {
+        core::arch::asm!(
+            "sfence.vma zero, {asid}",
+            asid = in(reg) u64::from(tag),
             options(nostack),
         );
     }

--- a/core/kernel/src/arch/x86_64/cpu.rs
+++ b/core/kernel/src/arch/x86_64/cpu.rs
@@ -204,6 +204,63 @@ pub unsafe fn enable_smep_smap()
     }
 }
 
+// ── PCID (Process-Context Identifiers) ────────────────────────────────────────
+
+/// Enable PCID-tagged TLBs by setting `CR4.PCIDE` (bit 17).
+///
+/// Tagged TLBs require both PCID (`CPUID.01H:ECX[17]`) and INVPCID
+/// (`CPUID.(EAX=07H,ECX=0):EBX[10]`): the kernel uses `invpcid` for
+/// single-address and single-context invalidation. Returns `true` if both
+/// features are present and `CR4.PCIDE` was set, `false` otherwise.
+///
+/// Unlike [`enable_smep_smap`], absence is **not** fatal — tagging is an
+/// optimization, not a security requirement, and the kernel falls back to
+/// full-flush context switches.
+///
+/// Per Intel SDM Vol. 3A §4.10.1, `CR3[11:0]` must be 0 at the moment
+/// `CR4.PCIDE` is set to 1, or the `MOV CR4` `#GP`s. At the call site (Phase 5
+/// BSP / AP init) the active CR3 is the kernel root with zero low bits; this is
+/// asserted in debug builds.
+///
+/// # Safety
+/// Must execute at ring 0, after the IDT is loaded, with the kernel root in
+/// CR3 (low 12 bits zero). Must be called at most once per CPU and before any
+/// PCID-tagged CR3 load.
+// Wired into Phase 5 / AP init by the tagged-TLB boot-enablement path.
+#[cfg(not(test))]
+#[allow(dead_code)]
+pub unsafe fn enable_pcid() -> bool
+{
+    // CPUID.01H:ECX[17] = PCID; CPUID.(07H,0):EBX[10] = INVPCID.
+    let pcid = cpuid(1).2 & (1 << 17) != 0;
+    let invpcid = cpuid(7).1 & (1 << 10) != 0;
+    if !pcid || !invpcid
+    {
+        return false;
+    }
+
+    // CR3[11:0] must be zero before setting PCIDE (SDM Vol. 3A §4.10.1).
+    let cr3: u64;
+    // SAFETY: reading CR3 is a ring-0 primitive.
+    unsafe {
+        core::arch::asm!("mov {}, cr3", out(reg) cr3, options(nostack, nomem));
+    }
+    debug_assert!(
+        cr3.trailing_zeros() >= 12,
+        "enable_pcid: CR3[11:0] must be 0 before setting CR4.PCIDE"
+    );
+
+    // Bit 17 = PCIDE.
+    let cr4 = read_cr4();
+    // SAFETY: CPUID confirmed PCID + INVPCID; CR3 low bits are zero (kernel
+    // root); long mode and PAE are active (4-level paging). The new CR4 value
+    // is valid.
+    unsafe {
+        write_cr4(cr4 | (1 << 17));
+    }
+    true
+}
+
 // ── Misc ──────────────────────────────────────────────────────────────────────
 
 /// Atomically enable interrupts and halt until an interrupt is recognised.

--- a/core/kernel/src/arch/x86_64/cpu.rs
+++ b/core/kernel/src/arch/x86_64/cpu.rs
@@ -226,9 +226,7 @@ pub unsafe fn enable_smep_smap()
 /// Must execute at ring 0, after the IDT is loaded, with the kernel root in
 /// CR3 (low 12 bits zero). Must be called at most once per CPU and before any
 /// PCID-tagged CR3 load.
-// Wired into Phase 5 / AP init by the tagged-TLB boot-enablement path.
 #[cfg(not(test))]
-#[allow(dead_code)]
 pub unsafe fn enable_pcid() -> bool
 {
     // CPUID.01H:ECX[17] = PCID; CPUID.(07H,0):EBX[10] = INVPCID.

--- a/core/kernel/src/arch/x86_64/paging.rs
+++ b/core/kernel/src/arch/x86_64/paging.rs
@@ -266,8 +266,22 @@ fn walk_or_alloc(entry: &mut PageTableEntry, pool: &mut PoolState) -> Result<u64
 #[cfg(not(test))]
 pub unsafe fn write_satp_no_fence(root_phys: u64)
 {
-    // SAFETY: delegated to activate; root_phys is valid per caller contract.
-    unsafe { activate(root_phys) };
+    // With PCID enabled, load the kernel root under PCID 0 without flushing
+    // (CR3 bit 63). Kernel translations are identical across roots, so retaining
+    // PCID 0's cached entries across this transition is correct and avoids a
+    // flush. Without PCID a CR3 write always flushes, so this degrades to the
+    // flushing form (functionally equivalent to `activate`).
+    // SAFETY: root_phys is a valid kernel root per caller contract.
+    unsafe {
+        if crate::mm::tag_allocator::tagging_enabled()
+        {
+            activate_tagged(root_phys, 0);
+        }
+        else
+        {
+            activate(root_phys);
+        }
+    }
 }
 
 /// Activate the page tables rooted at `root_phys` by writing CR3.
@@ -309,7 +323,6 @@ pub unsafe fn activate(root_phys: u64)
 /// invalidation required for correctness (the generation check in
 /// `AddressSpace::activate`).
 #[cfg(not(test))]
-#[allow(dead_code)]
 pub unsafe fn activate_tagged(root_phys: u64, tag: u16)
 {
     // Bit 63 = no-invalidate request (valid only when CR4.PCIDE = 1); the PCID
@@ -696,10 +709,8 @@ pub unsafe fn flush_page(virt: u64)
 // for per-VA remote shootdown (type 0) and whole-tag flush (type 1).
 
 /// INVPCID type 0: invalidate one linear address within one PCID.
-#[allow(dead_code)]
 const INVPCID_TYPE_ADDR: u64 = 0;
 /// INVPCID type 1: invalidate all non-global entries of one PCID.
-#[allow(dead_code)]
 const INVPCID_TYPE_SINGLE: u64 = 1;
 
 /// 128-bit INVPCID descriptor (Intel SDM Vol. 2A, "INVPCID").
@@ -723,7 +734,6 @@ struct InvpcidDescriptor
 /// Must execute at ring 0 with `CR4.PCIDE` set; the descriptor's reserved bits
 /// must be zero.
 #[cfg(not(test))]
-#[allow(dead_code)]
 unsafe fn invpcid(kind: u64, desc: &InvpcidDescriptor)
 {
     // SAFETY: invpcid is a ring-0 TLB primitive; desc is a valid 16-byte
@@ -745,7 +755,6 @@ unsafe fn invpcid(kind: u64, desc: &InvpcidDescriptor)
 /// # Safety
 /// Must execute at ring 0 with `CR4.PCIDE` set.
 #[cfg(not(test))]
-#[allow(dead_code)]
 pub unsafe fn flush_page_tagged(virt: u64, tag: u16)
 {
     let desc = InvpcidDescriptor {
@@ -765,7 +774,6 @@ pub unsafe fn flush_page_tagged(virt: u64, tag: u16)
 /// # Safety
 /// Must execute at ring 0 with `CR4.PCIDE` set.
 #[cfg(not(test))]
-#[allow(dead_code)]
 pub unsafe fn flush_tag(tag: u16)
 {
     let desc = InvpcidDescriptor {
@@ -909,8 +917,9 @@ pub unsafe fn unmap_identity_page(pa: u64)
     {
         crate::percpu::preempt_disable();
         // SAFETY: root_pa is the active kernel PML4; remote covers only
-        // online CPUs; preemption disabled around the shootdown.
-        unsafe { crate::mm::tlb_shootdown::shootdown(root_pa, &remote, virt) };
+        // online CPUs; preemption disabled around the shootdown. Tag 0: this is
+        // a kernel identity mapping torn down at boot, not a tagged user space.
+        unsafe { crate::mm::tlb_shootdown::shootdown(root_pa, &remote, virt, 0) };
         crate::percpu::preempt_enable();
     }
 }

--- a/core/kernel/src/arch/x86_64/paging.rs
+++ b/core/kernel/src/arch/x86_64/paging.rs
@@ -293,6 +293,40 @@ pub unsafe fn activate(root_phys: u64)
     }
 }
 
+/// Activate the page tables rooted at `root_phys` under PCID `tag` **without
+/// flushing** the TLB.
+///
+/// Writes CR3 with the PCID in bits \[11:0\] and bit 63 set, which (with
+/// `CR4.PCIDE = 1`) requests "do not invalidate" — cached translations for
+/// `tag` and every other PCID are retained (Intel SDM Vol. 3A §4.10.4.1). This
+/// is the context-switch fast path: the outgoing space's translations survive.
+///
+/// # Safety
+/// Must execute at ring 0 with `CR4.PCIDE` set. `root_phys` must be a valid
+/// PML4 frame (4 KiB-aligned, low 12 bits zero). The tables must map the
+/// currently executing code, the active stack, and all data accessed
+/// immediately after this call. The caller is responsible for any tag
+/// invalidation required for correctness (the generation check in
+/// `AddressSpace::activate`).
+#[cfg(not(test))]
+#[allow(dead_code)]
+pub unsafe fn activate_tagged(root_phys: u64, tag: u16)
+{
+    // Bit 63 = no-invalidate request (valid only when CR4.PCIDE = 1); the PCID
+    // occupies bits [11:0]; root_phys supplies bits [51:12] with low bits zero.
+    let cr3 = root_phys | u64::from(tag) | (1u64 << 63);
+    // SAFETY: CR3 write changes the active page table; root_phys is a valid
+    // PML4 frame with zero low bits; PCIDE is set so bit 63 is honoured as the
+    // no-flush request rather than faulting.
+    unsafe {
+        core::arch::asm!(
+            "mov cr3, {}",
+            in(reg) cr3,
+            options(nostack),
+        );
+    }
+}
+
 /// Enable No-Execute by setting `IA32_EFER.NXE` (bit 11) via RDMSR/WRMSR.
 ///
 /// Must be called before activating page tables that use the NX bit,
@@ -653,6 +687,94 @@ pub unsafe fn flush_page(virt: u64)
             in(reg) virt,
             options(nostack),
         );
+    }
+}
+
+// ── Tagged (PCID) invalidation ────────────────────────────────────────────────
+// INVPCID lets a CPU invalidate translations tagged with an arbitrary PCID,
+// independent of the PCID currently loaded in CR3. Used by the tagged-TLB path
+// for per-VA remote shootdown (type 0) and whole-tag flush (type 1).
+
+/// INVPCID type 0: invalidate one linear address within one PCID.
+#[allow(dead_code)]
+const INVPCID_TYPE_ADDR: u64 = 0;
+/// INVPCID type 1: invalidate all non-global entries of one PCID.
+#[allow(dead_code)]
+const INVPCID_TYPE_SINGLE: u64 = 1;
+
+/// 128-bit INVPCID descriptor (Intel SDM Vol. 2A, "INVPCID").
+///
+/// First qword: PCID in bits \[11:0\], bits \[63:12\] reserved (must be zero).
+/// Second qword: the linear address (ignored for type 1).
+///
+/// `dead_code`: the fields are consumed by `invpcid` through a pointer in inline
+/// asm, which the lint cannot see as a read.
+#[allow(dead_code)]
+#[repr(C, align(16))]
+struct InvpcidDescriptor
+{
+    pcid: u64,
+    linear_addr: u64,
+}
+
+/// Execute `invpcid` with the given invalidation `kind` and descriptor.
+///
+/// # Safety
+/// Must execute at ring 0 with `CR4.PCIDE` set; the descriptor's reserved bits
+/// must be zero.
+#[cfg(not(test))]
+#[allow(dead_code)]
+unsafe fn invpcid(kind: u64, desc: &InvpcidDescriptor)
+{
+    // SAFETY: invpcid is a ring-0 TLB primitive; desc is a valid 16-byte
+    // descriptor with reserved bits zero (constructed by the callers below).
+    // The asm reads the descriptor memory, so no nomem/readonly is asserted.
+    unsafe {
+        core::arch::asm!(
+            "invpcid {kind}, [{desc}]",
+            kind = in(reg) kind,
+            desc = in(reg) desc,
+            options(nostack),
+        );
+    }
+}
+
+/// Invalidate the TLB entry for `virt` tagged with PCID `tag` on the current
+/// CPU (INVPCID type 0), regardless of the PCID currently loaded in CR3.
+///
+/// # Safety
+/// Must execute at ring 0 with `CR4.PCIDE` set.
+#[cfg(not(test))]
+#[allow(dead_code)]
+pub unsafe fn flush_page_tagged(virt: u64, tag: u16)
+{
+    let desc = InvpcidDescriptor {
+        pcid: u64::from(tag),
+        linear_addr: virt,
+    };
+    // SAFETY: ring 0 with PCIDE set (caller contract); well-formed type-0 descriptor.
+    unsafe {
+        invpcid(INVPCID_TYPE_ADDR, &desc);
+    }
+}
+
+/// Invalidate all non-global TLB entries tagged with PCID `tag` on the current
+/// CPU (INVPCID type 1). Used when a tag is (re)assigned to a new address space
+/// or when a switched-away space accrued unmaps while this CPU was elsewhere.
+///
+/// # Safety
+/// Must execute at ring 0 with `CR4.PCIDE` set.
+#[cfg(not(test))]
+#[allow(dead_code)]
+pub unsafe fn flush_tag(tag: u16)
+{
+    let desc = InvpcidDescriptor {
+        pcid: u64::from(tag),
+        linear_addr: 0,
+    };
+    // SAFETY: ring 0 with PCIDE set (caller contract); well-formed type-1 descriptor.
+    unsafe {
+        invpcid(INVPCID_TYPE_SINGLE, &desc);
     }
 }
 

--- a/core/kernel/src/arch/x86_64/paging.rs
+++ b/core/kernel/src/arch/x86_64/paging.rs
@@ -340,6 +340,30 @@ pub unsafe fn activate_tagged(root_phys: u64, tag: u16)
     }
 }
 
+/// Per-CPU enable of PCID-tagged TLBs: set `CR4.PCIDE` and report the number of
+/// hardware tags (PCIDs) available, or `0` when PCID/INVPCID are unsupported.
+///
+/// Called on the BSP and every AP. On the BSP the returned count seeds the tag
+/// pool; on every CPU it sets `CR4.PCIDE`, required before any tagged CR3 load.
+///
+/// # Safety
+/// Must execute at ring 0 with the kernel root in CR3 (low 12 bits zero), at
+/// most once per CPU, before any tagged CR3 load.
+#[cfg(not(test))]
+pub unsafe fn enable_tagged_tlb() -> usize
+{
+    // SAFETY: caller's contract (ring 0, kernel root in CR3).
+    if unsafe { super::cpu::enable_pcid() }
+    {
+        // 12-bit PCID field ⇒ 4096 tags; tag 0 is reserved for kernel/fallback.
+        4096
+    }
+    else
+    {
+        0
+    }
+}
+
 /// Enable No-Execute by setting `IA32_EFER.NXE` (bit 11) via RDMSR/WRMSR.
 ///
 /// Must be called before activating page tables that use the NX bit,

--- a/core/kernel/src/cap/object.rs
+++ b/core/kernel/src/cap/object.rs
@@ -1731,6 +1731,16 @@ unsafe fn dealloc_object_one(
                     count += 1;
                 }
 
+                // Return this space's hardware tag (PCID/ASID) to the pool, if
+                // any. No TLB flush is needed: active_cpus is empty (asserted
+                // above), and any CPU that cached the tag while switched away is
+                // flushed lazily by the generation check the next time it loads
+                // the tag for whatever space claims it next.
+                // SAFETY: as_ptr is a valid AddressSpace being reclaimed; with
+                // active_cpus empty no concurrent activate races this read.
+                let tag = unsafe { (*as_ptr).tag.load(Ordering::Acquire) };
+                crate::mm::tag_allocator::free_tag(tag);
+
                 // Drop in-place objects before reclaiming their storage.
                 // `AddressSpace` and `AddressSpaceObject` have no Drop logic
                 // today; the explicit calls keep the contract correct if

--- a/core/kernel/src/main.rs
+++ b/core/kernel/src/main.rs
@@ -294,6 +294,18 @@ unsafe fn kernel_entry_post_rebase(
         percpu::init_bsp();
     }
     kprintln!("percpu ok");
+    // Enable hardware address-space tags (x86-64 PCID / RISC-V ASID) where
+    // available, seeding the tag pool sized to boot_cpu_count. Where the feature
+    // is absent this is a no-op and the kernel keeps the full-flush
+    // context-switch path. Must precede any tagged activate (Phase 9 / scheduler).
+    #[cfg(not(test))]
+    // SAFETY: BSP, ring 0 / S-mode; kernel root active; `allocator` is the live
+    // frame allocator; called once before any tagged activate.
+    unsafe {
+        let hw_tags = arch::current::paging::enable_tagged_tlb();
+        mm::tag_allocator::enable(hw_tags, boot_cpu_count as usize, allocator);
+    }
+    kprintln!("tagged-tlb ok");
     // SAFETY: IDT installed and interrupts initialized above; syscall entry
     // point registered during arch init; single-threaded boot phase.
     unsafe {
@@ -1252,6 +1264,18 @@ pub extern "C" fn kernel_entry_ap(cpu_id: u32, ist1_top: u64, ist2_top: u64) -> 
     // handler registered (Phase 5, BSP); per-CPU timer configuration.
     unsafe {
         arch::current::timer::init_ap(1_000);
+    }
+
+    // Enable hardware address-space tags on this AP (x86-64 sets CR4.PCIDE;
+    // RISC-V probes its ASID width). Must precede this AP's first tagged
+    // activate in the scheduler. If the BSP enabled tagging but this CPU lacks
+    // the feature, the tagged path cannot run here — a fatal heterogeneity.
+    // SAFETY: ring 0 / S-mode; kernel root active; once per AP, before any
+    // tagged activate.
+    let ap_hw_tags = unsafe { arch::current::paging::enable_tagged_tlb() };
+    if mm::tag_allocator::tagging_enabled() && ap_hw_tags == 0
+    {
+        fatal("AP lacks the hardware TLB tags enabled on the BSP");
     }
 
     kprintln!("smp: AP {} online", cpu_id);

--- a/core/kernel/src/mm/address_space.rs
+++ b/core/kernel/src/mm/address_space.rs
@@ -65,7 +65,7 @@
 // cast_possible_truncation: u64→usize page count arithmetic; bounded by address space size.
 #![allow(clippy::cast_possible_truncation)]
 
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU16, AtomicU64, Ordering};
 
 use boot_protocol::{InitSegment, SegmentFlags};
 
@@ -101,6 +101,26 @@ pub struct AddressSpace
     /// IF=1 to deliver IPIs). Preemption is prevented by caller's
     /// `preempt_disable()`.
     pt_lock: AtomicBool,
+    /// Hardware address-space tag (x86-64 PCID / RISC-V ASID), or `0` when
+    /// untagged (unclaimed, or the full-flush fallback when tagging is
+    /// unavailable). Claimed lazily on first `activate` from
+    /// [`crate::mm::tag_allocator`]. Written only under the tag-pool lock
+    /// (by the owner's own claim or by eviction); read lock-free by `activate`.
+    #[allow(dead_code)]
+    pub(crate) tag: AtomicU16,
+    /// The global allocator generation stamped when this space claimed its
+    /// current `tag`. Globally unique per claim; distinguishes this space's
+    /// claim on a tag from any later space that reuses the same tag value, so a
+    /// per-CPU generation check flushes a tag before its first use under a new
+    /// owner.
+    #[allow(dead_code)]
+    pub(crate) tag_gen: AtomicU64,
+    /// Bumped on every Replace-class modification (`unmap`, permission narrow).
+    /// A CPU switched away from this space compares its last-synced value
+    /// against this on reactivation and flushes the tag if it lags, catching
+    /// unmaps it missed while it was elsewhere.
+    #[allow(dead_code)]
+    pub(crate) tlb_gen: AtomicU64,
 }
 
 // SAFETY: All mutable state is protected by pt_lock (page tables) or atomic
@@ -187,6 +207,27 @@ impl AddressSpace
     #[inline]
     fn shootdown_remote(&self, virt: u64)
     {
+        // This is the Replace-class path (unmap / frame-replace / permission
+        // narrow). Reading `self.tag` is safe without the pool lock: the current
+        // CPU is running this space (it is performing the modification), so the
+        // space is active and cannot be selected as an eviction victim, so its
+        // tag is stable here.
+        let tag = self.tag.load(Ordering::Acquire);
+
+        if crate::mm::tag_allocator::tagging_enabled()
+        {
+            // Bump the per-space TLB generation so a CPU that was switched away
+            // (and is therefore NOT in active_cpus, so gets no IPI below) flushes
+            // this tag on its next reactivation. The SeqCst fence is the A-side
+            // of the INV-3 unmap-race Dekker: it orders the bump before the
+            // active-CPU snapshot, pairing with the fence in `activate`. Together
+            // they guarantee that for any CPU caching this space, either it is in
+            // the snapshot (gets an IPI) or it observes the bumped tlb_gen on
+            // reactivation. Never neither.
+            self.tlb_gen.fetch_add(1, Ordering::Release);
+            core::sync::atomic::fence(Ordering::SeqCst);
+        }
+
         let mut remote_cpus = self.active_cpu_mask();
         let current = crate::arch::current::cpu::current_cpu() as usize;
         remote_cpus.clear(current);
@@ -196,7 +237,7 @@ impl AddressSpace
             // contains only online CPUs (enforced by scheduler); the caller
             // holds preempt_disable() and no longer holds pt_lock.
             unsafe {
-                crate::mm::tlb_shootdown::shootdown(self.root_phys, &remote_cpus, virt);
+                crate::mm::tlb_shootdown::shootdown(self.root_phys, &remote_cpus, virt, tag);
             }
         }
     }
@@ -247,6 +288,9 @@ impl AddressSpace
             root_virt,
             active_cpus: AtomicCpuMask::new(),
             pt_lock: AtomicBool::new(false),
+            tag: AtomicU16::new(0),
+            tag_gen: AtomicU64::new(0),
+            tlb_gen: AtomicU64::new(0),
         }
     }
 
@@ -285,6 +329,9 @@ impl AddressSpace
             root_virt,
             active_cpus: AtomicCpuMask::new(),
             pt_lock: AtomicBool::new(false),
+            tag: AtomicU16::new(0),
+            tag_gen: AtomicU64::new(0),
+            tlb_gen: AtomicU64::new(0),
         }
     }
 
@@ -611,8 +658,17 @@ impl AddressSpace
 
     /// Activate this address space on the current CPU.
     ///
-    /// On x86-64: writes `root_phys` to CR3 (flushes TLB).
-    /// On RISC-V: writes the Sv48 SATP value and issues `sfence.vma`.
+    /// With tagging disabled this writes the page-table root with a full TLB
+    /// flush (x86-64 CR3 write; RISC-V `satp` + `sfence.vma`). With tagging
+    /// enabled it loads the root under this space's hardware tag **without**
+    /// flushing, then flushes only that tag if a per-CPU generation check shows
+    /// the tag was reissued to a different space or accrued unmaps while this
+    /// CPU was switched away.
+    ///
+    /// The caller (scheduler / first user entry) MUST have marked this CPU
+    /// active on this space (`mark_active_on_cpu`) before calling, both so the
+    /// space cannot be selected as its own eviction victim and so the INV-3
+    /// fence below has an active-bit store to order against.
     ///
     /// # Safety
     /// Must be called at ring 0 / S-mode. After this call, all virtual
@@ -620,10 +676,65 @@ impl AddressSpace
     #[cfg(not(test))]
     pub unsafe fn activate(&self)
     {
-        use crate::arch::current::paging::activate;
-        // SAFETY: caller's contract; root_phys is a valid page table root.
+        use crate::arch::current::paging::{activate, activate_tagged, flush_tag};
+        use crate::mm::tag_allocator;
+
+        if !tag_allocator::tagging_enabled()
+        {
+            // SAFETY: caller's contract; root_phys is a valid page table root.
+            unsafe {
+                activate(self.root_phys);
+            }
+            return;
+        }
+
+        // INV-3: the scheduler published this CPU's active bit (Release) before
+        // calling. This fence orders that store before the tag/generation reads
+        // below, forming the B-side of the unmap and eviction Dekker exclusions
+        // (paired with the SeqCst fences in `unmap_page`/`protect_page` and in
+        // `tag_allocator::claim`'s eviction). Without it a CPU could miss an
+        // unmap that did not IPI it and later run a stale tagged translation.
+        core::sync::atomic::fence(Ordering::SeqCst);
+
+        let mut tag = self.tag.load(Ordering::Acquire);
+        if tag == 0
+        {
+            tag = tag_allocator::claim(self);
+            if tag == 0
+            {
+                // Pool exhausted (every tag active): untagged full-flush fallback.
+                // SAFETY: caller's contract; root_phys is a valid root.
+                unsafe {
+                    activate(self.root_phys);
+                }
+                return;
+            }
+        }
+
+        let tag_gen = self.tag_gen.load(Ordering::Acquire);
+        let tlb_gen = self.tlb_gen.load(Ordering::Acquire);
+
+        // Load the tagged page tables without flushing — the optimization.
+        // SAFETY: tagging enabled ⇒ CR4.PCIDE set / ASID width > 0; root_phys is
+        // a valid root mapping current code, stack, and the direct map.
         unsafe {
-            activate(self.root_phys);
+            activate_tagged(self.root_phys, tag);
+        }
+
+        // Per-CPU generation check: flush this tag iff it was reissued to a
+        // different space (owner_gen mismatch) or this space accrued unmaps
+        // while this CPU was switched away (synced_tlb_gen lag).
+        let cpu = crate::arch::current::cpu::current_cpu() as usize;
+        // SAFETY: tagging enabled ⇒ the per-CPU slab is initialised; cpu is the
+        // current CPU and < cpu_count; tag < num_tags.
+        let (owner_gen, synced) = unsafe { tag_allocator::tag_state(cpu, tag) };
+        if owner_gen != tag_gen || synced < tlb_gen
+        {
+            // SAFETY: ring 0 / S-mode; tagging enabled.
+            unsafe {
+                flush_tag(tag);
+                tag_allocator::set_tag_state(cpu, tag, tag_gen, tlb_gen);
+            }
         }
     }
 

--- a/core/kernel/src/mm/address_space.rs
+++ b/core/kernel/src/mm/address_space.rs
@@ -106,6 +106,8 @@ pub struct AddressSpace
     /// unavailable). Claimed lazily on first `activate` from
     /// [`crate::mm::tag_allocator`]. Written only under the tag-pool lock
     /// (by the owner's own claim or by eviction); read lock-free by `activate`.
+    // dead_code: the tag fields are accessed only on `#[cfg(not(test))]` paths
+    // (activate / shootdown / destroy), so host-test builds see them as unread.
     #[allow(dead_code)]
     pub(crate) tag: AtomicU16,
     /// The global allocator generation stamped when this space claimed its
@@ -113,13 +115,13 @@ pub struct AddressSpace
     /// claim on a tag from any later space that reuses the same tag value, so a
     /// per-CPU generation check flushes a tag before its first use under a new
     /// owner.
-    #[allow(dead_code)]
+    #[allow(dead_code)] // see `tag`
     pub(crate) tag_gen: AtomicU64,
     /// Bumped on every Replace-class modification (`unmap`, permission narrow).
     /// A CPU switched away from this space compares its last-synced value
     /// against this on reactivation and flushes the tag if it lags, catching
     /// unmaps it missed while it was elsewhere.
-    #[allow(dead_code)]
+    #[allow(dead_code)] // see `tag`
     pub(crate) tlb_gen: AtomicU64,
 }
 
@@ -700,16 +702,21 @@ impl AddressSpace
         if tag == 0
         {
             tag = tag_allocator::claim(self);
-            if tag == 0
-            {
-                // Pool exhausted (every tag active): untagged full-flush fallback.
-                // SAFETY: caller's contract; root_phys is a valid root.
-                unsafe {
-                    activate(self.root_phys);
-                }
-                crate::percpu::record_ctxsw_flush(false);
-                return;
+        }
+        // `claim` never returns 0 when tagging is enabled (the enablement gate
+        // keeps usable tags > cpu_count, so a tag is always available). This
+        // defensive full-flush is unreachable; it exists so a logic error can
+        // never run a user space under tag 0 (which would mix tags across the
+        // space and miss a shootdown).
+        if tag == 0
+        {
+            debug_assert!(tag != 0, "claim returned 0 with tagging enabled");
+            // SAFETY: caller's contract; root_phys is a valid root.
+            unsafe {
+                activate(self.root_phys);
             }
+            crate::percpu::record_ctxsw_flush(false);
+            return;
         }
 
         let tag_gen = self.tag_gen.load(Ordering::Acquire);

--- a/core/kernel/src/mm/address_space.rs
+++ b/core/kernel/src/mm/address_space.rs
@@ -707,6 +707,7 @@ impl AddressSpace
                 unsafe {
                     activate(self.root_phys);
                 }
+                crate::percpu::record_ctxsw_flush(false);
                 return;
             }
         }
@@ -735,6 +736,11 @@ impl AddressSpace
                 flush_tag(tag);
                 tag_allocator::set_tag_state(cpu, tag, tag_gen, tlb_gen);
             }
+            crate::percpu::record_ctxsw_flush(false);
+        }
+        else
+        {
+            crate::percpu::record_ctxsw_flush(true);
         }
     }
 

--- a/core/kernel/src/mm/mod.rs
+++ b/core/kernel/src/mm/mod.rs
@@ -15,6 +15,7 @@ pub mod buddy;
 pub mod init;
 pub mod kernel_pt_pool;
 pub mod paging;
+pub mod tag_allocator;
 #[cfg(not(test))]
 pub mod tlb_shootdown;
 

--- a/core/kernel/src/mm/tag_allocator.rs
+++ b/core/kernel/src/mm/tag_allocator.rs
@@ -1,0 +1,514 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// kernel/src/mm/tag_allocator.rs
+
+//! Hardware address-space tag (PCID / ASID) allocator.
+//!
+//! Each user [`AddressSpace`](crate::mm::address_space::AddressSpace) that runs
+//! on a CPU claims a hardware tag so a context switch can load its page tables
+//! without flushing the TLB. Tags are a finite resource (x86-64 PCID is 12-bit;
+//! RISC-V ASID width is implementation-defined), so this module owns a global
+//! pool that hands out tags `1..num_tags` (tag `0` is reserved for the
+//! kernel/idle context and the full-flush fallback) and evicts the
+//! least-recently-claimed tag when the pool is exhausted.
+//!
+//! # Coherence model
+//!
+//! Two generation counters keep tagged TLBs coherent without flushing on every
+//! switch (see the `AddressSpace` field docs and `AddressSpace::activate`):
+//!
+//! - `alloc_gen` is a global monotonic counter; each claim stamps the claiming
+//!   space's `tag_gen` with a unique value. A CPU records, per tag, the
+//!   `tag_gen` it last synced; when it loads a tag whose recorded `tag_gen`
+//!   differs, the tag was reissued to a different space and the CPU flushes it.
+//!   This is the cross-CPU invalidation-before-reissue guarantee.
+//! - `tlb_gen` (per space) is bumped on every unmap / permission-narrow; a CPU
+//!   that was switched away flushes the tag on reactivation if its synced value
+//!   lags.
+//!
+//! # Concurrency (INV-1 / INV-4)
+//!
+//! `AddressSpace.tag` is written only by the owner's own claim or by eviction,
+//! both under `TAG_POOL_LOCK`. While eviction holds the lock it is the *sole*
+//! writer of any space's `tag`; the only concurrent access is `activate`'s
+//! lock-free read. A racing `activate` that reads `tag == 0` falls into
+//! [`claim`], which blocks on the lock, so it cannot load the evicted tag. The
+//! `SeqCst` fence between revoking a victim's tag and reading its active-CPU
+//! mask is the eviction-side half of the Dekker exclusion with `activate`.
+
+/// Maximum number of tags the pool tracks, regardless of how many the hardware
+/// supports. Bounds the per-CPU tag-state slab (`TAG_CAP * size_of::<TagState>`
+/// bytes per CPU). x86-64 exposes 4096 PCIDs; capping keeps the slab small
+/// while still comfortably exceeding realistic concurrent-address-space counts.
+pub const TAG_CAP: usize = 512;
+
+/// Number of `u64` words in the in-use bitmap.
+const BITMAP_WORDS: usize = TAG_CAP / 64;
+
+// ── Pure pool state ────────────────────────────────────────────────────────────
+
+/// The tag pool's pure bookkeeping: which tags are in use, who owns each, and
+/// when each was claimed. Separated from the global glue so it can be unit
+/// tested without a live `AddressSpace`.
+struct TagPool
+{
+    /// Bit `t` set ⇒ tag `t` is in use. Tag 0 is never allocated.
+    in_use: [u64; BITMAP_WORDS],
+    /// Owner token per tag (an `*const AddressSpace` as `usize`; `0` = free).
+    owners: [usize; TAG_CAP],
+    /// `alloc_gen` value stamped when each tag was last claimed (`0` = free).
+    /// Unique per claim, so it doubles as the least-recently-claimed key.
+    claimed_at: [u64; TAG_CAP],
+    /// Number of usable tags; tags `1..num_tags` may be allocated.
+    num_tags: usize,
+    /// Monotonic claim counter; never reused (64-bit).
+    alloc_gen: u64,
+}
+
+impl TagPool
+{
+    const fn new() -> Self
+    {
+        Self {
+            in_use: [0; BITMAP_WORDS],
+            owners: [0; TAG_CAP],
+            claimed_at: [0; TAG_CAP],
+            num_tags: 0,
+            alloc_gen: 0,
+        }
+    }
+
+    /// Set the number of usable tags (clamped to `[0, TAG_CAP]`).
+    fn configure(&mut self, num_tags: usize)
+    {
+        self.num_tags = num_tags.min(TAG_CAP);
+    }
+
+    /// Allocate the next unique claim generation.
+    fn next_gen(&mut self) -> u64
+    {
+        self.alloc_gen += 1;
+        self.alloc_gen
+    }
+
+    fn is_used(&self, tag: u16) -> bool
+    {
+        let t = tag as usize;
+        self.in_use[t / 64] & (1u64 << (t % 64)) != 0
+    }
+
+    /// First free tag in `1..num_tags`, or `None` if the pool is full.
+    // cast_possible_truncation: t < num_tags <= TAG_CAP <= u16::MAX.
+    #[allow(clippy::cast_possible_truncation)]
+    fn find_free(&self) -> Option<u16>
+    {
+        (1..self.num_tags)
+            .map(|t| t as u16)
+            .find(|&tag| !self.is_used(tag))
+    }
+
+    /// The in-use tag with the smallest `claimed_at` strictly greater than
+    /// `floor`, with that `claimed_at`. Used to iterate eviction candidates
+    /// least-recently-claimed first while skipping candidates already tried.
+    // cast_possible_truncation: t < num_tags <= TAG_CAP <= u16::MAX.
+    #[allow(clippy::cast_possible_truncation)]
+    fn oldest_used_above(&self, floor: u64) -> Option<(u16, u64)>
+    {
+        let mut best: Option<(u16, u64)> = None;
+        for t in 1..self.num_tags
+        {
+            let tag = t as u16;
+            if !self.is_used(tag)
+            {
+                continue;
+            }
+            let at = self.claimed_at[t];
+            if at <= floor
+            {
+                continue;
+            }
+            if best.is_none_or(|(_, b)| at < b)
+            {
+                best = Some((tag, at));
+            }
+        }
+        best
+    }
+
+    /// Record `tag` as claimed by `owner` at generation `claim_gen`.
+    fn record(&mut self, tag: u16, owner: usize, claim_gen: u64)
+    {
+        let t = tag as usize;
+        self.in_use[t / 64] |= 1u64 << (t % 64);
+        self.owners[t] = owner;
+        self.claimed_at[t] = claim_gen;
+    }
+
+    /// Return `tag` to the free pool.
+    fn clear(&mut self, tag: u16)
+    {
+        let t = tag as usize;
+        self.in_use[t / 64] &= !(1u64 << (t % 64));
+        self.owners[t] = 0;
+        self.claimed_at[t] = 0;
+    }
+}
+
+// ── Global pool, lock, and per-CPU state (kernel-only) ──────────────────────────
+
+#[cfg(not(test))]
+pub use glue::*;
+
+#[cfg(not(test))]
+mod glue
+{
+    use core::sync::atomic::{AtomicBool, AtomicPtr, AtomicUsize, Ordering};
+
+    use super::{TAG_CAP, TagPool};
+    use crate::mm::address_space::AddressSpace;
+
+    /// The global tag pool. Accessed only through [`with_tag_pool`].
+    // SAFETY: all access is serialised by TAG_POOL_LOCK via with_tag_pool.
+    static mut TAG_POOL: TagPool = TagPool::new();
+
+    /// Spin-lock protecting [`TAG_POOL`].
+    static TAG_POOL_LOCK: AtomicBool = AtomicBool::new(false);
+
+    /// Whether hardware tagging is enabled (PCID/ASID detected and configured).
+    static TAGGING_ENABLED: AtomicBool = AtomicBool::new(false);
+
+    /// Number of usable tags once enabled (lock-free mirror of
+    /// `TagPool::num_tags`); also the per-CPU tag-state slab stride.
+    static NUM_TAGS: AtomicUsize = AtomicUsize::new(0);
+
+    fn acquire_tag_pool_lock()
+    {
+        let mut spins = 0u64;
+        while TAG_POOL_LOCK
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            spins += 1;
+            if spins > 500_000
+            {
+                crate::kprintln!("[tag_alloc] DEADLOCK after {}k spins", spins / 1000);
+                loop
+                {
+                    core::hint::spin_loop();
+                }
+            }
+            core::hint::spin_loop();
+        }
+    }
+
+    fn release_tag_pool_lock()
+    {
+        TAG_POOL_LOCK.store(false, Ordering::Release);
+    }
+
+    /// Call `f` with exclusive access to the tag pool.
+    fn with_tag_pool<F, R>(f: F) -> R
+    where
+        F: FnOnce(&mut TagPool) -> R,
+    {
+        acquire_tag_pool_lock();
+        // SAFETY: we hold TAG_POOL_LOCK; no concurrent pool access is possible.
+        let result = f(unsafe { &mut *core::ptr::addr_of_mut!(TAG_POOL) });
+        release_tag_pool_lock();
+        result
+    }
+
+    /// Whether tagged TLBs are active. When `false`, `activate` uses the
+    /// full-flush fallback and behaves exactly as the untagged kernel did.
+    #[inline]
+    pub fn tagging_enabled() -> bool
+    {
+        TAGGING_ENABLED.load(Ordering::Acquire)
+    }
+
+    /// The number of usable tags (`0` when tagging is disabled).
+    // Consumed by the boot-enablement and measurement paths.
+    #[allow(dead_code)]
+    #[inline]
+    pub fn num_tags() -> usize
+    {
+        NUM_TAGS.load(Ordering::Acquire)
+    }
+
+    // ── Per-CPU tag state ───────────────────────────────────────────────────────
+
+    /// Per-CPU, per-tag synchronisation record. Written only by the owning CPU
+    /// in its own `activate`, so plain (non-atomic) access is correct.
+    #[repr(C)]
+    pub struct TagState
+    {
+        /// `tag_gen` of the space this CPU last loaded under this tag. A
+        /// mismatch with the space's current `tag_gen` means the tag was
+        /// reissued and the CPU must flush it.
+        pub owner_gen: u64,
+        /// `tlb_gen` this CPU last synced for this tag; a lag means unmaps
+        /// occurred while this CPU was switched away.
+        pub synced_tlb_gen: u64,
+    }
+
+    /// Base of the per-CPU tag-state slab (`cpu_count * NUM_TAGS` records,
+    /// row-major by CPU). Null until [`enable`] runs.
+    static PER_CPU_TAG_STATE: AtomicPtr<TagState> = AtomicPtr::new(core::ptr::null_mut());
+
+    /// Pointer to `(cpu, tag)`'s [`TagState`].
+    ///
+    /// # Safety
+    /// `cpu < cpu_count` and `tag < num_tags()`; [`enable`] must have run. The
+    /// returned record is owned exclusively by `cpu`.
+    #[inline]
+    unsafe fn tag_state_ptr(cpu: usize, tag: u16) -> *mut TagState
+    {
+        let base = PER_CPU_TAG_STATE.load(Ordering::Acquire);
+        debug_assert!(!base.is_null(), "tag_state_ptr: slab not initialised");
+        let stride = NUM_TAGS.load(Ordering::Relaxed);
+        // SAFETY: caller guarantees cpu < cpu_count and tag < num_tags, so the
+        // index is within the cpu_count * stride slab.
+        unsafe { base.add(cpu * stride + tag as usize) }
+    }
+
+    /// Read `(cpu, tag)`'s synchronisation record as `(owner_gen, synced)`.
+    ///
+    /// # Safety
+    /// Tagging enabled, `cpu < cpu_count`, `tag < num_tags()`, and `cpu` is the
+    /// current CPU (single-writer invariant).
+    #[inline]
+    pub unsafe fn tag_state(cpu: usize, tag: u16) -> (u64, u64)
+    {
+        // SAFETY: caller's contract.
+        let p = unsafe { tag_state_ptr(cpu, tag) };
+        // SAFETY: p is this CPU's own record; no other CPU writes it.
+        unsafe { ((*p).owner_gen, (*p).synced_tlb_gen) }
+    }
+
+    /// Update `(cpu, tag)`'s synchronisation record.
+    ///
+    /// # Safety
+    /// Same contract as [`tag_state`].
+    #[inline]
+    pub unsafe fn set_tag_state(cpu: usize, tag: u16, owner_gen: u64, synced_tlb_gen: u64)
+    {
+        // SAFETY: caller's contract.
+        let p = unsafe { tag_state_ptr(cpu, tag) };
+        // SAFETY: p is this CPU's own record; no other CPU writes it.
+        unsafe {
+            (*p).owner_gen = owner_gen;
+            (*p).synced_tlb_gen = synced_tlb_gen;
+        }
+    }
+
+    // ── Enablement ──────────────────────────────────────────────────────────────
+
+    /// Configure the pool for `hw_tags` hardware tags and enable tagging,
+    /// allocating the per-CPU tag-state slab for `cpu_count` CPUs.
+    ///
+    /// Call once on the BSP, before any AP runs a user thread. `hw_tags` is the
+    /// hardware tag count (`1 << PCID/ASID width`), clamped to [`TAG_CAP`]. If
+    /// fewer than two tags are usable (only the reserved tag 0), tagging stays
+    /// disabled and the full-flush fallback remains in effect.
+    ///
+    /// # Safety
+    /// Must run once on the BSP after the frame allocator is live (Phase 5),
+    /// before any CPU performs a tagged activate.
+    // Wired into Phase 5 / AP init by the tagged-TLB boot-enablement path.
+    #[allow(dead_code)]
+    pub unsafe fn enable(hw_tags: usize, cpu_count: usize)
+    {
+        let n = hw_tags.min(TAG_CAP);
+        if n < 2
+        {
+            return;
+        }
+
+        // Zero-filled slab: owner_gen 0 never matches a real tag_gen, so the
+        // first activate of any tag on any CPU flushes it.
+        let bytes = cpu_count * n * core::mem::size_of::<TagState>();
+        let slab = crate::mm::with_frame_allocator(|alloc| {
+            crate::sched::alloc_zeroed_slab::<TagState>(bytes, alloc, "PER_CPU_TAG_STATE")
+        });
+        PER_CPU_TAG_STATE.store(slab, Ordering::Release);
+
+        with_tag_pool(|pool| pool.configure(n));
+        NUM_TAGS.store(n, Ordering::Release);
+        TAGGING_ENABLED.store(true, Ordering::Release);
+    }
+
+    // ── Claim / free ────────────────────────────────────────────────────────────
+
+    /// Claim a tag for `as_ref`, allocating or evicting as needed.
+    ///
+    /// Returns the claimed tag (`1..num_tags`), or `0` if every tag is currently
+    /// active and none can be evicted — the caller then falls back to the
+    /// untagged full-flush path. Stamps `as_ref.tag_gen` and publishes
+    /// `as_ref.tag`.
+    ///
+    /// The current CPU must already be marked active on `as_ref` (the scheduler
+    /// does this before `activate`), so this space cannot be chosen as its own
+    /// eviction victim.
+    pub fn claim(as_ref: &AddressSpace) -> u16
+    {
+        with_tag_pool(|pool| {
+            // Idempotent: a concurrent activate on another CPU may have claimed
+            // for this space already.
+            let cur = as_ref.tag.load(Ordering::Acquire);
+            if cur != 0
+            {
+                return cur;
+            }
+
+            let owner = core::ptr::from_ref(as_ref) as usize;
+
+            if let Some(t) = pool.find_free()
+            {
+                let claim_gen = pool.next_gen();
+                pool.record(t, owner, claim_gen);
+                as_ref.tag_gen.store(claim_gen, Ordering::Relaxed);
+                as_ref.tag.store(t, Ordering::Release);
+                return t;
+            }
+
+            // Pool full: evict the least-recently-claimed space whose tag is not
+            // currently active on any CPU (INV-4).
+            let mut floor = 0u64;
+            loop
+            {
+                let Some((victim_tag, victim_at)) = pool.oldest_used_above(floor)
+                else
+                {
+                    // Every tag is active; caller falls back to untagged.
+                    return 0;
+                };
+
+                let victim = pool.owners[victim_tag as usize] as *const AddressSpace;
+                // INV-1: under the pool lock we are the sole writer of any tag.
+                // SAFETY: the victim is a live AddressSpace — its tag was claimed
+                // under this lock and free_tag() (called before the space is
+                // dropped) also takes this lock, so the pointer is valid here.
+                unsafe {
+                    (*victim).tag.store(0, Ordering::Release);
+                }
+                // INV-3 eviction-race Dekker: the revoke (store) is ordered before
+                // the active-mask read (load), pairing with activate's fence.
+                core::sync::atomic::fence(Ordering::SeqCst);
+                // SAFETY: victim is a live AddressSpace (see above).
+                let active_empty = unsafe { (*victim).active_cpu_mask().is_empty() };
+                if active_empty
+                {
+                    // Safe to reuse: the victim is not running this tag. Other
+                    // CPUs that cached it while switched away are flushed lazily
+                    // by the owner_gen check on their next load of this tag.
+                    let claim_gen = pool.next_gen();
+                    pool.record(victim_tag, owner, claim_gen);
+                    as_ref.tag_gen.store(claim_gen, Ordering::Relaxed);
+                    as_ref.tag.store(victim_tag, Ordering::Release);
+                    return victim_tag;
+                }
+
+                // Victim is (or just became) active and may be running this tag.
+                // Restore its claim (sole writer, INV-1) and try the next-oldest.
+                // SAFETY: victim is a live AddressSpace (see above).
+                unsafe {
+                    (*victim).tag.store(victim_tag, Ordering::Release);
+                }
+                floor = victim_at;
+            }
+        })
+    }
+
+    /// Return `tag` to the pool when an address space is destroyed.
+    ///
+    /// No TLB flush is issued: a CPU that cached this tag is flushed lazily by
+    /// the `owner_gen` check the next time it loads the tag for whatever space
+    /// claims it next.
+    pub fn free_tag(tag: u16)
+    {
+        if tag == 0
+        {
+            return;
+        }
+        with_tag_pool(|pool| pool.clear(tag));
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests
+{
+    use super::*;
+
+    #[test]
+    fn find_free_skips_tag_zero_and_used()
+    {
+        let mut pool = TagPool::new();
+        pool.configure(4); // tags 1..4 usable
+        assert_eq!(pool.find_free(), Some(1));
+        let g = pool.next_gen();
+        pool.record(1, 0x1000, g);
+        assert_eq!(pool.find_free(), Some(2));
+        let g = pool.next_gen();
+        pool.record(2, 0x2000, g);
+        let g = pool.next_gen();
+        pool.record(3, 0x3000, g);
+        assert_eq!(pool.find_free(), None); // tags 1,2,3 used; 0 reserved
+    }
+
+    #[test]
+    fn gen_is_monotonic_and_unique()
+    {
+        let mut pool = TagPool::new();
+        assert_eq!(
+            (pool.next_gen(), pool.next_gen(), pool.next_gen()),
+            (1, 2, 3)
+        );
+    }
+
+    #[test]
+    fn oldest_used_above_orders_by_claim_generation()
+    {
+        let mut pool = TagPool::new();
+        pool.configure(4);
+        // Claim 1, then 3, then 2 — claim order, not tag order, sets age.
+        let g = pool.next_gen();
+        pool.record(1, 0x1, g); // gen 1
+        let g = pool.next_gen();
+        pool.record(3, 0x3, g); // gen 2
+        let g = pool.next_gen();
+        pool.record(2, 0x2, g); // gen 3
+        // Oldest is tag 1 (gen 1), then tag 3 (gen 2), then tag 2 (gen 3).
+        let (t0, a0) = pool.oldest_used_above(0).unwrap();
+        assert_eq!(t0, 1);
+        let (t1, a1) = pool.oldest_used_above(a0).unwrap();
+        assert_eq!(t1, 3);
+        let (t2, _) = pool.oldest_used_above(a1).unwrap();
+        assert_eq!(t2, 2);
+    }
+
+    #[test]
+    fn clear_returns_tag_to_free_pool()
+    {
+        let mut pool = TagPool::new();
+        pool.configure(3);
+        let g = pool.next_gen();
+        pool.record(1, 0x1, g);
+        let g = pool.next_gen();
+        pool.record(2, 0x2, g);
+        assert_eq!(pool.find_free(), None);
+        pool.clear(1);
+        assert_eq!(pool.find_free(), Some(1));
+        assert!(!pool.is_used(1));
+    }
+
+    #[test]
+    fn configure_clamps_to_cap()
+    {
+        let mut pool = TagPool::new();
+        pool.configure(TAG_CAP * 4);
+        assert_eq!(pool.num_tags, TAG_CAP);
+    }
+}

--- a/core/kernel/src/mm/tag_allocator.rs
+++ b/core/kernel/src/mm/tag_allocator.rs
@@ -308,9 +308,17 @@ mod glue
     /// allocating the per-CPU tag-state slab for `cpu_count` CPUs.
     ///
     /// Call once on the BSP, before any AP runs a user thread. `hw_tags` is the
-    /// hardware tag count (`1 << PCID/ASID width`), clamped to [`TAG_CAP`]. If
-    /// fewer than two tags are usable (only the reserved tag 0), tagging stays
-    /// disabled and the full-flush fallback remains in effect.
+    /// hardware tag count (`1 << PCID/ASID width`), clamped to [`TAG_CAP`].
+    ///
+    /// Tagging is enabled only when the **usable** tag count (`n - 1`; tag 0 is
+    /// reserved) strictly exceeds `cpu_count`. This is load-bearing for
+    /// correctness, not just efficiency: at most `cpu_count` tags are active at
+    /// any instant, so `usable > cpu_count` guarantees a free-or-inactive tag
+    /// always exists and [`claim`] never has to run a user space untagged. A
+    /// user space under tag 0 while another CPU runs it under a real tag would
+    /// mix tags across the space and miss a shootdown. Where the hardware tag
+    /// field is too narrow (e.g. a 1-bit RISC-V ASID), tagging stays disabled
+    /// and the full-flush fallback remains in effect.
     ///
     /// # Safety
     /// Must run once on the BSP after the frame allocator is live (Phase 5),
@@ -323,7 +331,9 @@ mod glue
     )
     {
         let n = hw_tags.min(TAG_CAP);
-        if n < 2
+        // Usable tags are `1..n` (n - 1 of them); require strictly more than the
+        // CPU count so claim always succeeds (see the doc above).
+        if n < cpu_count + 2
         {
             return;
         }
@@ -344,10 +354,9 @@ mod glue
 
     /// Claim a tag for `as_ref`, allocating or evicting as needed.
     ///
-    /// Returns the claimed tag (`1..num_tags`), or `0` if every tag is currently
-    /// active and none can be evicted — the caller then falls back to the
-    /// untagged full-flush path. Stamps `as_ref.tag_gen` and publishes
-    /// `as_ref.tag`.
+    /// Returns a usable tag in `1..num_tags`; it never returns 0 while tagging
+    /// is enabled (the enablement gate guarantees a free-or-inactive tag always
+    /// exists). Stamps `as_ref.tag_gen` and publishes `as_ref.tag`.
     ///
     /// The current CPU must already be marked active on `as_ref` (the scheduler
     /// does this before `activate`), so this space cannot be chosen as its own
@@ -375,49 +384,69 @@ mod glue
             }
 
             // Pool full: evict the least-recently-claimed space whose tag is not
-            // currently active on any CPU (INV-4).
-            let mut floor = 0u64;
+            // currently active on any CPU (INV-4). The enablement gate keeps the
+            // usable tag count strictly above `cpu_count`, and active spaces are
+            // bounded by the CPU count, so an inactive in-use tag always exists.
+            // claim therefore never returns 0 when tagging is enabled — no user
+            // space ever runs untagged. The outer loop retries the scan to ride
+            // out the transient case where a candidate activates between
+            // selection and the active check (the least-recently-claimed tag is
+            // almost always inactive, so the first pass succeeds in practice).
+            let mut spins = 0u64;
             loop
             {
-                let Some((victim_tag, victim_at)) = pool.oldest_used_above(floor)
-                else
+                let mut floor = 0u64;
+                while let Some((victim_tag, victim_at)) = pool.oldest_used_above(floor)
                 {
-                    // Every tag is active; caller falls back to untagged.
-                    return 0;
-                };
+                    let victim = pool.owners[victim_tag as usize] as *const AddressSpace;
+                    // INV-1: under the pool lock we are the sole writer of any tag.
+                    // SAFETY: the victim is a live AddressSpace — its tag was
+                    // claimed under this lock and free_tag() (called before the
+                    // space is dropped) also takes this lock, so the pointer is
+                    // valid here.
+                    unsafe {
+                        (*victim).tag.store(0, Ordering::Release);
+                    }
+                    // INV-3 eviction-race Dekker: the revoke (store) is ordered
+                    // before the active-mask read (load), pairing with activate's
+                    // fence.
+                    core::sync::atomic::fence(Ordering::SeqCst);
+                    // SAFETY: victim is a live AddressSpace (see above).
+                    let active_empty = unsafe { (*victim).active_cpu_mask().is_empty() };
+                    if active_empty
+                    {
+                        // Safe to reuse: the victim is not running this tag. Other
+                        // CPUs that cached it while switched away are flushed
+                        // lazily by the owner_gen check on their next load of it.
+                        let claim_gen = pool.next_gen();
+                        pool.record(victim_tag, owner, claim_gen);
+                        as_ref.tag_gen.store(claim_gen, Ordering::Relaxed);
+                        as_ref.tag.store(victim_tag, Ordering::Release);
+                        return victim_tag;
+                    }
 
-                let victim = pool.owners[victim_tag as usize] as *const AddressSpace;
-                // INV-1: under the pool lock we are the sole writer of any tag.
-                // SAFETY: the victim is a live AddressSpace — its tag was claimed
-                // under this lock and free_tag() (called before the space is
-                // dropped) also takes this lock, so the pointer is valid here.
-                unsafe {
-                    (*victim).tag.store(0, Ordering::Release);
+                    // Victim is (or just became) active and may be running this
+                    // tag. Restore its claim (sole writer, INV-1) and try the
+                    // next-oldest. A transient tag-0 window on a *consistently*
+                    // tagged active space is harmless: its shootdowns degrade to
+                    // current-PCID invalidation, which is correct because all its
+                    // active CPUs share the same loaded tag.
+                    // SAFETY: victim is a live AddressSpace (see above).
+                    unsafe {
+                        (*victim).tag.store(victim_tag, Ordering::Release);
+                    }
+                    floor = victim_at;
                 }
-                // INV-3 eviction-race Dekker: the revoke (store) is ordered before
-                // the active-mask read (load), pairing with activate's fence.
-                core::sync::atomic::fence(Ordering::SeqCst);
-                // SAFETY: victim is a live AddressSpace (see above).
-                let active_empty = unsafe { (*victim).active_cpu_mask().is_empty() };
-                if active_empty
+
+                // A whole pass found every in-use tag transiently active. Given
+                // the gate this is a rare race, not exhaustion; retry. The guard
+                // mirrors the frame-allocator deadlock guard and fires only if
+                // the gate invariant is somehow violated.
+                spins += 1;
+                if spins > 10_000_000
                 {
-                    // Safe to reuse: the victim is not running this tag. Other
-                    // CPUs that cached it while switched away are flushed lazily
-                    // by the owner_gen check on their next load of this tag.
-                    let claim_gen = pool.next_gen();
-                    pool.record(victim_tag, owner, claim_gen);
-                    as_ref.tag_gen.store(claim_gen, Ordering::Relaxed);
-                    as_ref.tag.store(victim_tag, Ordering::Release);
-                    return victim_tag;
+                    crate::fatal("tag_allocator: eviction found no inactive victim");
                 }
-
-                // Victim is (or just became) active and may be running this tag.
-                // Restore its claim (sole writer, INV-1) and try the next-oldest.
-                // SAFETY: victim is a live AddressSpace (see above).
-                unsafe {
-                    (*victim).tag.store(victim_tag, Ordering::Release);
-                }
-                floor = victim_at;
             }
         })
     }

--- a/core/kernel/src/mm/tag_allocator.rs
+++ b/core/kernel/src/mm/tag_allocator.rs
@@ -314,10 +314,13 @@ mod glue
     ///
     /// # Safety
     /// Must run once on the BSP after the frame allocator is live (Phase 5),
-    /// before any CPU performs a tagged activate.
-    // Wired into Phase 5 / AP init by the tagged-TLB boot-enablement path.
-    #[allow(dead_code)]
-    pub unsafe fn enable(hw_tags: usize, cpu_count: usize)
+    /// before any CPU performs a tagged activate. `allocator` must be the live
+    /// frame allocator (exclusive access during this call).
+    pub unsafe fn enable(
+        hw_tags: usize,
+        cpu_count: usize,
+        allocator: &mut crate::mm::BuddyAllocator,
+    )
     {
         let n = hw_tags.min(TAG_CAP);
         if n < 2
@@ -328,9 +331,8 @@ mod glue
         // Zero-filled slab: owner_gen 0 never matches a real tag_gen, so the
         // first activate of any tag on any CPU flushes it.
         let bytes = cpu_count * n * core::mem::size_of::<TagState>();
-        let slab = crate::mm::with_frame_allocator(|alloc| {
-            crate::sched::alloc_zeroed_slab::<TagState>(bytes, alloc, "PER_CPU_TAG_STATE")
-        });
+        let slab =
+            crate::sched::alloc_zeroed_slab::<TagState>(bytes, allocator, "PER_CPU_TAG_STATE");
         PER_CPU_TAG_STATE.store(slab, Ordering::Release);
 
         with_tag_pool(|pool| pool.configure(n));

--- a/core/kernel/src/mm/tlb_shootdown.rs
+++ b/core/kernel/src/mm/tlb_shootdown.rs
@@ -64,7 +64,7 @@
 //! - **Release** on a remote CPU's bit clear ensures its TLB flush completes
 //!   before the initiator observes the acknowledgement.
 
-use core::sync::atomic::{AtomicU64, Ordering};
+use core::sync::atomic::{AtomicU16, AtomicU64, Ordering};
 
 use crate::cpu_mask::{AtomicCpuMask, CpuMask};
 use crate::sched::MAX_CPUS;
@@ -81,6 +81,13 @@ struct TlbShootdownRequest
     /// Virtual address to invalidate. `u64::MAX` means full flush.
     flush_va: AtomicU64,
 
+    /// Hardware address-space tag (PCID / ASID) the invalidation targets, or `0`
+    /// for the untagged path. When non-zero the target CPU invalidates the
+    /// `(tag, va)` entry regardless of the tag it currently has loaded, so a CPU
+    /// that has switched to a different space since the snapshot still flushes
+    /// the right translation.
+    tag: AtomicU16,
+
     /// CPUs that must still acknowledge this request. A set bit is both the
     /// "CPU N must flush" instruction and this request's per-target liveness
     /// token (see module docs).
@@ -94,6 +101,7 @@ impl TlbShootdownRequest
         Self {
             root_phys: AtomicU64::new(0),
             flush_va: AtomicU64::new(u64::MAX),
+            tag: AtomicU16::new(0),
             pending_cpus: AtomicCpuMask::new(),
         }
     }
@@ -145,15 +153,24 @@ pub unsafe fn service_shootdowns(my_cpu: usize)
         }
         let va = req.flush_va.load(Ordering::Acquire);
         let root = req.root_phys.load(Ordering::Acquire);
+        let tag = req.tag.load(Ordering::Acquire);
         // Both `flush_va == u64::MAX` and `root_phys == 0` are full-flush
         // sentinels per shootdown()'s contract; either alone selects flush_tlb_all.
-        // SAFETY: caller guarantees IPI-handler context; flush_page /
-        // flush_tlb_all are valid TLB primitives at ring 0 / S-mode. A per-VA
-        // flush preserves global kernel entries that a full flush would discard.
+        // A non-zero `tag` targets that PCID/ASID specifically (the initiating
+        // space may no longer be the tag loaded on this CPU); `tag == 0` is the
+        // untagged path. A non-zero tag only exists when tagging is enabled, so
+        // the tagged primitive's precondition holds.
+        // SAFETY: caller guarantees IPI-handler context; the flush primitives are
+        // valid at ring 0 / S-mode. A per-VA flush preserves global kernel
+        // entries that a full flush would discard.
         unsafe {
             if va == u64::MAX || root == 0
             {
                 crate::arch::current::paging::flush_tlb_all();
+            }
+            else if tag != 0
+            {
+                crate::arch::current::paging::flush_page_tagged(va, tag);
             }
             else
             {
@@ -175,12 +192,14 @@ pub unsafe fn service_shootdowns(my_cpu: usize)
 /// - Caller must have called `preempt_disable()` before this function.
 /// - `root_phys` must be a valid page table root physical address or 0 for full flush.
 /// - `cpus` must contain only online CPU indices and exclude the current CPU.
+/// - `tag` is the hardware address-space tag (PCID / ASID) to invalidate, or `0`
+///   for the untagged path. A non-zero `tag` must imply tagging is enabled.
 ///
 /// # Safety
 /// Caller must ensure `root_phys` and `cpus` are valid as described above.
 // Used by AddressSpace::map_page, unmap_page, protect_page.
 #[allow(dead_code)]
-pub unsafe fn shootdown(root_phys: u64, cpus: &CpuMask, virt: u64)
+pub unsafe fn shootdown(root_phys: u64, cpus: &CpuMask, virt: u64, tag: u16)
 {
     if cpus.is_empty()
     {
@@ -217,6 +236,7 @@ pub unsafe fn shootdown(root_phys: u64, cpus: &CpuMask, virt: u64)
     // visible before the IPI.
     req.root_phys.store(root_phys, Ordering::Release);
     req.flush_va.store(virt, Ordering::Release);
+    req.tag.store(tag, Ordering::Release);
     req.pending_cpus.store(cpus, Ordering::Release);
 
     // Drain the store buffer so a remote handler cannot read a stale slot. On

--- a/core/kernel/src/percpu.rs
+++ b/core/kernel/src/percpu.rs
@@ -37,7 +37,7 @@
 //! add a test in the `tests` module, and update any assembly that addresses
 //! the struct by offset.
 
-use core::sync::atomic::{AtomicPtr, Ordering};
+use core::sync::atomic::{AtomicPtr, AtomicU64, Ordering};
 
 use crate::sched::MAX_CPUS;
 use crate::sched::thread::ThreadControlBlock;
@@ -174,6 +174,14 @@ pub struct PerCpuData
     /// `arch/x86_64/fpu.rs` module docs. Unused on RISC-V (lazy via
     /// `sstatus.FS/VS`).
     pub fpu_owner: AtomicPtr<ThreadControlBlock>,
+    /// Count of context-switch activations on this CPU that loaded a tagged
+    /// address space **without** flushing (the tagged-TLB optimization firing).
+    /// Single-writer (this CPU's own `activate`); summed read-only for the
+    /// `CAP_INFO_TLB_*` diagnostic.
+    pub ctxsw_flush_elided: AtomicU64,
+    /// Count of context-switch activations on this CPU that performed a flush
+    /// (tag reissue, switched-away unmap catch-up, or pool-exhaustion fallback).
+    pub ctxsw_flush_performed: AtomicU64,
 }
 
 impl PerCpuData
@@ -190,6 +198,8 @@ impl PerCpuData
             preempt_count: 0,
             _pad1: 0,
             fpu_owner: AtomicPtr::new(core::ptr::null_mut()),
+            ctxsw_flush_elided: AtomicU64::new(0),
+            ctxsw_flush_performed: AtomicU64::new(0),
         }
     }
 }
@@ -377,6 +387,50 @@ pub fn fpu_owner_for(cpu: usize) -> &'static AtomicPtr<ThreadControlBlock>
     unsafe { &*core::ptr::addr_of!((*per_cpu_ptr(cpu)).fpu_owner) }
 }
 
+// ── Tagged-TLB context-switch flush counters ─────────────────────────────────
+
+/// Record a context-switch activation on the current CPU as either flush-elided
+/// (`elided = true`, the tagged-TLB optimization fired) or flush-performed.
+///
+/// Single-writer: only the owning CPU's `activate` calls this, so `Relaxed` is
+/// sufficient.
+#[cfg(not(test))]
+pub fn record_ctxsw_flush(elided: bool)
+{
+    let cpu = crate::arch::current::cpu::current_cpu() as usize;
+    // SAFETY: cpu is the current CPU (< CPU_COUNT); the PER_CPU slab is
+    // initialised before any tagged activate (Phase 5).
+    let pc = unsafe { &*per_cpu_ptr(cpu) };
+    let counter = if elided
+    {
+        &pc.ctxsw_flush_elided
+    }
+    else
+    {
+        &pc.ctxsw_flush_performed
+    };
+    counter.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Sum the tagged-TLB flush counters across all online CPUs as
+/// `(elided, performed)`. Read-only diagnostic; monotonic counters, so a
+/// lock-free `Relaxed` sum is fine.
+#[cfg(not(test))]
+pub fn ctxsw_flush_totals() -> (u64, u64)
+{
+    let n = crate::sched::CPU_COUNT.load(Ordering::Relaxed) as usize;
+    let mut elided = 0u64;
+    let mut performed = 0u64;
+    for cpu in 0..n
+    {
+        // SAFETY: cpu < CPU_COUNT; the PER_CPU slab covers CPU_COUNT entries.
+        let pc = unsafe { &*per_cpu_ptr(cpu) };
+        elided += pc.ctxsw_flush_elided.load(Ordering::Relaxed);
+        performed += pc.ctxsw_flush_performed.load(Ordering::Relaxed);
+    }
+    (elided, performed)
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -416,11 +470,13 @@ mod tests
     }
 
     #[test]
-    fn percpu_size_is_56_bytes()
+    fn percpu_size_is_72_bytes()
     {
         // cpu_id(4) + _pad0(4) + kernel_rsp(8) + user_rsp(8) + scratch(8) + tss_ptr(8)
-        // + preempt_count(4) + _pad1(4) + fpu_owner(8) = 56
-        assert_eq!(core::mem::size_of::<PerCpuData>(), 56);
+        // + preempt_count(4) + _pad1(4) + fpu_owner(8) + ctxsw_flush_elided(8)
+        // + ctxsw_flush_performed(8) = 72. The two tagged-TLB counters are
+        // appended after fpu_owner, so the asm-referenced offsets are unchanged.
+        assert_eq!(core::mem::size_of::<PerCpuData>(), 72);
     }
 
     #[test]

--- a/core/kernel/src/syscall/cap.rs
+++ b/core/kernel/src/syscall/cap.rs
@@ -2209,7 +2209,8 @@ pub fn sys_cap_info(tf: &mut TrapFrame) -> Result<u64, SyscallError>
         CAP_INFO_ASPACE_PT_BUDGET, CAP_INFO_CSPACE_BUDGET, CAP_INFO_CSPACE_CAPACITY,
         CAP_INFO_CSPACE_USED, CAP_INFO_FRAME_AVAILABLE, CAP_INFO_FRAME_HAS_RETYPE,
         CAP_INFO_FRAME_PHYS_BASE, CAP_INFO_FRAME_SIZE, CAP_INFO_TAG_RIGHTS, CAP_INFO_THREAD_STATE,
-        THREAD_STATE_ALIVE, THREAD_STATE_CREATED, THREAD_STATE_EXITED,
+        CAP_INFO_TLB_ELIDED, CAP_INFO_TLB_PERFORMED, THREAD_STATE_ALIVE, THREAD_STATE_CREATED,
+        THREAD_STATE_EXITED,
     };
 
     use crate::cap::object::{AddressSpaceObject, CSpaceKernelObject, FrameObject, ThreadObject};
@@ -2257,6 +2258,12 @@ pub fn sys_cap_info(tf: &mut TrapFrame) -> Result<u64, SyscallError>
             let packed = (u64::from(tag as u8) << 32) | u64::from(rights.0);
             Ok(packed)
         }
+        CAP_INFO_TLB_ELIDED =>
+        {
+            // System-wide tagged-TLB diagnostic; independent of the slot.
+            Ok(crate::percpu::ctxsw_flush_totals().0)
+        }
+        CAP_INFO_TLB_PERFORMED => Ok(crate::percpu::ctxsw_flush_totals().1),
         CAP_INFO_FRAME_SIZE =>
         {
             if tag != CapTag::Frame

--- a/core/ktest/src/bench/thread.rs
+++ b/core/ktest/src/bench/thread.rs
@@ -173,4 +173,21 @@ pub(super) fn bench_context_switch(ctx: &crate::TestContext, iters: u32)
     {
         crate::log_u64("ktest: bench  cycles_per_switch=", per);
     }
+
+    // Tagged-TLB intrinsic metric. These are cumulative system-wide counts of
+    // context-switch activations that elided the TLB flush versus performed it
+    // (tag reissue, switched-away unmap catch-up, or fallback). This is the
+    // emulation-independent signal: QEMU TCG does not model TLB-refill timing,
+    // so cycles_per_switch above is not a faithful cost measure, but these
+    // counters reflect intrinsic behaviour. A working optimization shows elided
+    // dominating; both are 0 when the hardware lacks tagging (full-flush path).
+    // The parent⇄child ping-pong above shares an address space, so it adds no
+    // tagged activations of its own; the totals reflect every cross-space and
+    // post-block re-activation since boot.
+    let elided =
+        syscall::cap_info(ctx.memory_frame_base, syscall_abi::CAP_INFO_TLB_ELIDED).unwrap_or(0);
+    let performed =
+        syscall::cap_info(ctx.memory_frame_base, syscall_abi::CAP_INFO_TLB_PERFORMED).unwrap_or(0);
+    crate::log_u64("ktest: bench  ctxsw_flush_elided_total=", elided);
+    crate::log_u64("ktest: bench  ctxsw_flush_performed_total=", performed);
 }

--- a/docs/memory-model.md
+++ b/docs/memory-model.md
@@ -117,22 +117,37 @@ data and heap are writable but not executable.
 
 ### TLB Management
 
-A context switch to a different address space performs a full TLB flush. The kernel does
-not use hardware address-space tags (x86-64 PCIDs, RISC-V ASIDs); switching the page-table
-root discards the outgoing space's cached user translations:
+Where the hardware provides address-space tags (x86-64 PCID, RISC-V ASID), the kernel
+assigns a tag per address space so a context switch loads the outgoing space's page-table
+root **without** flushing the TLB — cached translations survive across switches. Support is
+detected at boot; where it is unavailable the kernel falls back to a full flush on every
+switch (writing CR3 with `CR4.PCIDE` clear, or `satp` with ASID 0 followed by `sfence.vma`).
+A switch between threads that share an address space requires no TLB operation either way.
 
-- **x86-64:** the switch writes CR3 with `CR4.PCIDE` clear, which flushes all non-global
-  TLB entries.
-- **RISC-V:** the switch writes `satp` with ASID 0 and executes `sfence.vma`.
+Eliding the per-switch flush requires keeping tagged entries coherent without it. Two
+generation counters do this:
 
-A switch between threads that share an address space requires no TLB operation.
-Single-address invalidation after a mapping change uses `invlpg` (x86-64) or
-`sfence.vma <va>` (RISC-V); cross-CPU invalidation uses the SMP shootdown protocol
-described in the kernel memory-internals document.
+- A global tag allocator stamps each tag claim with a unique generation. A CPU records, per
+  tag, the generation it last loaded; when it loads a tag whose recorded generation differs,
+  the tag was reissued to a different address space and the CPU flushes just that tag. This
+  is the cross-CPU invalidation-before-reissue guarantee, so a finite tag pool can be
+  recycled safely — on exhaustion the least-recently-claimed tag whose owner is not active
+  on any CPU is evicted.
+- Each address space carries a TLB generation bumped on every unmap or permission
+  narrowing. A CPU that was switched away when the change happened flushes the tag on its
+  next reactivation if its synced generation lags; CPUs currently running the space are
+  reached directly by the SMP shootdown.
 
-Tagged TLBs would let context switches retain cached translations across address spaces and
-avoid the per-switch flush. They are not implemented; the optimization is tracked as future
-work in [#198](https://github.com/kottlerg/seraph/issues/198).
+Tag 0 is reserved for the kernel/idle context and the full-flush fallback and is never
+assigned to a user space. Single-address invalidation after a mapping change uses `invlpg`
+(x86-64) or `sfence.vma <va>` (RISC-V) on the current space; cross-CPU shootdown uses the
+tag-targeted forms (`invpcid` / `sfence.vma <va>, <asid>`) so a CPU that has since switched
+spaces still invalidates the right translation. Cross-CPU invalidation uses the SMP
+shootdown protocol described in the kernel memory-internals document.
+
+The `CAP_INFO_TLB_ELIDED` / `CAP_INFO_TLB_PERFORMED` `cap_info` selectors expose system-wide
+counts of context switches that elided versus performed the flush — the
+emulation-independent measure of the optimization.
 
 ### Kernel Isolation — SMEP and SMAP
 


### PR DESCRIPTION
Implements hardware address-space tagging (x86-64 PCID, RISC-V ASID) so a
context switch loads the outgoing space's page tables **without** flushing the
TLB, with a full-flush fallback where the hardware lacks the feature.

Closes #198.

## Design

Per the issue author's choices: generation-tracked coherence with
least-recently-claimed eviction, landed as one PR in reviewable commits with
the behavioral flip isolated.

- **Tag allocator** (`mm/tag_allocator.rs`): global pool (bitmap + monotonic
  claim generation), per-CPU per-tag generation slab, evict-oldest-inactive on
  exhaustion. `AddressSpace` gains `tag` / `tag_gen` / `tlb_gen`.
- **Coherence (two generations):** a unique claim generation per tag detects
  reissue (a CPU flushes a tag before its first use under a new owner — the
  cross-CPU invalidation-before-reissue guarantee); a per-space `tlb_gen` bumped
  on unmap/narrow makes a switched-away CPU flush on reactivation if it lags.
- **`activate`** loads the tag with no flush, then flushes only that tag when
  the generation check fails. A `SeqCst` fence after `mark_active` (paired with
  fences in the unmap and eviction paths) closes the switch-away Dekker windows.
- **`tlb_shootdown`** carries the tag so a remote CPU invalidates the right
  PCID/ASID even after it has switched spaces.
- **Exhaustion is impossible by construction:** tagging is enabled only when the
  usable tag count exceeds `cpu_count` (else the kernel stays in the full-flush
  regime), so a free-or-inactive tag always exists and no user space ever runs
  untagged — which would mix tag 0 with a real tag across a multithreaded space
  and miss a shootdown. (Added in the pre-merge-review fix commit.)

A latent RISC-V bug was fixed along the way: `read_root_phys` masked `satp`
with a 52-bit field where the Sv48 PPN is 44 bits, so a non-zero ASID leaked
into the returned physical address (root-caused via the `copy_kernel_entries`
fault when tagging first engaged).

## Acceptance

- [x] Boot detection: PCID via CPUID + INVPCID (x86), ASID width via `satp`
      probe (RISC-V); full-flush fallback retained (non-fatal when absent, and
      also when usable tags ≤ cpu_count).
- [x] Per-address-space tag allocation + recycling with generation tracking and
      correct cross-CPU invalidation before any tag is reissued.
- [x] `activate` loads the tag without a full flush when valid and not recycled.
- [x] `tlb_shootdown` is tag-aware (remote invalidation targets the right tag).
- [x] Measured reduction in context-switch flush cost, intrinsic /
      emulation-independent (QEMU TCG does not model TLB timing): cumulative
      flushes **elided vs performed** via the new `CAP_INFO_TLB_*` counters. The
      exact totals vary run-to-run with boot timing; representative ktest runs
      show ~99.8% elided — e.g. x86-64 `117768 / 221`, riscv64 `85821 / 21`.
- [x] Tagged-TLB description restored in `docs/memory-model.md` and
      `core/kernel/docs/memory-internals.md` (plus arch-interface and
      scheduling-internals).

## Validation

Full ktest suite passes **170/170 on both x86-64 and riscv64** with tagging
active (boot detection, per-AS allocation, tag-aware shootdown, SMP stress:
`thread_churn`, `concurrent_map_unmap`, `tlb_coherency`, …). Host unit tests
cover the pool logic. The full multi-process Init system also boots with
tagging on.

The **tagging-disabled / full-flush fallback** path was exercised in
development (a gated-off build runs the full ktest suite identically to the
pre-tagging kernel). It is not separately covered in CI: the CI QEMU CPU models
(`q35` / `virt`) expose PCID/ASID with more tags than CPUs, so tagging is active
in every CI job.

## Commits

1. arch encodings + boot probes (dormant)
2. tagged-TLB machinery behind a disabled flag (allocator, AddressSpace, activate, shootdown, lifecycle)
3. enable at boot — the behavioral flip — plus the `read_root_phys` fix
4. measurement (per-CPU counters + `CAP_INFO_TLB_*` + ktest bench)
5. docs
6. pre-merge-review fix: make tag-pool exhaustion impossible (never run a user space untagged)