### PR TITLE
Fix #203: close ram_accounted_identity residual (memmgr accounting + init-logd handover liveness)

### DIFF
--- a/docs/console-model.md
+++ b/docs/console-model.md
@@ -34,9 +34,10 @@ earlier ones, which remain as fallbacks.
    `services/init/src/logging.rs`) drains the master log endpoint and writes
    lines to the UART directly. It owns console output from the moment init
    spawns it through the entire init → svcmgr handover and svcmgr's reconcile,
-   until the svcmgr-launched real-logd assumes the endpoint's RECV and pulls
-   init-logd's captured history via `log_labels::HANDOVER_PULL` — at which
-   point init-logd self-terminates. This direct path is **permanent**, not
+   until the svcmgr-launched real-logd assumes the endpoint's RECV, pulls
+   init-logd's captured history via `log_labels::HANDOVER_PULL`, then releases
+   it with `log_labels::HANDOVER_RELEASE` — at which point init-logd
+   self-terminates. This direct path is **permanent**, not
    transitional: it is the only writer before the serial driver is up, and the
    fallback if the driver fails to come up. There is no parallel init-logd
    direct-framebuffer path today; pre-driver framebuffer writes are deferred

--- a/services/init/README.md
+++ b/services/init/README.md
@@ -54,7 +54,9 @@ Init runs three stages between `_start` and `sys_thread_exit`:
    supervise real-logd. Signal `HANDOVER_COMPLETE`; hand init's own kernel
    objects + reclaimable Frame caps to procmgr via `REGISTER_INIT_TEARDOWN`;
    call `sys_thread_exit`. Procmgr binds a death-EQ on both init threads
-   (main + init-logd) and runs the reap path once both have exited.
+   (main + init-logd) and runs the reap path once both have exited; a
+   liveness backstop force-stops a never-released init-logd so a dropped
+   log handover cannot pin init's frames.
    svcmgr publishes the well-known names it now owns (`rootfs.root`,
    `svcmgr`, `devmgr.registry`) and installs devmgr's `/services/drivers/`
    cap via `SET_DRIVERS_DIR` from the endowment; it then launches the

--- a/services/init/src/logging.rs
+++ b/services/init/src/logging.rs
@@ -28,17 +28,19 @@
 //!   `[name] <line>\r\n` to the serial port AND records the line in a
 //!   bounded history ring for handover to real-logd.
 //!
-//! * **Handover (`HANDOVER_PULL`):** real-logd, once up, calls
-//!   `log_labels::HANDOVER_PULL` on the same endpoint. Init-logd
-//!   serialises (token table + history ring) into one or more reply
-//!   chunks, then breaks its loop and `sys_thread_exit`s.
+//! * **Handover (`HANDOVER_PULL` + `HANDOVER_RELEASE`):** real-logd,
+//!   once up, drains (token table + history ring) via repeated
+//!   `log_labels::HANDOVER_PULL` calls on the same endpoint, then issues
+//!   a single `HANDOVER_RELEASE`. Init-logd breaks its loop and
+//!   `sys_thread_exit`s on the RELEASE — not on the drain's `DONE` — so a
+//!   dropped data chunk cannot leave it running and block procmgr's reap.
 
 use crate::PAGE_SIZE;
 use crate::arch;
 use crate::bootstrap::BootArena;
 use init_protocol::InitInfo;
 
-use ipc::log_labels::HANDOVER_PULL;
+use ipc::log_labels::{HANDOVER_PULL, HANDOVER_RELEASE};
 use ipc::stream_labels::STREAM_BYTES;
 
 // ── Constants ────────────────────────────────────────────────────────────────
@@ -417,9 +419,10 @@ fn history_push(slot: &SenderSlot)
 
 /// Receive byte-stream messages from services and write them to the serial
 /// port, prefixing each line with the sender's `[name]` (extracted from the
-/// per-message kernel-delivered token). Also services `HANDOVER_PULL`
-/// from real-logd; on the final chunk reply, sets `HANDOVER_COMPLETE`
-/// and the next loop iteration self-terminates the thread.
+/// per-message kernel-delivered token). Also services real-logd's
+/// `HANDOVER_PULL` data drain and its terminal `HANDOVER_RELEASE`; the
+/// latter sets `HANDOVER_COMPLETE`, and the next loop iteration
+/// self-terminates the thread.
 fn log_receive_loop(log_ep: u32, ipc_buf_raw: *mut u64) -> !
 {
     let mut slots: [SenderSlot; MAX_SENDERS] = [SenderSlot::empty(); MAX_SENDERS];
@@ -468,6 +471,15 @@ fn log_receive_loop(log_ep: u32, ipc_buf_raw: *mut u64) -> !
                 ipc_buf_raw,
             );
         }
+        else if label_id == HANDOVER_RELEASE
+        {
+            // Real-logd's terminal release: the sole init-logd exit trigger,
+            // independent of the data drain's progress. Ack, set the flag; the
+            // next loop iteration self-terminates the thread.
+            // SAFETY: ipc_buf_raw is the log thread's registered IPC buffer page.
+            let _ = unsafe { ipc::ipc_reply(&ipc::IpcMessage::new(0), ipc_buf_raw) };
+            HANDOVER_COMPLETE.store(true, core::sync::atomic::Ordering::Release);
+        }
         else
         {
             // Unknown label — reply empty so the sender unblocks.
@@ -506,9 +518,9 @@ mod handover_kind
 
 /// Stage one chunk of handover state into the reply. Cursor state
 /// (`hist_cursor`, `slot_idx`) advances across calls so each pull
-/// returns a fresh chunk. On the last entry, replies with `DONE` and
-/// sets `HANDOVER_COMPLETE`; the receive loop's next iteration exits
-/// the thread.
+/// returns a fresh chunk. On the last entry, replies with `DONE`,
+/// meaning only "no more data" — the init-logd thread terminates on a
+/// separate [`HANDOVER_RELEASE`], not on this `DONE`.
 fn handle_handover_pull(
     slots: &[SenderSlot; MAX_SENDERS],
     hist_cursor: &mut u64,
@@ -599,12 +611,14 @@ fn handle_handover_pull(
         return;
     }
 
-    // Drained. Final reply marks DONE; the receive loop self-
-    // terminates on the next iteration.
+    // Drained. Final reply marks DONE — data only. The thread does NOT
+    // exit here: real-logd issues HANDOVER_RELEASE once its drain settles,
+    // and the receive loop terminates on that. Decoupling termination from
+    // the multi-chunk drain keeps a dropped data chunk from wedging
+    // init-logd (which would block procmgr's reap of init's frames).
     let reply = ipc::IpcMessage::new(handover_reply::DONE);
     // SAFETY: ipc_buf is the log thread's registered IPC buffer page.
     let _ = unsafe { ipc::ipc_reply(&reply, ipc_buf) };
-    HANDOVER_COMPLETE.store(true, Ordering::Release);
 }
 
 /// Record a display name for the sender identified by `token`. Called

--- a/services/logd/README.md
+++ b/services/logd/README.md
@@ -88,7 +88,7 @@ endpoint, procmgr `SEND|GRANT`, devmgr registry):
 | Index | Cap |
 |---|---|
 | 0 | RECV on the master log endpoint |
-| 1 | SEND on the master log endpoint (single-use; HANDOVER_PULL only). `0` on a restart — there is no init-logd left to pull from, so logd skips the history pull |
+| 1 | SEND on the master log endpoint (single-use; carries `HANDOVER_PULL` for the history drain then the terminal `HANDOVER_RELEASE`, then deleted). `0` on a restart — there is no init-logd left to pull from, so logd skips the handover |
 | 2 | Tokened SEND on procmgr's service endpoint carrying `DEATH_EQ_AUTHORITY` |
 | 3 | Tokened SEND on devmgr's registry endpoint carrying `REGISTRY_QUERY_AUTHORITY` (to resolve the serial driver via `QUERY_SERIAL_DEVICE`) |
 

--- a/services/logd/docs/handover-protocol.md
+++ b/services/logd/docs/handover-protocol.md
@@ -9,10 +9,20 @@ On its **first launch**, real-logd holds a single-use SEND cap on the
 master log endpoint (bootstrap `cap[1]`) and calls
 `log_labels::HANDOVER_PULL` repeatedly on it. Init-logd's receive loop,
 on seeing the label, replies one chunk at a time until its captured
-state is drained, then breaks its loop and calls `sys_thread_exit`.
+state is drained (`DONE`). Real-logd then issues a single
+`log_labels::HANDOVER_RELEASE`; init-logd breaks its loop and calls
+`sys_thread_exit` on that release — **not** on the drain's `DONE`.
 Real-logd's existing tokened SEND caps held by every other sender remain
 valid because the kernel endpoint object is unchanged across the
 transition.
+
+Termination is deliberately decoupled from the data drain. The drain is a
+multi-chunk lockstep over a shared, multi-sender endpoint; a kernel IPC
+rendezvous race can drop one chunk under SMP. If `DONE` were the exit
+trigger, such a drop would leave init-logd running forever, which blocks
+procmgr's reap of init's frames and breaks the all-RAM-accounted identity.
+Gating exit on the single, retried `HANDOVER_RELEASE` instead means a
+dropped data chunk costs at most some unrecovered history.
 
 On a **restart**, svcmgr mints `cap[1] = 0`: init-logd exited after the
 first launch, so there is no handover source. The restarted logd skips
@@ -26,10 +36,12 @@ instance is not recoverable.
 
 * Request: `IpcMessage::new(HANDOVER_PULL)`. Empty payload, no caps.
 * Reply: `label = MORE (0)` for every intermediate chunk;
-  `label = DONE (1)` on the terminal chunk. Init-logd sets its
-  internal `HANDOVER_COMPLETE` flag immediately after replying
-  `DONE`; the next iteration of its receive loop self-terminates the
-  init-logd thread.
+  `label = DONE (1)` on the terminal data chunk. `DONE` means only
+  "no more data" — it does **not** terminate init-logd.
+* Release: `IpcMessage::new(HANDOVER_RELEASE)`. Empty payload, no caps.
+  Init-logd acks (empty reply), sets its internal `HANDOVER_COMPLETE`
+  flag, and self-terminates on its next receive-loop iteration. Real-logd
+  retries the release until the call is acknowledged.
 
 The reply label's upper 16 bits (`(byte_len << 16)`) carry the
 inline byte length on `SLOT` and `LINE` chunk kinds, matching the
@@ -95,21 +107,23 @@ outlive its registering sender's slot in init-logd's small
 ## Termination
 
 After the last `LINE` (or the last `SLOT` if no history), init-logd
-replies `DONE` with `word(0) = LINE` and zero inline bytes, then
-sets `HANDOVER_COMPLETE`. Real-logd, on seeing `DONE`, returns from
-[`handover::pull_all`](../src/handover.rs). Init-logd's next loop
-iteration sees the flag and calls `sys_thread_exit`.
+replies `DONE` with `word(0) = LINE` and zero inline bytes. `DONE`
+transfers no exit semantics; init-logd keeps serving. Real-logd, on
+seeing `DONE`, returns from [`handover::pull_all`](../src/handover.rs)
+and calls [`handover::send_release`](../src/handover.rs), which issues
+`HANDOVER_RELEASE` (retried until acked). Init-logd acks, sets
+`HANDOVER_COMPLETE`, and its next loop iteration calls `sys_thread_exit`.
 
-Between the `DONE` reply and init-logd's thread exit, no further log
-messages are processed by init-logd — any in-flight `STREAM_BYTES`
-sends from other processes queue at the kernel endpoint and are
-drained by real-logd once it enters its main receive loop.
+In-flight `STREAM_BYTES` sends from other processes queue at the kernel
+endpoint and are drained by real-logd once it enters its main receive
+loop.
 
 ## Failure modes
 
 | Symptom | Cause | Recovery |
 |---|---|---|
-| `HANDOVER_PULL` IPC returns error | `log_ep_handover_send` cap is invalid or init-logd already exited | Real-logd's `pull_all` returns silently; logd boots with an empty `SlotTable`. Pre-handover history is lost. |
+| `HANDOVER_PULL` IPC returns error mid-drain | A kernel IPC rendezvous race on the shared endpoint, or an invalid `log_ep_handover_send` | `pull_all` returns; logd still issues `HANDOVER_RELEASE`, so init-logd is released. At most some pre-handover history is lost. |
+| `HANDOVER_RELEASE` never delivered (cap is `0`, e.g. a logd restart; or logd never launches) | No init-logd→logd channel exists | init-logd would otherwise run forever. procmgr's reap backstop force-stops it after a bounded grace and reaps init regardless (see `services/procmgr/src/init_reap.rs`). |
 | Reply with unknown `word(0)` kind | Wire-format drift; one side built against an out-of-sync `shared/ipc` revision | Real-logd skips the chunk and continues. A bounded iteration cap (`MAX_ITERS`) in `pull_all` guarantees termination on a malformed reply stream. |
 
 ## Reference

--- a/services/logd/src/handover.rs
+++ b/services/logd/src/handover.rs
@@ -24,7 +24,7 @@
 //! See `services/logd/docs/handover-protocol.md`.
 
 use ipc::IpcMessage;
-use ipc::log_labels::HANDOVER_PULL;
+use ipc::log_labels::{HANDOVER_PULL, HANDOVER_RELEASE};
 
 use crate::slot::SlotTable;
 
@@ -37,11 +37,13 @@ const KIND_HEADER: u64 = 1;
 const KIND_SLOT: u64 = 2;
 const KIND_LINE: u64 = 3;
 
-/// Drain init-logd's handover state into `table`. Returns on the
-/// first `DONE` reply (init-logd has at that point set its
-/// handover-complete flag and will self-terminate on its next loop
-/// iteration). Caps the loop at a generous iteration bound to
-/// guarantee termination on a malformed init-logd reply.
+/// Drain init-logd's handover state into `table`, best-effort. Returns
+/// on the `DONE` reply (no more data), on an `ipc_call` error (drain
+/// aborted), or at the iteration cap. `DONE` means only "no more data" —
+/// init-logd's thread does NOT terminate here; the caller must follow
+/// with [`send_release`], which is what actually releases init-logd. A
+/// dropped data chunk therefore loses at most some boot history; it
+/// cannot wedge init-logd.
 ///
 /// # Safety
 /// `ipc_buf` must be the calling thread's registered IPC buffer.
@@ -62,6 +64,10 @@ pub unsafe fn pull_all(handover_send_cap: u32, ipc_buf: *mut u64, table: &mut Sl
         let Ok(reply) = (unsafe { ipc::ipc_call(handover_send_cap, &req, ipc_buf) })
         else
         {
+            // Drain aborted (e.g. a kernel IPC rendezvous race on the shared
+            // log endpoint dropped this call). Non-fatal: the caller still
+            // issues HANDOVER_RELEASE, so init-logd is released regardless —
+            // at most some boot history is not transferred.
             return;
         };
         // Init-logd packs SLOT/LINE byte lengths into label bits
@@ -113,5 +119,36 @@ pub unsafe fn pull_all(handover_send_cap: u32, ipc_buf: *mut u64, table: &mut Sl
             return;
         }
         debug_assert_eq!(status, REPLY_MORE);
+    }
+}
+
+/// Tell init-logd to terminate, retrying until the call is acknowledged.
+///
+/// Issued once [`pull_all`] settles (DONE, abort, or iteration cap).
+/// Init-logd's thread terminates on this message — not on the data drain's
+/// `DONE` chunk — so a dropped data chunk (a kernel IPC rendezvous race on
+/// the shared, multi-sender log endpoint) cannot leave init-logd running and
+/// block procmgr's reap of init's frames.
+///
+/// Init-logd is alive until it processes a RELEASE, so the first *delivered*
+/// call is acknowledged and returns `Ok`. The retry recovers a `RELEASE`
+/// whose request was dropped (init-logd never saw it, so it is still
+/// serving). The cap bounds the loop; a genuinely unreachable init-logd is
+/// covered by procmgr's reap backstop, never by an unbounded spin here.
+///
+/// # Safety
+/// `ipc_buf` must be the calling thread's registered IPC buffer.
+pub unsafe fn send_release(handover_send_cap: u32, ipc_buf: *mut u64)
+{
+    const MAX_RETRIES: usize = 64;
+    let req = IpcMessage::new(HANDOVER_RELEASE);
+    for _ in 0..MAX_RETRIES
+    {
+        // SAFETY: caller's invariant — ipc_buf is the registered IPC buffer.
+        if (unsafe { ipc::ipc_call(handover_send_cap, &req, ipc_buf) }).is_ok()
+        {
+            return;
+        }
+        let _ = syscall::thread_yield();
     }
 }

--- a/services/logd/src/main.rs
+++ b/services/logd/src/main.rs
@@ -153,11 +153,17 @@ fn main() -> !
 
     if caps.log_ep_handover_send != 0
     {
-        // First launch: pull init-logd's accrued boot history, then drop the
-        // single-use SEND so logd carries no SEND cap to its own log endpoint.
+        // First launch: pull init-logd's accrued boot history, release
+        // init-logd, then drop the single-use SEND so logd carries no SEND cap
+        // to its own log endpoint.
         self_log("started; pulling init-logd handover state");
         // SAFETY: ipc_buf is the registered IPC buffer page.
         unsafe { handover::pull_all(caps.log_ep_handover_send, ipc_buf, &mut table) };
+        // Terminal release: init-logd exits on this, not on the drain's DONE,
+        // so a dropped data chunk cannot wedge it (and thus cannot block
+        // procmgr's reap of init's frames).
+        // SAFETY: ipc_buf is the registered IPC buffer page.
+        unsafe { handover::send_release(caps.log_ep_handover_send, ipc_buf) };
         let _ = syscall::cap_delete(caps.log_ep_handover_send);
 
         let mut buf = SerialFmt::new();

--- a/services/memmgr/README.md
+++ b/services/memmgr/README.md
@@ -89,13 +89,22 @@ are easy to find when those workloads grow.
 |---|---|---|---|
 | `MAX_PROCESSES` | 64 | `REGISTER_PROCESS` returns `TooManyProcesses` | a workload approaches ~50 concurrent processes |
 | `MAX_PER_PROC` | 512 | `REQUEST_FRAMES` returns `Quota` | a single process needs > 2 MiB of pinned frames (current value bumped from 256; equivalent to ~2 MiB of pinned pages per process; covers std heap + thread stacks + a few zero-copy buffers for current workloads) |
-| `MAX_FREE_RUNS` | 512 | `pool.push` returns `Err` and the frame is leaked until a process-death `coalesce` recovers it | post-coalesce free-run count regularly approaches 512 |
+| `MAX_FREE_RUNS` | 512 | `push_or_coalesce` parks the run after a coalesce retry: still owned and counted in `pool_total`, but with no free-pool slot (unreachable for allocation until a later coalesce frees one) | post-coalesce free-run count regularly approaches 512 |
 
 `MAX_PER_PROC` is not a security quota; it is a structural bound that
 keeps memmgr's per-process record statically sized.
 
-Coalesce on `PROCESS_DIED` is enabled, so the `MAX_FREE_RUNS` leak path
-is reachable only if fragmentation exceeds what coalescing can recover.
+Donation and reclamation push through `push_or_coalesce`, which coalesces
+and retries before parking, so the `MAX_FREE_RUNS` park path is reachable
+only if fragmentation exceeds what coalescing can recover. A parked run is
+an allocatability degradation only — it never breaks the all-RAM-accounted
+identity, because `pool_total` counts owned RAM regardless of slot residency.
+
+These three constants are fixed static bounds: any value is permanently
+either undersized (parks RAM / rejects work under load) or oversized
+(wastes static RAM), so none can scale to a hardware-bound process count.
+Eliminating them via self-hosted, dynamically-sized bookkeeping is tracked
+as a separate redesign rather than resolved by raising a number.
 
 ---
 

--- a/services/memmgr/src/main.rs
+++ b/services/memmgr/src/main.rs
@@ -188,6 +188,27 @@ impl FreePool
         Err(())
     }
 
+    /// Push a run, coalescing once and retrying if the array is full.
+    ///
+    /// `push` fails only when all `MAX_FREE_RUNS` slots are occupied.
+    /// Occupancy is dominated by fragmentation — many small runs `frame_merge`
+    /// can fold into fewer, larger ones — so on a full array we `coalesce`
+    /// (freeing a slot per successful merge) and retry the push once. `Err`
+    /// means the array is still full afterward (every run physically
+    /// disjoint). This governs free-pool *residency*, not ownership: a caller
+    /// that retains the cap must account for it on ownership regardless of
+    /// this result. Eliminating the fixed array (so residency cannot fail
+    /// while RAM remains) is tracked as a separate redesign.
+    fn push_or_coalesce(&mut self, run: FreeRun) -> Result<(), ()>
+    {
+        if self.push(run).is_ok()
+        {
+            return Ok(());
+        }
+        self.coalesce();
+        self.push(run)
+    }
+
     /// Find the smallest run covering at least `want` pages. Returns the
     /// array index, or `None` if no run is large enough.
     fn smallest_fit(&self, want: u32) -> Option<usize>
@@ -901,21 +922,23 @@ fn handle_process_died(req: &IpcMessage, ipc_buf: *mut u64, procmgr_token: u64)
     {
         for frame in record.frames.iter().take(record.used).flatten()
         {
-            let _ = pool.push(FreeRun {
+            // Reachability-only: these pages were already counted in
+            // pool_total at acquisition, so a failure here cannot break the
+            // identity — coalesce-then-retry just shrinks the forgotten-cap
+            // window. The trailing batch coalesce below still runs.
+            let _ = pool.push_or_coalesce(FreeRun {
                 cap_slot: frame.cap_slot,
                 page_count: frame.page_count,
                 phys_base: frame.phys_base,
             });
         }
-        // Coalesce reclaimed runs back into larger contiguous chunks via
-        // `frame_merge`. Probing is O(N²) over MAX_FREE_RUNS but each
-        // probe is a single kernel syscall that returns immediately on
-        // non-adjacency, and successful merges decrease the run count —
-        // amortised cost per death is tolerable at expected workloads.
-        // Without coalescing, fragmentation accumulates monotonically:
-        // every spawn-and-die cycle leaves the pool with smaller runs
-        // than it started, until `MAX_FREE_RUNS` fills and `pool.push`
-        // starts leaking frames.
+        // Restore contiguity across all reclaimed runs in one pass (the
+        // per-frame `push_or_coalesce` above only fires `coalesce` under slot
+        // pressure). Without coalescing, fragmentation accumulates
+        // monotonically: every spawn-and-die cycle leaves the pool with
+        // smaller runs than it started, until the array fills and
+        // `push_or_coalesce` parks reclaimed frames (unreachable for
+        // allocation, though still owned and accounted).
         pool.coalesce();
     }
     // Idempotent: missing token is not an error.
@@ -976,21 +999,23 @@ fn handle_donate_frames(req: &IpcMessage, ipc_buf: *mut u64)
         // run we accept (4 GiB max ≈ 1M pages, well under u32::MAX).
         #[allow(clippy::cast_possible_truncation)]
         let page_count = (size_bytes / 4096) as u32;
-        if pool
-            .push(FreeRun {
-                cap_slot: slot,
-                page_count,
-                phys_base,
-            })
-            .is_err()
-        {
-            // Pool full: cap stays in memmgr's CSpace, leaking until
-            // shutdown. Bumping MAX_FREE_RUNS is the long-term fix.
-            continue;
-        }
+        // The cap is valid and now permanently owned by memmgr (it is never
+        // deleted past this point). Count it on ownership, not on pool-slot
+        // residency: pool_total must equal the live owned set whether the run
+        // lands in a free slot or is parked because the array is full.
         accepted_caps += 1;
         accepted_pages += u64::from(page_count);
         pool_total_add(u64::from(page_count));
+        // Best-effort placement. On failure (array full even after a coalesce
+        // retry) the cap stays owned (counted above) but has no free-pool
+        // slot, unreachable for allocation until a later coalesce frees one:
+        // a reachability leak only, never an identity residual. The structural
+        // fix is a non-fixed free pool (tracked separately).
+        let _ = pool.push_or_coalesce(FreeRun {
+            cap_slot: slot,
+            page_count,
+            phys_base,
+        });
     }
     if accepted_caps > 0
     {
@@ -1026,6 +1051,12 @@ fn handle_query_pool_status(ipc_buf: *mut u64, boot: &InitBootstrap)
 /// arenas, and reap donations. memmgr never returns RAM to the kernel, and
 /// `frame_split`/`frame_merge` preserve total page count, so this monotonic
 /// counter equals the live owned set exactly.
+///
+/// Ownership — and therefore the count — is taken when memmgr *retains* a cap
+/// (a donation that passes validation and is not deleted), independent of
+/// whether the run finds a free-pool slot. A run parked because the slot array
+/// is full is still owned and still counted; counting MUST NOT be gated on
+/// `push` success, or the identity under-counts owned-but-parked RAM.
 ///
 /// This is the `pool_total` of the all-RAM-accounted identity
 /// (`system_ram == kernel_reserved + pool_total`). Surfaced in the

--- a/services/memmgr/src/main.rs
+++ b/services/memmgr/src/main.rs
@@ -1123,16 +1123,16 @@ fn ingest_pool(boot: &InitBootstrap)
                 "memmgr: ingested RAM Frame cap missing RIGHTS_RETYPE",
             );
         }
-        if pool
-            .push(FreeRun {
-                cap_slot,
-                page_count: boot.page_counts[i],
-                phys_base: boot.phys_bases[i],
-            })
-            .is_ok()
-        {
-            pool_total_add(u64::from(boot.page_counts[i]));
-        }
+        // Ownership is taken on ingest — count on ownership, place best-effort
+        // (mirrors `handle_donate_frames`). Bootstrap never overflows the pool,
+        // but `pool_total` must equal owned RAM uniformly across every ingest
+        // site, never gated on free-slot residency.
+        pool_total_add(u64::from(boot.page_counts[i]));
+        let _ = pool.push_or_coalesce(FreeRun {
+            cap_slot,
+            page_count: boot.page_counts[i],
+            phys_base: boot.phys_bases[i],
+        });
     }
 }
 
@@ -1152,16 +1152,17 @@ fn ingest_in_use(boot: &InitBootstrap)
             ipc::memmgr_bootstrap::IN_USE_KIND_INIT => INIT_SELF_TOKEN,
             _ => continue,
         };
+        // Owned on ingest — count on ownership; the per-process record is
+        // best-effort tracking (these arenas are immortal, never reclaimed), so
+        // a record miss must not under-count `pool_total`.
+        pool_total_add(u64::from(entry.page_count));
         if let Some(record) = table_mut().find_mut(token)
-            && record
-                .push(OwnedFrame {
-                    cap_slot: entry.cap_slot,
-                    page_count: entry.page_count,
-                    phys_base: entry.phys_base,
-                })
-                .is_ok()
         {
-            pool_total_add(u64::from(entry.page_count));
+            let _ = record.push(OwnedFrame {
+                cap_slot: entry.cap_slot,
+                page_count: entry.page_count,
+                phys_base: entry.phys_base,
+            });
         }
     }
 }

--- a/services/procmgr/README.md
+++ b/services/procmgr/README.md
@@ -70,11 +70,14 @@ procmgr/
 
 Procmgr accepts init's `REGISTER_INIT_TEARDOWN` handoff at the end of
 init's Phase 3: init's own `AddressSpace` / `CSpace` / `Thread` caps
-plus every reclaimable Frame cap. Procmgr binds a death-EQ observer
-on init's main thread with `INIT_REAP_CORRELATOR`; on the death event
-(driven by init's `sys_thread_exit`) the reap path tears down init's
-kernel objects in order — Threads → AddressSpace → donate Frame caps
-to memmgr via `DONATE_FRAMES` → CSpace cascade — leaving zero init
+plus every reclaimable Frame cap. Procmgr binds a death-EQ observer on
+**both** init threads (main + init-logd) with `INIT_REAP_CORRELATOR` and
+reaps once both have exited — init-logd outlives main until the
+svcmgr-launched real-logd releases it via `HANDOVER_RELEASE`. A liveness
+backstop force-stops a never-released init-logd past a grace, so a
+dropped log handover cannot pin init's frames. The reap path tears down
+init's kernel objects in order — Threads → AddressSpace → donate Frame
+caps to memmgr via `DONATE_FRAMES` → CSpace cascade — leaving zero init
 residue. Implementation in [`src/init_reap.rs`](src/init_reap.rs).
 
 ---

--- a/services/procmgr/src/init_reap.rs
+++ b/services/procmgr/src/init_reap.rs
@@ -25,11 +25,18 @@
 //!   │  INIT_TEARDOWN_DONE
 //!   ▼
 //! Armed   (pending_deaths = 2; waiting for both threads' INIT_REAP_CORRELATOR
-//!          death events — run_reap counts down, reaping on the last)
+//!          death events — run_reap counts down, reaping on the last. The
+//!          first death stamps first_death_us, arming the liveness backstop.)
 //!   │
-//!   ▼  dispatch_death sees correlator == INIT_REAP_CORRELATOR (×2)
-//! Reaping (run_reap, last death):
-//!   1. cap_delete(logd_thread)
+//!   ├─▼  dispatch_death sees correlator == INIT_REAP_CORRELATOR (×2)
+//!   │  Reaping (run_reap, last death) → do_reap
+//!   │
+//!   └─▼  init-logd never released (dropped HANDOVER_RELEASE) and
+//!        now - first_death_us > BACKSTOP_GRACE_US
+//!      Reaping (check_backstop): thread_stop(logd_thread) → do_reap
+//!
+//! do_reap (both entry paths):
+//!   1. cap_delete(logd_thread)                — Exited, or Stopped→Exited
 //!   2. cap_delete(main_thread)
 //!   3. cap_revoke + cap_delete(aspace)        — mappings gone
 //!   4. DONATE_FRAMES(caps[..]) → memmgr       — safe; no aliasing
@@ -71,9 +78,26 @@ pub struct InitReapState
     /// reapable only when threadless, so the teardown waits for both init
     /// threads (main + init-logd) — `run_reap` decrements this per death event
     /// and reaps on the last. init-logd outlives the main thread until the
-    /// svcmgr-launched real-logd pulls its handover.
+    /// svcmgr-launched real-logd pulls its handover and releases it.
     pending_deaths: u8,
+    /// Boot-microsecond timestamp of the first init-thread death (the main
+    /// thread, in practice), recorded when `pending_deaths` drops to 1. Zero
+    /// until then. Anchors the liveness backstop: if init-logd has not exited
+    /// within [`BACKSTOP_GRACE_US`] of this instant — because a dropped
+    /// `HANDOVER_RELEASE` (e.g. a logd restart with no handover source, or
+    /// logd never launching) left it serving forever — `check_backstop`
+    /// force-stops it and reaps anyway, so a wedged handover can never
+    /// permanently block reclamation of init's frames.
+    first_death_us: u64,
 }
+
+/// Liveness deadline: how long after the first init-thread death the reap will
+/// wait for init-logd to exit on its own before force-stopping it. A liveness
+/// bound (sized like the kernel's idle watchdog), NOT a capacity constant —
+/// the normal handover releases init-logd in well under a second, and the
+/// bound stays far below the point at which svctest first queries the
+/// all-RAM-accounted identity, so the forced donation always lands first.
+const BACKSTOP_GRACE_US: u64 = 3_000_000;
 
 /// State machine slot. `None` until init's first
 /// `REGISTER_INIT_TEARDOWN`; populated and progressively filled by
@@ -160,6 +184,7 @@ pub fn handle_register(req: &IpcMessage, ipc_buf: *mut u64, death_eq: u32)
             donate_caps: Vec::with_capacity(32),
             armed: false,
             pending_deaths: 2,
+            first_death_us: 0,
         });
         reply(ipc_buf, procmgr_errors::SUCCESS);
         return;
@@ -229,8 +254,16 @@ pub fn run_reap(memmgr_ep: u32, ipc_buf: *mut u64)
         s.pending_deaths = s.pending_deaths.saturating_sub(1);
         if s.pending_deaths > 0
         {
-            // One init thread exited; the other still runs in init's
-            // aspace/cspace. Reclaiming now would fault it — wait.
+            // One init thread exited (the main thread); the other still runs
+            // in init's aspace/cspace. Reclaiming now would fault it — wait.
+            // Anchor the liveness backstop from this instant so a wedged
+            // handover (init-logd never released) cannot block the reap
+            // forever; the common path still reaps on init-logd's own exit
+            // below, well before the deadline.
+            if s.first_death_us == 0
+            {
+                s.first_death_us = elapsed_us();
+            }
             std::os::seraph::log!(
                 "init-reap: an init thread exited; {} still running",
                 s.pending_deaths
@@ -240,14 +273,87 @@ pub fn run_reap(memmgr_ep: u32, ipc_buf: *mut u64)
         guard.take().expect("armed init-reap state present")
     };
 
-    // 1. Reap init-logd's TCB. Both init threads have exited by now (the
-    //    last death triggered this reap). `dealloc_object` for Thread
-    //    handles Exited TCBs cleanly.
-    let _ = syscall::cap_delete(state.logd_thread);
+    do_reap(state, memmgr_ep, ipc_buf);
+}
+
+/// Liveness backstop, called from procmgr's main loop. If the main thread has
+/// exited but init-logd has not within [`BACKSTOP_GRACE_US`] — a dropped
+/// `HANDOVER_RELEASE` (a logd restart with no handover source, or logd never
+/// launching) left it serving forever — force-stop it and reap anyway.
+///
+/// `thread_stop` transitions a `Blocked`-in-`ipc_recv` init-logd to `Stopped`;
+/// it posts no death notification, which is why this path reaps directly
+/// rather than waiting for the death count. The `cap_delete` in `do_reap` then
+/// drives the `Stopped` TCB to `Exited` and wakes any thread blocked on a
+/// reply from it (a real-logd stuck mid-pull).
+///
+/// Best-effort scheduling: this only runs when procmgr's main loop is already
+/// awake for some other event. The cases it covers coincide with boot-time
+/// process-death and service traffic that keeps procmgr scheduled, so the
+/// deadline is observed well before svctest first queries the identity. A hard
+/// wall-clock guarantee would require a timed `wait_set` primitive the kernel
+/// does not expose today.
+pub fn check_backstop(memmgr_ep: u32, ipc_buf: *mut u64)
+{
+    let state = {
+        let mut guard = STATE.lock().expect("init-reap state poisoned");
+        let Some(s) = guard.as_mut()
+        else
+        {
+            return;
+        };
+        if !s.armed || s.pending_deaths != 1 || s.first_death_us == 0
+        {
+            return;
+        }
+        if elapsed_us().saturating_sub(s.first_death_us) < BACKSTOP_GRACE_US
+        {
+            return;
+        }
+        // The lagging init thread (init-logd in practice; main is straight-line
+        // to thread_exit) is still alive. Force BOTH off-CPU before reaping —
+        // thread_stop is a harmless InvalidState no-op on whichever already
+        // exited — so do_reap's cap_delete never frees a TCB still running on a
+        // CPU, regardless of which thread lagged. The cap_delete then drives a
+        // Stopped TCB to Exited and wakes any real-logd stuck on init-logd's
+        // reply.
+        let _ = syscall::thread_stop(s.main_thread);
+        let _ = syscall::thread_stop(s.logd_thread);
+        std::os::seraph::log!(
+            "init-reap: handover-release backstop fired; force-stopped init after \
+             {} ms grace",
+            BACKSTOP_GRACE_US / 1000
+        );
+        guard.take().expect("armed init-reap state present")
+    };
+
+    do_reap(state, memmgr_ep, ipc_buf);
+}
+
+/// Tear init down once it is threadless: both threads `Exited` (normal path),
+/// or init-logd forced `Stopped` by [`check_backstop`]. Ordering matters — see
+/// the inline steps.
+fn do_reap(state: InitReapState, memmgr_ep: u32, ipc_buf: *mut u64)
+{
+    // Consume the teardown state — this reap is one-shot.
+    let InitReapState {
+        aspace,
+        cspace,
+        main_thread,
+        logd_thread,
+        donate_caps,
+        ..
+    } = state;
+
+    // 1. Reap init-logd's TCB. It is `Exited` (it released and exited) or
+    //    `Stopped` (forced by the backstop); `dealloc_object` drives either to
+    //    `Exited`, removes it from scheduler queues, and wakes any reply-bound
+    //    client (a real-logd blocked mid-handover) with `Interrupted`.
+    let _ = syscall::cap_delete(logd_thread);
 
     // 2. Reap init's main thread TCB; it exited earlier in the countdown, so
     //    the cap_delete just drives the dealloc.
-    let _ = syscall::cap_delete(state.main_thread);
+    let _ = syscall::cap_delete(main_thread);
 
     // 3. Destroy init's AddressSpace. Revoke first to clear any
     //    derived child caps, then delete to drop procmgr's reference
@@ -255,14 +361,14 @@ pub fn run_reap(memmgr_ep: u32, ipc_buf: *mut u64)
     //    over via IPC). `dealloc_object` for AddressSpace returns PT
     //    chunks via `retype_free`; user-page mappings disappear at
     //    the same moment.
-    let _ = syscall::cap_revoke(state.aspace);
-    let _ = syscall::cap_delete(state.aspace);
+    let _ = syscall::cap_revoke(aspace);
+    let _ = syscall::cap_delete(aspace);
 
     // 4. Donate every reclaim Frame cap to memmgr. Safe now that
     //    init's AS is dead: no live mapping references the phys
     //    ranges, so memmgr can reissue them without aliasing.
     let (donated_caps, donated_pages, pool_total) =
-        donate_to_memmgr(memmgr_ep, &state.donate_caps, ipc_buf);
+        donate_to_memmgr(memmgr_ep, &donate_caps, ipc_buf);
 
     // 5. Destroy init's CSpace last. The cascade in `dealloc_object`
     //    drops every cap init still held — endpoint SENDs and the
@@ -270,8 +376,8 @@ pub fn run_reap(memmgr_ep: u32, ipc_buf: *mut u64)
     //    already forwarded to memmgr's pool, and every reclaimable
     //    Frame was donated in step 4, so no `owns_memory` cap reaches
     //    its last reference here: nothing frees to the sealed buddy.
-    let _ = syscall::cap_revoke(state.cspace);
-    let _ = syscall::cap_delete(state.cspace);
+    let _ = syscall::cap_revoke(cspace);
+    let _ = syscall::cap_delete(cspace);
 
     // 6. Summary line so the operator can confirm the reap actually ran.
     std::os::seraph::log!(
@@ -282,6 +388,13 @@ pub fn run_reap(memmgr_ep: u32, ipc_buf: *mut u64)
         donated_pages * 4,
         pool_total,
     );
+}
+
+/// Boot-microsecond clock via `SYS_SYSTEM_INFO(ElapsedUs)`; never errors
+/// (`unwrap_or(0)` matches the kernel handler's infallible contract).
+fn elapsed_us() -> u64
+{
+    syscall::system_info(syscall_abi::SystemInfoType::ElapsedUs as u64).unwrap_or(0)
 }
 
 fn donate_to_memmgr(memmgr_ep: u32, caps: &[u32], ipc_buf: *mut u64) -> (u32, u64, u64)

--- a/services/procmgr/src/main.rs
+++ b/services/procmgr/src/main.rs
@@ -174,6 +174,12 @@ fn main() -> !
             &mut recent,
         );
 
+        // Liveness backstop: if init's main thread has exited but init-logd is
+        // still wedged past the grace (a dropped HANDOVER_RELEASE), force-stop
+        // it and reap so init's frames cannot be pinned indefinitely. No-op
+        // until the deadline, and once init is reaped.
+        init_reap::check_backstop(ctx.memmgr_ep, ipc_buf);
+
         match token
         {
             WS_TOKEN_SERVICE =>

--- a/services/svctest/src/phases/memmgr.rs
+++ b/services/svctest/src/phases/memmgr.rs
@@ -171,8 +171,10 @@ pub fn alloc_grow_phase(_: &Caps)
 /// transient positive residual (donations still in flight). The residual only
 /// shrinks — `kernel_reserved` is fixed and `pool_total` only grows as
 /// donations land — so polling converges to zero on a clean system. A real
-/// leak (a minted page that never reaches the pool) holds the residual above
-/// zero and the poll times out.
+/// leak (a page memmgr never takes ownership of) holds the residual above
+/// zero and the poll times out. memmgr counts a donated page on ownership,
+/// not on free-pool residency, so a run parked by a full pool still closes
+/// the identity.
 pub fn ram_accounted_identity_phase(_: &Caps)
 {
     const MAX_POLL: u32 = 4096;

--- a/shared/ipc/src/lib.rs
+++ b/shared/ipc/src/lib.rs
@@ -1456,10 +1456,25 @@ pub mod log_labels
     ///   sequence for any further legacy callers.
     ///
     /// Wire encoding is documented in
-    /// `services/logd/docs/handover-protocol.md`. After the final
-    /// chunk is replied, init-logd breaks its receive loop and calls
-    /// `sys_thread_exit`.
+    /// `services/logd/docs/handover-protocol.md`. The data drain
+    /// (`MORE`/`DONE` chunks) only transfers state; init-logd's thread
+    /// terminates on [`HANDOVER_RELEASE`], not on the `DONE` chunk.
     pub const HANDOVER_PULL: u64 = 13;
+
+    /// One-shot terminal release: real-logd tells init-logd to exit.
+    ///
+    /// Sent by real-logd on the same single-use SEND cap, exactly once,
+    /// after its [`HANDOVER_PULL`] drain settles (whether the drain ran
+    /// to `DONE`, aborted on an IPC error, or hit its iteration cap).
+    /// Real-logd retries until the call is acknowledged. Init-logd, on
+    /// receipt, sets its handover-complete flag, replies an empty ack,
+    /// and `sys_thread_exit`s on its next loop iteration.
+    ///
+    /// Decoupling termination from the multi-chunk data drain keeps a
+    /// dropped data chunk (a kernel IPC rendezvous race on the shared,
+    /// multi-sender log endpoint) from wedging init-logd — which would
+    /// otherwise block procmgr's reap of init's frames indefinitely.
+    pub const HANDOVER_RELEASE: u64 = 14;
 }
 
 // ── Bootstrap protocol ──────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #203.

## Problem

svctest's `ram_accounted_identity` (`system_ram == kernel_reserved + pool_total`)
failed intermittently (~3% on x86_64 debug svctest) with a fixed ~93 MiB residual,
then watchdog-hung. Investigation found **two** distinct defects.

### Defect 1 — memmgr under-counts owned RAM on a full free pool (`ab3c473`)

`handle_donate_frames` gated `pool_total_add` on `pool.push().is_ok()`; on a full
`FreePool` (`MAX_FREE_RUNS = 512`) the cap was retained but never counted, so
`pool_total` undercounted owned RAM. Fix: count on **ownership**, place
best-effort via a new `push_or_coalesce` (coalesce-then-retry before parking).
Correct and necessary — but burn-in proved it does **not** close #203 (the
residual persisted with an identical no-donation signature).

### Defect 2 — init-logd→logd handover stall blocks the reap (`fea5e54`, dominant cause)

init-logd's thread exit was gated on the multi-chunk `HANDOVER_PULL` drain
reaching DONE. A kernel IPC rendezvous race on the shared, multi-sender log
endpoint can drop a chunk under SMP, leaving init-logd serving forever — which
blocks procmgr's reap of init's frames (`pending_deaths`), so init's reclaimed
RAM never reaches memmgr's pool and the identity holds the ~93 MiB residual.

A best-effort boot-log history transfer was gating a tier-1 RAM-accounting
invariant. The fix removes that coupling:

- **B1 — decouple termination.** New `log_labels::HANDOVER_RELEASE`. init-logd
  exits on this single, retried terminal message, not on the drain's DONE. A
  dropped data chunk now costs at most some unrecovered boot history.
- **B2 — procmgr liveness backstop.** If a release never arrives (a logd restart
  with no handover source, or logd never launching) and init-logd outlives the
  main thread past a 3 s grace, procmgr force-stops both init threads
  (`thread_stop`) and reaps directly. `thread_stop` posts no death notification,
  so the backstop reaps without the death count; `cap_delete` drives a Stopped
  TCB to Exited and wakes any real-logd blocked mid-pull.

## Test plan

- [x] `cargo xtask test` (host) — all green.
- [x] x86_64 debug svctest: normal boot releases+exits init-logd, donates,
      `residual=0`, `ALL TESTS PASSED`.
- [x] **Fault-injected dropped RELEASE** (deterministic; the natural race is
      non-reproducing post-rebase): backstop fires at the grace, reaps,
      `residual=0`, `ALL TESTS PASSED`.
- [x] **x86_64 acceptance burn-in: 200/200** (oversubscribed, `--cpus` varied),
      zero residual / hang.
- [x] riscv64 debug svctest: clean boot, `residual=0`, `ALL TESTS PASSED` — the
      pre-existing local-QEMU-11 init-teardown deadlock is gone under the merged
      TLB rework (#204).

## Acceptance (#203)

- [x] A FreePool donation that cannot be recorded does not silently under-count
      owned RAM (count on ownership; coalesce-before-reject).
- [x] `ram_accounted_identity` burn-in stable across ≥100 x86_64 debug svctest
      iterations (200/200).

## Notes

- Branched from current `master` (incl. TLB #204). Post-rebase the natural ~3%
  race no longer reproduces in 160+ runs — the PCID/ASID rework shifted the SMP
  timing — but the fix removes the *coupling*, so a recurrence cannot again wedge
  tier-1 reap.
- Follow-up filed: #209 (eliminate memmgr's fixed static bookkeeping caps).

## Reproducibility note (post-review)

CI runs one svctest pass per (arch, profile). The **200/200 x86_64 acceptance
burn-in** and the **fault-injected dropped-RELEASE backstop test** in the Test
plan above were run **locally** and are not reproducible from the diff. The
fault-injection toggle was a temporary local edit, removed before push — no
instrumentation or debug toggle ships in this PR (verified). The backstop
mechanism itself (`check_backstop` in `services/procmgr/src/init_reap.rs`) is
fully present and reviewable; CI's `validate (*, debug, svctest)` jobs
independently confirm a clean residual=0 boot on both arches.

## Post-review remediation (commit `6f29973`)

- memmgr: apply the count-on-ownership invariant uniformly to the two bootstrap
  ingest sites (`ingest_pool`, `ingest_in_use`), not just the donate path —
  behavior-neutral today (bootstrap never overflows) but the invariant must
  hold uniformly (pr-reviewer).
- Reconcile `services/procmgr/README.md` (both-thread death-EQ bind + reap
  backstop) and `services/logd/README.md` (cap[1] also carries
  `HANDOVER_RELEASE`) with the code (pr-reviewer drift findings).
