### PR TITLE
kernel: tagged-TLB follow-ups — AP guard, first-entry tagging, raise tag cap

### DIFF
--- a/core/kernel/src/arch/riscv64/context.rs
+++ b/core/kernel/src/arch/riscv64/context.rs
@@ -234,22 +234,33 @@ pub unsafe extern "C" fn switch(
 /// Activate a new address space and enter user mode for the first time.
 ///
 /// Architecture-neutral entry point for `sched::enter`. On RISC-V, activating
-/// via `satp` + `sfence.vma` is safe to do before `sret` because the boot
-/// stack lives in the direct-mapped region (covered by kernel PPN entries),
-/// which is present in the new address space.
+/// via `satp` is safe to do before `sret` because the boot stack lives in the
+/// direct-mapped region (covered by kernel PPN entries), which is present in the
+/// new address space — so the `ret` from the Rust `activate()` call lands on a
+/// still-mapped stack. Routing through [`AddressSpace::activate`] tags the entry
+/// (claims a tag and loads it, generation-checked) when tagging is enabled, so
+/// init does not run its first quantum untagged.
 ///
 /// `sscratch` must be set to `kernel_stack_top` before this call so that the
 /// trap entry can switch stacks on the first U-mode trap.
 ///
 /// # Safety
-/// `root_phys` must be a valid page-table root. `tf` must point to a
-/// [`TrapFrame`] on the init thread's kernel stack with `sepc` and `sp` set.
+/// `aspace` must be a valid `AddressSpace` already marked active on this CPU
+/// (caller did `mark_active_on_cpu`). `tf` must point to a [`TrapFrame`] on the
+/// init thread's kernel stack with `sepc` and `sp` set.
+///
+/// [`AddressSpace::activate`]: crate::mm::address_space::AddressSpace::activate
 #[cfg(not(test))]
-pub unsafe fn first_entry_to_user(root_phys: u64, tf: *const super::trap_frame::TrapFrame) -> !
+pub unsafe fn first_entry_to_user(
+    aspace: *const crate::mm::address_space::AddressSpace,
+    tf: *const super::trap_frame::TrapFrame,
+) -> !
 {
-    // SAFETY: root_phys is valid page-table root; tf is valid; direct map present in new space.
+    // SAFETY: aspace is a valid AddressSpace marked active on this CPU; tf is
+    // valid; the direct map (and thus the boot stack) is present in the new
+    // space, so activate()'s satp switch and its `ret` are safe before sret.
     unsafe {
-        crate::arch::current::paging::activate(root_phys);
+        (*aspace).activate();
         return_to_user(tf)
     }
 }

--- a/core/kernel/src/arch/x86_64/context.rs
+++ b/core/kernel/src/arch/x86_64/context.rs
@@ -312,21 +312,61 @@ pub unsafe extern "C" fn return_to_user(tf: *const super::trap_frame::TrapFrame)
 
 // ── first_entry_to_user ───────────────────────────────────────────────────────
 
-/// Switch to a new address space and enter user mode for the first time.
+/// Switch to a new (tagged) address space and enter user mode for the first
+/// time.
 ///
-/// Architecture-neutral entry point for `sched::enter`. On x86-64 this
-/// delegates to [`switch_and_enter_user`], which atomically switches CR3 and
-/// discards the boot stack before executing `iretq`.
+/// Architecture-neutral entry point for `sched::enter`. The CR3 write happens
+/// inside the naked [`switch_and_enter_user`] because the boot stack (identity-
+/// mapped, PML4 0–255) vanishes after the switch, so `AddressSpace::activate`
+/// cannot run between the CR3 write and `iretq` — its `ret` would fault on the
+/// gone boot stack. Instead this does the tagged bookkeeping (claim a tag,
+/// record the per-CPU sync) in Rust here, on the still-mapped boot stack, then
+/// hands the composed CR3 value (root | PCID) to the naked switch. With tagging
+/// disabled it passes the bare root (a full-flush CR3 load).
 ///
 /// # Safety
-/// Same contract as [`switch_and_enter_user`]: TSS RSP0 and
+/// `aspace` must be a valid `AddressSpace` already marked active on this CPU.
+/// Otherwise the [`switch_and_enter_user`] contract: TSS RSP0 and
 /// `SYSCALL_KERNEL_RSP` must already be set to init's `kernel_stack_top`.
+///
+/// [`AddressSpace::activate`]: crate::mm::address_space::AddressSpace::activate
 #[cfg(not(test))]
-pub unsafe fn first_entry_to_user(root_phys: u64, tf: *const super::trap_frame::TrapFrame) -> !
+pub unsafe fn first_entry_to_user(
+    aspace: *const crate::mm::address_space::AddressSpace,
+    tf: *const super::trap_frame::TrapFrame,
+) -> !
 {
-    // SAFETY: caller guarantees root_phys and tf satisfy switch_and_enter_user contract;
-    // TSS RSP0 and SYSCALL_KERNEL_RSP already set.
-    unsafe { switch_and_enter_user(root_phys, tf) }
+    use core::sync::atomic::Ordering;
+
+    // SAFETY: aspace is a valid AddressSpace (caller's contract).
+    let root = unsafe { (*aspace).root_phys };
+    let cr3 = if crate::mm::tag_allocator::tagging_enabled()
+    {
+        // Claim init's tag and record this CPU's sync for it. The CR3 write in
+        // switch_and_enter_user has bit 63 clear, so it flushes PCID `tag`
+        // (correct for the first use of the tag), and the recorded sync makes
+        // init's next activate elide.
+        // SAFETY: tagging enabled; aspace is active on this CPU (the scheduler
+        // marked it), so it cannot be its own eviction victim; the per-CPU slab
+        // is initialised and cpu/tag are in range.
+        let tag = crate::mm::tag_allocator::claim(unsafe { &*aspace });
+        let cpu = super::cpu::current_cpu() as usize;
+        // SAFETY: see above.
+        unsafe {
+            let tag_gen = (*aspace).tag_gen.load(Ordering::Acquire);
+            let tlb_gen = (*aspace).tlb_gen.load(Ordering::Acquire);
+            crate::mm::tag_allocator::set_tag_state(cpu, tag, tag_gen, tlb_gen);
+        }
+        root | u64::from(tag)
+    }
+    else
+    {
+        root
+    };
+
+    // SAFETY: cr3 is a valid CR3 value (PML4 root + optional PCID, bit 63 clear);
+    // tf satisfies switch_and_enter_user's contract; TSS RSP0 / SYSCALL_KERNEL_RSP set.
+    unsafe { switch_and_enter_user(cr3, tf) }
 }
 
 // ── switch_and_enter_user ─────────────────────────────────────────────────────
@@ -341,13 +381,15 @@ pub unsafe fn first_entry_to_user(root_phys: u64, tf: *const super::trap_frame::
 /// spaces).
 ///
 /// # Parameters
-/// - `root_phys` (rdi): physical address of init's PML4 root.
+/// - `cr3` (rdi): the CR3 value to load — init's PML4 root, optionally OR'd with
+///   a PCID in bits \[11:0\] (bit 63 clear, so the load flushes that PCID).
 /// - `tf` (rsi): pointer to the zeroed-and-filled [`TrapFrame`] on init's
 ///   kernel stack (at `kernel_stack_top - sizeof(TrapFrame)`).
 ///
 /// # Safety
-/// - `root_phys` must be the physical address of a valid 4 KiB-aligned PML4
-///   that maps the kernel upper half (entries 256–511) and the direct map.
+/// - `cr3` must encode a valid 4 KiB-aligned PML4 that maps the kernel upper
+///   half (entries 256–511) and the direct map; any PCID bits require
+///   `CR4.PCIDE` set.
 /// - `tf` must point to a `TrapFrame` on the direct-mapped init kernel stack,
 ///   with `rip`, `rsp`, `cs`, `ss`, and `rflags` set for user-mode entry.
 /// - TSS RSP0 and `SYSCALL_KERNEL_RSP` must be set to init's `kernel_stack_top`
@@ -355,11 +397,11 @@ pub unsafe fn first_entry_to_user(root_phys: u64, tf: *const super::trap_frame::
 #[cfg(not(test))]
 #[unsafe(naked)]
 pub unsafe extern "C" fn switch_and_enter_user(
-    root_phys: u64,
+    cr3: u64,
     tf: *const super::trap_frame::TrapFrame,
 ) -> !
 {
-    // rdi = root_phys, rsi = tf (*const TrapFrame)
+    // rdi = cr3 value, rsi = tf (*const TrapFrame)
     // TrapFrame field offsets (from trap_frame.rs):
     //   rax=0, rbx=8, rcx=16, rdx=24, rsi=32, rdi=40, rbp=48,
     //   r8=56, r9=64, r10=72, r11=80, r12=88, r13=96, r14=104, r15=112,

--- a/core/kernel/src/main.rs
+++ b/core/kernel/src/main.rs
@@ -1268,14 +1268,17 @@ pub extern "C" fn kernel_entry_ap(cpu_id: u32, ist1_top: u64, ist2_top: u64) -> 
 
     // Enable hardware address-space tags on this AP (x86-64 sets CR4.PCIDE;
     // RISC-V probes its ASID width). Must precede this AP's first tagged
-    // activate in the scheduler. If the BSP enabled tagging but this CPU lacks
-    // the feature, the tagged path cannot run here — a fatal heterogeneity.
+    // activate in the scheduler. If this CPU provides fewer tags than the pool
+    // the BSP configured, the tagged path could load a tag past this hart's
+    // tag-field width (RISC-V: a too-narrow ASID), aliasing address spaces —
+    // a fatal heterogeneity. (`< num_tags` also covers a CPU with no tags at
+    // all; on x86 enable_tagged_tlb returns 4096 or 0, so only 0 trips it.)
     // SAFETY: ring 0 / S-mode; kernel root active; once per AP, before any
     // tagged activate.
     let ap_hw_tags = unsafe { arch::current::paging::enable_tagged_tlb() };
-    if mm::tag_allocator::tagging_enabled() && ap_hw_tags == 0
+    if mm::tag_allocator::tagging_enabled() && ap_hw_tags < mm::tag_allocator::num_tags()
     {
-        fatal("AP lacks the hardware TLB tags enabled on the BSP");
+        fatal("AP provides fewer hardware TLB tags than the BSP configured");
     }
 
     kprintln!("smp: AP {} online", cpu_id);

--- a/core/kernel/src/mm/tag_allocator.rs
+++ b/core/kernel/src/mm/tag_allocator.rs
@@ -37,14 +37,16 @@
 //! `SeqCst` fence between revoking a victim's tag and reading its active-CPU
 //! mask is the eviction-side half of the Dekker exclusion with `activate`.
 
-/// Maximum number of tags the pool tracks. `NUM_TAGS = min(hardware tags,
-/// TAG_CAP)` is sized from the hardware at boot, so this is just an upper bound
-/// on the static pool arrays and the per-CPU tag-state slab stride. Set to the
-/// x86-64 PCID maximum (4096) so all PCIDs are usable; RISC-V uses its detected
-/// ASID count. Memory: the pool's `owners`/`claimed_at` arrays are
-/// `TAG_CAP * 8` bytes each (~64 KiB total), and the per-CPU slab is
-/// `NUM_TAGS * 16` bytes per CPU (allocated dynamically to the configured
-/// `NUM_TAGS`, not `TAG_CAP`). `boot_protocol::MAX_CPUS` bounds the worst case.
+/// Maximum number of tags the pool tracks. The configured count is
+/// `NUM_TAGS = min(hardware tags, TAG_CAP, slab-fit limit)` (see [`enable`]),
+/// sized from the hardware at boot, so this is just an upper bound on the static
+/// pool arrays and the per-CPU tag-state slab stride. Set to the x86-64 PCID
+/// maximum (4096) so all PCIDs are usable; RISC-V uses its detected ASID count.
+/// Memory: the pool's `owners`/`claimed_at` arrays are `TAG_CAP * 8` bytes each
+/// (~64 KiB total, in BSS), and the per-CPU slab is `NUM_TAGS * 16` bytes per
+/// CPU. `enable` additionally caps `NUM_TAGS` so the single slab allocation
+/// (`cpu_count * NUM_TAGS * 16`) fits the buddy's largest block, trimming the
+/// tag count on high-CPU-count machines instead of overflowing the allocator.
 pub const TAG_CAP: usize = 4096;
 
 /// Number of `u64` words in the in-use bitmap.
@@ -336,7 +338,14 @@ mod glue
         allocator: &mut crate::mm::BuddyAllocator,
     )
     {
-        let n = hw_tags.min(TAG_CAP);
+        // The per-CPU tag-state slab is one `cpu_count * n * size_of::<TagState>()`
+        // allocation, which must fit the buddy's largest single block
+        // (`2^MAX_ORDER` pages). Cap `n` so it always does — on a high-CPU-count
+        // machine this trims the tag count (down to the `< cpu_count + 2` gate,
+        // where tagging disables) rather than overflowing the allocator at boot.
+        let max_slab_bytes = (1usize << crate::mm::buddy::MAX_ORDER) * crate::mm::PAGE_SIZE;
+        let max_fit = max_slab_bytes / (cpu_count.max(1) * core::mem::size_of::<TagState>());
+        let n = hw_tags.min(TAG_CAP).min(max_fit);
         // Usable tags are `1..n` (n - 1 of them); require strictly more than the
         // CPU count so claim always succeeds (see the doc above).
         if n < cpu_count + 2

--- a/core/kernel/src/mm/tag_allocator.rs
+++ b/core/kernel/src/mm/tag_allocator.rs
@@ -37,11 +37,15 @@
 //! `SeqCst` fence between revoking a victim's tag and reading its active-CPU
 //! mask is the eviction-side half of the Dekker exclusion with `activate`.
 
-/// Maximum number of tags the pool tracks, regardless of how many the hardware
-/// supports. Bounds the per-CPU tag-state slab (`TAG_CAP * size_of::<TagState>`
-/// bytes per CPU). x86-64 exposes 4096 PCIDs; capping keeps the slab small
-/// while still comfortably exceeding realistic concurrent-address-space counts.
-pub const TAG_CAP: usize = 512;
+/// Maximum number of tags the pool tracks. `NUM_TAGS = min(hardware tags,
+/// TAG_CAP)` is sized from the hardware at boot, so this is just an upper bound
+/// on the static pool arrays and the per-CPU tag-state slab stride. Set to the
+/// x86-64 PCID maximum (4096) so all PCIDs are usable; RISC-V uses its detected
+/// ASID count. Memory: the pool's `owners`/`claimed_at` arrays are
+/// `TAG_CAP * 8` bytes each (~64 KiB total), and the per-CPU slab is
+/// `NUM_TAGS * 16` bytes per CPU (allocated dynamically to the configured
+/// `NUM_TAGS`, not `TAG_CAP`). `boot_protocol::MAX_CPUS` bounds the worst case.
+pub const TAG_CAP: usize = 4096;
 
 /// Number of `u64` words in the in-use bitmap.
 const BITMAP_WORDS: usize = TAG_CAP / 64;
@@ -68,6 +72,10 @@ struct TagPool
 
 impl TagPool
 {
+    // large_stack_arrays: this is the initializer for the `static mut TAG_POOL`,
+    // so the TAG_CAP-sized arrays live in BSS, not on the stack. The only stack
+    // instantiation is in the host unit tests, whose stacks are ample.
+    #[allow(clippy::large_stack_arrays)]
     const fn new() -> Self
     {
         Self {
@@ -228,8 +236,6 @@ mod glue
     }
 
     /// The number of usable tags (`0` when tagging is disabled).
-    // Consumed by the boot-enablement and measurement paths.
-    #[allow(dead_code)]
     #[inline]
     pub fn num_tags() -> usize
     {

--- a/core/kernel/src/sched/mod.rs
+++ b/core/kernel/src/sched/mod.rs
@@ -2695,12 +2695,10 @@ pub fn enter() -> !
     // find the correct frame when the thread is running.
     init_tcb.trap_frame = tf_ptr;
 
-    // Read init's page table root before entering the switch function.
-    // SAFETY: init_tcb.address_space is non-null and valid, set up in main.rs Phase 9 init;
-    // root_phys field is always valid.
-    let root_phys = unsafe { (*init_tcb.address_space).root_phys };
-
-    // Mark init's address space as active on CPU 0 (BSP) before entering user mode.
+    // Mark init's address space as active on CPU 0 (BSP) before entering user
+    // mode. Must precede `first_entry_to_user`, which tags the entry: the active
+    // bit lets init's space claim a tag without being its own eviction victim,
+    // and pairs with the SeqCst fence in `AddressSpace::activate`.
     // SAFETY: init_tcb.address_space is a valid AddressSpace pointer; mark_active_on_cpu
     // uses Release ordering to ensure address space setup is visible before marking active.
     unsafe {
@@ -2713,13 +2711,13 @@ pub fn enter() -> !
 
     crate::kprintln!("sched: enter - handing control to init");
 
-    // Activate init's address space and enter user mode.
-    // `first_entry_to_user` handles the arch-specific sequence:
-    //   x86-64: atomically switches CR3 and executes iretq from init's kernel stack.
-    //   RISC-V: writes satp (sfence serializes), then executes sret.
-    // SAFETY: root_phys is init's valid page-table root (from Phase 9 init address space);
+    // Activate init's address space (tagged when tagging is enabled) and enter
+    // user mode. `first_entry_to_user` handles the arch-specific sequence:
+    //   x86-64: switches CR3 (root + PCID) and executes iretq from init's kernel stack.
+    //   RISC-V: writes satp (tagged), generation-checks, then executes sret.
+    // SAFETY: init_tcb.address_space is a valid AddressSpace marked active above;
     // tf_ptr points to a valid, initialized TrapFrame on init's kernel stack.
     unsafe {
-        crate::arch::current::context::first_entry_to_user(root_phys, tf_ptr);
+        crate::arch::current::context::first_entry_to_user(init_tcb.address_space, tf_ptr);
     }
 }


### PR DESCRIPTION
Three tagged-TLB follow-ups deferred from #198 (PR #204).

Closes #205.

## Changes

- **AP ASID-width guard.** The AP enablement check rejected only a CPU with
  *zero* hardware tags. On RISC-V a hart with a non-zero but narrower ASID field
  than the BSP would pass yet alias address spaces (pool tags exceed its ASID
  width). Now rejects any AP whose tag count is below the configured `num_tags`
  (`main.rs`); subsumes the zero case, only fatals on genuine heterogeneity
  (uniform hardware reports `hw_tags >= num_tags`).

- **Tag init's first user entry (both arches).** `sched::enter()` entered init
  via the raw untagged `activate(root_phys)`, so init ran its first quantum
  untagged and claimed its tag on the first reschedule. `first_entry_to_user`
  now takes the `AddressSpace`: RISC-V routes through `(*as).activate()` (boot
  stack is direct-mapped); x86 does the tagged bookkeeping in Rust then hands the
  composed CR3 (`root | PCID`, bit 63 clear) to the naked `switch_and_enter_user`
  (the CR3 write must stay naked — the identity-mapped boot stack vanishes after
  it).

- **Raise the tag cap.** `TAG_CAP` 512 → 4096 (x86 PCID max). `NUM_TAGS =
  min(hardware tags, TAG_CAP)` already sizes from hardware; the per-CPU tag-state
  slab is allocated dynamically to `NUM_TAGS`. Static pool arrays grow to ~64 KiB
  BSS.

## Acceptance (#205)

- [x] AP guard rejects a hart whose tag count is below the configured `num_tags`
      (not just 0).
- [x] The first user entry runs tagged on both arches; init still boots to
      userspace (every boot exercises it).
- [x] `TAG_CAP` raised; `NUM_TAGS` derives from hardware; ktest passes on both
      arches.

## Validation

- ktest **171/171 on x86-64 and riscv64** (init reaches userspace via the tagged
  first entry every boot; a wrong first-entry CR3/satp faults init immediately).
- Full **Init system boots all services on x86-64** (svcmgr launches pwrmgr /
  timed / fb-charset / logd; procmgr reaps init).
- Host unit tests pass (the tag-pool tests pass with `TAG_CAP = 4096`).

## Commits

1. AP guard + raise TAG_CAP (allocator/boot hardening).
2. Tag init's first user entry on both arches.