### PR TITLE
fault: demand-paging pager consumer (memmgr) — #34 PR4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,6 +259,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "demandpaged"
+version = "0.1.0"
+
+[[package]]
 name = "devmgr"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
     "shared/registry-client",
     "shared/shmem",
     "shared/text",
+    "programs/demandpaged",
     "programs/fb-charset",
     "programs/fsbench",
     "programs/hello",

--- a/abi/process-abi/README.md
+++ b/abi/process-abi/README.md
@@ -40,82 +40,35 @@ for init at `INIT_INFO_VADDR`.
 The struct MUST be `#[repr(C)]` with stable layout. The process MUST check
 `version == PROCESS_ABI_VERSION` before accessing any other field.
 
-```rust
-#[repr(C)]
-pub struct ProcessInfo {
-    /// Protocol version. Must equal `PROCESS_ABI_VERSION`.
-    pub version: u32,
+The authoritative field list, with per-field doc comments and exact order, is
+[`src/lib.rs`](src/lib.rs) (`struct ProcessInfo`). This README summarises the
+field groups rather than mirroring every field, so the two cannot drift. As of
+`PROCESS_ABI_VERSION` 18 the groups are:
 
-    // ── Process identity ────────────────────────────────────────────
+- **Process identity** — `version`, `self_thread_cap`, `self_aspace_cap`,
+  `self_cspace_cap`, `sched_control_cap`.
+- **IPC / bootstrap** — `ipc_buffer_vaddr`, `creator_endpoint_cap`.
+- **Universal service endpoints** — `procmgr_endpoint_cap`, `memmgr_endpoint_cap`,
+  `service_registry_cap` (the single system-wide service-discovery handle).
+- **Stdio rings** — `stdin_memory_cap`, `stdout_memory_cap`, `stderr_memory_cap`
+  and their six `*_data_notification_cap` / `*_space_notification_cap` wakeup slots.
+- **TLS template** — `tls_template_vaddr`, `tls_template_filesz`,
+  `tls_template_memsz`, `tls_template_align`.
+- **argv / env blobs** — `args_offset`, `args_bytes`, `args_count`,
+  `env_offset`, `env_bytes`, `env_count` (blobs are written into the same page
+  after the fixed struct, bounded by the page remainder).
+- **Namespace** — `system_root_cap`, `current_dir_cap`.
+- **Logging** — `log_send_cap` (deprecated; migrating to `service_registry_cap`).
+- **Main-thread stack envelope** — `stack_top_vaddr`, `stack_pages`.
+- **Demand-paging pager** (v18, #34) — `pager_endpoint_cap`, `pager_badge`. The
+  `Endpoint` cap + badge of the process's pager (memmgr) when the process is
+  created demand-paged (`procmgr_labels::CREATE_DEMAND_PAGED`); both zero
+  otherwise. procmgr binds the main thread's fault handler to this endpoint at
+  creation, and the runtime inherits it onto every thread it spawns. Consumers
+  must tolerate zero.
 
-    /// CSpace slot of the process's own Thread capability (Control right).
-    pub self_thread_cap: u32,
-
-    /// CSpace slot of the process's own AddressSpace capability.
-    pub self_aspace_cap: u32,
-
-    /// CSpace slot of the process's own CSpace capability.
-    pub self_cspace_cap: u32,
-
-    /// CSpace slot of a baseline `SchedControl` cap (default band `[1, 20]`),
-    /// or zero. Authorises `SYS_THREAD_SET_PRIORITY` within the band; zero
-    /// means no scheduling authority. procmgr `cap_copy`s its own baseline
-    /// into every child.
-    pub sched_control_cap: u32,
-
-    // ── IPC ─────────────────────────────────────────────────────────
-
-    /// Virtual address of the pre-mapped IPC buffer page.
-    ///
-    /// Every thread requires a registered IPC buffer for extended message
-    /// payloads. procmgr maps this page and registers it with the kernel
-    /// before the process starts.
-    pub ipc_buffer_vaddr: u64,
-
-    /// CSpace slot of a badged send cap to the creator's bootstrap
-    /// endpoint.
-    ///
-    /// For processes created by procmgr directly, this points at procmgr's
-    /// bootstrap endpoint or, for services created on behalf of another
-    /// service (devmgr spawning a driver, vfsd spawning a filesystem
-    /// driver), at that service's bootstrap endpoint. The child issues
-    /// `ipc::bootstrap::REQUEST` rounds on this cap to collect its
-    /// service-specific capability set. Zero when no creator endpoint is
-    /// supplied (e.g. processes that receive all of their caps through
-    /// `ProcessInfo` alone).
-    pub creator_endpoint_cap: u32,
-
-    // ── Universal service endpoints ─────────────────────────────────
-
-    /// CSpace slot of a badged SEND cap on memmgr's service endpoint.
-    ///
-    /// Populated for every procmgr-spawned child. `std::os::seraph::
-    /// _start` calls `memmgr_labels::REQUEST_MEMORY_CAPS` on this cap to
-    /// bootstrap the `System` allocator before the user's `fn main()`
-    /// runs. The badged cap identifies this process to memmgr, so
-    /// memmgr accounts allocations against the correct per-process
-    /// frame record. Zero for processes with no memmgr above them
-    /// (init and memmgr itself).
-    pub memmgr_endpoint_cap: u32,
-
-    /// CSpace slot of a badged SEND cap on procmgr's service endpoint.
-    ///
-    /// Used for process-lifecycle queries (and any future
-    /// procmgr-served operation that is not heap-bootstrap). Zero for
-    /// processes with no procmgr above them (procmgr itself, or
-    /// init/ktest which receive `InitInfo` instead).
-    pub procmgr_endpoint_cap: u32,
-
-    /// CSpace slot of a SEND cap on the system log endpoint.
-    ///
-    /// Bound to `Stdout`/`Stderr` by `std::os::seraph::_start`, so
-    /// `println!`/`eprintln!` work without per-service bootstrap-round
-    /// wiring. Zero when no log sink is available — consumers MUST
-    /// tolerate zero (stdio writes are silently dropped, matching
-    /// `unsupported` semantics).
-    pub log_endpoint_cap: u32,
-}
-```
+Every cap field names a `CSpace` slot (`0` = absent); `*_vaddr` / size / count
+fields are plain values.
 
 ### Fixed CSpace slot conventions
 
@@ -134,7 +87,9 @@ protocol on `creator_endpoint_cap`, not through `ProcessInfo`.
 | `creator_endpoint_cap` | Badged send cap back to the creator's bootstrap endpoint (if nonzero) |
 | `memmgr_endpoint_cap` | Badged SEND cap on memmgr's service endpoint (if nonzero) |
 | `procmgr_endpoint_cap` | Badged SEND cap on procmgr's service endpoint (if nonzero) |
-| `log_endpoint_cap` | SEND cap on the system log endpoint (if nonzero) |
+| `service_registry_cap` | SEND cap on svcmgr's service-discovery endpoint (if nonzero) |
+| `log_send_cap` | Badged SEND cap on the system log endpoint (deprecated; if nonzero) |
+| `pager_endpoint_cap` | `Endpoint` cap on the demand-paging pager (if nonzero) |
 
 ---
 
@@ -144,39 +99,17 @@ The struct passed to `main()`. This is a Rust-native type (NOT `#[repr(C)]`)
 providing ergonomic access to the handover data. It is constructed by `_start()`
 from either `ProcessInfo` (normal processes) or `InitInfo` (init/ktest).
 
-```rust
-pub struct StartupInfo {
-    /// Virtual address of the IPC buffer page.
-    pub ipc_buffer: *mut u8,
-
-    /// CSpace slot of the creator endpoint. Zero if none.
-    pub creator_endpoint: u32,
-
-    /// CSpace slot of own Thread capability.
-    pub self_thread: u32,
-
-    /// CSpace slot of own AddressSpace capability.
-    pub self_aspace: u32,
-
-    /// CSpace slot of own CSpace capability.
-    pub self_cspace: u32,
-
-    /// CSpace slot of a badged SEND cap on memmgr's service endpoint.
-    /// Zero when unreachable.
-    pub memmgr_endpoint: u32,
-
-    /// CSpace slot of a badged SEND cap on procmgr's service endpoint.
-    /// Zero when unreachable.
-    pub procmgr_endpoint: u32,
-
-    /// CSpace slot of a SEND cap on the system log endpoint. Zero when
-    /// no log sink has been attached yet.
-    pub log_endpoint: u32,
-}
-```
+The authoritative definition is [`src/lib.rs`](src/lib.rs) (`struct StartupInfo`);
+the std overlay carries a `#[stable]`-attributed mirror at
+`runtime/ruststd/src/os/seraph.rs`. It exposes the same groups as `ProcessInfo`
+(identity, service endpoints, stdio rings + notifications, TLS template,
+argv/env as resolved `&[u8]` slices, namespace, stack envelope, and the v18
+`pager_endpoint_cap` / `pager_badge`), with cap slots delivered as `u32` values
+and `args_blob` / `env_blob` resolved from the handover page into slices.
 
 Values are copied out of the handover page verbatim, so the struct does
-not borrow from it.
+not borrow from it (except the argv/env slices, which point into the
+read-only handover page that lives for the process's lifetime).
 
 ---
 

--- a/abi/process-abi/src/lib.rs
+++ b/abi/process-abi/src/lib.rs
@@ -41,7 +41,11 @@ use core::prelude::rust_2024::*;
 /// v17: Added [`ProcessInfo::sched_control_cap`] (#185) — a baseline
 ///      `SchedControl` cap so a process can set its own threads' priorities
 ///      within its delegated band. Zero when none is delegated.
-pub const PROCESS_ABI_VERSION: u32 = 17;
+/// v18: Added [`ProcessInfo::pager_endpoint_cap`] / [`ProcessInfo::pager_badge`]
+///      (#34) — the demand-paging fault handler advertised to the runtime so it
+///      can inherit the pager onto spawned threads. Both zero when the process
+///      is not demand-paged.
+pub const PROCESS_ABI_VERSION: u32 = 18;
 
 // ── Address space constants ──────────────────────────────────────────────────
 
@@ -462,6 +466,21 @@ pub struct ProcessInfo
 
     /// Number of 4 KiB pages mapped for the main-thread stack.
     pub stack_pages: u32,
+
+    /// `CSpace` slot of an `Endpoint` cap on the process's demand-paging
+    /// pager (memmgr's service endpoint), or zero when the process is not
+    /// demand-paged.
+    ///
+    /// procmgr binds the main thread's fault handler to this endpoint at
+    /// creation; the runtime reads this slot and `pager_badge` to bind the
+    /// same handler onto every thread it spawns, so demand paging covers the
+    /// whole process and not just the main thread. Consumers must tolerate
+    /// zero.
+    pub pager_endpoint_cap: u32,
+
+    /// Fault-message badge bound with [`Self::pager_endpoint_cap`],
+    /// identifying this process to the pager. Zero when not demand-paged.
+    pub pager_badge: u64,
 }
 
 // ── StartupInfo ──────────────────────────────────────────────────────────────
@@ -573,6 +592,15 @@ pub struct StartupInfo
 
     /// Number of 4 KiB pages mapped for the main-thread stack.
     pub stack_pages: u32,
+
+    /// `CSpace` slot of the demand-paging pager endpoint, or zero when the
+    /// process is not demand-paged. The runtime binds this onto every
+    /// thread it spawns. See `ProcessInfo::pager_endpoint_cap`.
+    pub pager_endpoint_cap: u32,
+
+    /// Fault-message badge bound with [`Self::pager_endpoint_cap`]. Zero
+    /// when not demand-paged.
+    pub pager_badge: u64,
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────

--- a/core/kernel/src/main.rs
+++ b/core/kernel/src/main.rs
@@ -788,8 +788,8 @@ unsafe fn kernel_entry_post_rebase(
 
             // Mint a reclaimable Memory cap per InitInfo page so init's
             // reap-handoff donates the pages back to memmgr after AS
-            // teardown. Caps carry MAP|READ rights (matching the
-            // userspace mapping) and the standard reclaim flags
+            // teardown. Caps carry full pool-frame rights (see the per-mint
+            // comment below) and the standard reclaim flags
             // (RETYPE + owns_memory=true + full ledger).
             // SAFETY: ROOT_CSPACE initialised in Phase 7; single-threaded boot.
             let cs = unsafe { cap::root_cspace_mut() }

--- a/core/kernel/src/main.rs
+++ b/core/kernel/src/main.rs
@@ -525,7 +525,6 @@ unsafe fn kernel_entry_post_rebase(
         // so init can create child threads bound to its own address space and map
         // its code pages into child processes once a process manager is available.
         let (init_aspace_cap_slot, segment_memory_base, segment_memory_count) = {
-            use boot_protocol::SegmentFlags;
             use cap::object::{KernelObjectHeader, MemoryObject, ObjectType};
             use cap::slot::{CapTag, Rights};
 
@@ -557,12 +556,18 @@ unsafe fn kernel_entry_post_rebase(
             for i in 0..seg_count
             {
                 let seg = &init_image.segments[i];
-                let rights = match seg.flags
-                {
-                    SegmentFlags::Read => Rights::MAP | Rights::RETYPE,
-                    SegmentFlags::ReadWrite => Rights::MAP | Rights::WRITE | Rights::RETYPE,
-                    SegmentFlags::ReadExecute => Rights::MAP | Rights::EXECUTE | Rights::RETYPE,
-                };
+                // Full rights regardless of the segment's protection. This cap
+                // is held only to donate the frame into memmgr's pool at init's
+                // reap, where it becomes general anonymous RAM any consumer may
+                // map writable (demand paging, REQUEST_MEMORY_CAPS). Cap rights
+                // gate derivation, not the live mapping: init's segments are
+                // already mapped at their true protection (R/RW/RX) by
+                // `map_segment` above, so a writable cap cannot widen a running
+                // segment. A narrower cap donates a non-writable frame that
+                // fails downstream writable maps. Mirrors the boot-module and
+                // reclaim-scratch mints (`cap/mod.rs`).
+                let rights =
+                    Rights::MAP | Rights::READ | Rights::WRITE | Rights::EXECUTE | Rights::RETYPE;
                 // The bootloader encodes the ELF in-page offset into
                 // `phys_addr` so `map_segment` can preserve
                 // `phys & 0xFFF == virt & 0xFFF`. The Memory cap exposed

--- a/core/kernel/src/main.rs
+++ b/core/kernel/src/main.rs
@@ -813,10 +813,23 @@ unsafe fn kernel_entry_post_rebase(
                     allocator: crate::cap::retype::RetypeAllocator::new_inline(),
                     lock: core::sync::atomic::AtomicU32::new(0),
                 });
+                // Full rights, matching the segment caps above. This cap is
+                // held only to donate the page into memmgr's pool at init's
+                // reap, where it becomes general anonymous RAM any consumer may
+                // map writable or executable (demand paging, REQUEST_MEMORY_CAPS).
+                // Cap rights gate derivation, not the live mapping: the InitInfo
+                // region is already mapped read-only into init by `map_page`
+                // above, so a writable cap cannot widen it. A narrower cap
+                // donates a frame that cannot satisfy a downstream RW/RX map and
+                // fails the consumer's fault.
                 let slot = cs
                     .insert_cap(
                         CapTag::Memory,
-                        Rights::MAP | Rights::READ | Rights::RETYPE,
+                        Rights::MAP
+                            | Rights::READ
+                            | Rights::WRITE
+                            | Rights::EXECUTE
+                            | Rights::RETYPE,
                         fo_nn,
                     )
                     .unwrap_or_else(|_| fatal("Phase 9: cannot insert InitInfo Memory cap"));
@@ -910,10 +923,22 @@ unsafe fn kernel_entry_post_rebase(
                     allocator: crate::cap::retype::RetypeAllocator::new_inline(),
                     lock: core::sync::atomic::AtomicU32::new(0),
                 });
+                // Full rights, matching the segment and InitInfo caps. This cap
+                // is held only to donate the page into memmgr's pool at init's
+                // reap, where it becomes general anonymous RAM any consumer may
+                // map writable or executable. Cap rights gate derivation, not
+                // the live mapping: init's stack is already mapped RW by
+                // `map_page` above, so the EXECUTE right cannot make the running
+                // stack executable. A narrower cap donates a frame that cannot
+                // satisfy a downstream RX map and fails the consumer's fault.
                 let slot = cs
                     .insert_cap(
                         CapTag::Memory,
-                        Rights::MAP | Rights::READ | Rights::WRITE | Rights::RETYPE,
+                        Rights::MAP
+                            | Rights::READ
+                            | Rights::WRITE
+                            | Rights::EXECUTE
+                            | Rights::RETYPE,
                         fo_nn,
                     )
                     .unwrap_or_else(|_| fatal("Phase 9: cannot insert init stack Memory cap"));

--- a/core/ktest/src/unit/mm.rs
+++ b/core/ktest/src/unit/mm.rs
@@ -9,9 +9,14 @@
 //! `SYS_MEM_PROTECT`, `SYS_ASPACE_QUERY`.
 //!
 //! Memory cap layout after `aspace_cap` (as provided by the kernel/bootloader):
-//!   `aspace_cap + 1` — TEXT segment Memory cap (MAP | EXECUTE)
-//!   `aspace_cap + 2` — RODATA segment Memory cap (MAP)
-//!   `aspace_cap + 3` — BSS/DATA segment Memory cap (MAP | WRITE)
+//!   `aspace_cap + 1` — TEXT segment Memory cap
+//!   `aspace_cap + 2` — RODATA segment Memory cap
+//!   `aspace_cap + 3` — BSS/DATA segment Memory cap
+//!
+//! Every segment cap carries full rights (`MAP|READ|WRITE|EXECUTE|RETYPE`): the
+//! kernel mints all RAM frames uniformly so they flow into memmgr's pool as
+//! general RAM at init reap. Page-table protection (R/RW/RX) is applied at map
+//! time by `map_segment`, independent of cap rights.
 //!
 //! Segment Memory caps own their physical memory (the kernel mints them with
 //! `owns_memory=true` so the init-reap donation cascade can return them to
@@ -22,7 +27,7 @@
 //! Split/merge/delete exercises operate on pool-allocated frames; segments
 //! are read-only test surfaces for `mem_map` / `mem_protect`.
 
-use syscall::{MAP_READONLY, MAP_WRITABLE, aspace_query, mem_map, mem_unmap};
+use syscall::{MAP_READ, MAP_WRITABLE, aspace_query, mem_map, mem_unmap};
 
 use crate::{TestContext, TestResult};
 
@@ -273,45 +278,38 @@ pub fn memory_split_at_zero_err(_ctx: &TestContext) -> TestResult
 
 /// `mem_protect` requesting permissions beyond the Memory cap's rights must fail.
 ///
-/// Pool frames have `MAP|WRITE|EXECUTE` rights. To test insufficient rights,
-/// we'd need to derive an attenuated cap. For now, this test verifies that
-/// `mem_protect` with valid rights on a mapped page succeeds (sanity check).
-///
-/// A true negative test for insufficient rights would require capability
-/// derivation with attenuation, which is tested in `cap::derive_attenuation`.
+/// Maps a full-rights pool frame, then derives a no-WRITE cap over the same
+/// frame and requests WRITE through it via `mem_protect` — which must be rejected
+/// with `InsufficientRights`. Attenuation supplies the no-WRITE cap: every RAM
+/// frame the kernel mints (init segments included) carries full rights, so a
+/// segment cap can no longer serve as the no-WRITE surface.
 pub fn mem_protect_exceeds_cap_rights_err(ctx: &TestContext) -> TestResult
 {
     // Use a VA distinct from TEST_VA=0x4000_0000 to avoid conflicts.
     const PROTECT_TEST_VA: u64 = 0x4100_0000;
 
-    // Use the TEXT segment Memory cap which has MAP|EXECUTE but no WRITE.
-    let text_memory = ctx.aspace_cap + 1;
+    let mut frame = crate::frame_pool::FrameGuard::new(ctx.aspace_cap)
+        .ok_or("mem_protect_exceeds_cap_rights_err: frame pool exhausted")?;
+    frame
+        .map(PROTECT_TEST_VA)
+        .map_err(|_| "mem_map for protect-rights test failed")?;
 
-    mem_map(
-        text_memory,
-        ctx.aspace_cap,
-        PROTECT_TEST_VA,
-        0,
-        1,
-        MAP_READONLY,
-    )
-    .map_err(|_| "mem_map for protect-rights test failed")?;
+    // Attenuate to a no-WRITE cap (MAP only) over the same frame; mem_protect
+    // checks the requested perms against this cap's rights, not the mapping cap.
+    let ro_cap = syscall::cap_derive(frame.cap(), syscall::RIGHTS_MAP_READ)
+        .map_err(|_| "mem_protect_exceeds_cap_rights_err: cap_derive failed")?;
 
-    // TEXT cap has MAP|EXECUTE but no WRITE — requesting WRITE must fail.
-    let err = syscall::mem_protect(
-        text_memory,
-        ctx.aspace_cap,
-        PROTECT_TEST_VA,
-        1,
-        MAP_WRITABLE,
-    );
+    // Read-only cap has no WRITE — requesting WRITE must fail.
+    let err = syscall::mem_protect(ro_cap, ctx.aspace_cap, PROTECT_TEST_VA, 1, MAP_WRITABLE);
 
-    // Always unmap regardless of protect result.
-    mem_unmap(ctx.aspace_cap, PROTECT_TEST_VA, 1).ok();
+    // The parent frame keeps the object alive, so deleting the derived slot is
+    // safe; FrameGuard's drop unmaps PROTECT_TEST_VA and returns the frame.
+    syscall::cap_delete(ro_cap).ok();
+    drop(frame);
 
     if err.is_ok()
     {
-        return Err("mem_protect with WRITE on MAP|EXECUTE cap should fail (InsufficientRights)");
+        return Err("mem_protect with WRITE on a read-only cap should fail (InsufficientRights)");
     }
     Ok(())
 }
@@ -521,8 +519,11 @@ pub fn init_segment_caps_aligned(ctx: &TestContext) -> TestResult
     for i in 0..SEG_COUNT
     {
         let seg_cap = ctx.aspace_cap + 1 + i;
-        // TEXT lacks the WRITE right; map every segment read-only.
-        mem_map(seg_cap, ctx.aspace_cap, SEG_PROBE_VA, 0, 1, MAP_READONLY)
+        // Map read-only via explicit prot (not prot=0): segment caps are now
+        // full-rights, so deriving perms from cap rights would request W+X and
+        // trip W^X. Explicit MAP_READ maps read-only regardless of cap rights;
+        // the probe only needs the page's phys base.
+        mem_map(seg_cap, ctx.aspace_cap, SEG_PROBE_VA, 0, 1, MAP_READ)
             .map_err(|_| "init_segment_caps_aligned: mem_map failed")?;
 
         let phys = aspace_query(ctx.aspace_cap, SEG_PROBE_VA)

--- a/docs/fault-handling.md
+++ b/docs/fault-handling.md
@@ -45,11 +45,19 @@ including register inspection and modification of a fault-blocked thread via
 [`SYS_THREAD_READ_REGS`/`SYS_THREAD_WRITE_REGS`](capability-model.md#thread). A thread with
 no handler bound is still terminated, the behavior for all faults absent this mechanism.
 
+The demand-paging consumer is implemented: memmgr acts as the pager, procmgr binds it for
+processes created with the `CREATE_DEMAND_PAGED` flag and delegates the child address space,
+and the `ProcessInfo` pager field (`pager_endpoint_cap` / `pager_badge`, `PROCESS_ABI_VERSION`
+18) advertises it so the runtime inherits the handler onto spawned threads. Userspace reserves
+unbacked VA and registers it via `std::os::seraph::register_demand_paged`; first touch faults,
+memmgr maps a frame and resumes. See
+[memmgr/docs/ipc-interface.md](../services/memmgr/docs/ipc-interface.md) (`REGISTER_REGION`,
+`DELEGATE_ASPACE`, and the fault arm). Binding a default pager to *all* ordinary processes
+remains a userspace policy decision (a creator default plus runtime propagation), not yet
+enabled.
+
 Not yet implemented (this section is narrowed as each part lands):
 
-- **The demand-paging consumer.** The `ProcessInfo` pager field referenced under
-  [Demand Paging](#demand-paging-and-the-default-system-pager) and the demand-paged-memory
-  consumer are not present yet.
 - **Active unbind/rebind cancellation.** Clearing or rebinding a handler governs *future*
   faults; it does not yet actively cancel a fault already in flight on the affected thread.
   An in-flight fault is still resolved by the handler's reply, handler-thread death, the

--- a/programs/demandpaged/Cargo.toml
+++ b/programs/demandpaged/Cargo.toml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+[package]
+name = "demandpaged"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[[bin]]
+name = "demandpaged"
+path = "src/main.rs"
+test = false
+
+[lints]
+workspace = true

--- a/programs/demandpaged/src/main.rs
+++ b/programs/demandpaged/src/main.rs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// programs/demandpaged/src/main.rs
+
+//! Demand-paging fixture for the svctest pager phase.
+//!
+//! Spawned with `std::os::seraph::CommandExt::demand_paged(true)`, so procmgr
+//! binds this process's fault handler to memmgr (the pager). Two modes,
+//! selected by argv:
+//!
+//!   * default — reserve an unbacked region, register it as demand-paged, and
+//!     write a per-page pattern across it. Each first touch faults to memmgr,
+//!     which backs the page and resumes. A second read-back pass verifies the
+//!     data persisted (no re-fault, no zero-fill), proving the round-trip.
+//!     Exits `SUCCESS` on success; a register failure or mismatch exits
+//!     non-zero.
+//!   * `oor` — touch a reserved but *unregistered* page. The pager finds no
+//!     region and declines, so the kernel kills this process. If the touch
+//!     somehow survives (a pager bug), exit `SUCCESS` so the harness's "must
+//!     be killed" assertion fails loudly rather than hanging.
+//!
+//! Driven by `services/svctest`'s pager phase.
+
+use std::os::seraph::{register_demand_paged, reserve_pages};
+use std::process::ExitCode;
+
+const PAGES: usize = 4;
+const PAGE: usize = 4096;
+
+fn main() -> ExitCode
+{
+    if std::env::args().any(|a| a == "oor")
+    {
+        out_of_region()
+    }
+    else
+    {
+        in_region()
+    }
+}
+
+// cast_possible_truncation: the pattern byte is intentionally the low 8 bits of
+// a per-(page, byte) mix; truncation is the point.
+#[allow(clippy::cast_possible_truncation)]
+fn pattern(page: usize, byte: usize) -> u8
+{
+    (page as u8).wrapping_mul(31).wrapping_add(byte as u8)
+}
+
+fn in_region() -> ExitCode
+{
+    let Ok(range) = register_demand_paged(PAGES as u64)
+    else
+    {
+        return ExitCode::from(2);
+    };
+    let base = range.va_start() as *mut u8;
+
+    // First pass: write. The first store into each page faults; memmgr backs it
+    // and the store retries against the now-mapped page.
+    for p in 0..PAGES
+    {
+        let off = p * PAGE;
+        for i in 0..PAGE
+        {
+            // SAFETY: [base, base + PAGES*PAGE) is a registered demand-paged
+            // region; touches are backed by the pager on fault.
+            unsafe {
+                *base.add(off + i) = pattern(p, i);
+            }
+        }
+    }
+
+    // Second pass: read back. Proves the pages stayed mapped (no re-fault, no
+    // zero-fill) and were mapped writable.
+    for p in 0..PAGES
+    {
+        let off = p * PAGE;
+        for i in 0..PAGE
+        {
+            // SAFETY: same region, now fully backed.
+            let got = unsafe { *base.add(off + i) };
+            if got != pattern(p, i)
+            {
+                return ExitCode::from(3);
+            }
+        }
+    }
+    ExitCode::SUCCESS
+}
+
+fn out_of_region() -> ExitCode
+{
+    let Ok(range) = reserve_pages(1)
+    else
+    {
+        return ExitCode::from(2);
+    };
+    let p = range.va_start() as *mut u8;
+    // SAFETY: deliberate fault on an unregistered VA. The pager replies KILL
+    // and control should not return.
+    unsafe {
+        core::ptr::write_volatile(p, 0xAB);
+    }
+    // Reached only if the pager wrongly backed an unregistered fault; exit
+    // success so the harness's "must be killed" assertion fails loudly.
+    ExitCode::SUCCESS
+}

--- a/runtime/ruststd/src/os/seraph.rs
+++ b/runtime/ruststd/src/os/seraph.rs
@@ -178,6 +178,16 @@ pub struct StartupInfo {
     /// Number of 4 KiB pages mapped for the main-thread stack.
     #[stable(feature = "seraph_ext", since = "1.0.0")]
     pub stack_pages: u32,
+    /// `Endpoint` cap on the process's demand-paging pager, or zero when
+    /// the process is not demand-paged. The runtime binds this as the fault
+    /// handler on every thread it spawns; the main thread is bound by
+    /// procmgr at creation. See `process_abi::ProcessInfo::pager_endpoint_cap`.
+    #[stable(feature = "seraph_ext", since = "1.0.0")]
+    pub pager_endpoint_cap: u32,
+    /// Fault-message badge bound with [`Self::pager_endpoint_cap`]. Zero
+    /// when not demand-paged.
+    #[stable(feature = "seraph_ext", since = "1.0.0")]
+    pub pager_badge: u64,
 }
 
 // SAFETY: `ipc_buffer` points at a process-global page mapped for the life of
@@ -368,6 +378,8 @@ pub extern "C" fn _start() -> ! {
         env_count: info.env_count as usize,
         stack_top_vaddr: info.stack_top_vaddr,
         stack_pages: info.stack_pages,
+        pager_endpoint_cap: info.pager_endpoint_cap,
+        pager_badge: info.pager_badge,
     };
 
     // SAFETY: single writer; we are the only code running at this point.
@@ -718,6 +730,47 @@ pub fn fund_aspace_pt_budget(self_aspace: u32, region_pages: u64) -> bool {
 #[stable(feature = "seraph_ext", since = "1.0.0")]
 pub use pal_reserve::{ReserveError, ReservedRange, reserve_pages, unreserve_pages};
 
+/// Reserve `pages` of unbacked virtual address space and register it as a
+/// read-write demand-paged region with the process's pager (memmgr).
+///
+/// The range maps lazily: the first access to each page faults, the pager
+/// backs it read-write, and the access retries transparently. The process
+/// must be demand-paged (created with `procmgr_labels::CREATE_DEMAND_PAGED`);
+/// otherwise the first fault kills the thread.
+///
+/// On any failure the reservation is released. On success the caller owns the
+/// range and must `mem_unmap` any backed pages, then `unreserve_pages`, when
+/// done.
+#[stable(feature = "seraph_ext", since = "1.0.0")]
+pub fn register_demand_paged(pages: u64) -> crate::io::Result<ReservedRange> {
+    let ipc_buf = current_ipc_buf();
+    if ipc_buf.is_null() {
+        return Err(crate::io::Error::other("seraph: IPC buffer not registered"));
+    }
+    let memmgr_ep = startup_info().memmgr_endpoint;
+    if memmgr_ep == 0 {
+        return Err(crate::io::Error::other("seraph: no pager (memmgr unreachable)"));
+    }
+    let range = reserve_pages(pages)
+        .map_err(|_| crate::io::Error::other("seraph: VA reservation failed"))?;
+    let len_bytes = pages.saturating_mul(syscall_abi::PAGE_SIZE);
+    let msg = ipc::IpcMessage::builder(ipc::memmgr_labels::REGISTER_REGION)
+        .word(0, range.va_start())
+        .word(1, len_bytes)
+        .word(2, syscall_abi::MAP_WRITABLE)
+        .build();
+    // SAFETY: current_ipc_buf returns the registered IPC buffer page.
+    let accepted = matches!(
+        unsafe { ipc::ipc_call(memmgr_ep, &msg, ipc_buf) },
+        Ok(reply) if reply.label == ipc::memmgr_errors::SUCCESS
+    );
+    if !accepted {
+        unreserve_pages(range);
+        return Err(crate::io::Error::other("seraph: REGISTER_REGION rejected"));
+    }
+    Ok(range)
+}
+
 // ── System log macro surface ────────────────────────────────────────────────
 //
 // The badged SEND cap procmgr seeds at process create-time (recorded in
@@ -881,6 +934,15 @@ pub mod process {
         /// default chain.
         #[stable(feature = "seraph_ext", since = "1.0.0")]
         fn cwd_dir_cap(&mut self, cap: u32) -> &mut Self;
+
+        /// Create the child as demand-paged: procmgr binds its main thread's
+        /// fault handler to the system pager (memmgr) and delegates the child
+        /// address space, and the runtime inherits the pager onto threads the
+        /// child spawns. The child can then back regions lazily via
+        /// [`super::register_demand_paged`]. No effect on infrastructure
+        /// processes. Defaults to off.
+        #[stable(feature = "seraph_ext", since = "1.0.0")]
+        fn demand_paged(&mut self, on: bool) -> &mut Self;
     }
 
     #[stable(feature = "seraph_ext", since = "1.0.0")]
@@ -892,6 +954,11 @@ pub mod process {
 
         fn cwd_dir_cap(&mut self, cap: u32) -> &mut Command {
             self.as_inner_mut().set_cwd_dir_cap(cap);
+            self
+        }
+
+        fn demand_paged(&mut self, on: bool) -> &mut Command {
+            self.as_inner_mut().set_demand_paged(on);
             self
         }
     }

--- a/runtime/ruststd/src/os/seraph.rs
+++ b/runtime/ruststd/src/os/seraph.rs
@@ -747,12 +747,22 @@ pub fn register_demand_paged(pages: u64) -> crate::io::Result<ReservedRange> {
     if ipc_buf.is_null() {
         return Err(crate::io::Error::other("seraph: IPC buffer not registered"));
     }
-    let memmgr_ep = startup_info().memmgr_endpoint;
+    let info = startup_info();
+    let memmgr_ep = info.memmgr_endpoint;
     if memmgr_ep == 0 {
         return Err(crate::io::Error::other("seraph: no pager (memmgr unreachable)"));
     }
     let range = reserve_pages(pages)
         .map_err(|_| crate::io::Error::other("seraph: VA reservation failed"))?;
+    // Fund this address space's page-table growth budget for the region. The
+    // pager maps frames into this AS on fault via `map_page_pooled`, which
+    // draws intermediate page tables from the AS's own retype-backed pool; the
+    // demand region is far from the eager mappings, so without funding the pool
+    // is exhausted and the on-fault map fails (the pager then kills the thread).
+    if !fund_aspace_pt_budget(info.self_aspace, pages) {
+        unreserve_pages(range);
+        return Err(crate::io::Error::other("seraph: page-table budget funding failed"));
+    }
     let len_bytes = pages.saturating_mul(syscall_abi::PAGE_SIZE);
     let msg = ipc::IpcMessage::builder(ipc::memmgr_labels::REGISTER_REGION)
         .word(0, range.va_start())

--- a/runtime/ruststd/src/sys/process/seraph.rs
+++ b/runtime/ruststd/src/sys/process/seraph.rs
@@ -140,6 +140,10 @@ pub struct Command {
     /// then `current_dir_cap()` parent inherit, then zero). Same
     /// ownership contract as `namespace_cap`.
     cwd_dir_cap: u32,
+    /// When set, spawn ORs `procmgr_labels::CREATE_DEMAND_PAGED` into the
+    /// `CREATE_FROM_FILE` label so procmgr binds the child to the system
+    /// pager. Set via `CommandExt::demand_paged`. Defaults to off.
+    demand_paged: bool,
 }
 
 impl Command {
@@ -154,6 +158,7 @@ impl Command {
             stderr: None,
             namespace_cap: 0,
             cwd_dir_cap: 0,
+            demand_paged: false,
         }
     }
 
@@ -169,6 +174,11 @@ impl Command {
     /// `ProcessInfo.current_dir_cap`. Called by `CommandExt::cwd_dir_cap`.
     pub fn set_cwd_dir_cap(&mut self, cap: u32) {
         self.cwd_dir_cap = cap;
+    }
+
+    /// Request a demand-paged child. Called by `CommandExt::demand_paged`.
+    pub fn set_demand_paged(&mut self, on: bool) {
+        self.demand_paged = on;
     }
 
     pub fn arg(&mut self, arg: &OsStr) {
@@ -350,7 +360,13 @@ impl Command {
         let env_len_word_offset = argv_word_offset + argv_words;
         let env_blob_word_offset = env_len_word_offset + 1;
 
+        let demand_paged_flag = if self.demand_paged {
+            procmgr_labels::CREATE_DEMAND_PAGED
+        } else {
+            0
+        };
         let builder = ipc::IpcMessage::builder(procmgr_labels::CREATE_FROM_FILE
+            | demand_paged_flag
             | ((args_blob.len() as u64) << 32)
             | ((u64::from(args_count)) << 48)
             | ((u64::from(env_count)) << 56))

--- a/runtime/ruststd/src/sys/thread/seraph.rs
+++ b/runtime/ruststd/src/sys/thread/seraph.rs
@@ -22,7 +22,7 @@ use crate::num::NonZero;
 use crate::thread::ThreadInit;
 use crate::time::Duration;
 
-use syscall_abi::PAGE_SIZE;
+use syscall_abi::{FAULT_CLASS_ALL, PAGE_SIZE};
 
 /// Default minimum stack size. Matches the upstream unsupported-PAL value.
 pub const DEFAULT_MIN_STACK_SIZE: usize = 64 * 1024;
@@ -197,6 +197,18 @@ impl Thread {
                 dealloc(stack_base, stack_layout);
             }
             return Err(io::Error::other("seraph: thread_configure failed"));
+        }
+
+        // Inherit the process's demand-paging pager onto this thread before it
+        // starts (the main thread is bound by procmgr at creation). Best-effort
+        // and a no-op for non-demand-paged processes (`pager_endpoint_cap == 0`).
+        if info.pager_endpoint_cap != 0 {
+            let _ = syscall::thread_set_fault_handler(
+                thread_cap,
+                info.pager_endpoint_cap,
+                info.pager_badge,
+                FAULT_CLASS_ALL,
+            );
         }
 
         if let Err(_) = syscall::thread_start(thread_cap) {

--- a/services/init/src/bootstrap.rs
+++ b/services/init/src/bootstrap.rs
@@ -494,6 +494,10 @@ fn populate_memmgr_info(
             pi.stderr_space_notification_cap = 0;
             pi.stack_top_vaddr = PROCESS_STACK_TOP;
             pi.stack_pages = stack_pages;
+            // Infrastructure is never demand-paged (would recurse on its own
+            // faults); leave the pager unbound.
+            pi.pager_endpoint_cap = 0;
+            pi.pager_badge = 0;
         },
     )?;
 
@@ -1041,6 +1045,10 @@ fn populate_procmgr_info(
             pi.tls_template_align = caps.tls.align;
             pi.stack_top_vaddr = PROCESS_STACK_TOP;
             pi.stack_pages = stack_pages;
+            // Infrastructure is never demand-paged (would recurse on its own
+            // faults); leave the pager unbound.
+            pi.pager_endpoint_cap = 0;
+            pi.pager_badge = 0;
         },
     )?;
 

--- a/services/memmgr/docs/ipc-interface.md
+++ b/services/memmgr/docs/ipc-interface.md
@@ -32,17 +32,27 @@ badge is the procmgr-minted process identity established at
 
 Two privilege classes:
 
-- **Procmgr-only** labels (`REGISTER_PROCESS`, `PROCESS_DIED`) are
-  callable only over the cap that init transfers to procmgr at
-  procmgr's bootstrap round. memmgr identifies this cap by badge and
-  rejects procmgr-only calls received over any other badged cap.
-- **Universal** labels (`REQUEST_MEMORY_CAPS`, `RELEASE_MEMORY_CAPS`) are
-  callable over any badged cap, including those memmgr returned from
-  `REGISTER_PROCESS`.
+- **Procmgr-only** labels (`REGISTER_PROCESS`, `PROCESS_DIED`,
+  `DELEGATE_ASPACE`) are callable only over the cap that init transfers
+  to procmgr at procmgr's bootstrap round. memmgr identifies this cap by
+  badge and rejects procmgr-only calls received over any other badged cap.
+- **Universal** labels (`REQUEST_MEMORY_CAPS`, `RELEASE_MEMORY_CAPS`,
+  `REGISTER_REGION`) are callable over any badged cap, including those
+  memmgr returned from `REGISTER_PROCESS`. `REGISTER_REGION` is attributed
+  to the caller by its own badge.
 
 Badges cannot be forged: they are minted by `cap_derive_badge` only
 under the kernel's derivation rules, and procmgr is the only process
 that holds memmgr's procmgr-only cap.
+
+A third, kernel-origin class is the **fault message**: when a demand-paged
+process's thread takes a page fault, the kernel (not a userspace caller)
+synthesises an IPC to memmgr's endpoint with label `FAULT_LABEL`
+(`u64::MAX - 1`) and `badge` set to the faulting process's memmgr badge.
+Userspace cannot forge it — no SEND cap to the fault delivery is
+distributed; the binding is installed by procmgr via
+`SYS_THREAD_SET_FAULT_HANDLER` and the kernel owns the send. See
+[docs/fault-handling.md](../../../docs/fault-handling.md).
 
 ---
 
@@ -232,6 +242,78 @@ IPC. Idempotent on stale badges (already-reaped or never-registered).
 
 `PROCESS_DIED` for an unknown badge is not an error — memmgr returns
 success. Reclamation is idempotent.
+
+### Label 7: `REGISTER_REGION`
+
+A demand-paged process registers an anonymous region it has reserved (but
+not backed). A later page fault inside the region is backed on demand by
+the fault arm below; a fault outside every registered region is declined
+(the thread is killed), preserving segfault semantics. Privilege:
+universal — attributed to the caller by `recv.badge`.
+
+**Request:**
+
+| Field | Value |
+|---|---|
+| label | 7 |
+| data[0] | `va_base` (page-aligned virtual address) |
+| data[1] | `len_bytes` (region length; page-multiple, nonzero) |
+| data[2] | `prot` (MAP_* protection bits; W^X enforced) |
+
+**Reply (success):** `label` 0. No mapping is installed — backing happens
+lazily on fault, and only once procmgr has delegated this process's
+`AddressSpace` cap via `DELEGATE_ASPACE`.
+
+**Error codes:**
+
+| Code | Name | Meaning |
+|---|---|---|
+| 3 | `Quota` | Per-process region list at static cap |
+| 4 | `InvalidArgument` | Bad alignment, zero length, W^X violation, unknown prot bit, unknown badge, or overlap |
+
+### Label 8: `DELEGATE_ASPACE`
+
+Procmgr delegates a demand-paged child's `AddressSpace` cap to memmgr so
+the pager can map backing frames into it on fault. Sent at process
+finalize, after the child address space exists (so it cannot ride on the
+earlier `REGISTER_PROCESS` handshake). Privilege: procmgr-only.
+
+**Request:**
+
+| Field | Value |
+|---|---|
+| label | 8 |
+| data[0] | `child_memmgr_badge` (from the child's `REGISTER_PROCESS` reply) |
+| cap[0] | the child `AddressSpace` cap (MAP rights); ownership transfers to memmgr |
+
+memmgr stores the cap against the child's tracking entry and drops it on
+`PROCESS_DIED`.
+
+**Reply (success):** `label` 0.
+
+**Error codes:**
+
+| Code | Name | Meaning |
+|---|---|---|
+| 4 | `InvalidArgument` | Unknown badge or missing cap (a stray transferred cap is dropped) |
+| 5 | `Unauthorized` | Caller is not procmgr |
+
+### Kernel-origin fault message (`FAULT_LABEL`)
+
+Not a callable label. When a demand-paged process's thread takes a page
+fault the kernel cannot resolve, it synthesises an IPC to memmgr's
+endpoint with label `FAULT_LABEL` (`u64::MAX - 1`), `badge` = the faulting
+process's memmgr badge, and data words `[kind, faulting_va, access, ip]`
+(see [docs/fault-handling.md](../../../docs/fault-handling.md)). For a
+`FAULT_KIND_VM` fault whose `faulting_va` lies in a registered region of a
+process with a delegated address space, memmgr allocates one frame, maps
+it at the faulting page with the region's protection, and replies
+`FAULT_REPLY_RESUME` to retry the access. Every other case — non-VM fault,
+unknown process, address outside every region, no delegated AS, or any
+allocation/map failure — replies `FAULT_REPLY_KILL`. Demand frames are
+tracked exactly like `REQUEST_MEMORY_CAPS` allocations, so `PROCESS_DIED`
+reclaims them and the all-RAM-accounted identity is unaffected (the page
+moves from a free run to the process record; it was already owned).
 
 ---
 

--- a/services/memmgr/docs/memory-pool.md
+++ b/services/memmgr/docs/memory-pool.md
@@ -24,6 +24,21 @@ each ingested cap at its native size; splitting happens on the
 allocation path via `memory_split`, and coalescing reverses the split on
 the free path.
 
+Beyond the bootstrap pool, memmgr also receives reclaimed frames at init's reap
+(`DONATE_MEMORY_CAPS`: init's ELF segments, InitInfo, stack, boot-module ELF
+sources, reclaim scratch, AP trampoline). Both entry points feed the same free
+pool, so every pool frame is uniform anonymous RAM: a consumer may map any of
+it read-only, read-write, or read-execute (W^X still enforced at map time).
+This requires each pool frame's Memory cap to carry **WRITE, EXECUTE, and
+RETYPE** rights — memmgr derives the R/RW/RX inner from the pooled outer on
+demand and `cap_derive` only narrows rights, so a frame whose outer lacks WRITE
+(or EXECUTE) cannot satisfy a writable (or executable) map and would fail the
+consumer's fault. The kernel mints every donatable RAM cap with these rights
+(rights gate derivation, not the live mapping); memmgr enforces the invariant at
+both ingest and donation, rejecting (or, for the bootstrap pool, panicking on) a
+frame that lacks them so a mint-rights regression fails loudly rather than
+surfacing as an intermittent consumer fault.
+
 ---
 
 ## Free-Pool Data Structure

--- a/services/memmgr/src/main.rs
+++ b/services/memmgr/src/main.rs
@@ -103,6 +103,20 @@ const MAX_REGIONS_PER_PROC: usize = 8;
 /// or more contiguous pages.
 const MAX_FREE_RUNS: usize = 512;
 
+/// Rights every pool frame MUST carry. A pool frame is general anonymous RAM:
+/// memmgr derives an R / RW / RX inner from it on demand (`cap_derive`, which
+/// only narrows), so the outer must hold WRITE (`1 << 1`) and EXECUTE
+/// (`1 << 2`) — the `cap::slot::Rights` bit positions mirrored by
+/// `RIGHTS_MAP_RW` / `RIGHTS_MAP_RX` — plus RETYPE so a consumer can still
+/// retype the frame. READ is omitted: the kernel grants read at every map
+/// (`sys_mem_map`) and the bulk usable-RAM caps are minted without it. Enforced
+/// at both pool entry points (`ingest_pool`, `handle_donate_memory_caps`) so a
+/// kernel mint-rights regression fails loudly instead of surfacing as an
+/// intermittent consumer fault.
+const POOL_FRAME_RIGHTS: u64 = ((syscall::RIGHTS_MAP_RW | syscall::RIGHTS_MAP_RX)
+    & !syscall::RIGHTS_MAP_READ)
+    | syscall::RIGHTS_RETYPE;
+
 /// One free run: a Memory cap memmgr owns, covering `page_count` pages
 /// starting at physical address `phys_base`.
 #[derive(Clone, Copy)]
@@ -1062,22 +1076,24 @@ fn handle_process_died(req: &IpcMessage, ipc_buf: *mut u64, procmgr_badge: u64)
 
 fn handle_donate_memory_caps(req: &IpcMessage, ipc_buf: *mut u64)
 {
-    // Caller (init or procmgr) is permanently transferring boot-module
-    // Memory caps into memmgr's pool after loading the ELF contents. Each
-    // donated cap must carry RETYPE so memmgr's downstream `cap_derive`
-    // calls produce caps that consumers can retype into kernel objects.
+    // Caller (init or procmgr) is permanently transferring reclaimed Memory
+    // caps (init's ELF segments, InitInfo, stack, boot-module ELF sources,
+    // reclaim scratch, AP trampoline) into memmgr's pool. Each donated cap
+    // must carry the full pool-frame rights ([`POOL_FRAME_RIGHTS`]) so memmgr
+    // can derive the R / RW / RX inner a demand fault or REQUEST_MEMORY_CAPS
+    // consumer needs and retype on their behalf.
     //
     // We trust the caller (single-tenant userspace; donation is gated by
     // possessing a memmgr SEND cap, which only init and procmgr hold) but
-    // still validate the cap shape via `cap_info` — a malformed cap from
-    // a buggy loader should reject, not poison the pool.
+    // still validate the cap shape via `cap_info` — a malformed or under-rights
+    // cap from a buggy loader should reject, not poison the pool.
     let pool = pool_mut();
     let mut accepted_caps: u32 = 0;
     let mut accepted_pages: u64 = 0;
     for &slot in req.caps()
     {
         // Required: Memory tag implied by MEMORY_SIZE selector returning Ok.
-        // Required: RETYPE rights so derived caps can retype.
+        // Required: full pool-frame rights (WRITE|EXECUTE|RETYPE).
         // Required: contiguous run (we read the whole cap as one run).
         let Ok(packed) = syscall::cap_info(slot, syscall::CAP_INFO_TAG_RIGHTS)
         else
@@ -1085,8 +1101,16 @@ fn handle_donate_memory_caps(req: &IpcMessage, ipc_buf: *mut u64)
             let _ = syscall::cap_delete(slot);
             continue;
         };
-        if packed & syscall::RIGHTS_RETYPE == 0
+        if packed & POOL_FRAME_RIGHTS != POOL_FRAME_RIGHTS
         {
+            // Under-rights frame: cannot derive the R/RW/RX inner a demand
+            // fault or REQUEST_MEMORY_CAPS consumer needs (cap_derive only
+            // narrows). Reject rather than poison the pool — a pool frame that
+            // silently lacks WRITE/EXECUTE surfaces later as an intermittent
+            // consumer fault when allocation order happens to draw it. The
+            // kernel mints every donatable RAM cap full-rights
+            // (`core/kernel/src/main.rs`, `core/kernel/src/cap/mod.rs`), so this
+            // only fires on a mint-rights regression.
             let _ = syscall::cap_delete(slot);
             continue;
         }
@@ -1383,21 +1407,22 @@ fn ingest_pool(boot: &InitBootstrap)
     for i in 0..(boot.memory_count as usize)
     {
         let cap_slot = boot.memory_base + i as u32;
-        // Every RAM Memory cap memmgr ingests from init MUST carry
-        // `Rights::RETYPE`. The kernel stamps RETYPE on usable RAM at
-        // Phase-7 mint (`core/kernel/src/cap/mod.rs`), and init's
-        // `finalize_memmgr` forwards caps through `cap_derive(_, RIGHTS_ALL)`
-        // which preserves RETYPE. If this ever fires, memmgr cannot retype
-        // these memory caps into kernel objects on its consumers' behalf and the
-        // typed-memory contract is broken — fail fast at boot. The check
-        // fires for at least the first cap (gating panic on i == 0);
-        // subsequent caps would be debit-cheap to also check, but the
-        // kernel mints them as a uniform batch so one is sufficient.
+        // Every RAM Memory cap memmgr ingests from init MUST carry the full
+        // pool-frame rights ([`POOL_FRAME_RIGHTS`]: WRITE | EXECUTE | RETYPE).
+        // The kernel stamps these on usable RAM at Phase-7 mint
+        // (`core/kernel/src/cap/mod.rs`), and init's `finalize_memmgr` forwards
+        // caps through `cap_derive(_, RIGHTS_ALL)` which preserves them. If this
+        // ever fires, memmgr cannot derive the writable/executable inner a
+        // consumer needs (nor retype on its behalf) and the pool contract is
+        // broken — fail fast at boot rather than surface as an intermittent
+        // consumer fault. The check fires for at least the first cap (gating
+        // panic on i == 0); the kernel mints them as a uniform batch so one is
+        // sufficient.
         if i == 0
         {
             // `packed` is `(tag << 32) | rights`; low 32 bits are rights, and
-            // `RIGHTS_RETYPE` (1 << 21) is a low-bit-position right so the
-            // comparison against the full u64 is exact. cap_info(slot,
+            // every bit in `POOL_FRAME_RIGHTS` is a low-bit-position right so the
+            // mask comparison against the full u64 is exact. cap_info(slot,
             // TAG_RIGHTS) cannot fail on a non-null slot — init has just
             // forwarded the cap, so an Err here means the cap-routing graph
             // is broken and the bootstrap invariant fails.
@@ -1407,8 +1432,8 @@ fn ingest_pool(boot: &InitBootstrap)
                 panic!("memmgr: cap_info failed on bootstrap Memory cap");
             };
             assert!(
-                packed & syscall::RIGHTS_RETYPE != 0,
-                "memmgr: ingested RAM Memory cap missing RIGHTS_RETYPE",
+                packed & POOL_FRAME_RIGHTS == POOL_FRAME_RIGHTS,
+                "memmgr: ingested RAM Memory cap missing pool-frame rights (WRITE|EXECUTE|RETYPE)",
             );
         }
         // Ownership is taken on ingest — count on ownership, place best-effort

--- a/services/memmgr/src/main.rs
+++ b/services/memmgr/src/main.rs
@@ -171,6 +171,19 @@ impl ProcessRecord
         }
     }
 
+    /// Reuse this free slot for `badge`, in place. Resets only the scalar
+    /// cursors — stale `memory_caps` / `regions` entries beyond `used` /
+    /// `region_count` are never read, so they need no clearing. In-place reset
+    /// is load-bearing: constructing a fresh `ProcessRecord` by value (~12 KiB)
+    /// would overflow memmgr's VA-capped main-thread stack.
+    fn reset(&mut self, badge: u64)
+    {
+        self.badge = badge;
+        self.used = 0;
+        self.aspace_cap = 0;
+        self.region_count = 0;
+    }
+
     fn push(&mut self, memory_cap: OwnedMemory) -> Result<(), ()>
     {
         if self.used >= MAX_PER_PROC
@@ -397,59 +410,48 @@ impl FreePool
 /// process identity).
 struct ProcessTable
 {
-    records: [Option<ProcessRecord>; MAX_PROCESSES],
+    /// Slots are stored inline (not `Option`) so insert/free never move a
+    /// ~12 KiB `ProcessRecord` by value onto memmgr's VA-capped stack. A slot
+    /// is free iff `badge == 0` (every minted badge is nonzero).
+    records: [ProcessRecord; MAX_PROCESSES],
 }
 
 impl ProcessTable
 {
-    // large_stack_arrays: const-evaluated at static-initialization time;
-    // never touches a runtime stack frame.
+    // large_stack_arrays: const-evaluated at static-initialization time. The
+    // EMPTY record is all-zero, so the static lands in .bss — never a stack
+    // frame.
     #[allow(clippy::large_stack_arrays)]
     const fn new() -> Self
     {
-        const NONE: Option<ProcessRecord> = None;
+        const EMPTY: ProcessRecord = ProcessRecord::new(0);
         Self {
-            records: [NONE; MAX_PROCESSES],
+            records: [EMPTY; MAX_PROCESSES],
         }
     }
 
+    /// Claim a free slot for `badge`, resetting it in place. Returns `None`
+    /// when the table is full.
     fn insert(&mut self, badge: u64) -> Option<&mut ProcessRecord>
     {
-        for slot in &mut self.records
-        {
-            if slot.is_none()
-            {
-                *slot = Some(ProcessRecord::new(badge));
-                return slot.as_mut();
-            }
-        }
-        None
+        let slot = self.records.iter_mut().find(|slot| slot.badge == 0)?;
+        slot.reset(badge);
+        Some(slot)
     }
 
     fn find_mut(&mut self, badge: u64) -> Option<&mut ProcessRecord>
     {
-        for slot in &mut self.records
-        {
-            if let Some(rec) = slot
-                && rec.badge == badge
-            {
-                return slot.as_mut();
-            }
-        }
-        None
+        self.records.iter_mut().find(|slot| slot.badge == badge)
     }
 
-    fn take(&mut self, badge: u64) -> Option<ProcessRecord>
+    /// Mark the slot owned by `badge` free (reusable) in place. The caller has
+    /// already reclaimed the record's resources.
+    fn free(&mut self, badge: u64)
     {
-        for slot in &mut self.records
+        if let Some(rec) = self.find_mut(badge)
         {
-            if let Some(rec) = slot
-                && rec.badge == badge
-            {
-                return slot.take();
-            }
+            rec.badge = 0;
         }
-        None
     }
 }
 
@@ -702,6 +704,26 @@ fn derive_for_caller(outer_slot: u32) -> Option<u32>
     syscall::cap_derive(outer_slot, syscall::RIGHTS_ALL).ok()
 }
 
+/// Map a demand-region protection mask to the cap rights to derive for the
+/// fault-backing inner cap: least-privilege, exactly the rights `mem_map` will
+/// validate against the requested prot bits. `region.prot` is W^X-exclusive
+/// (checked at registration), so this never produces a W+X cap.
+fn rights_for_prot(prot: u64) -> u64
+{
+    if prot & MAP_EXECUTABLE != 0
+    {
+        syscall::RIGHTS_MAP_RX
+    }
+    else if prot & MAP_WRITABLE != 0
+    {
+        syscall::RIGHTS_MAP_RW
+    }
+    else
+    {
+        syscall::RIGHTS_MAP_READ
+    }
+}
+
 // ── IPC handlers ─────────────────────────────────────────────────────────────
 
 /// Reply slot count for `REQUEST_MEMORY_CAPS`. Per-cap page counts pack into
@@ -946,7 +968,7 @@ fn handle_register_process(req: &IpcMessage, ipc_buf: *mut u64, service_ep: u32,
     else
     {
         // Roll back the table insertion.
-        let _ = table.take(new_badge);
+        table.free(new_badge);
         reply_label(ipc_buf, memmgr_errors::TOO_MANY_PROCESSES);
         return;
     };
@@ -993,7 +1015,7 @@ fn handle_process_died(req: &IpcMessage, ipc_buf: *mut u64, procmgr_badge: u64)
     // `integration::retype_reclaim` covers the same invariant on a
     // dedicated source cap with no allocator residual.
     let pool = pool_mut();
-    if let Some(record) = table_mut().take(dead_badge)
+    if let Some(record) = table_mut().find_mut(dead_badge)
     {
         for memory_cap in record.memory_caps.iter().take(record.used).flatten()
         {
@@ -1023,6 +1045,8 @@ fn handle_process_died(req: &IpcMessage, ipc_buf: *mut u64, procmgr_badge: u64)
         {
             let _ = syscall::cap_delete(record.aspace_cap);
         }
+        // Free the slot in place (mark reusable); no by-value move.
+        record.badge = 0;
     }
     // Idempotent: missing badge is not an error.
 
@@ -1274,7 +1298,13 @@ fn handle_fault(req: &IpcMessage, ipc_buf: *mut u64)
         return;
     }
 
-    let Some(inner) = derive_for_caller(outer)
+    // Derive the inner mapping cap with exactly the rights the region's
+    // protection needs (R / R+W / R+X), least-privilege. Pool outers are
+    // full-rights (every RAM frame, including init's donated segments, carries
+    // WRITE), so the narrowing always succeeds; `mem_map` then validates the
+    // requested prot bits against these rights. Mirrors procmgr's RW mapping
+    // pattern (`cap_derive(_, RIGHTS_MAP_RW)`).
+    let Ok(inner) = syscall::cap_derive(outer, rights_for_prot(region.prot))
     else
     {
         record.pop();

--- a/services/memmgr/src/main.rs
+++ b/services/memmgr/src/main.rs
@@ -21,7 +21,7 @@ use ipc::{IpcMessage, memmgr_errors, memmgr_labels};
 use process_abi::{
     PROCESS_ABI_VERSION, PROCESS_INFO_VADDR, ProcessInfo, StartupInfo, process_info_ref,
 };
-use syscall_abi::PAGE_SIZE;
+use syscall_abi::{MAP_EXECUTABLE, MAP_READ, MAP_WRITABLE, PAGE_SIZE};
 
 // memmgr's bootstrap parser carries page-count buffers on stack and
 // pushes deeper through `bootstrap_from_init`; declare a 12-page
@@ -77,6 +77,8 @@ pub extern "C" fn _start(_info_ptr: u64) -> !
         env_count: 0,
         stack_top_vaddr: info.stack_top_vaddr,
         stack_pages: info.stack_pages,
+        pager_endpoint_cap: info.pager_endpoint_cap,
+        pager_badge: info.pager_badge,
     };
 
     main(&startup)
@@ -94,6 +96,9 @@ fn panic(_info: &core::panic::PanicInfo) -> !
 const MAX_PROCESSES: usize = 64;
 /// Maximum memory-cap records per process.
 const MAX_PER_PROC: usize = 512;
+/// Maximum demand-paged regions tracked per process. Generous for the
+/// anonymous-memory consumer; a process needing more registers coarser regions.
+const MAX_REGIONS_PER_PROC: usize = 8;
 /// Maximum free runs in the pool. Each run is one Memory cap covering one
 /// or more contiguous pages.
 const MAX_FREE_RUNS: usize = 512;
@@ -121,6 +126,17 @@ struct OwnedMemory
     phys_base: u64,
 }
 
+/// One demand-paged anonymous region a process registered via
+/// `REGISTER_REGION`. A page fault inside `[va_base, va_base + len)` is backed
+/// on demand with `prot`; a fault outside every region is declined.
+#[derive(Clone, Copy)]
+struct DemandRegion
+{
+    va_base: u64,
+    len: u64,
+    prot: u64,
+}
+
 /// Process accounting record: badge plus the list of memory caps memmgr has
 /// issued to that process.
 struct ProcessRecord
@@ -128,6 +144,13 @@ struct ProcessRecord
     badge: u64,
     used: usize,
     memory_caps: [Option<OwnedMemory>; MAX_PER_PROC],
+    /// Demand-paged child `AddressSpace` cap delegated by procmgr, or `0` when
+    /// the process is not demand-paged. memmgr maps fault-backing frames into
+    /// it.
+    aspace_cap: u32,
+    /// Registered demand-paged regions and their live count.
+    regions: [Option<DemandRegion>; MAX_REGIONS_PER_PROC],
+    region_count: usize,
 }
 
 impl ProcessRecord
@@ -142,6 +165,9 @@ impl ProcessRecord
             badge,
             used: 0,
             memory_caps: [None; MAX_PER_PROC],
+            aspace_cap: 0,
+            regions: [None; MAX_REGIONS_PER_PROC],
+            region_count: 0,
         }
     }
 
@@ -154,6 +180,52 @@ impl ProcessRecord
         self.memory_caps[self.used] = Some(memory_cap);
         self.used += 1;
         Ok(())
+    }
+
+    /// Undo the most recent [`Self::push`]. Used to roll an accounting entry
+    /// back when a later step in the same handler fails.
+    fn pop(&mut self)
+    {
+        if self.used > 0
+        {
+            self.used -= 1;
+            self.memory_caps[self.used] = None;
+        }
+    }
+
+    /// Register a demand-paged region, rejecting overlap and over-quota.
+    /// Returns the `memmgr_errors` code to reply with on failure.
+    fn add_region(&mut self, region: DemandRegion) -> Result<(), u64>
+    {
+        if self.region_count >= MAX_REGIONS_PER_PROC
+        {
+            return Err(memmgr_errors::QUOTA);
+        }
+        let new_end = region.va_base.saturating_add(region.len);
+        for existing in self.regions.iter().take(self.region_count).flatten()
+        {
+            let end = existing.va_base.saturating_add(existing.len);
+            if region.va_base < end && existing.va_base < new_end
+            {
+                return Err(memmgr_errors::INVALID_ARGUMENT);
+            }
+        }
+        self.regions[self.region_count] = Some(region);
+        self.region_count += 1;
+        Ok(())
+    }
+
+    /// Find the registered region containing `va`, if any.
+    fn region_for(&self, va: u64) -> Option<DemandRegion>
+    {
+        for region in self.regions.iter().take(self.region_count).flatten()
+        {
+            if va >= region.va_base && va < region.va_base.saturating_add(region.len)
+            {
+                return Some(*region);
+            }
+        }
+        None
     }
 }
 
@@ -943,6 +1015,14 @@ fn handle_process_died(req: &IpcMessage, ipc_buf: *mut u64, procmgr_badge: u64)
         // `push_or_coalesce` parks reclaimed memory caps (unreachable for
         // allocation, though still owned and accounted).
         pool.coalesce();
+
+        // Drop memmgr's copy of a demand-paged process's delegated address
+        // space, freeing the CSpace slot. The child's own AS is torn down by
+        // procmgr; this only releases memmgr's reference.
+        if record.aspace_cap != 0
+        {
+            let _ = syscall::cap_delete(record.aspace_cap);
+        }
     }
     // Idempotent: missing badge is not an error.
 
@@ -1047,6 +1127,181 @@ fn handle_query_pool_status(ipc_buf: *mut u64, boot: &InitBootstrap)
         .build();
     // SAFETY: ipc_buf is the registered IPC buffer page.
     let _ = unsafe { ipc::ipc_reply(&reply, ipc_buf) };
+}
+
+/// Register a demand-paged anonymous region for the calling process.
+///
+/// Attributed by `req.badge` (the caller's per-process badge). The region is
+/// validated (page alignment, nonzero length, W^X, known prot bits) and stored
+/// against the caller's record; no mapping is installed here — backing happens
+/// lazily in [`handle_fault`].
+fn handle_register_region(req: &IpcMessage, ipc_buf: *mut u64)
+{
+    let va_base = req.word(0);
+    let len = req.word(1);
+    let prot = req.word(2);
+
+    let known_prot = MAP_READ | MAP_WRITABLE | MAP_EXECUTABLE;
+    let wx = MAP_WRITABLE | MAP_EXECUTABLE;
+    if len == 0
+        || !va_base.is_multiple_of(PAGE_SIZE)
+        || !len.is_multiple_of(PAGE_SIZE)
+        || va_base.checked_add(len).is_none()
+        || prot & !known_prot != 0
+        || prot & wx == wx
+    {
+        reply_label(ipc_buf, memmgr_errors::INVALID_ARGUMENT);
+        return;
+    }
+
+    let Some(record) = table_mut().find_mut(req.badge)
+    else
+    {
+        reply_label(ipc_buf, memmgr_errors::INVALID_ARGUMENT);
+        return;
+    };
+    match record.add_region(DemandRegion { va_base, len, prot })
+    {
+        Ok(()) => reply_label(ipc_buf, memmgr_errors::SUCCESS),
+        Err(code) => reply_label(ipc_buf, code),
+    }
+}
+
+/// Procmgr-only: store a demand-paged child's delegated `AddressSpace` cap so
+/// [`handle_fault`] can map backing frames into it. Keyed by the child's
+/// memmgr badge in `data[0]`; the cap arrives in `caps[0]`.
+fn handle_delegate_aspace(req: &IpcMessage, ipc_buf: *mut u64, procmgr_badge: u64)
+{
+    if req.badge != procmgr_badge
+    {
+        for &slot in req.caps()
+        {
+            let _ = syscall::cap_delete(slot);
+        }
+        reply_label(ipc_buf, memmgr_errors::UNAUTHORIZED);
+        return;
+    }
+    let child_badge = req.word(0);
+    let Some(&as_cap) = req.caps().first()
+    else
+    {
+        reply_label(ipc_buf, memmgr_errors::INVALID_ARGUMENT);
+        return;
+    };
+    let Some(record) = table_mut().find_mut(child_badge)
+    else
+    {
+        let _ = syscall::cap_delete(as_cap);
+        reply_label(ipc_buf, memmgr_errors::INVALID_ARGUMENT);
+        return;
+    };
+    // Replace any prior delegation, dropping the stale cap.
+    if record.aspace_cap != 0
+    {
+        let _ = syscall::cap_delete(record.aspace_cap);
+    }
+    record.aspace_cap = as_cap;
+    reply_label(ipc_buf, memmgr_errors::SUCCESS);
+}
+
+/// Service a kernel-synthesized page fault for a demand-paged process.
+///
+/// `req.badge` is the faulting process's memmgr badge; words are
+/// `[kind, faulting_va, access, ip]`. On a VM fault whose address lies in a
+/// registered region of a process with a delegated address space, memmgr
+/// allocates one frame, maps it at the faulting page with the region's
+/// protection, and replies [`syscall_abi::FAULT_REPLY_RESUME`]. Every other
+/// case — non-VM fault, unknown process, address outside every region, no
+/// delegated AS, or any allocation/map failure — replies
+/// [`syscall_abi::FAULT_REPLY_KILL`], preserving default segfault semantics.
+///
+/// The frame is accounted to the process record (reclaimed on `PROCESS_DIED`
+/// like any other issued cap); `pool_total` is unchanged because the page was
+/// already owned — it moves from a free run to the process's record.
+fn handle_fault(req: &IpcMessage, ipc_buf: *mut u64)
+{
+    if req.word(0) != syscall_abi::FAULT_KIND_VM
+    {
+        reply_label(ipc_buf, syscall_abi::FAULT_REPLY_KILL);
+        return;
+    }
+    let va = req.word(1);
+    let page_base = va & !(PAGE_SIZE - 1);
+
+    let pool = pool_mut();
+    let Some(record) = table_mut().find_mut(req.badge)
+    else
+    {
+        reply_label(ipc_buf, syscall_abi::FAULT_REPLY_KILL);
+        return;
+    };
+    let Some(region) = record.region_for(va)
+    else
+    {
+        reply_label(ipc_buf, syscall_abi::FAULT_REPLY_KILL);
+        return;
+    };
+    if record.aspace_cap == 0
+    {
+        reply_label(ipc_buf, syscall_abi::FAULT_REPLY_KILL);
+        return;
+    }
+
+    let Ok((granted, _count)) = select_memory_caps(pool, 1, true)
+    else
+    {
+        reply_label(ipc_buf, syscall_abi::FAULT_REPLY_KILL);
+        return;
+    };
+    let (outer, pages, phys) = granted[0];
+
+    // Account the frame so it is reclaimed on death; roll back to the pool on
+    // any subsequent failure.
+    if record
+        .push(OwnedMemory {
+            cap_slot: outer,
+            page_count: pages,
+            phys_base: phys,
+        })
+        .is_err()
+    {
+        let _ = pool.push(FreeRun {
+            cap_slot: outer,
+            page_count: pages,
+            phys_base: phys,
+        });
+        reply_label(ipc_buf, syscall_abi::FAULT_REPLY_KILL);
+        return;
+    }
+
+    let Some(inner) = derive_for_caller(outer)
+    else
+    {
+        record.pop();
+        let _ = pool.push(FreeRun {
+            cap_slot: outer,
+            page_count: pages,
+            phys_base: phys,
+        });
+        reply_label(ipc_buf, syscall_abi::FAULT_REPLY_KILL);
+        return;
+    };
+    if syscall::mem_map(inner, record.aspace_cap, page_base, 0, 1, region.prot).is_err()
+    {
+        let _ = syscall::cap_delete(inner);
+        record.pop();
+        let _ = pool.push(FreeRun {
+            cap_slot: outer,
+            page_count: pages,
+            phys_base: phys,
+        });
+        reply_label(ipc_buf, syscall_abi::FAULT_REPLY_KILL);
+        return;
+    }
+    // The kernel holds the mapping independently of the inner cap; the outer
+    // pins the frame until reclaim.
+    let _ = syscall::cap_delete(inner);
+    reply_label(ipc_buf, syscall_abi::FAULT_REPLY_RESUME);
 }
 
 /// Total pages of RAM memmgr owns: every page it has taken ownership of since
@@ -1172,6 +1427,14 @@ fn ingest_in_use(boot: &InitBootstrap)
 
 fn dispatch(req: &IpcMessage, ipc_buf: *mut u64, boot: &InitBootstrap)
 {
+    // The kernel-synthesized fault IPC carries the full `FAULT_LABEL` sentinel
+    // (`u64::MAX - 1`), which would alias other opcodes under the `& 0xFFFF`
+    // mask below; match it on the full label first.
+    if req.label == syscall_abi::FAULT_LABEL
+    {
+        handle_fault(req, ipc_buf);
+        return;
+    }
     match req.label & 0xFFFF
     {
         memmgr_labels::REQUEST_MEMORY_CAPS =>
@@ -1197,6 +1460,14 @@ fn dispatch(req: &IpcMessage, ipc_buf: *mut u64, boot: &InitBootstrap)
         memmgr_labels::QUERY_POOL_STATUS =>
         {
             handle_query_pool_status(ipc_buf, boot);
+        }
+        memmgr_labels::REGISTER_REGION =>
+        {
+            handle_register_region(req, ipc_buf);
+        }
+        memmgr_labels::DELEGATE_ASPACE =>
+        {
+            handle_delegate_aspace(req, ipc_buf, boot.procmgr_badge);
         }
         _ =>
         {

--- a/services/procmgr/docs/ipc-interface.md
+++ b/services/procmgr/docs/ipc-interface.md
@@ -74,6 +74,19 @@ stop/configure the thread.
 | 2 | `OutOfMemory` | Insufficient memory caps to allocate stack, ProcessInfo page, or IPC buffer |
 | 3 | `CSpaceFull` | Cannot allocate kernel objects (address space, CSpace, thread) |
 
+**Demand-paged flag.** The label's bit 16 (`CREATE_DEMAND_PAGED`, in the
+reserved `[16..32]` window shared with `CREATE_FROM_FILE`) requests a
+demand-paged child. At finalize, for non-infrastructure children (badge
+≥ `LOG_BADGE_FIRST_CHILD`), procmgr binds the main thread's fault handler to
+memmgr (the system pager) via `SYS_THREAD_SET_FAULT_HANDLER`, delegates the
+child `AddressSpace` to memmgr via `memmgr_labels::DELEGATE_ASPACE`, and sets
+`ProcessInfo.pager_endpoint_cap` / `pager_badge` so the runtime inherits the
+handler onto spawned threads. The child then backs reserved regions lazily via
+`std::os::seraph::register_demand_paged`. See
+[docs/fault-handling.md](../../../docs/fault-handling.md). The binding is
+best-effort: a failure degrades to "no pager" (faults kill), never blocking
+creation.
+
 ### Label 2: `START_PROCESS`
 
 Start a previously created (suspended) process. The caller must have

--- a/services/procmgr/src/main.rs
+++ b/services/procmgr/src/main.rs
@@ -812,6 +812,8 @@ fn handle_create(
         memmgr_badge,
         registry_send_source: ctx.registry_ep,
         sched_baseline: ctx.sched_baseline,
+        demand_paged: label & procmgr_labels::CREATE_DEMAND_PAGED != 0,
+        self_memmgr_ep: ctx.memmgr_ep,
     };
 
     let result = process::create_process(
@@ -990,6 +992,7 @@ fn handle_create_from_file(
         &args,
         &env,
         ctx.death_eq,
+        label & procmgr_labels::CREATE_DEMAND_PAGED != 0,
     );
 
     match result

--- a/services/procmgr/src/process.rs
+++ b/services/procmgr/src/process.rs
@@ -10,12 +10,12 @@
 //! suspended processes.
 
 use crate::loader::{self, ScratchMapping};
-use ipc::{IpcMessage, memmgr_labels, procmgr_errors};
+use ipc::{IpcMessage, memmgr_errors, memmgr_labels, procmgr_errors};
 use process_abi::{
     DEFAULT_PROCESS_STACK_PAGES, MAX_PROCESS_STACK_PAGES, PROCESS_ABI_VERSION, PROCESS_INFO_VADDR,
     PROCESS_MAIN_TLS_MAX_PAGES, PROCESS_MAIN_TLS_VADDR, PROCESS_STACK_TOP,
 };
-use syscall_abi::PAGE_SIZE;
+use syscall_abi::{FAULT_CLASS_ALL, PAGE_SIZE};
 
 // Bootstrap-cross-boundary VA: procmgr picks the per-child main-thread
 // IPC-buffer VA and writes it into `ProcessInfo.ipc_buffer_vaddr`. The
@@ -556,6 +556,17 @@ pub struct UniversalCaps
     /// priorities within the band. Zero when procmgr was given no baseline;
     /// children then receive zero and cannot set any priority.
     pub sched_baseline: u32,
+    /// Whether the caller requested a demand-paged child (the
+    /// `procmgr_labels::CREATE_DEMAND_PAGED` flag). When set and the child is
+    /// not infrastructure, `finalize_creation` binds the child's main-thread
+    /// fault handler to memmgr and delegates the child `AddressSpace`, and
+    /// `populate_child_info` advertises the pager in `ProcessInfo`.
+    pub demand_paged: bool,
+    /// Procmgr's own (procmgr-badged) SEND cap on memmgr's endpoint, used to
+    /// issue the procmgr-only `DELEGATE_ASPACE`. Distinct from
+    /// [`Self::memmgr_endpoint`] (the child's badged cap). Zero when memmgr is
+    /// not reachable.
+    pub self_memmgr_ep: u32,
 }
 
 /// Program arguments delivered to a child process at spawn time.
@@ -836,6 +847,16 @@ fn populate_child_info(
     pi.tls_template_align = tls.align;
     pi.stack_top_vaddr = PROCESS_STACK_TOP;
     pi.stack_pages = stack_pages;
+    // Advertise the demand-paging pager so the runtime can inherit it onto
+    // spawned threads. The child's badged memmgr endpoint is the pager
+    // endpoint; the fault badge equals the child's memmgr badge so the
+    // kernel-synthesized fault is attributed to the right memmgr record.
+    // procmgr binds the main thread separately in `finalize_creation`.
+    if universals.demand_paged
+    {
+        pi.pager_endpoint_cap = pi.memmgr_endpoint_cap;
+        pi.pager_badge = universals.memmgr_badge;
+    }
 
     // Write the argv blob, then the env blob, into the page region
     // following the struct. Each blob begins at a u64-aligned offset so
@@ -1161,6 +1182,9 @@ fn finalize_creation(
     memmgr_send_cap: u32,
     memmgr_badge: u64,
     process_badge: u64,
+    demand_paged: bool,
+    self_memmgr_ep: u32,
+    ipc_buf: *mut u64,
 ) -> Option<CreateResult>
 {
     let badge = process_badge;
@@ -1215,6 +1239,49 @@ fn finalize_creation(
         let _ = syscall::cap_delete(thread_for_caller);
         let _ = syscall::cap_delete(process_handle);
         return None;
+    }
+
+    // Demand-paged wiring (best-effort): delegate the child address space to
+    // memmgr and bind the main thread's fault handler to it. A failure here
+    // degrades to "no pager" (faults kill the thread) rather than failing an
+    // otherwise-complete creation. Infrastructure (badge below
+    // LOG_BADGE_FIRST_CHILD) is never paged; procmgr never spawns it anyway,
+    // but the floor is an explicit guard.
+    if demand_paged
+        && process_badge >= ipc::log_badges::LOG_BADGE_FIRST_CHILD
+        && memmgr_send_cap != 0
+        && self_memmgr_ep != 0
+    {
+        // Hand memmgr its own copy of the child AS, keyed by the child's
+        // memmgr badge, over procmgr's (procmgr-badged) endpoint so it lands
+        // on the privileged DELEGATE_ASPACE tier. procmgr keeps `child_aspace`.
+        if let Ok(as_copy) = syscall::cap_derive(child_aspace, syscall::RIGHTS_ALL)
+        {
+            let msg = IpcMessage::builder(memmgr_labels::DELEGATE_ASPACE)
+                .word(0, memmgr_badge)
+                .cap(as_copy)
+                .build();
+            // SAFETY: ipc_buf is the registered IPC buffer page.
+            let delegated = unsafe { ipc::ipc_call(self_memmgr_ep, &msg, ipc_buf) }
+                .is_ok_and(|r| r.label == memmgr_errors::SUCCESS);
+            if delegated
+            {
+                // Bind only after the AS is delegated, so memmgr can service
+                // the first fault. fault_badge = the child's memmgr badge.
+                let _ = syscall::thread_set_fault_handler(
+                    child_thread,
+                    memmgr_send_cap,
+                    memmgr_badge,
+                    FAULT_CLASS_ALL,
+                );
+            }
+            else
+            {
+                // Call failed or memmgr declined: drop the copy if the IPC did
+                // not transfer it (deleting an already-moved slot is harmless).
+                let _ = syscall::cap_delete(as_copy);
+            }
+        }
     }
 
     Some(CreateResult {
@@ -1370,6 +1437,9 @@ fn create_process_from_bytes(
         child_memmgr_send,
         universals.memmgr_badge,
         process_badge,
+        universals.demand_paged,
+        universals.self_memmgr_ep,
+        ipc_buf,
     )
 }
 
@@ -1907,6 +1977,7 @@ pub fn create_process_from_file(
     args: &ChildArgs<'_>,
     env: &ChildEnv<'_>,
     death_eq: u32,
+    demand_paged: bool,
 ) -> Result<CreateResult, u64>
 {
     let self_aspace = ctx.self_aspace;
@@ -2146,6 +2217,8 @@ pub fn create_process_from_file(
         memmgr_badge: mms.badge(),
         registry_send_source: ctx.registry_ep,
         sched_baseline: ctx.sched_baseline,
+        demand_paged,
+        self_memmgr_ep: ctx.memmgr_ep,
     };
     let process_badge = next_process_badge();
     let pi_memory_cap = populate_child_info(
@@ -2192,6 +2265,9 @@ pub fn create_process_from_file(
         mms.cap(),
         mms.badge(),
         process_badge,
+        universals.demand_paged,
+        universals.self_memmgr_ep,
+        ipc_buf,
     )
     .ok_or(procmgr_errors::OUT_OF_MEMORY);
     if result.is_ok()

--- a/services/svctest/src/phases/mod.rs
+++ b/services/svctest/src/phases/mod.rs
@@ -36,6 +36,7 @@ pub mod fs_ipc;
 pub mod fs_std;
 pub mod memmgr;
 pub mod namespace;
+pub mod pager;
 pub mod pipes;
 pub mod process_faults;
 pub mod procmgr;
@@ -55,6 +56,7 @@ pub fn all() -> Vec<Phase>
     out.extend_from_slice(threading::phases());
     out.extend_from_slice(procmgr::spawn_only());
     out.extend_from_slice(process_faults::phases());
+    out.extend_from_slice(pager::phases());
     out.extend_from_slice(shmem::phases());
     out.extend_from_slice(pipes::phases());
     out.extend_from_slice(namespace::early());

--- a/services/svctest/src/phases/pager.rs
+++ b/services/svctest/src/phases/pager.rs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+//! Demand-paging pager surface: memmgr backs reserved anonymous regions on
+//! fault, and declines (kills) faults outside any registered region.
+//!
+//! Drives `/programs/demandpaged`, spawned demand-paged via
+//! `std::os::seraph::CommandExt::demand_paged`:
+//!
+//!   * **positive** — the child reserves, registers, touches, and reads back a
+//!     multi-page region; memmgr backs each first touch on fault. A clean exit
+//!     proves the round-trip (touch → fault → map → resume) and that repeat
+//!     access does not re-fault (the read-back pass sees the written pattern).
+//!   * **negative** — the child touches an *unregistered* reserved page; memmgr
+//!     declines and the kernel kills it, proving preserved segfault semantics
+//!     under a bound pager.
+//!
+//! After the spawn/die cycle the all-RAM-accounted identity must still hold,
+//! directly guarding against fault-path accounting drift (a stray
+//! `pool_total` credit on demand allocation would break it).
+
+use std::os::seraph::process::CommandExt;
+use std::os::seraph::startup_info;
+
+use crate::bootstrap::Caps;
+use crate::runner::Phase;
+
+pub fn phases() -> &'static [Phase]
+{
+    &[
+        Phase {
+            name: "demand_paging",
+            run: demand_paging_phase,
+        },
+        Phase {
+            name: "demand_paging_segfault",
+            run: demand_paging_segfault_phase,
+        },
+    ]
+}
+
+fn demand_paging_phase(_: &Caps)
+{
+    use std::process::Command;
+
+    let mut child = Command::new("/programs/demandpaged")
+        .demand_paged(true)
+        .spawn()
+        .expect("spawn /programs/demandpaged failed");
+    let status = child.wait().expect("demandpaged wait failed");
+    std::os::seraph::log!("demandpaged exited: {status}");
+    assert!(
+        status.success(),
+        "demand-paged child must exit cleanly: {status}"
+    );
+
+    // The child has exited; procmgr's PROCESS_DIED reclaims its demand frames.
+    // memmgr's accounting identity must remain closed across the cycle.
+    assert_ram_identity();
+    std::os::seraph::log!("demand_paging phase passed");
+}
+
+// cast_sign_loss: ExitStatus::code() is i32 but exit reasons are non-negative
+// (fault 0x1000+vec, killed 0x2000); the u64 cast is safe.
+#[allow(clippy::cast_sign_loss)]
+fn demand_paging_segfault_phase(_: &Caps)
+{
+    use std::process::Command;
+
+    const EXIT_FAULT_BASE: u64 = 0x1000;
+
+    let mut child = Command::new("/programs/demandpaged")
+        .arg("oor")
+        .demand_paged(true)
+        .spawn()
+        .expect("spawn /programs/demandpaged oor failed");
+    let status = child.wait().expect("demandpaged oor wait failed");
+    std::os::seraph::log!("demandpaged oor exited: {status}");
+    assert!(
+        !status.success(),
+        "out-of-region touch must be killed, not exit cleanly: {status}"
+    );
+    let raw = status.code().expect("oor ExitStatus must carry a code") as u64;
+    assert!(
+        raw >= EXIT_FAULT_BASE,
+        "expected a fault/kill exit_reason >= {EXIT_FAULT_BASE:#x}, got {raw:#x}"
+    );
+    std::os::seraph::log!("demand_paging_segfault phase passed (exit_reason={raw:#x})");
+}
+
+/// Assert `system_ram == kernel_reserved + pool_total` via memmgr
+/// `QUERY_POOL_STATUS`.
+fn assert_ram_identity()
+{
+    let info = startup_info();
+    #[allow(clippy::cast_ptr_alignment)]
+    let ipc_buf = info.ipc_buffer.cast::<u64>();
+    let req = ipc::IpcMessage::builder(ipc::memmgr_labels::QUERY_POOL_STATUS).build();
+    // SAFETY: ipc_buf is the kernel-registered IPC buffer page.
+    let reply = unsafe { ipc::ipc_call(info.memmgr_endpoint, &req, ipc_buf) }
+        .expect("QUERY_POOL_STATUS ipc_call failed");
+    assert_eq!(
+        reply.label,
+        ipc::memmgr_errors::SUCCESS,
+        "QUERY_POOL_STATUS status"
+    );
+    let (system_ram, kernel_reserved, pool_total) = (reply.word(0), reply.word(1), reply.word(2));
+    assert_eq!(
+        system_ram,
+        kernel_reserved.saturating_add(pool_total),
+        "RAM identity broken after demand paging: \
+         system_ram={system_ram} kernel_reserved={kernel_reserved} pool_total={pool_total}"
+    );
+}

--- a/shared/ipc/src/lib.rs
+++ b/shared/ipc/src/lib.rs
@@ -111,6 +111,17 @@ pub mod procmgr_labels
     /// completes (success or failure). Stdio pipes are installed via
     /// separate [`CONFIGURE_PIPE`] calls between create and start.
     pub const CREATE_FROM_FILE: u64 = 13;
+    /// Label flag (bit 16) for [`CREATE_PROCESS`] / [`CREATE_FROM_FILE`]:
+    /// create the new process as demand-paged. At finalize procmgr binds
+    /// the child's main thread fault handler to memmgr (the system pager),
+    /// delegates the child `AddressSpace` cap to memmgr via
+    /// `memmgr_labels::DELEGATE_ASPACE`, and advertises the pager in
+    /// `ProcessInfo` (`pager_endpoint_cap` / `pager_badge`) so the runtime
+    /// inherits it onto spawned threads. Occupies bit 16 of the reserved
+    /// `[16..32]` label window. Infrastructure processes (badge below
+    /// `log_badges::LOG_BADGE_FIRST_CHILD`) are never paged regardless of
+    /// this flag.
+    pub const CREATE_DEMAND_PAGED: u64 = 1 << 16;
     /// Destroy a process: `cap_delete` its kernel objects (thread, aspace,
     /// cspace, `ProcessInfo` Memory cap), dec-refing any pages the child
     /// still holds so they recycle back into the kernel buddy allocator. The
@@ -274,7 +285,7 @@ pub mod procmgr_labels
     pub const INIT_REAP_CORRELATOR: u32 = u32::MAX;
 }
 
-pub const MEMMGR_LABELS_VERSION: u32 = 2;
+pub const MEMMGR_LABELS_VERSION: u32 = 3;
 /// IPC labels for the memory manager (`memmgr`).
 ///
 /// memmgr owns the userspace RAM frame pool. All std-built processes
@@ -352,6 +363,47 @@ pub mod memmgr_labels
     /// invisible residue. A nonzero `data[0] - data[1] - data[2]` is leaked
     /// "dark" memory.
     pub const QUERY_POOL_STATUS: u64 = 6;
+    /// Register a demand-paged anonymous region for the calling process.
+    ///
+    /// Universal label — attributed to the caller by `recv.badge` (the
+    /// per-process badge minted at [`REGISTER_PROCESS`], carried by the
+    /// badged SEND cap installed in `ProcessInfo.memmgr_endpoint_cap`).
+    /// memmgr records the region against that badge's tracking entry; a
+    /// later page fault inside a registered region is backed on demand by
+    /// the fault-handler arm, while a fault outside every registered region
+    /// is declined (the faulting thread is killed), preserving segfault
+    /// semantics.
+    ///
+    /// Wire format:
+    /// * `data[0]` — `va_base` (page-aligned virtual address).
+    /// * `data[1]` — `len_bytes` (region length; page-multiple, nonzero).
+    /// * `data[2]` — `prot` (MAP_* protection bits; W^X enforced).
+    ///
+    /// Reply: `memmgr_errors::SUCCESS`; `INVALID_ARGUMENT` (bad alignment,
+    /// zero length, W^X violation, unknown badge, or overlap); or `QUOTA`
+    /// (per-process region list at static cap). No mapping is installed
+    /// here — backing happens lazily on fault, and only once procmgr has
+    /// delegated the process `AddressSpace` cap via [`DELEGATE_ASPACE`].
+    pub const REGISTER_REGION: u64 = 7;
+    /// Procmgr-only: delegate a demand-paged child's `AddressSpace` cap to
+    /// memmgr so the pager can map frames into it on fault.
+    ///
+    /// Sent at process finalize for processes created with the
+    /// [`CREATE_DEMAND_PAGED`] flag, after the child address space exists
+    /// (so it cannot ride on the earlier [`REGISTER_PROCESS`] handshake).
+    /// memmgr stores the transferred cap against the child's tracking
+    /// entry, keyed by the badge minted at [`REGISTER_PROCESS`].
+    ///
+    /// Wire format:
+    /// * `data[0]` — `child_memmgr_badge` (from the child's
+    ///   `REGISTER_PROCESS` reply).
+    /// * `caps[0]` — the child `AddressSpace` cap (MAP rights); ownership
+    ///   transfers to memmgr.
+    ///
+    /// Reply: `memmgr_errors::SUCCESS`; `UNAUTHORIZED` (caller is not
+    /// procmgr); or `INVALID_ARGUMENT` (unknown badge or missing cap — a
+    /// stray transferred cap is dropped).
+    pub const DELEGATE_ASPACE: u64 = 8;
 
     /// `REQUEST_MEMORY_CAPS` flag: reply MUST contain exactly one Memory cap
     /// covering all `want_pages`, or fail with

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -117,6 +117,7 @@ pub enum BuildComponent
     Fsbench,
     Pipefault,
     Stackoverflow,
+    Demandpaged,
     Stdiotest,
     StdiotestTester,
     All,

--- a/xtask/src/commands/build.rs
+++ b/xtask/src/commands/build.rs
@@ -304,6 +304,13 @@ const SPECS: &[Spec] = &[
         arch_only: None,
     },
     Spec {
+        name: "demandpaged",
+        install_name: None,
+        profile: BuildProfile::StdUser,
+        dest: InstallDest::Programs,
+        arch_only: None,
+    },
+    Spec {
         name: "stdiotest",
         install_name: None,
         profile: BuildProfile::StdUser,
@@ -349,6 +356,7 @@ fn spec_for(component: BuildComponent) -> Option<&'static Spec>
         BuildComponent::Fsbench => "fsbench",
         BuildComponent::Stackoverflow => "stackoverflow",
         BuildComponent::Pipefault => "pipefault",
+        BuildComponent::Demandpaged => "demandpaged",
         BuildComponent::Stdiotest => "stdiotest",
         BuildComponent::StdiotestTester => "stdiotest-tester",
     };


### PR DESCRIPTION
PR4 of the userspace fault-handler protocol (#34): a userspace demand-paging
pager built on the merged PR2/PR3 kernel mechanism. The pager itself is pure
userspace (memmgr); validation of the consumer also surfaced a latent
kernel Memory-cap mint-rights defect, fixed here (see **Kernel changes**).

## What's included

- [x] **memmgr pager.** A `FAULT_LABEL` arm in the single-threaded dispatch
  loop. New labels `REGISTER_REGION` (universal, badge-attributed) and
  `DELEGATE_ASPACE` (procmgr-only). `ProcessRecord` gains a delegated
  `AddressSpace` cap + a demand-paged region list. On a `FAULT_KIND_VM` fault
  inside a registered region of a process with a delegated AS, memmgr allocates
  a frame, maps it with the region protection, and replies `FAULT_REPLY_RESUME`;
  every other case (non-VM, unknown process, out-of-region, no AS, alloc/map
  failure) replies `FAULT_REPLY_KILL`, preserving segfault semantics.
- [x] **Reclaim.** Demand frames are tracked as ordinary `OwnedMemory`, so the
  existing `PROCESS_DIED` path reclaims them; `pool_total` is unchanged (the
  page was already owned — it moves free-run → process record), so the
  all-RAM-accounted identity stays closed.
- [x] **procmgr opt-in binding.** `CREATE_DEMAND_PAGED` flag on
  `CREATE_PROCESS` / `CREATE_FROM_FILE`. At finalize, for non-infrastructure
  children (badge ≥ `LOG_BADGE_FIRST_CHILD`), procmgr delegates the child AS to
  memmgr and binds the main thread's fault handler (best-effort; failure
  degrades to "no pager").
- [x] **ProcessInfo pager field.** `pager_endpoint_cap` + `pager_badge`,
  `PROCESS_ABI_VERSION` 17 → 18. All writers/readers updated; init sets them
  zero for memmgr/procmgr.
- [x] **ruststd.** `std::os::seraph::register_demand_paged` (reserve unbacked
  VA + `REGISTER_REGION`) and `CommandExt::demand_paged`; the runtime inherits
  the pager onto `std::thread::spawn` threads.
- [x] **Tests.** `programs/demandpaged` fixture + svctest pager phase covering
  the round-trip (touch → fault → map → resume, no re-fault on read-back), the
  out-of-region kill, and a post-cycle RAM-identity guard.
- [x] **Docs.** memmgr/procmgr `ipc-interface.md`, memmgr `memory-pool.md`
  (pool-frame rights invariant), `docs/fault-handling.md` Implementation
  Status, and a rewrite of the stale `process-abi` README
  `ProcessInfo`/`StartupInfo` listings.

## Kernel changes (surfaced by consumer validation)

The demand-paging consumer is the first to draw arbitrary frames from memmgr's
pool and map them **writable**. That exposed a latent defect: several donatable
RAM Memory caps were minted with rights narrower than the pool's contract
requires. memmgr's pool is uniform anonymous RAM (a consumer may map any frame
R/RW/RX), and `cap_derive` only narrows, so a frame whose outer cap lacks WRITE
(or EXECUTE) cannot satisfy a writable (or executable) map. `smallest_fit`
preferentially draws the small donated frames for a 1-page demand fault, so when
a non-WRITE frame survived boot allocation, the fault was declined → child
killed → svctest panicked → all-CPU-idle watchdog (the "flaky hang"). Fixed:

- [x] **Full-rights donatable mints** (`core/kernel/src/main.rs`): init's ELF
  segment, InitInfo, and stack Memory caps are now minted
  `MAP|READ|WRITE|EXECUTE|RETYPE`. Rights gate derivation, not the live mapping
  (segments/InitInfo/stack keep their R/RX/RO/RW page protections via map
  flags; W^X is enforced at map time, not cap level), so no protection is
  widened. ktest `unit/mm.rs` adapted accordingly.
- [x] **Pool-frame rights invariant** (`services/memmgr`): `POOL_FRAME_RIGHTS`
  (WRITE|EXECUTE|RETYPE) enforced at both pool entry points — `ingest_pool`
  asserts, `handle_donate_memory_caps` rejects — so a future mint-rights
  regression fails loudly at boot instead of as an intermittent consumer fault.

## Remaining in #34 (out of scope for this PR)

Thread-inheritance is wired and compiles but is not separately exercised
end-to-end (a kernel-killed std thread never signals its join notification, so
a negative test would hang rather than fail cleanly); the main-thread path is
covered. The post-implementation follow-ups are now filed as GitHub Issues:

- **Kernel/ABI:** #222 (x86-64 entry-frame unification), #223 (per-class fault
  handlers), #224 (fault-handler introspection)
- **Policy:** #225 (default system pager), #226 (pager liveness/hardening),
  #227 (fault-path performance)
- **Consumers:** #228 (guard-page stack growth), #229 (file-backed mmap),
  #230 (swap), #231 (copy-on-write), #232 (snapshot/checkpoint-restore),
  #233 (userspace debugger)

## Test plan

`cargo xtask clean` between arches, then on **both x86_64 and riscv64**:
`cargo xtask build [--arch riscv64]`; for svctest stage svctest+crasher recipes
and `cargo xtask mkdisk`; for usertest stage usertest and `cargo xtask mkdisk`;
for ktest `cargo xtask compose-bundle --harness ktest`; then
`cargo xtask run-parallel`. Local results (release): svctest 60/60 (x86_64) +
12/12 (riscv64), ktest 8/8 + 4/4, usertest 4/4. CI: all 13 jobs green
(x86_64/riscv64 × debug/release × {svctest,usertest,ktest} + host-tests).

Refs #34
