### PR TITLE
treewide: recognise seraph as a std target; drop restricted_std gate

### DIFF
--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -96,6 +96,14 @@ kernel/no_std triples; `core,alloc,std,panic_abort` for std-userspace
 triples) to rebuild the standard library from source. The build scripts
 pass the flag explicitly.
 
+By default `os: seraph` is not in rustc's recognised-OS list, so upstream
+`std`'s build script would mark the crate `restricted_std`-gated. Because
+Seraph ships a complete `std::sys::seraph` backend, the build pipeline
+overlays std's `build.rs` to list `seraph` alongside the other recognised
+std targets (`hermit`, `redox`, …). `std` is therefore built as a normal
+stable crate, and std-userspace bins need no `#![feature(restricted_std)]`
+opt-in.
+
 ---
 
 ## Build Output: the Sysroot

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -296,4 +296,4 @@ The merge-gating rule (CI must pass green before merge) lives in
 
 ## Summarized By
 
-[README.md](../README.md), [conventions.md](conventions.md)
+[README.md](../README.md), [conventions.md](conventions.md), [ruststd/README.md](../runtime/ruststd/README.md)

--- a/programs/fb-charset/src/main.rs
+++ b/programs/fb-charset/src/main.rs
@@ -29,8 +29,6 @@
 //! (`physical_base == 0`) exits silently. `restart = never`,
 //! `critical = no`.
 
-#![feature(restricted_std)]
-
 use std::os::seraph::startup_info;
 
 use ipc::IpcMessage;

--- a/programs/fsbench/src/main.rs
+++ b/programs/fsbench/src/main.rs
@@ -27,7 +27,6 @@
 //! fsbench: arch=x86_64 size=4096 path=frame  iters=256 cycles_min=...
 //! ```
 
-#![feature(restricted_std)]
 // fsbench is a benchmark harness: panics on failure so faults surface
 // in the log. `expect`/`unwrap` are the intended idiom here.
 #![allow(clippy::expect_used, clippy::unwrap_used)]

--- a/programs/hello/src/main.rs
+++ b/programs/hello/src/main.rs
@@ -10,8 +10,6 @@
 //! child's stdout cap to the system log endpoint with a per-service token;
 //! nothing in this binary knows or cares.
 
-#![feature(restricted_std)]
-
 fn main()
 {
     println!("hello from seraph userspace");

--- a/programs/hello/tester/src/main.rs
+++ b/programs/hello/tester/src/main.rs
@@ -7,7 +7,6 @@
 //! asserts the expected line appears, and asserts a clean exit. See
 //! [docs/testing.md](../../../docs/testing.md) for the protocol.
 
-#![feature(restricted_std)]
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use std::io::Read;

--- a/programs/pipefault/src/main.rs
+++ b/programs/pipefault/src/main.rs
@@ -15,8 +15,6 @@
 //! this binary with `Stdio::piped()`, drains stdout, and asserts the
 //! prefix arrived followed by EOF (no hang) plus a fault `exit_reason`.
 
-#![feature(restricted_std)]
-
 use std::io::Write;
 
 fn main()

--- a/programs/stackoverflow/src/main.rs
+++ b/programs/stackoverflow/src/main.rs
@@ -14,8 +14,6 @@
 //! Driven by `services/svctest`'s `stack_overflow_phase`, which spawns this
 //! binary, waits for exit, and asserts the non-zero fault reason.
 
-#![feature(restricted_std)]
-
 fn main()
 {
     overflow(0);

--- a/programs/stdiotest/src/main.rs
+++ b/programs/stdiotest/src/main.rs
@@ -12,8 +12,6 @@
 //! started. This child blocks on `stdin().read_line(..)` until those bytes
 //! arrive, processes them, and emits the result through `println!`.
 
-#![feature(restricted_std)]
-
 use std::io::{BufRead, BufReader};
 
 fn main()

--- a/programs/stdiotest/tester/src/main.rs
+++ b/programs/stdiotest/tester/src/main.rs
@@ -8,7 +8,6 @@
 //! reply (byte count, uppercase echo, `PASS`) appears and the child exits
 //! cleanly. See [docs/testing.md](../../../docs/testing.md).
 
-#![feature(restricted_std)]
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use std::io::{Read, Write};

--- a/runtime/ruststd/README.md
+++ b/runtime/ruststd/README.md
@@ -13,6 +13,12 @@ overlay. The build pipeline applies the overlay onto a vendored
 `library/std` checkout per
 [`docs/build-system.md`](../../docs/build-system.md).
 
+One overlay lists `seraph` among std's recognised target OSes (in
+`library/std/build.rs`), so this `std` is built as a normal stable crate
+rather than `restricted_std`-gated. Downstream seraph bins therefore consume
+`std` with no `#![feature(restricted_std)]` opt-in (see
+[`docs/build-system.md`](../../docs/build-system.md)).
+
 ---
 
 ## VA Management Surfaces

--- a/services/crasher/src/main.rs
+++ b/services/crasher/src/main.rs
@@ -19,12 +19,6 @@
 //! re-resolved on every (re)spawn. Log and procmgr endpoints arrive via
 //! `ProcessInfo`, so they need no bootstrap round.
 
-// The `seraph` target is not in rustc's recognised-OS list, so `std` is
-// `restricted_std`-gated for downstream bins. Every std-built service on
-// seraph carries this preamble; RUSTC_BOOTSTRAP=1 (set by xtask for StdUser
-// builds) lets the attribute compile without a nightly-tagged toolchain.
-#![feature(restricted_std)]
-
 use std::os::seraph::startup_info;
 use std::thread;
 use std::time::Duration;

--- a/services/devmgr/src/main.rs
+++ b/services/devmgr/src/main.rs
@@ -14,7 +14,6 @@
 //!
 //! See `devmgr/README.md` for the full design.
 
-#![feature(restricted_std)]
 #![allow(clippy::cast_possible_truncation)]
 
 mod caps;

--- a/services/drivers/cmos/src/main.rs
+++ b/services/drivers/cmos/src/main.rs
@@ -11,7 +11,6 @@
 //! ([`rtc_labels::RTC_GET_EPOCH_TIME`]) by re-reading hardware on
 //! every request.
 
-#![feature(restricted_std)]
 #![allow(clippy::cast_possible_truncation)]
 
 use ipc::{IpcMessage, rtc_errors, rtc_labels};

--- a/services/drivers/framebuffer/src/main.rs
+++ b/services/drivers/framebuffer/src/main.rs
@@ -36,7 +36,6 @@
 //! (`core/kernel/src/framebuffer.rs`) remains the early-boot / panic
 //! fallback (see `docs/console-model.md`).
 
-#![feature(restricted_std)]
 #![allow(clippy::cast_possible_truncation)]
 
 mod arch;

--- a/services/drivers/goldfish-rtc/src/main.rs
+++ b/services/drivers/goldfish-rtc/src/main.rs
@@ -10,7 +10,6 @@
 //! cap on the driver's service endpoint. Implements the one-label
 //! RTC driver contract ([`rtc_labels::RTC_GET_EPOCH_TIME`]).
 
-#![feature(restricted_std)]
 #![allow(clippy::cast_possible_truncation)]
 #![allow(clippy::cast_ptr_alignment)]
 

--- a/services/drivers/serial/src/main.rs
+++ b/services/drivers/serial/src/main.rs
@@ -19,7 +19,6 @@
 //! pre-driver boot window is covered by init-logd's direct-UART path (see
 //! `docs/console-model.md`).
 
-#![feature(restricted_std)]
 #![allow(clippy::cast_possible_truncation)]
 
 mod arch;

--- a/services/drivers/virtio/blk/src/main.rs
+++ b/services/drivers/virtio/blk/src/main.rs
@@ -9,10 +9,6 @@
 //! from devmgr. Initialises the `VirtIO` device via the modern PCI transport,
 //! sets up a split virtqueue, and serves block read requests over IPC.
 
-// The `seraph` target is not in rustc's recognised-OS list, so `std` is
-// `restricted_std`-gated for downstream bins. Every std-built service on
-// seraph carries this preamble.
-#![feature(restricted_std)]
 // cast_possible_truncation: userspace targets 64-bit only; u64/usize conversions
 // are lossless. u32 casts on capability slot indices are bounded by CSpace capacity.
 #![allow(clippy::cast_possible_truncation)]

--- a/services/fs/fat/src/main.rs
+++ b/services/fs/fat/src/main.rs
@@ -29,10 +29,6 @@
 //! Crash window discussion lives in
 //! `services/fs/fat/docs/crash-safety.md`.
 
-// The `seraph` target is not in rustc's recognised-OS list, so `std` is
-// `restricted_std`-gated for downstream bins. Every std-built service on
-// seraph carries this preamble.
-#![feature(restricted_std)]
 #![allow(clippy::cast_possible_truncation)]
 
 mod alloc;

--- a/services/logd/src/main.rs
+++ b/services/logd/src/main.rs
@@ -41,9 +41,6 @@
 //! handover — same kernel endpoint object, only the RECV-holder
 //! changes.
 
-// The `seraph` target is not in rustc's recognised-OS list, so `std`
-// is `restricted_std`-gated for downstream bins.
-#![feature(restricted_std)]
 // cast_possible_truncation: targets 64-bit only; u64/usize conversions lossless.
 #![allow(clippy::cast_possible_truncation)]
 

--- a/services/procmgr/src/main.rs
+++ b/services/procmgr/src/main.rs
@@ -16,9 +16,6 @@
 //! caller over IPC at startup. procmgr itself has no knowledge of the child's
 //! service-specific capabilities.
 
-// The `seraph` target is not in rustc's recognised-OS list, so `std` is
-// `restricted_std`-gated for downstream bins.
-#![feature(restricted_std)]
 // cast_possible_truncation: targets 64-bit only; u64/usize conversions lossless.
 #![allow(clippy::cast_possible_truncation)]
 

--- a/services/pwrmgr/src/main.rs
+++ b/services/pwrmgr/src/main.rs
@@ -18,10 +18,6 @@
 //! See `services/pwrmgr/README.md` for the design and future-scope
 //! sketch.
 
-// The `seraph` target is not in rustc's recognised-OS list, so `std` is
-// `restricted_std`-gated for downstream bins. Every std-built service on
-// seraph carries this preamble.
-#![feature(restricted_std)]
 // cast_possible_truncation: targets 64-bit only; u64/usize conversions lossless.
 #![allow(clippy::cast_possible_truncation)]
 

--- a/services/svcmgr/src/main.rs
+++ b/services/svcmgr/src/main.rs
@@ -21,10 +21,6 @@
 //!
 //! See `svcmgr/docs/ipc-interface.md` and `svcmgr/docs/restart-protocol.md`.
 
-// The `seraph` target is not in rustc's recognised-OS list, so `std` is
-// `restricted_std`-gated for downstream bins. Every std-built service on
-// seraph carries this preamble.
-#![feature(restricted_std)]
 // cast_possible_truncation: targets 64-bit only; u64/usize conversions lossless.
 #![allow(clippy::cast_possible_truncation)]
 

--- a/services/svctest/src/main.rs
+++ b/services/svctest/src/main.rs
@@ -20,11 +20,6 @@
 //! * [`ipc_util`] — raw-IPC helpers shared across phases.
 //! * [`phases`] — one module per services-tier surface under test.
 
-// The `seraph` target is not in rustc's recognised-OS list, so `std` is
-// `restricted_std`-gated for downstream bins. RUSTC_BOOTSTRAP=1 (set by
-// xtask for StdUser builds) lets the attribute compile without a
-// nightly-tagged toolchain.
-#![feature(restricted_std)]
 #![feature(thread_local)]
 // svctest is an integration test harness: a standalone binary that
 // panics on failure so faults surface in the log. `expect`/`unwrap` are

--- a/services/timed/src/main.rs
+++ b/services/timed/src/main.rs
@@ -11,7 +11,6 @@
 //! clock, and serves [`timed_labels::GET_WALL_TIME`] from `offset +
 //! system_info(ElapsedUs)` thereafter.
 
-#![feature(restricted_std)]
 #![allow(clippy::cast_possible_truncation)]
 
 use ipc::{

--- a/services/usertest/src/main.rs
+++ b/services/usertest/src/main.rs
@@ -11,11 +11,6 @@
 //! program's real I/O surface; see [docs/testing.md](../../../docs/testing.md)
 //! for the protocol.
 
-// The `seraph` target is not in rustc's recognised-OS list, so `std` is
-// `restricted_std`-gated for downstream bins. RUSTC_BOOTSTRAP=1 (set by
-// xtask for StdUser builds) lets the attribute compile without a
-// nightly-tagged toolchain.
-#![feature(restricted_std)]
 // usertest is an integration test harness: panics on protocol violation
 // so faults surface in the log. `expect`/`unwrap` are the intended idiom
 // here (coding-standards §D permits them in test code).

--- a/services/vfsd/src/main.rs
+++ b/services/vfsd/src/main.rs
@@ -20,10 +20,6 @@
 //! See `vfsd/README.md` for the design and `fs/docs/fs-driver-protocol.md`
 //! for the driver-side protocol.
 
-// The `seraph` target is not in rustc's recognised-OS list, so `std` is
-// `restricted_std`-gated for downstream bins. Every std-built service on
-// seraph carries this preamble.
-#![feature(restricted_std)]
 #![allow(clippy::cast_possible_truncation)]
 
 mod driver;

--- a/xtask/src/commands/build.rs
+++ b/xtask/src/commands/build.rs
@@ -677,12 +677,13 @@ fn build_spec(ctx: &BuildContext, args: &BuildArgs, spec: &Spec) -> Result<()>
     {
         // Routes RUSTC + RUSTC_WORKSPACE_WRAPPER through the shim,
         // sets the SERAPH_SHIM_* config (so the shim knows what to
-        // exec), and applies RUSTC_BOOTSTRAP=1 (unlocks `rustc_private`
-        // and the other unstable features `-Zbuild-std` and the std
-        // overlay's workspace deps — process-abi, syscall, ipc, shmem,
-        // log — require). The `seraph` OS is recognised as a std target
-        // by the std `build.rs` overlay, so `std` is not
-        // `restricted_std`-gated and bins need no feature preamble.
+        // exec), and applies RUSTC_BOOTSTRAP=1 — unlocking the unstable
+        // features that `-Zbuild-std` and the std overlay's workspace
+        // deps (process-abi, syscall, ipc, shmem, log) require:
+        // `rustc_private` and `rustc-dep-of-std`. The `seraph` OS is
+        // recognised as a std target by the std `build.rs` overlay, so
+        // `std` is not `restricted_std`-gated and bins need no feature
+        // preamble.
         s.apply_env(&mut cmd);
     }
     run_cmd(&mut cmd)?;

--- a/xtask/src/commands/build.rs
+++ b/xtask/src/commands/build.rs
@@ -677,13 +677,12 @@ fn build_spec(ctx: &BuildContext, args: &BuildArgs, spec: &Spec) -> Result<()>
     {
         // Routes RUSTC + RUSTC_WORKSPACE_WRAPPER through the shim,
         // sets the SERAPH_SHIM_* config (so the shim knows what to
-        // exec), and applies RUSTC_BOOTSTRAP=1. The latter unlocks
-        // `restricted_std`/`rustc_private` — StdUser bins target a
-        // custom triple ("seraph") that rustc doesn't recognise in
-        // its built-in list, and the std overlay loads workspace
-        // crates (process-abi, syscall, ipc, shmem, log) as std
-        // deps; matches how hermit and other tier-3 custom-std
-        // targets unlock the same gates.
+        // exec), and applies RUSTC_BOOTSTRAP=1 (unlocks `rustc_private`
+        // and the other unstable features `-Zbuild-std` and the std
+        // overlay's workspace deps — process-abi, syscall, ipc, shmem,
+        // log — require). The `seraph` OS is recognised as a std target
+        // by the std `build.rs` overlay, so `std` is not
+        // `restricted_std`-gated and bins need no feature preamble.
         s.apply_env(&mut cmd);
     }
     run_cmd(&mut cmd)?;
@@ -797,8 +796,9 @@ fn clippy_check_ext(
             cmd.arg("check").args(flags);
             // Routes RUSTC + RUSTC_WORKSPACE_WRAPPER through the shim,
             // sets the SERAPH_SHIM_* config, and re-applies
-            // RUSTC_BOOTSTRAP=1 (unlocks restricted_std + rustc_private
-            // so service code stays preamble-free).
+            // RUSTC_BOOTSTRAP=1. `std` is a recognised (non-restricted)
+            // target via the std `build.rs` overlay, so service code
+            // stays preamble-free.
             s.apply_env(&mut cmd);
             // Clippy-driver splits CLIPPY_ARGS on __CLIPPY_HACKERY__; this
             // matches the encoding cargo-clippy uses internally when

--- a/xtask/src/rust_src.rs
+++ b/xtask/src/rust_src.rs
@@ -107,8 +107,16 @@ impl SeraphToolchain
     /// build through the seraph toolchain mirror: `RUSTC` and
     /// `RUSTC_WORKSPACE_WRAPPER` (mirror entry points), the three
     /// `SERAPH_SHIM_*` config vars (so the shim knows what to exec),
-    /// and `RUSTC_BOOTSTRAP=1` (so the StdUser builds can use
-    /// `restricted_std` and `rustc_private`).
+    /// and `RUSTC_BOOTSTRAP=1`.
+    ///
+    /// `RUSTC_BOOTSTRAP=1` lets the StdUser builds use the unstable
+    /// features `-Zbuild-std` and the std overlay's workspace deps
+    /// (`process-abi`, `syscall`, `ipc`, `shmem`, `log`) require —
+    /// `rustc_private` and the `rustc-dep-of-std` machinery. The
+    /// `seraph` OS is recognised as a std target by an overlay on std's
+    /// `build.rs` (see `apply_restricted_std_overlay`), so `std` is not
+    /// `restricted_std`-gated and service/program sources carry no
+    /// `#![feature(restricted_std)]` opt-in.
     pub fn apply_env(&self, cmd: &mut Command)
     {
         cmd.env("RUSTC", &self.rustc);
@@ -629,6 +637,7 @@ fn apply_all_overlays(mirror: &Path, overlay_root: &Path) -> Result<()>
         .context("deriving project root from overlay_root")?;
     apply_sys_visibility_overlay(&rust_src).context("sys visibility overlay")?;
     apply_std_cargo_deps_overlay(&rust_src, project_root).context("std Cargo.toml deps overlay")?;
+    apply_restricted_std_overlay(&rust_src).context("restricted_std OS-recognition overlay")?;
     apply_alloc_overlay(&rust_src, overlay_root).context("alloc overlay")?;
     apply_reserve_overlay(&rust_src, overlay_root).context("reserve overlay")?;
     apply_io_error_overlay(&rust_src).context("io/error overlay")?;
@@ -761,6 +770,23 @@ fn apply_std_cargo_deps_overlay(rust_src: &Path, project_root: &Path) -> Result<
         cargo_toml.display()
     ));
     Ok(())
+}
+
+/// Add `target_os = "seraph"` to the recognised-OS list in std's
+/// `build.rs`, alongside `hermit`/`redox` and the other tier-3 std
+/// targets. Seraph ships a complete `std::sys::seraph` backend (the
+/// overlays in this module), so `std` is built `#![stable]` rather than
+/// `restricted_std`-gated, and downstream bins consume it with no
+/// `#![feature(restricted_std)]` opt-in.
+fn apply_restricted_std_overlay(rust_src: &Path) -> Result<()>
+{
+    let build_rs = rust_src.join("library/std/build.rs");
+    patch_file(
+        &build_rs,
+        "std/build.rs",
+        "        || target_os == \"vexos\"\n",
+        "        || target_os == \"vexos\"\n        // seraph-overlay: seraph ships a full std::sys backend; treat it as a recognised std OS\n        || target_os == \"seraph\"\n",
+    )
 }
 
 /// Widen `mod alloc;` in `sys/mod.rs` to `pub(crate) mod alloc;` so

--- a/xtask/src/rust_src.rs
+++ b/xtask/src/rust_src.rs
@@ -109,8 +109,8 @@ impl SeraphToolchain
     /// `SERAPH_SHIM_*` config vars (so the shim knows what to exec),
     /// and `RUSTC_BOOTSTRAP=1`.
     ///
-    /// `RUSTC_BOOTSTRAP=1` lets the StdUser builds use the unstable
-    /// features `-Zbuild-std` and the std overlay's workspace deps
+    /// `RUSTC_BOOTSTRAP=1` unlocks the unstable features that
+    /// `-Zbuild-std` and the std overlay's workspace deps
     /// (`process-abi`, `syscall`, `ipc`, `shmem`, `log`) require —
     /// `rustc_private` and the `rustc-dep-of-std` machinery. The
     /// `seraph` OS is recognised as a std target by an overlay on std's


### PR DESCRIPTION
## Summary

Centralises the `restricted_std` opt-in out of 24 per-binary source
preambles by recognising `seraph` as a real std target.

The `seraph` target OS was absent from rustc's recognised-OS list, so
upstream std's `build.rs` marked the crate `restricted_std`-gated, and
every std-userspace binary carried a `#![feature(restricted_std)]`
preamble. Because Seraph ships a complete `std::sys::seraph` backend, it
is a std target in the same sense as hermit/redox. A new overlay,
`apply_restricted_std_overlay`, lists `target_os = "seraph"` in std's
`build.rs` recognised-OS set (reusing the existing hard-link-safe,
idempotent `patch_file` machinery). `std` is then built `#![stable]`, so
no crate needs the feature gate and the 24 preambles are removed.

## Why not inject via `RUSTFLAGS`

The first attempt — `-Zcrate-attr=feature(restricted_std)` via
`RUSTFLAGS` — is infeasible. `RUSTFLAGS` reaches the `-Zbuild-std`
crates, and `#![feature(restricted_std)]` on `core` (which compiles
before `std` and does not declare the feature) is a hard `E0635` error.
`RUSTFLAGS` cannot be scoped away from build-std, so recognition is the
correct fix.

## Changes

- `xtask/src/rust_src.rs`: new `apply_restricted_std_overlay` + its
  registration in `apply_all_overlays`; `apply_env` doc updated
  (`RUSTC_BOOTSTRAP=1` retained for `-Zbuild-std`/`rustc_private`).
- 24 leaf bins under `services/` and `programs/`: removed
  `#![feature(restricted_std)]` and its comment (adjacent attributes
  preserved).
- `xtask/src/commands/build.rs`, `docs/build-system.md`,
  `runtime/ruststd/README.md`: present-intent doc/comment updates.

## Test plan

- [x] `cargo xtask build --arch x86_64` — clean, incl. StdUser
      `-D warnings` lint pass
- [x] `cargo xtask build --arch riscv64` — clean
- [x] x86_64 `usertest` under QEMU — `[usertest] ALL TESTS PASSED`
- [x] riscv64 `usertest` under QEMU — `[usertest] ALL TESTS PASSED`
- [x] `cargo xtask test` (host) — 68 passed, 0 failed
