### PR TITLE
kernel: gate thread dealloc on not-current-on-any-CPU (#207)

### DIFF
--- a/core/kernel/docs/scheduling-internals.md
+++ b/core/kernel/docs/scheduling-internals.md
@@ -93,7 +93,7 @@ The transition table below pins every ThreadState write to a syscall/event, the 
 | `Ready` | `Stopped` | `sys_thread_stop` on a Ready target | calling CPU | `set_state_under_all_locks(Stopped)`; the helper also walks every CPU's run queue and calls `remove_from_queue` inside the all-locks region. See § *Stopped/Exited drain* below. |
 | `Blocked` | `Stopped` | `sys_thread_stop` on blocked target | calling CPU | `cancel_ipc_block` first (acquires the source IPC lock and unlinks the waiter), then `set_state_under_all_locks(Stopped)` |
 | `*` | `Exited` | `sys_thread_exit` (self) or fault handler | running CPU | `set_state_under_all_locks(Exited)` (on the dying CPU), then `schedule(false)` |
-| `*` | `Exited` | `dealloc_object(Thread)` (refcount → 0) | calling CPU | acquires every CPU's scheduler.lock in ascending order, writes `Exited`, walks `remove_from_queue` for every CPU, snapshots `running_on`, releases all; then waits for both `sched.current != tcb` *and* `tcb.context_saved == 1` (see Cross-CPU TCB Ownership) before freeing |
+| `*` | `Exited` | `dealloc_object(Thread)` (refcount → 0) | calling CPU | acquires every CPU's scheduler.lock in ascending order, writes `Exited`, walks `remove_from_queue` for every CPU, releases all; then waits unconditionally for `sched.current != tcb` on *every* CPU *and* `tcb.context_saved == 1` (see Cross-CPU TCB Ownership) before freeing |
 
 All `Running→Blocked` parks MUST route through `commit_blocked_under_local_lock`; all `Blocked→Ready` wakes MUST route through `enqueue_and_wake`. Direct `(*tcb).state` writes from an IPC primitive — under the source lock or otherwise — are forbidden; they race `set_state_under_all_locks(Stopped)` and silently clobber Stopped.
 
@@ -235,14 +235,15 @@ Remote dequeue (after dequeue_highest returns this TCB):
   7. // saved_state is now safe to read on this CPU
 
 dealloc_object(Thread) (after the all-locks region releases):
-  8. if running_on == Some(cpu): spin until sched.current != tcb
+  8. loop { scan every cpu under its sched.lock; if some cpu.current == tcb,
+            spin on that cpu until cpu.current != tcb, then re-scan }  // unconditional, all-CPU
   9. while context_saved.load(Acquire) == 0 { spin_loop() }    // unconditional
  10. // safe to free TCB body and kernel stack
 ```
 
 Step 3.5 is the outgoing CPU's cross-CPU dispatch barrier: when this CPU is about to switch INTO `next`, it must observe `next.context_saved == 1` from the CPU that previously ran `next`. Step 3.5 MUST run with the local `sched.lock` already released (step 3). Holding the lock across the spin re-introduces issue #144's cross-CPU deadlock: a peer CPU's cross-CPU `enqueue_and_wake` (e.g. its own outgoing-branch re-enqueue) targets this CPU's lock; if this CPU is spinning on `next.context_saved` under the lock while waiting on the peer to publish, the peer cannot reach its own `switch()` and the cycle never breaks. Step 3.5 runs lockless on both arches.
 
-The Release in step 5 pairs with both the Acquire in step 6 (cross-CPU dequeue), the Acquire in step 3.5 (outgoing-CPU dispatch barrier), and the Acquire in step 9 (TCB free). Without step 9, the lock release at step 3 lets `dealloc_object(Thread)` observe `sched.current = idle` (set at step 2) *while step 4 is still writing into `tcb.saved_state`* — freeing the TCB at that point lets the next allocation reuse the memory and `switch()` then corrupts the new allocation. The check is unconditional on the result of `running_on`, because the all-locks `running_on` snapshot can race step 2/3 and miss the in-flight switch. New TCBs initialise `context_saved = 1`, so the wait is bounded for threads that never ran.
+The Release in step 5 pairs with both the Acquire in step 6 (cross-CPU dequeue), the Acquire in step 3.5 (outgoing-CPU dispatch barrier), and the Acquire in step 9 (TCB free). Step 8 is the prerequisite: it scans *every* CPU and will not let the free proceed while any CPU still names `tcb` as `current`, so it does not rely on an all-locks `running_on` snapshot (which names at most one CPU and can be stale once the locks drop). Step 9 then closes the residual window step 8 cannot see: the lock release at step 3 lets a peer observe `sched.current = next` (set at step 2) *while step 4 is still writing into `tcb.saved_state`* — a CPU that has just switched *away* passes step 8 but its register save may still be in flight, and freeing the TCB there lets the next allocation reuse the memory while `switch()` corrupts it. Step 9 is unconditional; new TCBs initialise `context_saved = 1`, so the wait is bounded for threads that never ran.
 
 **`context_saved = 1` and `popfq` ordering inside `context::switch` (issue #117).** Step 5 above hides a finer-grained ordering invariant inside the `switch()` asm itself. Both the `context_saved = 1` publication AND the `popfq` that restores `next.saved_state.rflags` (which may set `IF = 1`) MUST happen AFTER `mov rsp, [rsi + 8]` (the rsp swap to the next thread's kstack), not before it. Doing either earlier opens this window:
 1. `popfq` before the rsp swap re-enables interrupts while this CPU is still executing on the OUTGOING thread's kstack. A trap taken in that window pushes its iretq frame onto the outgoing kstack.

--- a/core/kernel/docs/thread-lifecycle-and-sleep.md
+++ b/core/kernel/docs/thread-lifecycle-and-sleep.md
@@ -104,7 +104,7 @@ This table is the authoritative per-transition rule set for the lifecycle syscal
 | `sys_thread_write_regs` | `Stopped` | `Stopped` | calling CPU | none beyond the source-state check. Validates user `TrapFrame` then writes; target is not running (state == Stopped). |
 | `sys_exit` (self) | `*` | `Exited` | running CPU = current CPU | `set_state_under_all_locks(self, Exited)`, then `post_death_notification`, then `schedule(false)`. The all-locks write ensures any peer-CPU `schedule()` reading `state` under its own sched.lock sees `Exited` and refuses to re-enqueue. |
 | arch fault handler (page fault, GP fault, etc.) | `*` | `Exited` | trapping CPU = current CPU | Same as `sys_exit`. |
-| `dealloc_object(Thread)` | `*` | `Exited` | calling CPU (refcount → 0) | Acquires every CPU's scheduler.lock in ascending order, writes `state = Exited`, walks `remove_from_queue` for every CPU, snapshots `running_on`, releases all. After release: spins on `sched.current != tcb` (if `running_on = Some(cpu)`), then unconditionally on `tcb.context_saved == 1`, then proceeds to source-IPC unlink + free. See Drain Protocol below. |
+| `dealloc_object(Thread)` | `*` | `Exited` | calling CPU (refcount → 0) | Acquires every CPU's scheduler.lock in ascending order, writes `state = Exited`, walks `remove_from_queue` for every CPU, releases all. After release: unconditionally scans every CPU until none has `sched.current == tcb`, then unconditionally on `tcb.context_saved == 1`, then proceeds to source-IPC unlink + free. See Drain Protocol below. |
 
 **Why the all-CPU lock acquire in `dealloc_object(Thread)`:**
 
@@ -131,12 +131,17 @@ The teardown sequence binds the following ordered steps. Each step's preconditio
    blocked_on = null, trap_frame.return = Interrupted). The actual
    enqueue_and_wake happens AFTER step 7 because it would deadlock against
    the held scheduler.locks.
-6. For each CPU: check if scheduler_for(cpu).current == tcb; record running_on
-   (at most one).
+6. No in-region `current` snapshot is required: the post-release gate (step 9)
+   scans every CPU unconditionally, so reclamation does not depend on an
+   all-locks `running_on` reading (which names at most one CPU and can be stale
+   the instant the locks drop).
 7. Release every scheduler.lock in descending order.
 8. If a server_reply_wake was prepared in step 5, enqueue_and_wake(bound, ...).
-9. If running_on was recorded, spin (re-acquire that CPU's lock per iteration)
-   until scheduler_for(run_cpu).current != tcb.
+9. `current`-anywhere gate (UNCONDITIONAL): scan every CPU, each under its own
+   scheduler.lock; if some CPU has `scheduler_for(cpu).current == tcb`, spin on
+   that CPU's lock until it switches away, then re-scan. Proceed only when a
+   full scan finds no CPU running tcb. tcb is `Exited` and unlinked from every
+   run queue (steps 3-4), so no CPU can re-install it after a clean scan.
 10. Spin on tcb.context_saved.load(Acquire) == 1 (UNCONDITIONAL — see invariant 4).
     Steps 9-10 run with `preempt_disable` and interrupts enabled
     (`save_and_disable_interrupts` → `enable`); the local CPU MUST be
@@ -144,8 +149,7 @@ The teardown sequence binds the following ordered steps. Each step's preconditio
     spin or it deadlocks against a peer CPU sending an IPI to it
     (observed locally and on `ubuntu-latest` CI). Preemption is
     disabled so a timer tick mid-spin cannot reschedule the dealloc
-    caller off this CPU (which would invalidate the `running_on`
-    snapshot captured at step 6).
+    caller off this CPU.
 11. Acquire the source IPC lock for tcb's blocked_on_object (if any) and unlink
     tcb from the source's wait queue / waiter slot. Branches:
       - BlockedOnSend / BlockedOnRecv: ep.lock; unlink_from_wait_queue.
@@ -171,11 +175,11 @@ The teardown sequence binds the following ordered steps. Each step's preconditio
 
 2. **Step 3 (state = Exited) commits under all locks.** No `schedule()` on any CPU can subsequently observe this TCB as `Ready` or `Running` for purposes of re-enqueue — the protection in `schedule()` reads `state` while holding its CPU's scheduler.lock and refuses to re-enqueue if `state ∈ {Exited, Stopped}`. `enqueue_and_wake` performs the same check before enqueueing (see [scheduling-internals.md § Lock Hierarchy](scheduling-internals.md#lock-hierarchy) rule 9).
 
-3. **Step 9's `running_on` spin is bounded.** The remote CPU is mid-`schedule()`; once it sets `current = next_tcb` (which happens *before* the arch switch on both arches — `release_lock_only` runs in Rust before `switch()`), the spin exits.
+3. **Step 9's `current`-anywhere scan is bounded.** A TCB is `current` on at most one CPU at a time. That CPU is mid-`schedule()`; once it sets `current = next_tcb` (which happens *before* the arch switch on both arches — `release_lock_only` runs in Rust before `switch()`), the inner spin exits. After it switches away no CPU can re-install tcb (it is `Exited` and unlinked from every run queue), so the next full scan is clean and the loop terminates. The scan does not rely on the all-locks `running_on` snapshot, which names at most one CPU and may be stale once the locks drop.
 
 4a. **No `fpu_owner` sweep is needed after eager save (#108).** The `#NM` handler only ever installs the currently Running thread on its CPU as `fpu_owner`. `switch_out_save` clears the slot on switch-out before the thread re-enters the Ready / Blocked / Stopped / Exited states. By the time steps 9 and 10 above have completed — the thread has switched out on every CPU and `context_saved == 1` — no CPU's owner slot can name this TCB. Steps 9-10's interrupt-enabled-while-spinning discipline is still required to prevent the spin from deadlocking against a peer CPU's TLB-shootdown IPI; without it, two CPUs in mutual TLB shootdown would deadlock.
 
-4. **Step 10's `context_saved` spin is the load-bearing UAF gate, and is unconditional.** On both arches, `schedule()` calls `set_current(next)` and `release_lock_only(sched.lock)` *before* `switch()` saves the dying thread's registers into `tcb.saved_state`. A peer CPU acquiring the same lock at any moment after the release can therefore observe `sched.current = idle` while `switch()` is still mid-save into `tcb.saved_state`. Freeing the TCB at that point lets the next allocation reuse the memory; `switch()` then corrupts the new allocation, producing hangs (`stress::thread_churn`, `bench thread_lifecycle`) or worse. Step 10 closes the window: `context_saved` is cleared by `schedule()` *before* the save and written `1` (Release) by `switch()` *after* the save; spinning on the Acquire load until it observes `1` guarantees the save has fully published. The spin is unconditional on the result of `running_on`, because the all-locks `running_on` snapshot can race past the lock release and miss the in-flight switch entirely. New TCBs initialise `context_saved = 1`, so the wait is bounded for threads that never ran.
+4. **Step 10's `context_saved` spin is the load-bearing UAF gate, and is unconditional.** On both arches, `schedule()` calls `set_current(next)` and `release_lock_only(sched.lock)` *before* `switch()` saves the dying thread's registers into `tcb.saved_state`. A peer CPU acquiring the same lock at any moment after the release can therefore observe `sched.current = idle` while `switch()` is still mid-save into `tcb.saved_state`. Freeing the TCB at that point lets the next allocation reuse the memory; `switch()` then corrupts the new allocation, producing hangs (`stress::thread_churn`, `bench thread_lifecycle`) or worse. Step 10 closes the window: `context_saved` is cleared by `schedule()` *before* the save and written `1` (Release) by `switch()` *after* the save; spinning on the Acquire load until it observes `1` guarantees the save has fully published. It is unconditional and runs after step 9's `current`-anywhere scan: that scan guarantees no CPU still names tcb as `current`, but a CPU that has just switched *away* may still be mid-save into `tcb.saved_state` (the save trails the `current = next` store and the lock release), and step 10 is what waits for that save. New TCBs initialise `context_saved = 1`, so the wait is bounded for threads that never ran.
 
 5. **Step 11's source-IPC unlink MUST acquire the source's lock for every variant.** This is the symmetry rule with `cancel_ipc_block`: both clear IPC-blocking field-group writes from a non-owning CPU and MUST hold the matching source lock.
 

--- a/core/kernel/src/cap/object.rs
+++ b/core/kernel/src/cap/object.rs
@@ -1378,18 +1378,6 @@ unsafe fn dealloc_object_one(
                         }
                     };
 
-                    // Check if the thread is actively running (sched.current)
-                    // on any CPU.
-                    let mut running_on: Option<usize> = None;
-                    for cpu in 0..cpu_count
-                    {
-                        if crate::sched::scheduler_for(cpu).current == tcb
-                        {
-                            running_on = Some(cpu);
-                            break;
-                        }
-                    }
-
                     // Release all locks.
                     for cpu in (0..cpu_count).rev()
                     {
@@ -1397,30 +1385,60 @@ unsafe fn dealloc_object_one(
                         s.lock.unlock_raw(s.saved_lock_flags);
                     }
 
-                    // UAF gate: wait for the in-flight switch (if any) to
-                    // both move off `tcb` AND publish context_saved=1. The
-                    // context_saved spin is unconditional — the all-locks
-                    // running_on snapshot can race past schedule()'s
-                    // pre-save lock release. See
-                    // docs/scheduling-internals.md § Cross-CPU TCB Ownership.
+                    // UAF gate: a TCB that is `current` on any CPU MUST NOT be
+                    // reclaimed until every CPU has switched away from it AND
+                    // the in-flight register save has published. Two steps:
                     //
-                    // The spin runs with interrupts ENABLED and preemption
+                    //   1. Spin until `tcb` is not `current` on ANY CPU —
+                    //      unconditional, across every CPU. A single-CPU wait
+                    //      keyed on one all-locks snapshot would be insufficient:
+                    //      such a snapshot names at most one CPU and can be stale
+                    //      the instant the locks drop (a CPU mid-`schedule()` may
+                    //      install or retain `tcb` as `current` after it was
+                    //      taken). #207.
+                    //   2. Spin until `context_saved == 1`, covering the window
+                    //      where a CPU set `current = next` and dropped its lock
+                    //      but `switch()` has not yet saved `tcb`'s registers.
+                    //
+                    // The spins run with interrupts ENABLED and preemption
                     // DISABLED, mirroring `mm::tlb_shootdown::shootdown`. We
                     // enter dealloc from a syscall with `IF=0`; spinning here
                     // with `IF=0` blocks incoming IPIs (FPU flush, TLB
                     // shootdown) targeted at this CPU and deadlocks them.
-                    // Enabling IF lets us service those, while
-                    // `preempt_disable` keeps the scheduler from migrating us
-                    // mid-dealloc (which would invalidate the `running_on`
-                    // snapshot we captured under the all-locks region).
+                    // Enabling IF lets us service those, while `preempt_disable`
+                    // keeps the scheduler from migrating us mid-dealloc.
                     crate::percpu::preempt_disable();
                     // SAFETY: ring 0; saved in matching restore below.
                     let saved_int = crate::arch::current::cpu::save_and_disable_interrupts();
                     // SAFETY: ring 0; IDT loaded; preempt disabled.
                     crate::arch::current::interrupts::enable();
 
-                    if let Some(run_cpu) = running_on
+                    // Step 1: not `current` on any CPU. Find the (at most one)
+                    // CPU still running `tcb`, spin on just that CPU's lock
+                    // until it switches away, then re-scan; once a full scan is
+                    // clean, no CPU can re-install `tcb` (it is `Exited` and
+                    // unlinked from every run queue under the all-locks region).
+                    loop
                     {
+                        let run_cpu = 'scan: {
+                            for cpu in 0..cpu_count
+                            {
+                                let s = crate::sched::scheduler_for(cpu);
+                                let f = s.lock.lock_raw();
+                                let is_cur = s.current == tcb;
+                                s.lock.unlock_raw(f);
+                                if is_cur
+                                {
+                                    break 'scan Some(cpu);
+                                }
+                            }
+                            None
+                        };
+                        let Some(run_cpu) = run_cpu
+                        else
+                        {
+                            break;
+                        };
                         let sched = crate::sched::scheduler_for(run_cpu);
                         while {
                             let s = sched.lock.lock_raw();
@@ -1432,6 +1450,8 @@ unsafe fn dealloc_object_one(
                             core::hint::spin_loop();
                         }
                     }
+
+                    // Step 2: register save published.
                     while (*tcb)
                         .context_saved
                         .load(core::sync::atomic::Ordering::Acquire)
@@ -1449,8 +1469,8 @@ unsafe fn dealloc_object_one(
                     // needed: `nm_handler` only ever names the currently
                     // Running thread on its CPU, and `switch_out_save`
                     // clears the slot on switch-out — so by the time the
-                    // `running_on` and `context_saved` spins above have
-                    // completed, no CPU's owner slot can name this TCB.
+                    // not-`current`-anywhere and `context_saved` spins above
+                    // have completed, no CPU's owner slot can name this TCB.
                 }
 
                 // Wake the captured reply-bound client outside the all-locks

--- a/core/ktest/src/stress/priority_dealloc_race.rs
+++ b/core/ktest/src/stress/priority_dealloc_race.rs
@@ -4,18 +4,21 @@
 //! Stress: race `sys_thread_set_priority` against `cap_delete(Thread)` and
 //! the load balancer.
 //!
-//! Reproduces issue #122 family hazards by writing the same scheduler-owned
-//! TCB fields (`priority`, `state`, `run_queue_next`) from cross-CPU
-//! syscalls under contention:
+//! Reproduces issue #122 / #207 family hazards by writing the same
+//! scheduler-owned TCB fields (`priority`, `state`, `run_queue_next`) from
+//! cross-CPU syscalls under contention, and by freeing a TCB while it is
+//! `current` on another CPU:
 //!
 //!   * **Phase 1** churns priority on every worker each cycle and, once
 //!     per 4-cycle window, also flips affinity — the load balancer /
 //!     active migration races the priority-change's locate-and-relocate
 //!     and exercises the cross-CPU outgoing re-enqueue branch under heavy
 //!     contention.
-//!   * **Phase 2** does two rapid priority writes followed by
-//!     `cap_delete(Thread)` — the dealloc all-locks walk races the
-//!     priority-change in flight.
+//!   * **Phase 2** pins each worker to a remote CPU and yields so it runs
+//!     there, then does two rapid priority writes followed by
+//!     `cap_delete(Thread)` — the dealloc all-locks walk + drain protocol
+//!     race the priority-change in flight *and* a target that is `current`
+//!     on another CPU (the #207 free-vs-`current`-read window).
 //!
 //! Pass criterion: harness boots clean to `[ktest] ALL TESTS PASSED`. Any
 //! double-link, stale-link UAF, or magic-cookie corruption surfaces as a
@@ -89,14 +92,32 @@ pub fn run(ctx: &TestContext) -> TestResult
         }
     }
 
-    // ── Phase 2: priority churn racing dealloc. ──────────────────────────
+    // ── Phase 2: dealloc racing a remote-running, priority-churned target. ─
     //
     // Hazard 1 surface: dealloc reads priority under all-CPU locks and
     // calls remove_from_queue per CPU; a concurrent set_priority that
     // changes the priority field without relocating the queue entry would
     // leave a stale link the dealloc misses.
+    //
+    // #207 surface: each worker is pinned to a CPU and given a slice to run
+    // there *before* deletion, so `cap_delete` drives the dealloc drain
+    // protocol against a TCB that is `current` on another CPU — the exact
+    // free-vs-`current`-read window the timer-tick magic assert guards.
+    // `(i + 1) % cpus` spreads the workers across CPUs; with cpus > 1 most
+    // land on a CPU other than the controller's, which is the case of interest
+    // (it is not guaranteed for every worker — the controller's own CPU may
+    // coincide with a target, which is harmless).
     for i in 0..NUM_WORKERS
     {
+        let i_u32 = u32::try_from(i).unwrap_or(0);
+        let target_cpu = (i_u32 + 1) % cpu_mod;
+        let _ = thread_set_affinity(threads[i], target_cpu);
+        // Yield so the pinned worker migrates to and starts running on the
+        // remote CPU before we churn its priority and delete it.
+        for _ in 0..4
+        {
+            let _ = thread_yield();
+        }
         let _ = thread_set_priority(threads[i], 5, 0);
         let _ = thread_set_priority(threads[i], 11, 0);
         cap_delete(threads[i])


### PR DESCRIPTION
## Summary

Closes #207 (intermittent `timer_tick: current TCB magic corrupt` under dealloc/priority stress).

`dealloc_object(Thread)`'s reclamation gate decided which CPU to wait on before
freeing a TCB using a single all-locks `running_on` snapshot with an early break
(first CPU whose `current == tcb`). That snapshot names at most one CPU and can
be stale the moment the all-CPU locks drop. This PR replaces it with an
**unconditional all-CPU gate**: scan every CPU, spin on whichever still has
`current == tcb` until it switches away, re-scan until a full pass is clean, then
the existing unconditional `context_saved` gate, then poison/free. This
enforces — for every CPU — the invariant that *a TCB installed as `current` on
any CPU cannot be reclaimed until that CPU has switched away*, independent of any
snapshot. The gate keeps the existing `preempt_disable` + interrupts-enabled
discipline (IPI servicing); its two-level structure (scan, then single-CPU spin)
means the O(cpu_count) scan runs ~twice, not per spin iteration.

## On root-cause (honest status)

The assert fired **once** and passed on re-run. I traced the documented drain
protocol against every constructible interleaving and found it **sound on
x86-TSO**: `set_current(next)` commits under the CPU's lock before
`release_lock_only`, so the all-locks snapshot observes `current == tcb` on at
most one CPU (the two-CPU transient is always hidden behind a held lock), and the
`context_saved` gate covers the in-flight register save. Under **250
widened-window stress runs** (ephemeral delays injected into `schedule()`'s
`set_current`→`switch` window and `dealloc`'s release→gate→poison windows, plus a
strengthened stress that `cap_delete`s a worker while it runs on a remote CPU)
the assert did **not** reproduce.

No reproducible defect was found in the protocol. This lands the hardening
anyway: it removes the only structural dependency (the early-break `running_on`
snapshot) that could theoretically let the gate miss a CPU, and directly
implements acceptance criterion #2.

## Changes

- **Fix** — `core/kernel/src/cap/object.rs`: unconditional all-CPU `current`
  gate in the Thread dealloc arm (the `running_on` snapshot is gone).
- **Stress** — `core/ktest/src/stress/priority_dealloc_race.rs`: Phase 2 pins
  each worker to a remote CPU and runs it there before `cap_delete`, exercising
  dealloc against a TCB that is `current` on another CPU.
- **Docs** — `thread-lifecycle-and-sleep.md` (Drain Protocol steps 6/9/10,
  invariants 3/4, lifecycle table) and `scheduling-internals.md`
  (context_saved pseudocode/prose, state table) updated to the all-CPU gate.

## Test plan

All via `cargo xtask` (clean between arch switches):

- x86_64 debug ktest, pre-fix, widened windows + remote-delete stress:
  **250/250 PASS** (`run-parallel --cpus 4`).
- x86_64 debug ktest, with fix, widened windows: **150/150 PASS** (no
  deadlock/regression from the all-CPU gate).
- x86_64 debug ktest, production: clean-run batch PASS.
- riscv64 debug ktest, production: clean-run batch PASS.
- Host workspace tests (`cargo xtask test`): **68 passed, 0 failed**.
- CI: full validate matrix (x86_64 + riscv64, debug + release, ktest/svctest/
  usertest) + host-tests green.

The ktest suite exercises `priority_dealloc_race`, `thread_churn`, and
`cap_delete_running` on every run (acceptance criterion #3).

## Acceptance criteria (#207)

- [x] **Root-cause the race** — *not reproducible*: no defect found. Under 250
  widened-window runs the assert did not recur and the drain protocol was shown
  sound on x86-TSO (see "On root-cause" above). Resolved by the hardening below
  rather than by a located fix.
- [x] **Fix the lifecycle gap** so a TCB `current` on any CPU cannot be
  reclaimed until that CPU has switched away — the unconditional all-CPU gate.
- [x] **Stress passes repeatedly** with no magic-corruption assert — see test
  plan.
