### PR TITLE
fault: route general ring-3 exceptions through the fault handler

### DIFF
--- a/abi/syscall/src/lib.rs
+++ b/abi/syscall/src/lib.rs
@@ -544,9 +544,14 @@ pub const FAULT_LABEL: u64 = u64::MAX - 1;
 pub const FAULT_KIND_VM: u64 = 0;
 
 /// Fault kind (data word 0): a CPU exception with no kernel resolution (illegal
-/// instruction, alignment, divide error, …). Data words 1–3 are
-/// `[normalized_code, arch_aux_code, faulting_ip]`. Routed by a later phase;
-/// reserved here so the taxonomy is stable.
+/// instruction, alignment, breakpoint, …). Data words 1–3 are
+/// `[normalized_code, arch_aux_code, faulting_ip]`:
+/// - `normalized_code` is an architecture-neutral [`FAULT_EXC_UNKNOWN`]-family
+///   class so a handler can dispatch without architecture knowledge.
+/// - `arch_aux_code` is the architecture's auxiliary datum for the trap:
+///   x86-64 the hardware error code (`0` when the vector has none); RISC-V
+///   `stval` (the faulting address for misaligned/access faults, the faulting
+///   instruction bits for an illegal instruction).
 pub const FAULT_KIND_EXCEPTION: u64 = 1;
 
 /// `FAULT_KIND_VM` access flag: the access was a read.
@@ -558,6 +563,43 @@ pub const FAULT_ACCESS_EXEC: u64 = 1 << 2;
 /// `FAULT_KIND_VM` access flag: the page was present (protection violation)
 /// rather than not-present.
 pub const FAULT_ACCESS_PRESENT: u64 = 1 << 3;
+
+// ── Normalized exception codes (FAULT_KIND_EXCEPTION data word 1) ───────────────
+//
+// Architecture-neutral classification of a CPU exception, so a handler dispatches
+// on the class without architecture knowledge. The raw architectural code/value
+// is carried separately in `arch_aux_code` (data word 2). Values not listed are
+// reserved; a handler MUST treat an unrecognized code as [`FAULT_EXC_UNKNOWN`].
+
+/// Normalized exception: unclassified — the architecture raised a U-mode
+/// exception that maps to no class below. Consult `arch_aux_code` for detail.
+pub const FAULT_EXC_UNKNOWN: u64 = 0;
+/// Normalized exception: illegal / undefined instruction (x86-64 `#UD`; RISC-V
+/// illegal instruction).
+pub const FAULT_EXC_ILLEGAL_INSTRUCTION: u64 = 1;
+/// Normalized exception: software breakpoint (x86-64 `#BP`; RISC-V `ebreak`).
+pub const FAULT_EXC_BREAKPOINT: u64 = 2;
+/// Normalized exception: debug trap — single-step or hardware breakpoint
+/// (x86-64 `#DB`). No RISC-V mapping (debug is an external-debugger facility).
+pub const FAULT_EXC_DEBUG: u64 = 3;
+/// Normalized exception: integer divide error (x86-64 `#DE`). RISC-V has no
+/// hardware divide trap.
+pub const FAULT_EXC_DIVIDE: u64 = 4;
+/// Normalized exception: arithmetic overflow trap (x86-64 `#OF` / `INTO`).
+pub const FAULT_EXC_OVERFLOW: u64 = 5;
+/// Normalized exception: bound-range exceeded (x86-64 `#BR`).
+pub const FAULT_EXC_BOUND_RANGE: u64 = 6;
+/// Normalized exception: misaligned access (x86-64 `#AC`; RISC-V instruction /
+/// load / store address-misaligned).
+pub const FAULT_EXC_ALIGNMENT: u64 = 7;
+/// Normalized exception: physical access fault — the access reached memory the
+/// hardware forbids (RISC-V instruction / load / store access fault).
+pub const FAULT_EXC_ACCESS: u64 = 8;
+/// Normalized exception: protection / segmentation violation (x86-64 `#GP`,
+/// `#SS`, `#NP`, `#TS`).
+pub const FAULT_EXC_PROTECTION: u64 = 9;
+/// Normalized exception: floating-point / SIMD error (x86-64 `#MF` / `#XM`).
+pub const FAULT_EXC_FP: u64 = 10;
 
 /// Fault reply label: resume the faulting thread (re-execute the faulting
 /// instruction, or continue from a handler-modified instruction pointer). The

--- a/core/kernel/docs/syscalls.md
+++ b/core/kernel/docs/syscalls.md
@@ -983,8 +983,10 @@ merely names where the thread's faults are delivered. The kernel synthesizes fau
 delivery via the binding and distributes no send capability to the endpoint, so a
 fault message bearing `FAULT_LABEL` cannot be forged.
 
-Only page faults (`FAULT_KIND_VM`) are routed in the current implementation; see
-the fault-handling design doc's implementation-status note.
+Both page faults (`FAULT_KIND_VM`) and other kernel-unresolvable ring-3 exceptions
+(`FAULT_KIND_EXCEPTION`) are routed to the bound handler; the handler dispatches on
+the fault kind and replies `FAULT_REPLY_KILL` for kinds it does not handle. See the
+fault-handling design doc's implementation-status note.
 
 **Capability requirement:** `thread_cap` MUST have Control rights; `endpoint_cap`
 (when non-zero) MUST refer to an `Endpoint`.

--- a/core/kernel/src/arch/riscv64/interrupts.rs
+++ b/core/kernel/src/arch/riscv64/interrupts.rs
@@ -533,21 +533,23 @@ extern "C" fn trap_dispatch(frame: &mut TrapFrame)
             // in exception context because we entered from a running user thread.
             let tcb = unsafe { crate::syscall::current_tcb() };
 
-            // Redirect a page fault (cause 12/13/15) to the thread's bound fault
-            // handler, if any. On a resume reply the trap returns and `sret`
-            // re-executes the faulting instruction (sepc is not advanced for
-            // faults) or continues from a handler-modified sepc.
+            // Redirect a kernel-unresolvable U-mode exception to the thread's
+            // bound fault handler, if any. Page faults (cause 12/13/15) carry
+            // `FAULT_KIND_VM`; every other U-mode exception carries
+            // `FAULT_KIND_EXCEPTION` (see `fault_info_for`). On a resume reply the
+            // trap returns and `sret` re-executes the faulting instruction (sepc
+            // is not advanced for faults) or continues from a handler-modified
+            // sepc.
             // SAFETY: tcb is the running user thread; has_handler only reads the
             // atomic fault_handler field.
-            let handler_bound = matches!(cause_code, 12 | 13 | 15)
-                && !tcb.is_null()
-                && unsafe { crate::ipc::fault::has_handler(tcb) };
+            let handler_bound = !tcb.is_null() && unsafe { crate::ipc::fault::has_handler(tcb) };
             if handler_bound
             {
+                let info = fault_info_for(cause_code, frame);
                 // SAFETY: frame is the live trap frame on this kernel stack; the
                 // redirect points trap_frame at it for the handler's reg access
                 // and returns whether to resume.
-                if unsafe { redirect_user_page_fault(tcb, frame, cause_code) }
+                if unsafe { redirect_user_fault(tcb, frame, &info) }
                 {
                     return;
                 }
@@ -642,10 +644,65 @@ extern "C" fn trap_dispatch(frame: &mut TrapFrame)
     }
 }
 
-/// Redirect a genuine userspace page fault to the faulting thread's bound fault
+/// Build the architecture-neutral [`FaultInfo`](crate::ipc::fault::FaultInfo) for
+/// a U-mode exception `cause_code`. Page faults (12/13/15) become `FAULT_KIND_VM`
+/// with access flags; every other cause becomes `FAULT_KIND_EXCEPTION` with a
+/// normalized class and `stval` as the architecture auxiliary datum.
+#[cfg(not(test))]
+fn fault_info_for(cause_code: u64, frame: &TrapFrame) -> crate::ipc::fault::FaultInfo
+{
+    match cause_code
+    {
+        // scause: 12 = instruction page fault, 13 = load page fault, 15 =
+        // store/AMO page fault. RISC-V does not encode present-vs-not-present in
+        // scause, so the PRESENT flag is left unset (a handler that needs it
+        // inspects its mappings).
+        12 | 13 | 15 =>
+        {
+            let access = match cause_code
+            {
+                12 => syscall::FAULT_ACCESS_EXEC,
+                15 => syscall::FAULT_ACCESS_WRITE,
+                _ => syscall::FAULT_ACCESS_READ, // 13 = load
+            };
+            crate::ipc::fault::FaultInfo {
+                kind: syscall::FAULT_KIND_VM,
+                d1: frame.stval,
+                d2: access,
+                ip: frame.sepc,
+            }
+        }
+        _ => crate::ipc::fault::FaultInfo {
+            kind: syscall::FAULT_KIND_EXCEPTION,
+            d1: normalize_riscv_exception(cause_code),
+            d2: frame.stval,
+            ip: frame.sepc,
+        },
+    }
+}
+
+/// Map a RISC-V exception cause code to the architecture-neutral
+/// [`syscall::FAULT_EXC_UNKNOWN`]-family normalized code delivered in a
+/// `FAULT_KIND_EXCEPTION` message. Page-fault causes (12/13/15) and `ecall`
+/// (cause 8) are handled elsewhere and never reach here.
+#[cfg(not(test))]
+fn normalize_riscv_exception(cause: u64) -> u64
+{
+    match cause
+    {
+        0 | 4 | 6 => syscall::FAULT_EXC_ALIGNMENT, // instr / load / store misaligned
+        1 | 5 | 7 => syscall::FAULT_EXC_ACCESS,    // instr / load / store access fault
+        2 => syscall::FAULT_EXC_ILLEGAL_INSTRUCTION,
+        3 => syscall::FAULT_EXC_BREAKPOINT,
+        _ => syscall::FAULT_EXC_UNKNOWN,
+    }
+}
+
+/// Redirect a genuine userspace fault to the faulting thread's bound fault
 /// handler. Returns `true` if the handler resolved the fault and the thread
-/// should resume (re-execute the faulting instruction), `false` if the fault is
-/// terminal (the handler declined or the binding was severed).
+/// should resume (re-execute the faulting instruction, or continue from a
+/// handler-modified sepc), `false` if the fault is terminal (the handler declined
+/// or the binding was severed).
 ///
 /// RISC-V already uses a single [`TrapFrame`] for every kernel entry, so — unlike
 /// x86-64 — no frame copy is needed: `(*tcb).trap_frame` is pointed at the live
@@ -657,29 +714,12 @@ extern "C" fn trap_dispatch(frame: &mut TrapFrame)
 /// `tcb` is the current user thread and has a bound handler; `frame` is the live
 /// trap frame on the current kernel stack; no lock is held.
 #[cfg(not(test))]
-unsafe fn redirect_user_page_fault(
+unsafe fn redirect_user_fault(
     tcb: *mut crate::sched::thread::ThreadControlBlock,
     frame: &mut TrapFrame,
-    cause_code: u64,
+    info: &crate::ipc::fault::FaultInfo,
 ) -> bool
 {
-    // scause: 12 = instruction page fault, 13 = load page fault, 15 = store/AMO
-    // page fault. RISC-V does not encode present-vs-not-present in scause, so the
-    // PRESENT flag is left unset (a handler that needs it inspects its mappings).
-    let access = match cause_code
-    {
-        12 => syscall::FAULT_ACCESS_EXEC,
-        15 => syscall::FAULT_ACCESS_WRITE,
-        _ => syscall::FAULT_ACCESS_READ, // 13 = load
-    };
-
-    let info = crate::ipc::fault::FaultInfo {
-        kind: syscall::FAULT_KIND_VM,
-        d1: frame.stval,
-        d2: access,
-        ip: frame.sepc,
-    };
-
     // Point trap_frame at the live frame so the handler's register access targets
     // the faulting state; restore the previous pointer afterward.
     // SAFETY: tcb valid; frame is a valid live TrapFrame.
@@ -691,7 +731,7 @@ unsafe fn redirect_user_page_fault(
     }
 
     // SAFETY: handler bound; trap_frame points at the live frame; no lock held.
-    let outcome = unsafe { crate::ipc::fault::fault_dispatch(tcb, &info) };
+    let outcome = unsafe { crate::ipc::fault::fault_dispatch(tcb, info) };
 
     // SAFETY: restore the previous trap_frame pointer.
     unsafe {

--- a/core/kernel/src/arch/x86_64/idt.rs
+++ b/core/kernel/src/arch/x86_64/idt.rs
@@ -153,7 +153,9 @@ pub struct ExceptionFrame
 
 // ── Common exception handler ──────────────────────────────────────────────────
 
-/// Called from all exception stubs with a pointer to the exception frame.
+/// The terminal exception path: a fault that no fault handler resolved. Invoked
+/// (and never returned from) by [`exception_handler`], [`page_fault_handler`],
+/// and the NMI handler once they determine the fault is unrecoverable.
 ///
 /// If the fault originated in userspace (CPL != 0), the faulting thread is
 /// terminated and a death notification is posted (if bound). If the fault
@@ -280,6 +282,58 @@ unsafe extern "C" fn common_exception_handler(frame: *const ExceptionFrame) -> !
         crate::kprintln!("  cs={:#x}  rflags={:#018x}", f.cs, f.rflags,);
         dump_x86_regs_console(f);
         fatal("unhandled kernel exception");
+    }
+}
+
+/// Generic exception dispatch for vectors routed through
+/// [`common_exception_trampoline`] (every ring-3-reachable vector except `#PF`,
+/// `#NM`, and NMI, which have dedicated stubs).
+///
+/// A userspace exception whose thread has a bound fault handler is redirected to
+/// it ([`redirect_user_exception`]); on a resume reply this returns and the
+/// trampoline's `iretq` re-executes the faulting instruction (or continues from a
+/// handler-modified PC). Every other case — no/declined handler, the
+/// non-restartable abort vectors, or any kernel exception — is handed to the
+/// diverging [`common_exception_handler`], so this returns only on a
+/// resolved-and-resumed userspace fault.
+///
+/// Mirrors the call-from-naked-asm pattern of [`page_fault_handler`]: the
+/// trampoline upholds the precondition that `frame` is a valid, writable
+/// `ExceptionFrame` on the current stack, so this is a safe `extern "C"` fn.
+#[cfg(not(test))]
+extern "C" fn exception_handler(frame: *mut ExceptionFrame)
+{
+    // SAFETY: frame is constructed by common_exception_trampoline on this stack.
+    let f = unsafe { &*frame };
+    let from_user = (f.cs & 3) != 0;
+    // #DF (8) and #MC (18) are non-restartable aborts; #DF additionally runs on a
+    // dedicated IST stack that is not re-entrant across the reschedule a redirect
+    // performs. They are never delivered to a resumable handler — always terminal.
+    let redirectable = f.vector != 8 && f.vector != 18;
+    if from_user && redirectable
+    {
+        // SAFETY: from_user implies a running user thread; current_tcb is valid
+        // in exception context (the kill path uses it too).
+        let tcb = unsafe { crate::syscall::current_tcb() };
+        // SAFETY: tcb is the running user thread; has_handler only reads the
+        // atomic fault_handler field.
+        let handler_bound = !tcb.is_null() && unsafe { crate::ipc::fault::has_handler(tcb) };
+        if handler_bound
+        {
+            // SAFETY: frame is the live ExceptionFrame; the redirect copies it
+            // to/from the canonical TrapFrame and returns whether to resume.
+            if unsafe { redirect_user_exception(tcb, frame) }
+            {
+                return;
+            }
+            // Handler declined (Kill) — fall through to terminate the thread.
+        }
+    }
+
+    // Not resumed by a handler — kill (userspace) or fatal (kernel).
+    // SAFETY: frame valid; common_exception_handler never returns.
+    unsafe {
+        common_exception_handler(frame.cast_const());
     }
 }
 
@@ -421,7 +475,13 @@ macro_rules! isr_stub {
     };
 }
 
-/// Common trampoline: saves GPRs and calls `common_exception_handler`.
+/// Common trampoline: saves GPRs, calls [`exception_handler`], then — reached
+/// only when a userspace exception was redirected to a bound fault handler that
+/// resolved it — restores the (possibly handler-edited) register state and
+/// `iretq`s, re-executing the faulting instruction (or continuing from a
+/// handler-modified PC). Every terminal fault (no/declined handler, or any
+/// kernel exception) diverges inside [`exception_handler`] →
+/// `common_exception_handler`, so the restore tail is dead for those.
 ///
 /// At entry, the stack holds the ISR stub frame (vector + error code) and
 /// hardware frame (rip, cs, rflags, rsp, ss). We push all GPRs to create
@@ -450,9 +510,26 @@ unsafe extern "C" fn common_exception_trampoline()
         // rsp now points at the full ExceptionFrame.
         "mov rdi, rsp",
         "call {handler}",
-        // common_exception_handler never returns; ud2 guards against it.
-        "ud2",
-        handler = sym common_exception_handler,
+        // Reached only on a resolved-and-resumed userspace exception; restore the
+        // register state the handler may have edited and re-enter userspace.
+        "pop rax",
+        "pop rbx",
+        "pop rcx",
+        "pop rdx",
+        "pop rsi",
+        "pop rdi",
+        "pop rbp",
+        "pop r8",
+        "pop r9",
+        "pop r10",
+        "pop r11",
+        "pop r12",
+        "pop r13",
+        "pop r14",
+        "pop r15",
+        "add rsp, 16", // drop vector + error_code
+        "iretq",
+        handler = sym exception_handler,
     );
 }
 
@@ -888,21 +965,10 @@ extern "C" fn page_fault_handler(frame: *mut ExceptionFrame)
     }
 }
 
-/// Redirect a genuine userspace page fault to the faulting thread's bound
-/// fault handler. Returns `true` if the handler resolved the fault and the
-/// thread should resume (re-execute the faulting instruction), `false` if the
-/// fault is terminal (the handler declined or the binding was severed).
-///
-/// The `#PF` stub frame ([`ExceptionFrame`]) differs in layout from the
-/// canonical [`TrapFrame`](crate::arch::current::trap_frame::TrapFrame) the
-/// register syscalls operate on, and the two overlap on the kernel stack, so
-/// the faulting registers are copied into a stack-local `TrapFrame` for the
-/// duration of the block. `(*tcb).trap_frame` is repointed at that copy so the
-/// handler's `SYS_THREAD_READ_REGS` / `SYS_THREAD_WRITE_REGS` see and edit the
-/// faulting state; on resume the (possibly edited) copy is written back into the
-/// `ExceptionFrame` so the stub's `iretq` uses it. (Full entry-frame
-/// unification, which would remove this copy, is a deferred follow-up that does
-/// not change the userspace ABI.)
+/// Redirect a genuine userspace page fault to the faulting thread's bound fault
+/// handler. Builds the `FAULT_KIND_VM` message describing the access and delegates
+/// the block to [`redirect_user_fault`]. Returns `true` to resume, `false` to
+/// terminate (handler declined or binding severed).
 ///
 /// # Safety
 /// `tcb` is the current user thread and has a bound handler; `frame` is the live
@@ -944,6 +1010,86 @@ unsafe fn redirect_user_page_fault(
         ip: rip,
     };
 
+    // SAFETY: preconditions forwarded — handler bound, live frame, no lock held.
+    unsafe { redirect_user_fault(tcb, frame, &info) }
+}
+
+/// Redirect a genuine userspace CPU exception (any vector routed through
+/// [`exception_handler`]) to the faulting thread's bound fault handler. Builds the
+/// `FAULT_KIND_EXCEPTION` message (normalized class + hardware error code +
+/// faulting `rip`) and delegates the block to [`redirect_user_fault`]. Returns
+/// `true` to resume, `false` to terminate.
+///
+/// # Safety
+/// `tcb` is the current user thread and has a bound handler; `frame` is the live
+/// exception `ExceptionFrame` on the current kernel stack; no lock is held.
+#[cfg(not(test))]
+unsafe fn redirect_user_exception(
+    tcb: *mut crate::sched::thread::ThreadControlBlock,
+    frame: *mut ExceptionFrame,
+) -> bool
+{
+    // SAFETY: frame is valid.
+    let f = unsafe { &*frame };
+    let info = crate::ipc::fault::FaultInfo {
+        kind: syscall::FAULT_KIND_EXCEPTION,
+        d1: normalize_x86_exception(f.vector),
+        d2: f.error_code,
+        ip: f.rip,
+    };
+
+    // SAFETY: preconditions forwarded — handler bound, live frame, no lock held.
+    unsafe { redirect_user_fault(tcb, frame, &info) }
+}
+
+/// Map an x86-64 exception vector to the architecture-neutral
+/// [`syscall::FAULT_EXC_UNKNOWN`]-family normalized code delivered in a
+/// `FAULT_KIND_EXCEPTION` message. Vectors with a dedicated path (`#PF` = 14,
+/// `#NM` = 7, NMI = 2) never reach here.
+#[cfg(not(test))]
+fn normalize_x86_exception(vector: u64) -> u64
+{
+    match vector
+    {
+        0 => syscall::FAULT_EXC_DIVIDE,              // #DE
+        1 => syscall::FAULT_EXC_DEBUG,               // #DB
+        3 => syscall::FAULT_EXC_BREAKPOINT,          // #BP
+        4 => syscall::FAULT_EXC_OVERFLOW,            // #OF
+        5 => syscall::FAULT_EXC_BOUND_RANGE,         // #BR
+        6 => syscall::FAULT_EXC_ILLEGAL_INSTRUCTION, // #UD
+        10..=13 => syscall::FAULT_EXC_PROTECTION,    // #TS #NP #SS #GP
+        16 | 19 => syscall::FAULT_EXC_FP,            // #MF #XM
+        17 => syscall::FAULT_EXC_ALIGNMENT,          // #AC
+        _ => syscall::FAULT_EXC_UNKNOWN,
+    }
+}
+
+/// Deliver `info` to `tcb`'s bound handler and block until it resolves the fault
+/// or the binding is severed. Returns `true` if the thread should resume
+/// (re-execute the faulting instruction, or continue from a handler-modified PC),
+/// `false` if the fault is terminal.
+///
+/// The stub frame ([`ExceptionFrame`]) differs in layout from the canonical
+/// [`TrapFrame`](crate::arch::current::trap_frame::TrapFrame) the register
+/// syscalls operate on, and the two overlap on the kernel stack, so the faulting
+/// registers are copied into a stack-local `TrapFrame` for the duration of the
+/// block. `(*tcb).trap_frame` is repointed at that copy so the handler's
+/// `SYS_THREAD_READ_REGS` / `SYS_THREAD_WRITE_REGS` see and edit the faulting
+/// state; on resume the (possibly edited) copy is written back into the
+/// `ExceptionFrame` so the stub's `iretq` uses it. (Full entry-frame unification,
+/// which would remove this copy, is a deferred follow-up that does not change the
+/// userspace ABI.)
+///
+/// # Safety
+/// `tcb` is the current user thread and has a bound handler; `frame` is the live
+/// `ExceptionFrame` on the current kernel stack; no lock is held.
+#[cfg(not(test))]
+unsafe fn redirect_user_fault(
+    tcb: *mut crate::sched::thread::ThreadControlBlock,
+    frame: *mut ExceptionFrame,
+    info: &crate::ipc::fault::FaultInfo,
+) -> bool
+{
     // Canonical register frame the handler reads/edits. Lives in this kernel
     // stack frame, which is preserved across the block (the context switch saves
     // and restores the kernel rsp), so the pointer stays valid while the faulter
@@ -960,7 +1106,7 @@ unsafe fn redirect_user_page_fault(
     }
 
     // SAFETY: handler bound; trap_frame points at the canonical frame; no lock held.
-    let outcome = unsafe { crate::ipc::fault::fault_dispatch(tcb, &info) };
+    let outcome = unsafe { crate::ipc::fault::fault_dispatch(tcb, info) };
 
     // SAFETY: restore the canonical kstack-slot pointer.
     unsafe {

--- a/core/ktest/src/integration/fault_exception_no_handler_kills.rs
+++ b/core/ktest/src/integration/fault_exception_no_handler_kills.rs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// ktest/src/integration/fault_exception_no_handler_kills.rs
+
+//! Integration: a non-page-fault CPU exception with no handler bound is terminal.
+//!
+//! The counterpart to `fault_exception_redirect`: routing exceptions through the
+//! fault-handler mechanism must not weaken the default terminal behavior for a
+//! thread that has no handler bound.
+//!
+//!   1. A child with no fault handler executes an illegal instruction (`ud2` on
+//!      x86-64, `unimp` on RISC-V), trapping.
+//!   2. The parent polls the kernel-authoritative lifecycle state until it
+//!      reports `Exited`.
+//!   3. The recorded exit reason must be `EXIT_FAULT_BASE + <fault vector>`
+//!      (`#UD` = 6 on x86-64; illegal instruction = 2 on RISC-V).
+//!
+//! A bug that delivered the exception to a (non-existent) handler instead of
+//! killing would never reach `Exited`, tripping the poll bound rather than
+//! hanging.
+
+use syscall::{cap_delete, cap_info, thread_sleep};
+use syscall_abi::{CAP_INFO_THREAD_STATE, EXIT_FAULT_BASE, THREAD_STATE_EXITED};
+
+use crate::{ChildStack, TestContext, TestResult};
+
+/// Fault vector recorded in `exit_reason` for an illegal instruction.
+#[cfg(target_arch = "x86_64")]
+const FAULT_VECTOR: u64 = 6; // #UD
+#[cfg(target_arch = "riscv64")]
+const FAULT_VECTOR: u64 = 2; // illegal instruction
+
+/// Poll bound: ~2 s at ~1 ms per `thread_sleep(1)` before declaring failure.
+const MAX_POLLS: u32 = 2000;
+
+static mut CHILD_STACK: ChildStack = ChildStack::ZERO;
+
+pub fn run(ctx: &TestContext) -> TestResult
+{
+    let child = crate::spawn::new_child(ctx)
+        .map_err(|_| "fault_exception_no_handler_kills: spawn::new_child failed")?;
+
+    let stack_top = ChildStack::top(core::ptr::addr_of!(CHILD_STACK));
+    crate::spawn::configure_and_start(&child, fault_child, stack_top, 0)
+        .map_err(|_| "fault_exception_no_handler_kills: configure_and_start failed")?;
+
+    let expected = EXIT_FAULT_BASE + FAULT_VECTOR;
+    let mut polls = 0;
+    loop
+    {
+        let packed = cap_info(child.th, CAP_INFO_THREAD_STATE)
+            .map_err(|_| "fault_exception_no_handler_kills: cap_info(THREAD_STATE) failed")?;
+        // cast_possible_truncation: state code is the packed high word.
+        #[allow(clippy::cast_possible_truncation)]
+        let state = (packed >> 32) as u32;
+        if state == THREAD_STATE_EXITED
+        {
+            if packed & 0xFFFF_FFFF != expected
+            {
+                return Err("fault_exception_no_handler_kills: wrong exit reason");
+            }
+            break;
+        }
+        polls += 1;
+        if polls >= MAX_POLLS
+        {
+            return Err("fault_exception_no_handler_kills: child never died");
+        }
+        thread_sleep(1).ok();
+    }
+
+    cap_delete(child.th).ok();
+    cap_delete(child.cs).ok();
+    Ok(())
+}
+
+/// Child entry: execute an illegal instruction with no fault handler bound, which
+/// the kernel resolves by terminating this thread. The loop only satisfies `-> !`
+/// and is never reached.
+fn fault_child(_arg: u64) -> !
+{
+    // SAFETY: a deliberately illegal instruction; with no handler bound the
+    // kernel terminates this thread before control returns here.
+    unsafe {
+        #[cfg(target_arch = "x86_64")]
+        core::arch::asm!("ud2");
+        #[cfg(target_arch = "riscv64")]
+        core::arch::asm!("unimp");
+    }
+    loop
+    {
+        core::hint::spin_loop();
+    }
+}

--- a/core/ktest/src/integration/fault_exception_redirect.rs
+++ b/core/ktest/src/integration/fault_exception_redirect.rs
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// ktest/src/integration/fault_exception_redirect.rs
+
+//! Integration: a non-page-fault CPU exception is redirected to a bound fault
+//! handler, which resumes the thread at a new instruction pointer.
+//!
+//! Page faults already prove the `FAULT_KIND_VM` path (`fault_pager_roundtrip`,
+//! `fault_resume_modifies_pc`). This exercises the `FAULT_KIND_EXCEPTION` path on
+//! the real trap surface:
+//!
+//!   1. A child bound to an endpoint executes an illegal instruction (`ud2` on
+//!      x86-64, `unimp` on RISC-V), trapping.
+//!   2. The harness thread receives the kernel-synthesized fault, verifies its
+//!      shape (`FAULT_LABEL`, badge, `FAULT_KIND_EXCEPTION`, normalized
+//!      `FAULT_EXC_ILLEGAL_INSTRUCTION`, captured faulting IP), reads the
+//!      fault-blocked thread's registers, points the instruction pointer at a
+//!      recovery routine, writes the registers back, and replies
+//!      `FAULT_REPLY_RESUME`.
+//!   3. The child resumes in the recovery routine — never re-executing the
+//!      illegal instruction — and signals success.
+//!
+//! A mechanism that only routed page faults would leave the child killed before
+//! any fault message arrived, tripping the bounded `notification_wait`.
+
+use core::sync::atomic::{AtomicU32, Ordering};
+
+use ipc::IpcMessage;
+use syscall::{
+    cap_copy, cap_create_endpoint, cap_create_notification, cap_delete, notification_wait,
+    thread_read_regs, thread_set_fault_handler, thread_write_regs,
+};
+use syscall_abi::{
+    FAULT_CLASS_ALL, FAULT_EXC_ILLEGAL_INSTRUCTION, FAULT_KIND_EXCEPTION, FAULT_LABEL,
+    FAULT_REPLY_RESUME, RIGHTS_ALL,
+};
+
+use crate::{ChildStack, TestContext, TestResult};
+
+/// Badge bound with the handler and delivered in the fault message.
+const FAULT_BADGE: u64 = 0xC0FF_EE04;
+
+/// Instruction-pointer field offset in the architecture `TrapFrame` (matches the
+/// kernel layout: x86-64 `rip` at 120, RISC-V `sepc` at 248).
+#[cfg(target_arch = "x86_64")]
+const IP_OFFSET: usize = 120;
+#[cfg(target_arch = "riscv64")]
+const IP_OFFSET: usize = 248;
+
+/// Register-file buffer size; the arch `TrapFrame` is 168 B (x86-64) / 280 B
+/// (RISC-V), both within this bound.
+const BUF: usize = 512;
+
+/// Child cap slot for the success notification, stashed so the recovery routine
+/// can read it without depending on register state across the PC redirect.
+static RECOVERY_SIG: AtomicU32 = AtomicU32::new(0);
+
+static mut CHILD_STACK: ChildStack = ChildStack::ZERO;
+
+pub fn run(ctx: &TestContext) -> TestResult
+{
+    let ep = cap_create_endpoint(ctx.memory_base)
+        .map_err(|_| "fault_exception_redirect: cap_create_endpoint failed")?;
+    let sig = cap_create_notification(ctx.memory_base)
+        .map_err(|_| "fault_exception_redirect: cap_create_notification failed")?;
+
+    let child = crate::spawn::new_child(ctx)
+        .map_err(|_| "fault_exception_redirect: spawn::new_child failed")?;
+    let child_sig = cap_copy(sig, child.cs, RIGHTS_ALL)
+        .map_err(|_| "fault_exception_redirect: cap_copy(sig) failed")?;
+    RECOVERY_SIG.store(child_sig, Ordering::Release);
+
+    thread_set_fault_handler(child.th, ep, FAULT_BADGE, FAULT_CLASS_ALL)
+        .map_err(|_| "fault_exception_redirect: thread_set_fault_handler failed")?;
+
+    let stack_top = ChildStack::top(core::ptr::addr_of!(CHILD_STACK));
+    crate::spawn::configure_and_start(&child, fault_child, stack_top, 0)
+        .map_err(|_| "fault_exception_redirect: configure_and_start failed")?;
+
+    // Receive the fault and verify it is the expected illegal-instruction
+    // exception (not a VM fault).
+    // SAFETY: ctx.ipc_buf is the registered per-thread IPC buffer.
+    let msg = unsafe { ipc::ipc_recv(ep, ctx.ipc_buf) }
+        .map_err(|_| "fault_exception_redirect: ipc_recv failed")?;
+    if msg.label != FAULT_LABEL || msg.badge != FAULT_BADGE
+    {
+        return Err("fault_exception_redirect: unexpected fault message");
+    }
+    if msg.word(0) != FAULT_KIND_EXCEPTION
+    {
+        return Err("fault_exception_redirect: fault kind is not EXCEPTION");
+    }
+    if msg.word(1) != FAULT_EXC_ILLEGAL_INSTRUCTION
+    {
+        return Err("fault_exception_redirect: normalized code is not ILLEGAL_INSTRUCTION");
+    }
+    let fault_ip = msg.word(3);
+
+    // Read the fault-blocked thread's registers and confirm the captured IP in
+    // the message matches the register frame.
+    let mut reg_buf = [0u8; BUF];
+    thread_read_regs(child.th, reg_buf.as_mut_ptr(), BUF)
+        .map_err(|_| "fault_exception_redirect: thread_read_regs failed")?;
+    let ip = u64::from_le_bytes(
+        reg_buf[IP_OFFSET..IP_OFFSET + 8]
+            .try_into()
+            .unwrap_or([0u8; 8]),
+    );
+    if ip == 0 || ip != fault_ip
+    {
+        return Err("fault_exception_redirect: register IP does not match fault message IP");
+    }
+
+    // Redirect the instruction pointer to the recovery routine and resume, so the
+    // child never re-executes the illegal instruction.
+    let recovery_ptr = recovery_child as *const () as u64;
+    reg_buf[IP_OFFSET..IP_OFFSET + 8].copy_from_slice(&recovery_ptr.to_le_bytes());
+    thread_write_regs(child.th, reg_buf.as_ptr(), BUF)
+        .map_err(|_| "fault_exception_redirect: thread_write_regs failed")?;
+
+    // SAFETY: ctx.ipc_buf is the registered per-thread IPC buffer.
+    unsafe { ipc::ipc_reply(&IpcMessage::new(FAULT_REPLY_RESUME), ctx.ipc_buf) }
+        .map_err(|_| "fault_exception_redirect: ipc_reply(RESUME) failed")?;
+
+    notification_wait(sig).map_err(|_| "fault_exception_redirect: notification_wait failed")?;
+
+    cap_delete(child.th).ok();
+    cap_delete(child.cs).ok();
+    cap_delete(ep).ok();
+    cap_delete(sig).ok();
+    Ok(())
+}
+
+/// Child entry: execute an illegal instruction. The trap is redirected to the
+/// bound handler, which points this thread at [`recovery_child`] rather than
+/// resuming the faulting instruction. The loop only satisfies `-> !` and is
+/// never reached.
+fn fault_child(_arg: u64) -> !
+{
+    // SAFETY: a deliberately illegal instruction. The bound handler resumes this
+    // thread at recovery_child, so control never returns here.
+    unsafe {
+        #[cfg(target_arch = "x86_64")]
+        core::arch::asm!("ud2");
+        #[cfg(target_arch = "riscv64")]
+        core::arch::asm!("unimp");
+    }
+    loop
+    {
+        core::hint::spin_loop();
+    }
+}
+
+/// Recovery routine the handler redirects the faulting thread into. Signals
+/// success through the stashed notification cap.
+fn recovery_child() -> !
+{
+    syscall::notification_send(RECOVERY_SIG.load(Ordering::Acquire), 1).ok();
+    loop
+    {
+        core::hint::spin_loop();
+    }
+}

--- a/core/ktest/src/integration/mod.rs
+++ b/core/ktest/src/integration/mod.rs
@@ -35,11 +35,15 @@
 //! - `fault_pager_roundtrip.rs`  — a bound userspace pager maps a frame on fault and resumes the thread
 //! - `fault_resume_modifies_pc.rs` — a handler reads/edits the fault-blocked thread's registers and resumes it at a new PC
 //! - `fault_handler_declines_kills.rs` — a handler that replies KILL terminates the faulting thread
+//! - `fault_exception_redirect.rs` — a non-page-fault CPU exception is redirected to a handler that resumes the thread at a new PC
+//! - `fault_exception_no_handler_kills.rs` — a non-page-fault CPU exception with no handler bound terminates the thread
 //! - `tlb_widen_retry.rs`        — a permission-widen elides its shootdown; a remote stale-TLB write still completes via spurious-fault retry
 
 pub mod cap_delegation_chain;
 pub mod cap_move_into_fresh_cspace_then_ipc;
 pub mod cap_transfer;
+pub mod fault_exception_no_handler_kills;
+pub mod fault_exception_redirect;
 pub mod fault_handler_declines_kills;
 pub mod fault_kills_thread;
 pub mod fault_pager_roundtrip;
@@ -116,6 +120,14 @@ pub fn run_all(ctx: &TestContext)
     run_integration_test!(
         "integration::fault_handler_declines_kills",
         fault_handler_declines_kills::run(ctx)
+    );
+    run_integration_test!(
+        "integration::fault_exception_redirect",
+        fault_exception_redirect::run(ctx)
+    );
+    run_integration_test!(
+        "integration::fault_exception_no_handler_kills",
+        fault_exception_no_handler_kills::run(ctx)
     );
     run_integration_test!("integration::tlb_widen_retry", tlb_widen_retry::run(ctx));
 }

--- a/docs/fault-handling.md
+++ b/docs/fault-handling.md
@@ -36,19 +36,17 @@ checks) is owned by the [memory model](memory-model.md) and the
 
 ## Implementation Status
 
-The **page-fault** path of this protocol is implemented on both x86-64 and RISC-V:
-`SYS_THREAD_SET_FAULT_HANDLER`, the per-thread fault-handler binding, the
-[fault message](#fault-message) for `FAULT_KIND_VM`, and the
-[resume and kill](#delivery-resume-and-kill) state machine — including register inspection
-and modification of a fault-blocked thread via
+The fault-redirection mechanism is implemented on both x86-64 and RISC-V for **both**
+fault kinds: `SYS_THREAD_SET_FAULT_HANDLER`, the per-thread fault-handler binding, the
+[fault message](#fault-message) for `FAULT_KIND_VM` (page faults) and `FAULT_KIND_EXCEPTION`
+(every other kernel-unresolvable ring-3 exception — illegal instruction, breakpoint,
+alignment, divide, …), and the [resume and kill](#delivery-resume-and-kill) state machine —
+including register inspection and modification of a fault-blocked thread via
 [`SYS_THREAD_READ_REGS`/`SYS_THREAD_WRITE_REGS`](capability-model.md#thread). A thread with
 no handler bound is still terminated, the behavior for all faults absent this mechanism.
 
 Not yet implemented (this section is narrowed as each part lands):
 
-- **Non-VM fault kinds.** Only page faults (`FAULT_KIND_VM`) are routed; other CPU
-  exceptions (`FAULT_KIND_EXCEPTION`) still terminate the thread. The taxonomy and message
-  reserve the encoding.
 - **The demand-paging consumer.** The `ProcessInfo` pager field referenced under
   [Demand Paging](#demand-paging-and-the-default-system-pager) and the demand-paged-memory
   consumer are not present yet.
@@ -144,8 +142,13 @@ thread's behalf. Its format is a stable cross-boundary contract.
 - **Data words 1–3** — kind-specific:
   - `FAULT_KIND_VM`: faulting virtual address; access flags (bit 0 read, bit 1 write,
     bit 2 instruction fetch, bit 3 present-vs-not-present); faulting instruction pointer.
-  - `FAULT_KIND_EXCEPTION`: normalized exception code; architecture auxiliary/error code;
-    faulting instruction pointer.
+  - `FAULT_KIND_EXCEPTION`: a **normalized exception code** (an architecture-neutral class —
+    illegal instruction, breakpoint, alignment, divide, protection, … — so a handler
+    dispatches without architecture knowledge; an unrecognized code is treated as the
+    unknown class); the **architecture auxiliary code** (x86-64 the hardware error code,
+    `0` where the vector has none; RISC-V `stval`); the faulting instruction pointer. The
+    kernel maps each architecture's raw vector/cause to a normalized class
+    (`arch/x86_64/idt.rs`, `arch/riscv64/interrupts.rs`).
 
 The faulting thread's full register state is not embedded; a handler that needs it reads
 it with [`SYS_THREAD_READ_REGS`](capability-model.md#thread) on the faulting thread.


### PR DESCRIPTION
PR3 of #34 (after PR1 docs #218 and PR2 kernel-core #219). Part of #34 — does
**not** close it; the demand-paging consumer (PR4) remains.

> #34 had been auto-closed by closing-keyword wording in PR #218 (docs); it has
> been reopened, since PR3 (this PR) and PR4 are still outstanding.

## What this does

PR2 routed only page faults (`FAULT_KIND_VM`); every other kernel-unresolvable
ring-3 exception (illegal instruction, breakpoint, alignment, divide, …) still
terminated the thread. This routes them too, as `FAULT_KIND_EXCEPTION`, through
the same delivery / resume / kill helper — on both architectures. No new syscall,
no new state: the binding, `BlockedOnFault`, and the reply path are unchanged.

### ABI — finalized exception taxonomy (`abi/syscall`)
- `FAULT_KIND_EXCEPTION` data word 1 = an architecture-neutral **normalized class**
  (`FAULT_EXC_*`: illegal-instruction, breakpoint, debug, divide, overflow,
  bound-range, alignment, access, protection, fp; `FAULT_EXC_UNKNOWN` = 0 fallback).
- data word 2 = the **per-arch auxiliary datum**: x86-64 hardware error code
  (`0` where the vector has none); RISC-V `stval`.
- data word 3 = faulting instruction pointer (unchanged).

### x86-64 (`arch/x86_64/idt.rs`)
- The generic exception trampoline gains a restore+`iretq` tail (mirroring the
  `#PF` stub) and routes through a new non-diverging `exception_handler`. A
  userspace exception with a bound handler is redirected and resumable; every
  other case (no/declined handler, any kernel exception) still diverges into the
  unchanged `common_exception_handler`.
- The non-restartable abort vectors `#DF` (8, IST stack) and `#MC` (18) are
  explicitly excluded from the resumable redirect — they remain terminal.
- The `ExceptionFrame`↔canonical-`TrapFrame` contained-copy is extracted into a
  shared `redirect_user_fault`; `redirect_user_page_fault` and the new
  `redirect_user_exception` both build a `FaultInfo` and delegate to it.

### RISC-V (`arch/riscv64/interrupts.rs`)
- The redirect gate is generalized beyond causes 12/13/15 to every U-mode
  exception. `fault_info_for` builds the right `FaultInfo` per cause (VM vs
  EXCEPTION), `normalize_riscv_exception` maps the cause to a normalized class,
  and the shared `redirect_user_fault` performs the block. The FP/V lazy-restore
  (cause 2) and `ecall` (cause 8) branches still take precedence.

### Docs
- `docs/fault-handling.md`: implementation-status narrowed (both fault kinds now
  route on both arches); exception fault-message bullet expanded with the
  normalized-class / per-arch-aux contract.
- `core/kernel/docs/syscalls.md`: `SET_FAULT_HANDLER` note updated (both kinds
  route; handler replies `KILL` for kinds it does not handle).

## #34 acceptance items completed here
- [x] General exceptions (non-VM kernel-unresolvable ring-3 faults) routed through
  the fault handler on x86_64 and riscv64.
- [x] Fault taxonomy finalized (normalized class + per-arch aux).
- [x] Tests: illegal instruction redirected/handled, and unhandled → kill.

## Remaining in #34 (out of scope for this PR)
PR4 — the demand-paging consumer (memmgr pager + procmgr binding + `ProcessInfo`
pager field + std page-reservation hook + svctest/usertest) — is the remaining
phase of #34 and is intentionally not part of this PR.

## Test plan
- `cargo xtask build` + `compose-bundle --harness ktest` + `run` on **x86_64**:
  `[ktest] ALL TESTS PASSED`, passed=177 failed=0. New: `fault_exception_redirect`,
  `fault_exception_no_handler_kills` both PASS.
- `cargo xtask clean` → same on **riscv64**: passed=177 failed=0, both new tests PASS.
- `cargo xtask test` (host): all suites pass.