### PR TITLE
kernel: unify x86-64 ring-3 entry frame into a single TrapFrame

### DIFF
--- a/core/kernel/docs/scheduling-internals.md
+++ b/core/kernel/docs/scheduling-internals.md
@@ -402,7 +402,7 @@ Every synchronous-IPI ack wait MUST route through `arch::current::interrupts::wa
 |---|---|---|
 | A | 0 – 250 ms | Spin with `core::hint::spin_loop()` while `cond()` reports unacked. |
 | B | 250 – 750 ms | Call `ctx.resend()` once at the boundary, then continue spinning. Recovers from a dropped IPI under emulators with non-deterministic LAPIC delivery. |
-| C | 750 ms – 5 s | x86-64: set `NMI_BACKTRACE_REQUEST[target_cpu]` and send a vector-2 NMI to that CPU; the target's dedicated NMI handler dumps its `ExceptionFrame` to serial so the eventual Phase-D panic is diagnosable. RISC-V: emit a single logged warning (no S-mode NMI surface; Phase C degrades to a warn). |
+| C | 750 ms – 5 s | x86-64: set `NMI_BACKTRACE_REQUEST[target_cpu]` and send a vector-2 NMI to that CPU; the target's dedicated NMI handler dumps its `TrapFrame` to serial so the eventual Phase-D panic is diagnosable. RISC-V: emit a single logged warning (no S-mode NMI surface; Phase C degrades to a warn). |
 | D | > 5 s | Print `target_cpu`, `op_name`, `elapsed_ms` to serial, then `crate::fatal`. |
 
 `wait_for_ack` MUST be called with preemption disabled and `IF=1` / `sstatus.SIE=1` — the same envelope `mm::tlb_shootdown::shootdown` establishes. The `cond` closure MUST be side-effect-free beyond the atomic loads needed to inspect pending state (it runs many times per spin).
@@ -415,7 +415,7 @@ For broadcast IPIs (TLB shootdown), `target_cpu` names the lowest-numbered CPU s
 
 ### `ipi_nmi_backtrace_stub` / `ipi_nmi_backtrace_handler`
 
-The x86-64 IDT registers a dedicated stub at vector 2 (IST=2 per the NMI ABI) that saves the standard `ExceptionFrame` shape, calls a returning handler, then restores GPRs and `iretq`s. The handler reads `NMI_BACKTRACE_REQUEST[cpu]`:
+The x86-64 IDT registers a dedicated stub at vector 2 (IST=2 per the NMI ABI) that builds the canonical `TrapFrame`, calls a returning handler, then writes back and `iretq`s. The handler reads `NMI_BACKTRACE_REQUEST[cpu]`:
 - **Set** (watchdog-requested): dump the saved frame to serial and return; the stub's `iretq` resumes the interrupted code.
 - **Clear** (real hardware NMI): tail-call `common_exception_handler` which never returns — the stub's `iretq` tail is dead code in that case.
 

--- a/core/kernel/src/arch/x86_64/idt.rs
+++ b/core/kernel/src/arch/x86_64/idt.rs
@@ -11,6 +11,11 @@
 //! - Stubs for the APIC timer (vector 32) and spurious (vector 255).
 //! - A common exception handler that prints diagnostics and halts.
 //!
+//! Every ring-3 entry at which a thread can be stopped (exception, `#PF`, NMI,
+//! and ring-3 IRQ) builds the one canonical [`TrapFrame`] on the kernel stack via
+//! [`tf_build_asm`]/[`tf_resume_asm`]; the fault redirect points `tcb->trap_frame`
+//! at that live frame with no copy. See the "Unified entry frame" section.
+//!
 //! # Exception vector groups
 //! Vectors with a hardware-pushed error code: 8, 10, 11, 12, 13, 14, 17, 21, 29, 30.
 //! All others: a dummy 0 is pushed by the stub to keep the frame layout uniform.
@@ -29,6 +34,7 @@
 #![allow(clippy::cast_possible_truncation)]
 
 use super::gdt::KERNEL_CS;
+use super::trap_frame::TrapFrame;
 #[cfg(not(test))]
 use crate::fatal;
 
@@ -105,50 +111,119 @@ struct Idtr
     base: u64,
 }
 
-// ── ExceptionFrame ────────────────────────────────────────────────────────────
+// ── Unified entry frame ─────────────────────────────────────────────────────
+//
+// Every ring-3 entry at which a thread can be stopped — syscall (syscall.rs),
+// exception/#PF/NMI, and ring-3 IRQ — lands on the one canonical `TrapFrame`
+// (the userspace register ABI). The fault redirect points `tcb->trap_frame` at
+// the live on-stack frame directly (symmetric with
+// riscv64/interrupts.rs::redirect_user_fault), so there is no second frame type
+// and no copy.
+//
+// The CPU + each stub leave a uniform stub frame on entry to a trampoline
+// (S = rsp at the trampoline label):
+//
+//   [S+0]   vector       (pushed by the stub)
+//   [S+8]   error_code   (hardware where the vector has one, else a stub-pushed 0)
+//   [S+16]  rip          (hardware)
+//   [S+24]  cs           (hardware)
+//   [S+32]  rflags       (hardware)
+//   [S+40]  rsp          (hardware — always present in long mode)
+//   [S+48]  ss           (hardware — always present in long mode)
+//
+// `tf_build_asm` reserves the 168-byte TrapFrame below this stub frame (leaving
+// it intact for `iretq`) and fills it; `tf_resume_asm` writes any handler-edited
+// CPU-state back into the stub frame and `iretq`s. The two-word error_code +
+// vector stub prologue is load-bearing for 16-byte `call` alignment — see the
+// stub macros.
+//
+// vector/error_code are passed to handlers as arguments, not stored in the
+// frame: they are consumed at fault-classification time only. cr2 is read via
+// `mov reg, cr2` in the handler. fs_base is zeroed (the authoritative TLS base
+// lives in SavedState.fs_base; see trap_frame.rs).
 
-/// Full register state saved on the stack by the ISR trampoline.
+/// Naked-asm fragment: build the canonical [`TrapFrame`] from the stub frame.
 ///
-/// The trampoline pushes all GPRs before calling the exception handler, so
-/// fault diagnostics can dump the complete register snapshot. Layout:
-///
-/// ```text
-/// [rsp+0..120]  GPRs: rax rbx rcx rdx rsi rdi rbp r8-r15
-/// [rsp+120]     vector        (pushed by ISR stub)
-/// [rsp+128]     error_code    (hardware or dummy 0)
-/// [rsp+136]     rip           (hardware)
-/// [rsp+144]     cs            (hardware)
-/// [rsp+152]     rflags        (hardware)
-/// [rsp+160]     rsp           (hardware; pushed on CPL change only)
-/// [rsp+168]     ss            (hardware; pushed on CPL change only)
-/// ```
-#[repr(C)]
-pub struct ExceptionFrame
-{
-    // GPRs pushed by trampoline (lowest addresses).
-    pub rax: u64,
-    pub rbx: u64,
-    pub rcx: u64,
-    pub rdx: u64,
-    pub rsi: u64,
-    pub rdi: u64,
-    pub rbp: u64,
-    pub r8: u64,
-    pub r9: u64,
-    pub r10: u64,
-    pub r11: u64,
-    pub r12: u64,
-    pub r13: u64,
-    pub r14: u64,
-    pub r15: u64,
-    // Hardware + stub fields (higher addresses).
-    pub vector: u64,
-    pub error_code: u64,
-    pub rip: u64,
-    pub cs: u64,
-    pub rflags: u64,
-    pub rsp: u64,
-    pub ss: u64,
+/// On entry rsp = `S` (stub-frame layout above). Reserves 168 bytes with
+/// `sub rsp` and fills every field with explicit `mov`s (the `syscall_entry`
+/// pattern — chosen over `push qword ptr [rsp+disp]` because the
+/// effective-address timing of an rsp-relative `push` source is error-prone).
+/// `rax` is saved first, then reused as the copy scratch. After the fragment
+/// rsp = `S-168` = `TrapFrame` base; the stub frame sits at `[rsp+168 ..=
+/// rsp+216]`.
+#[cfg(not(test))]
+macro_rules! tf_build_asm {
+    () => {
+        concat!(
+            "sub rsp, 168\n",
+            "mov [rsp + 0], rax\n",
+            "mov [rsp + 8], rbx\n",
+            "mov [rsp + 16], rcx\n",
+            "mov [rsp + 24], rdx\n",
+            "mov [rsp + 32], rsi\n",
+            "mov [rsp + 40], rdi\n",
+            "mov [rsp + 48], rbp\n",
+            "mov [rsp + 56], r8\n",
+            "mov [rsp + 64], r9\n",
+            "mov [rsp + 72], r10\n",
+            "mov [rsp + 80], r11\n",
+            "mov [rsp + 88], r12\n",
+            "mov [rsp + 96], r13\n",
+            "mov [rsp + 104], r14\n",
+            "mov [rsp + 112], r15\n",
+            "mov rax, [rsp + 184]\n", // stub rip
+            "mov [rsp + 120], rax\n",
+            "mov rax, [rsp + 200]\n", // stub rflags
+            "mov [rsp + 128], rax\n",
+            "mov rax, [rsp + 208]\n", // stub rsp
+            "mov [rsp + 136], rax\n",
+            "mov rax, [rsp + 192]\n", // stub cs
+            "mov [rsp + 144], rax\n",
+            "mov rax, [rsp + 216]\n", // stub ss
+            "mov [rsp + 152], rax\n",
+            "mov qword ptr [rsp + 160], 0\n", // fs_base
+        )
+    };
+}
+
+/// Naked-asm fragment: write the (possibly handler-edited) `TrapFrame`
+/// CPU-state back into the stub frame, restore all GPRs from the frame, drop the
+/// frame + stub prologue, and `iretq`. Inverse of [`tf_build_asm`]; rsp on entry
+/// = `TrapFrame` base, on exit (`iretq`) the stub frame's hardware iret words are
+/// at the top of stack. `rax` is the copy scratch, then restored from the frame.
+#[cfg(not(test))]
+macro_rules! tf_resume_asm {
+    () => {
+        concat!(
+            "mov rax, [rsp + 120]\n", // rip
+            "mov [rsp + 184], rax\n",
+            "mov rax, [rsp + 128]\n", // rflags
+            "mov [rsp + 200], rax\n",
+            "mov rax, [rsp + 136]\n", // rsp
+            "mov [rsp + 208], rax\n",
+            "mov rax, [rsp + 144]\n", // cs
+            "mov [rsp + 192], rax\n",
+            "mov rax, [rsp + 152]\n", // ss
+            "mov [rsp + 216], rax\n",
+            "mov rax, [rsp + 0]\n",
+            "mov rbx, [rsp + 8]\n",
+            "mov rcx, [rsp + 16]\n",
+            "mov rdx, [rsp + 24]\n",
+            "mov rsi, [rsp + 32]\n",
+            "mov rdi, [rsp + 40]\n",
+            "mov rbp, [rsp + 48]\n",
+            "mov r8, [rsp + 56]\n",
+            "mov r9, [rsp + 64]\n",
+            "mov r10, [rsp + 72]\n",
+            "mov r11, [rsp + 80]\n",
+            "mov r12, [rsp + 88]\n",
+            "mov r13, [rsp + 96]\n",
+            "mov r14, [rsp + 104]\n",
+            "mov r15, [rsp + 112]\n",
+            "add rsp, 184\n", // drop frame (168) + vector + error_code (16)
+            "iretq\n",
+        )
+    };
 }
 
 // ── Common exception handler ──────────────────────────────────────────────────
@@ -162,14 +237,19 @@ pub struct ExceptionFrame
 /// originated in the kernel, diagnostics are printed and the system halts.
 ///
 /// # Safety
-/// `frame` must point to a valid `ExceptionFrame` on the current stack.
+/// `tf` must point to a valid [`TrapFrame`] on the current stack; `vector` and
+/// `error_code` are the trap metadata from the stub frame.
 #[cfg(not(test))]
-unsafe extern "C" fn common_exception_handler(frame: *const ExceptionFrame) -> !
+unsafe extern "C" fn common_exception_handler(
+    tf: *const TrapFrame,
+    vector: u64,
+    error_code: u64,
+) -> !
 {
-    // SAFETY: frame pointer is valid — constructed by ISR stubs on this stack.
-    let f = unsafe { &*frame };
+    // SAFETY: tf is valid — constructed by the entry trampoline on this stack.
+    let f = unsafe { &*tf };
     // Read CR2 (faulting address) for page faults (vector 14).
-    let cr2: u64 = if f.vector == 14
+    let cr2: u64 = if vector == 14
     {
         let v: u64;
         // SAFETY: CR2 is a valid read-only register at ring 0; page fault context.
@@ -210,9 +290,9 @@ unsafe extern "C" fn common_exception_handler(frame: *const ExceptionFrame) -> !
             "USERSPACE FAULT: tid={} cpu={} cause={} (vec={} err={:#x})",
             tid,
             cpu,
-            x86_exception_name(f.vector),
-            f.vector,
-            f.error_code,
+            x86_exception_name(vector),
+            vector,
+            error_code,
         );
         // Include fs_base (IA32_FS_BASE) to aid TLS-plumbing diagnosis.
         // SAFETY: interrupts are disabled above; rdmsr on IA32_FS_BASE is
@@ -246,7 +326,7 @@ unsafe extern "C" fn common_exception_handler(frame: *const ExceptionFrame) -> !
             // observes the reason alongside the Exited transition.
             // SAFETY: tcb validated non-null.
             unsafe {
-                (*tcb).exit_reason = 0x1000 + f.vector;
+                (*tcb).exit_reason = 0x1000 + vector;
                 crate::sched::set_state_under_all_locks(
                     tcb,
                     crate::sched::thread::ThreadState::Exited,
@@ -257,7 +337,7 @@ unsafe extern "C" fn common_exception_handler(frame: *const ExceptionFrame) -> !
             // EXIT_FAULT_BASE = 0x1000 (matches syscall_abi::EXIT_FAULT_BASE).
             // SAFETY: tcb is valid; post_death_notification handles null check.
             unsafe {
-                crate::sched::post_death_notification(tcb, 0x1000 + f.vector);
+                crate::sched::post_death_notification(tcb, 0x1000 + vector);
             }
         }
 
@@ -274,9 +354,9 @@ unsafe extern "C" fn common_exception_handler(frame: *const ExceptionFrame) -> !
         crate::kprintln!(
             "KERNEL EXCEPTION: cpu={} cause={} (vec={} err={:#x})",
             cpu,
-            x86_exception_name(f.vector),
-            f.vector,
-            f.error_code,
+            x86_exception_name(vector),
+            vector,
+            error_code,
         );
         crate::kprintln!("  rip={:#018x}  cr2={:#018x}", f.rip, cr2);
         crate::kprintln!("  cs={:#x}  rflags={:#018x}", f.cs, f.rflags,);
@@ -298,18 +378,19 @@ unsafe extern "C" fn common_exception_handler(frame: *const ExceptionFrame) -> !
 /// resolved-and-resumed userspace fault.
 ///
 /// Mirrors the call-from-naked-asm pattern of [`page_fault_handler`]: the
-/// trampoline upholds the precondition that `frame` is a valid, writable
-/// `ExceptionFrame` on the current stack, so this is a safe `extern "C"` fn.
+/// trampoline upholds the precondition that `tf` is a valid, writable
+/// [`TrapFrame`] on the current stack, so this is a safe `extern "C"` fn.
+/// `vector`/`error_code` are the trap metadata from the stub frame.
 #[cfg(not(test))]
-extern "C" fn exception_handler(frame: *mut ExceptionFrame)
+extern "C" fn exception_handler(tf: *mut TrapFrame, vector: u64, error_code: u64)
 {
-    // SAFETY: frame is constructed by common_exception_trampoline on this stack.
-    let f = unsafe { &*frame };
+    // SAFETY: tf is constructed by common_exception_trampoline on this stack.
+    let f = unsafe { &*tf };
     let from_user = (f.cs & 3) != 0;
     // #DF (8) and #MC (18) are non-restartable aborts; #DF additionally runs on a
     // dedicated IST stack that is not re-entrant across the reschedule a redirect
     // performs. They are never delivered to a resumable handler — always terminal.
-    let redirectable = f.vector != 8 && f.vector != 18;
+    let redirectable = vector != 8 && vector != 18;
     if from_user && redirectable
     {
         // SAFETY: from_user implies a running user thread; current_tcb is valid
@@ -320,9 +401,9 @@ extern "C" fn exception_handler(frame: *mut ExceptionFrame)
         let handler_bound = !tcb.is_null() && unsafe { crate::ipc::fault::has_handler(tcb) };
         if handler_bound
         {
-            // SAFETY: frame is the live ExceptionFrame; the redirect copies it
-            // to/from the canonical TrapFrame and returns whether to resume.
-            if unsafe { redirect_user_exception(tcb, frame) }
+            // SAFETY: tf is the live TrapFrame; the redirect points the TCB at it
+            // for the block and returns whether to resume.
+            if unsafe { redirect_user_exception(tcb, tf, vector, error_code) }
             {
                 return;
             }
@@ -331,9 +412,9 @@ extern "C" fn exception_handler(frame: *mut ExceptionFrame)
     }
 
     // Not resumed by a handler — kill (userspace) or fatal (kernel).
-    // SAFETY: frame valid; common_exception_handler never returns.
+    // SAFETY: tf valid; common_exception_handler never returns.
     unsafe {
-        common_exception_handler(frame.cast_const());
+        common_exception_handler(tf.cast_const(), vector, error_code);
     }
 }
 
@@ -368,8 +449,8 @@ fn x86_exception_name(vector: u64) -> &'static str
     }
 }
 
-/// Dump all general-purpose registers from an x86-64 exception frame (serial only).
-fn dump_x86_regs(f: &ExceptionFrame)
+/// Dump all general-purpose registers from an x86-64 trap frame (serial only).
+fn dump_x86_regs(f: &TrapFrame)
 {
     crate::kprintln_serial!(
         "  rax={:#018x}  rbx={:#018x}  rcx={:#018x}  rdx={:#018x}",
@@ -402,7 +483,7 @@ fn dump_x86_regs(f: &ExceptionFrame)
 }
 
 /// Dump all general-purpose registers to both serial and framebuffer (for kernel faults).
-fn dump_x86_regs_console(f: &ExceptionFrame)
+fn dump_x86_regs_console(f: &TrapFrame)
 {
     crate::kprintln!(
         "  rax={:#018x}  rbx={:#018x}  rcx={:#018x}  rdx={:#018x}",
@@ -475,60 +556,31 @@ macro_rules! isr_stub {
     };
 }
 
-/// Common trampoline: saves GPRs, calls [`exception_handler`], then — reached
-/// only when a userspace exception was redirected to a bound fault handler that
-/// resolved it — restores the (possibly handler-edited) register state and
-/// `iretq`s, re-executing the faulting instruction (or continuing from a
-/// handler-modified PC). Every terminal fault (no/declined handler, or any
-/// kernel exception) diverges inside [`exception_handler`] →
-/// `common_exception_handler`, so the restore tail is dead for those.
+/// Common trampoline: builds the canonical [`TrapFrame`] ([`tf_build_asm`]),
+/// calls [`exception_handler`] with the frame pointer + trap metadata, then —
+/// reached only when a userspace exception was redirected to a bound fault
+/// handler that resolved it — writes back the (possibly handler-edited) register
+/// state and `iretq`s ([`tf_resume_asm`]), re-executing the faulting instruction
+/// (or continuing from a handler-modified PC). Every terminal fault (no/declined
+/// handler, or any kernel exception) diverges inside [`exception_handler`] →
+/// `common_exception_handler`, so the resume tail is dead for those.
 ///
-/// At entry, the stack holds the ISR stub frame (vector + error code) and
-/// hardware frame (rip, cs, rflags, rsp, ss). We push all GPRs to create
-/// a full [`ExceptionFrame`], then pass a pointer to it.
+/// At entry the stack holds the stub frame (vector + `error_code` + hardware iret
+/// frame); the build reserves the `TrapFrame` below it and the resume tail leaves
+/// the hardware iret frame at the top of stack for `iretq`.
 #[cfg(not(test))]
 #[unsafe(naked)]
 unsafe extern "C" fn common_exception_trampoline()
 {
     core::arch::naked_asm!(
-        // Save all GPRs (must match ExceptionFrame field order).
-        "push r15",
-        "push r14",
-        "push r13",
-        "push r12",
-        "push r11",
-        "push r10",
-        "push r9",
-        "push r8",
-        "push rbp",
-        "push rdi",
-        "push rsi",
-        "push rdx",
-        "push rcx",
-        "push rbx",
-        "push rax",
-        // rsp now points at the full ExceptionFrame.
-        "mov rdi, rsp",
-        "call {handler}",
-        // Reached only on a resolved-and-resumed userspace exception; restore the
-        // register state the handler may have edited and re-enter userspace.
-        "pop rax",
-        "pop rbx",
-        "pop rcx",
-        "pop rdx",
-        "pop rsi",
-        "pop rdi",
-        "pop rbp",
-        "pop r8",
-        "pop r9",
-        "pop r10",
-        "pop r11",
-        "pop r12",
-        "pop r13",
-        "pop r14",
-        "pop r15",
-        "add rsp, 16", // drop vector + error_code
-        "iretq",
+        concat!(
+            tf_build_asm!(),
+            "mov rdi, rsp\n",          // arg0 = *mut TrapFrame
+            "mov rsi, [rsp + 168]\n",  // arg1 = vector
+            "mov rdx, [rsp + 176]\n",  // arg2 = error_code
+            "call {handler}\n",
+            tf_resume_asm!(),
+        ),
         handler = sym exception_handler,
     );
 }
@@ -573,123 +625,164 @@ isr_stub!(isr31, 31, has_error_code = false, ist = 0);
 
 // ── Timer and spurious stubs ──────────────────────────────────────────────────
 
+// ── Shared IRQ trampoline ─────────────────────────────────────────────────────
+
+/// Route a device/timer/IPI interrupt by its IDT vector to the existing handler.
+///
+/// Called from [`common_irq_trampoline`] with the stub-pushed vector. Each
+/// handler performs its own EOI; this only dispatches. The device range carries
+/// the GSI as `vector - 33` (the GSI indexes `IRQ_TABLE`; see `irq.rs`).
+#[cfg(not(test))]
+extern "C" fn irq_dispatch(vector: u64)
+{
+    match vector
+    {
+        v if v == u64::from(super::timer::TIMER_VECTOR) => super::timer::timer_isr(),
+        33..=55 =>
+        {
+            // SAFETY: IRQ-handler context at ring 0; `dispatch_device_irq` masks
+            // and EOIs internally. `vector - 33` is in 0..=22 (one IOAPIC GSI).
+            unsafe {
+                crate::irq::dispatch_device_irq((vector - 33) as u32);
+            }
+        }
+        v if v == u64::from(super::interrupts::IPI_VECTOR_TLB_SHOOTDOWN) =>
+        {
+            ipi_tlb_shootdown_handler();
+        }
+        v if v == u64::from(super::interrupts::IPI_VECTOR_WAKEUP) => ipi_wakeup_handler(),
+        // No routed vector falls here; matches the spurious vector's no-EOI policy.
+        _ =>
+        {}
+    }
+}
+
+/// Shared trampoline for device/timer/IPI interrupts (vectors routed through
+/// [`irq_dispatch`]). Branches on the interrupted privilege level (saved CS RPL):
+///
+/// - **Ring-3 origin** (a user thread was preempted): builds the canonical
+///   [`TrapFrame`] ([`tf_build_asm`]) so a complete, live user register snapshot
+///   exists on the kernel stack (the invariant a userspace debugger consumes —
+///   see #233), dispatches, then returns frame-authoritatively ([`tf_resume_asm`]) —
+///   all GPRs are restored from the frame, not from the implicit call-chain
+///   preservation.
+/// - **Ring-0 origin** (the kernel/idle was interrupted): the interrupted context
+///   carries no user state (any in-flight user state lives in the thread's syscall
+///   frame), so only caller-clobbered registers are saved, matching the legacy
+///   minimal path.
+///
+/// Each stub enters via `push 0; push <vector>; jmp` — the two-word prologue keeps
+/// the `call` 16-byte aligned (identical parity to the exception stubs).
+#[cfg(not(test))]
+#[unsafe(naked)]
+unsafe extern "C" fn common_irq_trampoline()
+{
+    core::arch::naked_asm!(
+        concat!(
+            "test byte ptr [rsp + 24], 0x3\n", // saved CS RPL; 0 => ring 0
+            "jz 2f\n",
+            // ── ring-3: build TrapFrame, dispatch, frame-authoritative return ──
+            tf_build_asm!(),
+            "mov rdi, [rsp + 168]\n", // arg0 = vector
+            "call {dispatch}\n",
+            tf_resume_asm!(),
+            // ── ring-0: minimal save (no user state) ──
+            "2:\n",
+            "push rax\n",
+            "push rcx\n",
+            "push rdx\n",
+            "push rsi\n",
+            "push rdi\n",
+            "push r8\n",
+            "push r9\n",
+            "push r10\n",
+            "push r11\n",
+            "mov rdi, [rsp + 72]\n", // arg0 = vector
+            "call {dispatch}\n",
+            "pop r11\n",
+            "pop r10\n",
+            "pop r9\n",
+            "pop r8\n",
+            "pop rdi\n",
+            "pop rsi\n",
+            "pop rdx\n",
+            "pop rcx\n",
+            "pop rax\n",
+            "add rsp, 16\n", // drop vector + placeholder
+            "iretq\n",
+        ),
+        dispatch = sym irq_dispatch,
+    );
+}
+
 // ── Device IRQ stubs ──────────────────────────────────────────────────────────
 
 /// Generate a naked device IRQ stub for IDT vector `$vector`.
 ///
-/// Each stub:
-/// 1. Saves all caller-saved registers.
-/// 2. Calls `irq::dispatch_device_irq(gsi)` where `gsi = vector - 33`.
-/// 3. Restores registers and executes `iretq`.
-///
-/// `dispatch_device_irq` handles masking and EOI internally; the stub itself
-/// does not interact with the APIC or IOAPIC.
+/// Each stub pushes the two-word `placeholder + vector` prologue and jumps to
+/// [`common_irq_trampoline`], which builds the [`TrapFrame`] (ring-3 origin) and
+/// routes to `irq::dispatch_device_irq(vector - 33)` via [`irq_dispatch`].
+/// `dispatch_device_irq` handles masking, notification delivery, and EOI.
 ///
 /// # Modification notes
-/// - To add more GSIs: invoke `device_irq_stub!(isr_devN, N)` for each
-///   new vector N, then add `set(N, isr_devN, 0)` in `init()`.
-///
-/// Generate a naked device IRQ stub for IDT vector `DEVICE_VECTOR_BASE + $gsi`.
-///
-/// Each stub:
-/// 1. Saves all caller-saved registers.
-/// 2. Loads the GSI number into `edi` (first argument register).
-/// 3. Calls `irq::dispatch_device_irq(gsi)`.
-/// 4. Restores registers and executes `iretq`.
-///
-/// `dispatch_device_irq` handles masking, notification delivery, and EOI internally.
-///
-/// # Modification notes
-/// - To add more GSIs: `device_irq_stub!(isr_devN, N)` then `set(33+N, isr_devN, 0)`.
+/// - To add more GSIs: `device_irq_stub!(isr_devN, 33+N)` then
+///   `set(33+N, isr_devN, 0)` in `init()`.
 macro_rules! device_irq_stub {
-    ($name:ident, $gsi:literal) => {
+    ($name:ident, $vector:literal) => {
         #[cfg(not(test))]
         #[unsafe(naked)]
         unsafe extern "C" fn $name()
         {
             core::arch::naked_asm!(
-                "push rax",
-                "push rcx",
-                "push rdx",
-                "push rsi",
-                "push rdi",
-                "push r8",
-                "push r9",
-                "push r10",
-                "push r11",
-                concat!("mov edi, ", $gsi), // GSI as first argument
-                "call {dispatch}",
-                "pop r11",
-                "pop r10",
-                "pop r9",
-                "pop r8",
-                "pop rdi",
-                "pop rsi",
-                "pop rdx",
-                "pop rcx",
-                "pop rax",
-                "iretq",
-                dispatch = sym crate::irq::dispatch_device_irq,
+                concat!("push 0\n", "push ", $vector, "\n"), // placeholder + vector
+                "jmp {tramp}",
+                tramp = sym common_irq_trampoline,
             );
         }
     };
 }
 
-device_irq_stub!(isr_dev0, 0);
-device_irq_stub!(isr_dev1, 1);
-device_irq_stub!(isr_dev2, 2);
-device_irq_stub!(isr_dev3, 3);
-device_irq_stub!(isr_dev4, 4);
-device_irq_stub!(isr_dev5, 5);
-device_irq_stub!(isr_dev6, 6);
-device_irq_stub!(isr_dev7, 7);
-device_irq_stub!(isr_dev8, 8);
-device_irq_stub!(isr_dev9, 9);
-device_irq_stub!(isr_dev10, 10);
-device_irq_stub!(isr_dev11, 11);
-device_irq_stub!(isr_dev12, 12);
-device_irq_stub!(isr_dev13, 13);
-device_irq_stub!(isr_dev14, 14);
-device_irq_stub!(isr_dev15, 15);
-device_irq_stub!(isr_dev16, 16);
-device_irq_stub!(isr_dev17, 17);
-device_irq_stub!(isr_dev18, 18);
-device_irq_stub!(isr_dev19, 19);
-device_irq_stub!(isr_dev20, 20);
-device_irq_stub!(isr_dev21, 21);
-device_irq_stub!(isr_dev22, 22);
+device_irq_stub!(isr_dev0, 33);
+device_irq_stub!(isr_dev1, 34);
+device_irq_stub!(isr_dev2, 35);
+device_irq_stub!(isr_dev3, 36);
+device_irq_stub!(isr_dev4, 37);
+device_irq_stub!(isr_dev5, 38);
+device_irq_stub!(isr_dev6, 39);
+device_irq_stub!(isr_dev7, 40);
+device_irq_stub!(isr_dev8, 41);
+device_irq_stub!(isr_dev9, 42);
+device_irq_stub!(isr_dev10, 43);
+device_irq_stub!(isr_dev11, 44);
+device_irq_stub!(isr_dev12, 45);
+device_irq_stub!(isr_dev13, 46);
+device_irq_stub!(isr_dev14, 47);
+device_irq_stub!(isr_dev15, 48);
+device_irq_stub!(isr_dev16, 49);
+device_irq_stub!(isr_dev17, 50);
+device_irq_stub!(isr_dev18, 51);
+device_irq_stub!(isr_dev19, 52);
+device_irq_stub!(isr_dev20, 53);
+device_irq_stub!(isr_dev21, 54);
+device_irq_stub!(isr_dev22, 55);
 
 // ── Timer and spurious stubs ──────────────────────────────────────────────────
 
 /// APIC timer ISR stub (vector 32).
 ///
-/// Calls `timer::timer_isr`, which increments the tick counter and sends EOI.
+/// Pushes the `placeholder + vector` prologue and jumps to
+/// [`common_irq_trampoline`], which (ring-3 origin) builds the [`TrapFrame`] and
+/// routes to `timer::timer_isr` via [`irq_dispatch`] — `timer_isr` increments the
+/// tick counter, sends EOI, and may preempt.
 #[cfg(not(test))]
 #[unsafe(naked)]
 pub unsafe extern "C" fn isr_timer()
 {
     core::arch::naked_asm!(
-        "push rax",
-        "push rcx",
-        "push rdx",
-        "push rsi",
-        "push rdi",
-        "push r8",
-        "push r9",
-        "push r10",
-        "push r11",
-        "call {handler}",
-        "pop r11",
-        "pop r10",
-        "pop r9",
-        "pop r8",
-        "pop rdi",
-        "pop rsi",
-        "pop rdx",
-        "pop rcx",
-        "pop rax",
-        "iretq",
-        handler = sym super::timer::timer_isr,
+        "push 0",  // placeholder
+        "push 32", // vector
+        "jmp {tramp}",
+        tramp = sym common_irq_trampoline,
     );
 }
 
@@ -838,52 +931,26 @@ extern "C" fn nm_handler()
 
 /// Page-fault (`#PF`, vector 14) stub.
 ///
-/// Saves the full [`ExceptionFrame`] (the hardware already pushed the error
-/// code; this stub pushes the vector), calls [`page_fault_handler`], then —
-/// reached only when the fault was a resolved spurious stale-TLB fault —
-/// restores the unmodified user register state and `iretq`s, re-executing the
-/// faulting instruction. For every genuine fault the handler diverges
-/// (`common_exception_handler` never returns) and the restore tail is dead.
+/// Builds the canonical [`TrapFrame`] ([`tf_build_asm`]; the hardware already
+/// pushed the error code, this stub pushes the vector), calls
+/// [`page_fault_handler`], then — reached only when the fault was a resolved
+/// spurious stale-TLB fault — writes back the unmodified register state and
+/// `iretq`s ([`tf_resume_asm`]), re-executing the faulting instruction. For every
+/// genuine fault the handler diverges (`common_exception_handler` never returns)
+/// and the resume tail is dead.
 #[cfg(not(test))]
 #[unsafe(naked)]
 unsafe extern "C" fn isr_page_fault()
 {
     core::arch::naked_asm!(
-        "push 14", // vector (hardware already pushed the error code)
-        "push r15",
-        "push r14",
-        "push r13",
-        "push r12",
-        "push r11",
-        "push r10",
-        "push r9",
-        "push r8",
-        "push rbp",
-        "push rdi",
-        "push rsi",
-        "push rdx",
-        "push rcx",
-        "push rbx",
-        "push rax",
-        "mov rdi, rsp",
-        "call {handler}",
-        "pop rax",
-        "pop rbx",
-        "pop rcx",
-        "pop rdx",
-        "pop rsi",
-        "pop rdi",
-        "pop rbp",
-        "pop r8",
-        "pop r9",
-        "pop r10",
-        "pop r11",
-        "pop r12",
-        "pop r13",
-        "pop r14",
-        "pop r15",
-        "add rsp, 16", // drop vector + error_code
-        "iretq",
+        concat!(
+            "push 14\n", // vector (hardware already pushed the error code)
+            tf_build_asm!(),
+            "mov rdi, rsp\n",          // arg0 = *mut TrapFrame
+            "mov rsi, [rsp + 176]\n",  // arg1 = error_code (vector is implicit 14)
+            "call {handler}\n",
+            tf_resume_asm!(),
+        ),
         handler = sym page_fault_handler,
     );
 }
@@ -899,7 +966,7 @@ unsafe extern "C" fn isr_page_fault()
 /// userspace fault, or any kernel fault) is handed to
 /// [`common_exception_handler`], which never returns.
 #[cfg(not(test))]
-extern "C" fn page_fault_handler(frame: *mut ExceptionFrame)
+extern "C" fn page_fault_handler(tf: *mut TrapFrame, error_code: u64)
 {
     /// `#PF` error-code bits (Intel SDM Vol 3 §4.7).
     const ERR_PRESENT: u64 = 1 << 0;
@@ -907,12 +974,12 @@ extern "C" fn page_fault_handler(frame: *mut ExceptionFrame)
     const ERR_RSVD: u64 = 1 << 3;
     const ERR_INSTR: u64 = 1 << 4;
 
-    // SAFETY: frame is constructed by isr_page_fault on this stack.
-    let f = unsafe { &*frame };
+    // SAFETY: tf is constructed by isr_page_fault on this stack.
+    let f = unsafe { &*tf };
     let from_user = (f.cs & 3) != 0;
     // A reserved-bit violation is never a stale-TLB fault; only well-formed
     // present/permission faults from userspace are retry candidates.
-    if from_user && f.error_code & ERR_RSVD == 0
+    if from_user && error_code & ERR_RSVD == 0
     {
         let cr2: u64;
         // SAFETY: CR2 holds the faulting linear address for a #PF; read-only at
@@ -920,8 +987,8 @@ extern "C" fn page_fault_handler(frame: *mut ExceptionFrame)
         unsafe {
             core::arch::asm!("mov {}, cr2", out(reg) cr2, options(nostack, nomem));
         }
-        let write = f.error_code & ERR_WRITE != 0;
-        let instr = f.error_code & ERR_INSTR != 0;
+        let write = error_code & ERR_WRITE != 0;
+        let instr = error_code & ERR_INSTR != 0;
         // SAFETY: ring 0; the faulting thread's CR3 is still active (no context
         // switch since entry — the interrupt gate left IF=0).
         if unsafe { super::paging::user_fault_is_spurious(cr2, write, instr) }
@@ -946,10 +1013,10 @@ extern "C" fn page_fault_handler(frame: *mut ExceptionFrame)
         let handler_bound = !tcb.is_null() && unsafe { crate::ipc::fault::has_handler(tcb) };
         if handler_bound
         {
-            let present = f.error_code & ERR_PRESENT != 0;
-            // SAFETY: frame is the live ExceptionFrame; the redirect copies it
-            // to/from the canonical TrapFrame and returns whether to resume.
-            if unsafe { redirect_user_page_fault(tcb, frame, cr2, write, instr, present) }
+            let present = error_code & ERR_PRESENT != 0;
+            // SAFETY: tf is the live TrapFrame; the redirect points the TCB at it
+            // for the block and returns whether to resume.
+            if unsafe { redirect_user_page_fault(tcb, tf, cr2, write, instr, present) }
             {
                 return;
             }
@@ -959,9 +1026,9 @@ extern "C" fn page_fault_handler(frame: *mut ExceptionFrame)
 
     // Not a recoverable spurious fault and not resumed by a handler — kill
     // (userspace) or fatal (kernel).
-    // SAFETY: frame is valid; common_exception_handler never returns.
+    // SAFETY: tf is valid; common_exception_handler never returns.
     unsafe {
-        common_exception_handler(frame.cast_const());
+        common_exception_handler(tf.cast_const(), 14, error_code);
     }
 }
 
@@ -972,11 +1039,11 @@ extern "C" fn page_fault_handler(frame: *mut ExceptionFrame)
 ///
 /// # Safety
 /// `tcb` is the current user thread and has a bound handler; `frame` is the live
-/// `#PF` `ExceptionFrame` on the current kernel stack; no lock is held.
+/// `#PF` [`TrapFrame`] on the current kernel stack; no lock is held.
 #[cfg(not(test))]
 unsafe fn redirect_user_page_fault(
     tcb: *mut crate::sched::thread::ThreadControlBlock,
-    frame: *mut ExceptionFrame,
+    frame: *mut TrapFrame,
     cr2: u64,
     write: bool,
     instr: bool,
@@ -1022,20 +1089,23 @@ unsafe fn redirect_user_page_fault(
 ///
 /// # Safety
 /// `tcb` is the current user thread and has a bound handler; `frame` is the live
-/// exception `ExceptionFrame` on the current kernel stack; no lock is held.
+/// exception [`TrapFrame`] on the current kernel stack; `vector`/`error_code` are
+/// the trap metadata from the stub frame; no lock is held.
 #[cfg(not(test))]
 unsafe fn redirect_user_exception(
     tcb: *mut crate::sched::thread::ThreadControlBlock,
-    frame: *mut ExceptionFrame,
+    frame: *mut TrapFrame,
+    vector: u64,
+    error_code: u64,
 ) -> bool
 {
     // SAFETY: frame is valid.
-    let f = unsafe { &*frame };
+    let ip = unsafe { (*frame).rip };
     let info = crate::ipc::fault::FaultInfo {
         kind: syscall::FAULT_KIND_EXCEPTION,
-        d1: normalize_x86_exception(f.vector),
-        d2: f.error_code,
-        ip: f.rip,
+        d1: normalize_x86_exception(vector),
+        d2: error_code,
+        ip,
     };
 
     // SAFETY: preconditions forwarded — handler bound, live frame, no lock held.
@@ -1069,223 +1139,89 @@ fn normalize_x86_exception(vector: u64) -> u64
 /// (re-execute the faulting instruction, or continue from a handler-modified PC),
 /// `false` if the fault is terminal.
 ///
-/// The stub frame ([`ExceptionFrame`]) differs in layout from the canonical
-/// [`TrapFrame`](crate::arch::current::trap_frame::TrapFrame) the register
-/// syscalls operate on, and the two overlap on the kernel stack, so the faulting
-/// registers are copied into a stack-local `TrapFrame` for the duration of the
-/// block. `(*tcb).trap_frame` is repointed at that copy so the handler's
-/// `SYS_THREAD_READ_REGS` / `SYS_THREAD_WRITE_REGS` see and edit the faulting
-/// state; on resume the (possibly edited) copy is written back into the
-/// `ExceptionFrame` so the stub's `iretq` uses it. (Full entry-frame unification,
-/// which would remove this copy, is a deferred follow-up that does not change the
-/// userspace ABI.)
+/// `frame` is the live canonical [`TrapFrame`] the entry trampoline built on the
+/// kernel stack — the same layout the register syscalls operate on — so
+/// `(*tcb).trap_frame` is pointed at it directly with no copy. The kernel stack
+/// (and thus the frame) is preserved across the block: the context switch saves
+/// and restores the kernel rsp, so the pointer stays valid while the faulter is
+/// descheduled. The handler's `SYS_THREAD_READ_REGS` / `SYS_THREAD_WRITE_REGS`
+/// see and edit the live frame; on resume the trampoline's [`tf_resume_asm`]
+/// writes any edits back into the iret frame. Symmetric with
+/// `riscv64/interrupts.rs::redirect_user_fault`.
 ///
 /// # Safety
 /// `tcb` is the current user thread and has a bound handler; `frame` is the live
-/// `ExceptionFrame` on the current kernel stack; no lock is held.
+/// [`TrapFrame`] on the current kernel stack; no lock is held.
 #[cfg(not(test))]
 unsafe fn redirect_user_fault(
     tcb: *mut crate::sched::thread::ThreadControlBlock,
-    frame: *mut ExceptionFrame,
+    frame: *mut TrapFrame,
     info: &crate::ipc::fault::FaultInfo,
 ) -> bool
 {
-    // Canonical register frame the handler reads/edits. Lives in this kernel
-    // stack frame, which is preserved across the block (the context switch saves
-    // and restores the kernel rsp), so the pointer stays valid while the faulter
-    // is descheduled.
-    // SAFETY: frame valid.
-    let mut canonical = unsafe { exception_to_trap_frame(&*frame) };
-    // SAFETY: tcb valid; repoint trap_frame at the canonical copy for the
-    // duration of the block, restoring the kstack slot afterward.
+    // SAFETY: tcb valid; repoint trap_frame at the live frame for the duration of
+    // the block, restoring the prior pointer afterward.
     let saved_tf = unsafe { (*tcb).trap_frame };
-    // SAFETY: tcb valid; trap_frame is the canonical-frame pointer read by the
+    // SAFETY: tcb valid; trap_frame is the live-frame pointer read/edited by the
     // register syscalls while this thread is BlockedOnFault.
     unsafe {
-        (*tcb).trap_frame = core::ptr::from_mut(&mut canonical);
+        (*tcb).trap_frame = frame;
     }
 
-    // SAFETY: handler bound; trap_frame points at the canonical frame; no lock held.
+    // SAFETY: handler bound; trap_frame points at the live frame; no lock held.
     let outcome = unsafe { crate::ipc::fault::fault_dispatch(tcb, info) };
 
-    // SAFETY: restore the canonical kstack-slot pointer.
+    // SAFETY: restore the prior trap_frame pointer.
     unsafe {
         (*tcb).trap_frame = saved_tf;
     }
 
-    match outcome
-    {
-        crate::ipc::fault::FaultOutcome::Resume =>
-        {
-            // SAFETY: frame valid and mutable; write back the (possibly edited)
-            // registers so the stub's iretq uses them.
-            unsafe {
-                trap_frame_to_exception(&canonical, frame);
-            }
-            true
-        }
-        crate::ipc::fault::FaultOutcome::Kill => false,
-    }
-}
-
-/// Copy a `#PF`/exception [`ExceptionFrame`] into a canonical
-/// [`TrapFrame`](crate::arch::current::trap_frame::TrapFrame).
-///
-/// `fs_base` is left zero: on x86-64 the authoritative TLS base lives in
-/// `SavedState.fs_base`, not the trap frame (the trap-frame field is retained
-/// for layout stability only — see `trap_frame.rs`), so the contained copy does
-/// not round-trip it.
-#[cfg(not(test))]
-fn exception_to_trap_frame(f: &ExceptionFrame) -> crate::arch::current::trap_frame::TrapFrame
-{
-    crate::arch::current::trap_frame::TrapFrame {
-        rax: f.rax,
-        rbx: f.rbx,
-        rcx: f.rcx,
-        rdx: f.rdx,
-        rsi: f.rsi,
-        rdi: f.rdi,
-        rbp: f.rbp,
-        r8: f.r8,
-        r9: f.r9,
-        r10: f.r10,
-        r11: f.r11,
-        r12: f.r12,
-        r13: f.r13,
-        r14: f.r14,
-        r15: f.r15,
-        rip: f.rip,
-        rflags: f.rflags,
-        rsp: f.rsp,
-        cs: f.cs,
-        ss: f.ss,
-        fs_base: 0,
-    }
-}
-
-/// Write a canonical [`TrapFrame`](crate::arch::current::trap_frame::TrapFrame)
-/// back into a `#PF` [`ExceptionFrame`] before the stub's `iretq`.
-///
-/// The `vector` / `error_code` fields are not restored — the stub drops them
-/// (`add rsp, 16`) before `iretq`. `fs_base` is not propagated (see
-/// [`exception_to_trap_frame`]).
-///
-/// # Safety
-/// `frame` must point at a valid, writable `ExceptionFrame`.
-#[cfg(not(test))]
-unsafe fn trap_frame_to_exception(
-    t: &crate::arch::current::trap_frame::TrapFrame,
-    frame: *mut ExceptionFrame,
-)
-{
-    // SAFETY: frame validated by caller.
-    let f = unsafe { &mut *frame };
-    f.rax = t.rax;
-    f.rbx = t.rbx;
-    f.rcx = t.rcx;
-    f.rdx = t.rdx;
-    f.rsi = t.rsi;
-    f.rdi = t.rdi;
-    f.rbp = t.rbp;
-    f.r8 = t.r8;
-    f.r9 = t.r9;
-    f.r10 = t.r10;
-    f.r11 = t.r11;
-    f.r12 = t.r12;
-    f.r13 = t.r13;
-    f.r14 = t.r14;
-    f.r15 = t.r15;
-    f.rip = t.rip;
-    f.rflags = t.rflags;
-    f.rsp = t.rsp;
-    f.cs = t.cs;
-    f.ss = t.ss;
+    matches!(outcome, crate::ipc::fault::FaultOutcome::Resume)
 }
 
 /// TLB shootdown IPI handler stub (vector 250).
 ///
-/// Saves caller-clobbered registers, calls the Rust handler — which services
-/// any shootdown request naming this CPU and clears its acknowledgement bit —
-/// then restores and `iretq`s.
+/// Pushes the `placeholder + vector` prologue and jumps to
+/// [`common_irq_trampoline`], which routes to `ipi_tlb_shootdown_handler` via
+/// [`irq_dispatch`] — the handler services any shootdown request naming this CPU,
+/// clears its acknowledgement bit, and EOIs.
 #[cfg(not(test))]
 #[unsafe(naked)]
 unsafe extern "C" fn ipi_tlb_shootdown_stub()
 {
     core::arch::naked_asm!(
-        "push rax",
-        "push rcx",
-        "push rdx",
-        "push rsi",
-        "push rdi",
-        "push r8",
-        "push r9",
-        "push r10",
-        "push r11",
-        "call {handler}",
-        "pop r11",
-        "pop r10",
-        "pop r9",
-        "pop r8",
-        "pop rdi",
-        "pop rsi",
-        "pop rdx",
-        "pop rcx",
-        "pop rax",
-        "iretq",
-        handler = sym ipi_tlb_shootdown_handler,
+        "push 0",   // placeholder
+        "push 250", // vector
+        "jmp {tramp}",
+        tramp = sym common_irq_trampoline,
     );
 }
 
 /// NMI backtrace stub (vector 2 with IST=2).
 ///
-/// Replaces the generic exception stub for NMI. Saves the same
-/// `ExceptionFrame` shape as `common_exception_trampoline`, calls the
-/// returning [`ipi_nmi_backtrace_handler`], then restores GPRs and
-/// `iretq`s. The handler decides at runtime whether the NMI is a
-/// watchdog backtrace request (returns normally → iretq fires) or a
-/// real hardware NMI (falls through to `common_exception_handler` which
-/// never returns — the iretq tail is unreachable in that case).
+/// Builds the canonical [`TrapFrame`] ([`tf_build_asm`]) — unconditionally, since
+/// an NMI backtraces whatever ran (kernel or user) and the long-mode iret frame is
+/// always present — calls the returning [`ipi_nmi_backtrace_handler`], then writes
+/// back and `iretq`s ([`tf_resume_asm`]). The handler decides at runtime whether
+/// the NMI is a watchdog backtrace request (returns normally → iretq fires) or a
+/// real hardware NMI (falls through to `common_exception_handler` which never
+/// returns — the resume tail is unreachable in that case). The two-word
+/// `placeholder + vector` prologue matches the exception stubs' alignment parity.
 #[cfg(not(test))]
 #[unsafe(naked)]
 unsafe extern "C" fn ipi_nmi_backtrace_stub()
 {
     core::arch::naked_asm!(
-        "push 0",      // dummy error code (NMI has none)
-        "push 2",      // vector
-        "push r15",
-        "push r14",
-        "push r13",
-        "push r12",
-        "push r11",
-        "push r10",
-        "push r9",
-        "push r8",
-        "push rbp",
-        "push rdi",
-        "push rsi",
-        "push rdx",
-        "push rcx",
-        "push rbx",
-        "push rax",
-        "mov rdi, rsp",
-        "call {handler}",
-        "pop rax",
-        "pop rbx",
-        "pop rcx",
-        "pop rdx",
-        "pop rsi",
-        "pop rdi",
-        "pop rbp",
-        "pop r8",
-        "pop r9",
-        "pop r10",
-        "pop r11",
-        "pop r12",
-        "pop r13",
-        "pop r14",
-        "pop r15",
-        "add rsp, 16",  // drop vector + error_code
-        "iretq",
+        concat!(
+            "push 0\n", // placeholder (NMI has no error code)
+            "push 2\n", // vector
+            tf_build_asm!(),
+            "mov rdi, rsp\n",         // arg0 = *mut TrapFrame
+            "mov rsi, [rsp + 168]\n", // arg1 = vector (= 2)
+            "mov rdx, [rsp + 176]\n", // arg2 = error_code (= placeholder 0)
+            "call {handler}\n",
+            tf_resume_asm!(),
+        ),
         handler = sym ipi_nmi_backtrace_handler,
     );
 }
@@ -1299,7 +1235,7 @@ unsafe extern "C" fn ipi_nmi_backtrace_stub()
 ///
 /// NMI is not APIC-EOI'd, so no `acknowledge()` call.
 #[cfg(not(test))]
-extern "C" fn ipi_nmi_backtrace_handler(frame: *const ExceptionFrame)
+extern "C" fn ipi_nmi_backtrace_handler(tf: *const TrapFrame, vector: u64, error_code: u64)
 {
     let cpu = super::cpu::current_cpu() as usize;
     let requested = super::interrupts::nmi_backtrace_request(cpu)
@@ -1307,13 +1243,13 @@ extern "C" fn ipi_nmi_backtrace_handler(frame: *const ExceptionFrame)
     if !requested
     {
         // Real hardware NMI — defer to the standard fatal path.
-        // SAFETY: frame pointer constructed by ipi_nmi_backtrace_stub above.
+        // SAFETY: tf constructed by ipi_nmi_backtrace_stub above.
         unsafe {
-            common_exception_handler(frame);
+            common_exception_handler(tf, vector, error_code);
         }
     }
-    // SAFETY: frame pointer constructed by ipi_nmi_backtrace_stub above.
-    let f = unsafe { &*frame };
+    // SAFETY: tf constructed by ipi_nmi_backtrace_stub above.
+    let f = unsafe { &*tf };
     // Use the NMI-safe console path: `CONSOLE_LOCK` is swap-and-
     // restored rather than spin-acquired, so an NMI that interrupts
     // the lock-holder does not deadlock the dump.
@@ -1358,34 +1294,19 @@ extern "C" fn ipi_nmi_backtrace_handler(frame: *const ExceptionFrame)
 
 /// Wakeup IPI handler stub (vector 251).
 ///
-/// Breaks idle CPUs out of `hlt` when work is enqueued. The handler itself
-/// just sends EOI; the interrupt is sufficient to wake the CPU.
+/// Breaks idle CPUs out of `hlt` when work is enqueued. Pushes the
+/// `placeholder + vector` prologue and jumps to [`common_irq_trampoline`], which
+/// routes to `ipi_wakeup_handler` via [`irq_dispatch`]; the handler just sends EOI
+/// (the interrupt itself wakes the CPU).
 #[cfg(not(test))]
 #[unsafe(naked)]
 unsafe extern "C" fn ipi_wakeup_stub()
 {
     core::arch::naked_asm!(
-        "push rax",
-        "push rcx",
-        "push rdx",
-        "push rsi",
-        "push rdi",
-        "push r8",
-        "push r9",
-        "push r10",
-        "push r11",
-        "call {handler}",
-        "pop r11",
-        "pop r10",
-        "pop r9",
-        "pop r8",
-        "pop rdi",
-        "pop rsi",
-        "pop rdx",
-        "pop rcx",
-        "pop rax",
-        "iretq",
-        handler = sym ipi_wakeup_handler,
+        "push 0",   // placeholder
+        "push 251", // vector
+        "jmp {tramp}",
+        tramp = sym common_irq_trampoline,
     );
 }
 

--- a/core/kernel/src/arch/x86_64/idt.rs
+++ b/core/kernel/src/arch/x86_64/idt.rs
@@ -13,7 +13,7 @@
 //!
 //! Every ring-3 entry at which a thread can be stopped (exception, `#PF`, NMI,
 //! and ring-3 IRQ) builds the one canonical [`TrapFrame`] on the kernel stack via
-//! [`tf_build_asm`]/[`tf_resume_asm`]; the fault redirect points `tcb->trap_frame`
+//! `tf_build_asm`/`tf_resume_asm`; the fault redirect points `tcb->trap_frame`
 //! at that live frame with no copy. See the "Unified entry frame" section.
 //!
 //! # Exception vector groups
@@ -188,7 +188,7 @@ macro_rules! tf_build_asm {
 
 /// Naked-asm fragment: write the (possibly handler-edited) `TrapFrame`
 /// CPU-state back into the stub frame, restore all GPRs from the frame, drop the
-/// frame + stub prologue, and `iretq`. Inverse of [`tf_build_asm`]; rsp on entry
+/// frame + stub prologue, and `iretq`. Inverse of `tf_build_asm`; rsp on entry
 /// = `TrapFrame` base, on exit (`iretq`) the stub frame's hardware iret words are
 /// at the top of stack. `rax` is the copy scratch, then restored from the frame.
 #[cfg(not(test))]
@@ -556,11 +556,11 @@ macro_rules! isr_stub {
     };
 }
 
-/// Common trampoline: builds the canonical [`TrapFrame`] ([`tf_build_asm`]),
+/// Common trampoline: builds the canonical [`TrapFrame`] (`tf_build_asm`),
 /// calls [`exception_handler`] with the frame pointer + trap metadata, then —
 /// reached only when a userspace exception was redirected to a bound fault
 /// handler that resolved it — writes back the (possibly handler-edited) register
-/// state and `iretq`s ([`tf_resume_asm`]), re-executing the faulting instruction
+/// state and `iretq`s (`tf_resume_asm`), re-executing the faulting instruction
 /// (or continuing from a handler-modified PC). Every terminal fault (no/declined
 /// handler, or any kernel exception) diverges inside [`exception_handler`] →
 /// `common_exception_handler`, so the resume tail is dead for those.
@@ -661,9 +661,9 @@ extern "C" fn irq_dispatch(vector: u64)
 /// [`irq_dispatch`]). Branches on the interrupted privilege level (saved CS RPL):
 ///
 /// - **Ring-3 origin** (a user thread was preempted): builds the canonical
-///   [`TrapFrame`] ([`tf_build_asm`]) so a complete, live user register snapshot
+///   [`TrapFrame`] (`tf_build_asm`) so a complete, live user register snapshot
 ///   exists on the kernel stack (the invariant a userspace debugger consumes —
-///   see #233), dispatches, then returns frame-authoritatively ([`tf_resume_asm`]) —
+///   see #233), dispatches, then returns frame-authoritatively (`tf_resume_asm`) —
 ///   all GPRs are restored from the frame, not from the implicit call-chain
 ///   preservation.
 /// - **Ring-0 origin** (the kernel/idle was interrupted): the interrupted context
@@ -931,11 +931,11 @@ extern "C" fn nm_handler()
 
 /// Page-fault (`#PF`, vector 14) stub.
 ///
-/// Builds the canonical [`TrapFrame`] ([`tf_build_asm`]; the hardware already
+/// Builds the canonical [`TrapFrame`] (`tf_build_asm`; the hardware already
 /// pushed the error code, this stub pushes the vector), calls
 /// [`page_fault_handler`], then — reached only when the fault was a resolved
 /// spurious stale-TLB fault — writes back the unmodified register state and
-/// `iretq`s ([`tf_resume_asm`]), re-executing the faulting instruction. For every
+/// `iretq`s (`tf_resume_asm`), re-executing the faulting instruction. For every
 /// genuine fault the handler diverges (`common_exception_handler` never returns)
 /// and the resume tail is dead.
 #[cfg(not(test))]
@@ -1145,7 +1145,7 @@ fn normalize_x86_exception(vector: u64) -> u64
 /// (and thus the frame) is preserved across the block: the context switch saves
 /// and restores the kernel rsp, so the pointer stays valid while the faulter is
 /// descheduled. The handler's `SYS_THREAD_READ_REGS` / `SYS_THREAD_WRITE_REGS`
-/// see and edit the live frame; on resume the trampoline's [`tf_resume_asm`]
+/// see and edit the live frame; on resume the trampoline's `tf_resume_asm`
 /// writes any edits back into the iret frame. Symmetric with
 /// `riscv64/interrupts.rs::redirect_user_fault`.
 ///
@@ -1199,10 +1199,10 @@ unsafe extern "C" fn ipi_tlb_shootdown_stub()
 
 /// NMI backtrace stub (vector 2 with IST=2).
 ///
-/// Builds the canonical [`TrapFrame`] ([`tf_build_asm`]) — unconditionally, since
+/// Builds the canonical [`TrapFrame`] (`tf_build_asm`) — unconditionally, since
 /// an NMI backtraces whatever ran (kernel or user) and the long-mode iret frame is
 /// always present — calls the returning [`ipi_nmi_backtrace_handler`], then writes
-/// back and `iretq`s ([`tf_resume_asm`]). The handler decides at runtime whether
+/// back and `iretq`s (`tf_resume_asm`). The handler decides at runtime whether
 /// the NMI is a watchdog backtrace request (returns normally → iretq fires) or a
 /// real hardware NMI (falls through to `common_exception_handler` which never
 /// returns — the resume tail is unreachable in that case). The two-word

--- a/core/kernel/src/arch/x86_64/interrupts.rs
+++ b/core/kernel/src/arch/x86_64/interrupts.rs
@@ -306,7 +306,7 @@ pub const IPI_VECTOR_WAKEUP: u8 = 251;
 /// Per-CPU "dump backtrace from your NMI handler" request flag, set by the
 /// synchronous-IPI watchdog before raising a vector-2 NMI at the stuck
 /// target CPU. The target's NMI handler reads it, dumps the saved
-/// `ExceptionFrame` to serial, and clears the flag. A hardware NMI with
+/// `TrapFrame` to serial, and clears the flag. A hardware NMI with
 /// the flag clear falls through to the existing fatal path.
 ///
 /// Single-bit publication, no caller-side ordering beyond Release/Acquire
@@ -543,7 +543,7 @@ pub struct IpiWaitCtx<'a>
 /// - **C** (750 ms → ~5 s): at the boundary, set
 ///   the `nmi_backtrace_request` flag for `ctx.target_cpu` and send a vector-2
 ///   NMI to that CPU. The receiver's handler dumps its
-///   `ExceptionFrame` to serial so a subsequent panic is diagnosable.
+///   `TrapFrame` to serial so a subsequent panic is diagnosable.
 /// - **D** (>5 s): print the context and fatal.
 ///
 /// # Safety

--- a/core/ktest/src/integration/irq_preserves_user_regs.rs
+++ b/core/ktest/src/integration/irq_preserves_user_regs.rs
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// ktest/src/integration/irq_preserves_user_regs.rs
+
+//! Tier 2 integration: a ring-3 thread's callee-saved registers survive a timer
+//! preemption via the frame-authoritative IRQ path.
+//!
+//! On x86-64 every ring-3 IRQ (including the APIC timer) now builds the canonical
+//! `TrapFrame` on entry and restores all GPRs from it on exit (see
+//! `arch/x86_64/idt.rs::common_irq_trampoline`), rather than relying on the Rust
+//! call chain to preserve user callee-saved registers across a preemption. RISC-V
+//! has always built one `TrapFrame` per trap. This test pins two spinners to the
+//! same CPU so the timer round-robins them: each loads a *distinct* sentinel into
+//! the callee-saved registers and re-checks them every iteration. When one is
+//! preempted the other runs and overwrites those registers with its own sentinel,
+//! so a mishandled save/restore (wrong offset, dropped register) surfaces as a
+//! mismatch in the resumed thread. Runs on UP and SMP (both pinned to CPU 0).
+
+use core::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+
+use syscall::{cap_delete, thread_exit, thread_sleep};
+
+use crate::{ChildStack, TestContext, TestResult, spawn};
+
+/// Distinct callee-saved sentinels, one per spinner. They must differ so a
+/// preempting sibling that leaves its own value in a register is detected.
+static PATTERN: [u64; 2] = [0x1111_2222_3333_4444, 0x5555_6666_7777_8888];
+
+/// Iterations each spinner runs. Sized so the round-robin timer fires many times
+/// across the loop; the per-iteration check means a single corrupting preemption
+/// is caught, so the exact count is not load-bearing for correctness.
+const SPIN_ITERS: u64 = 4_000_000;
+
+/// Set non-zero by any spinner that observes a corrupted callee-saved register.
+static MISMATCHES: AtomicU64 = AtomicU64::new(0);
+
+/// Incremented by each spinner as it exits its loop. The parent waits for 2.
+static DONE: AtomicU32 = AtomicU32::new(0);
+
+static mut STACK0: ChildStack = ChildStack::ZERO;
+static mut STACK1: ChildStack = ChildStack::ZERO;
+
+#[cfg(target_arch = "x86_64")]
+fn spin_check(pat_ptr: *const u64) -> u64
+{
+    let mut mism: u64 = 0;
+    let iters: u64 = SPIN_ITERS;
+    // SAFETY: loads the sentinel at `pat_ptr` into r12..r15, then re-checks each
+    // against the (stable, in-memory) sentinel every iteration. r12..r15 are
+    // callee-saved; a timer preemption that mishandles the entry frame would
+    // restore a wrong value, which the compare catches into `mism`. The
+    // sentinel-in-memory compare is immune to register save/restore so it
+    // detects corruption regardless of which register the operands land in.
+    unsafe {
+        core::arch::asm!(
+            "mov r12, [{pat}]",
+            "mov r13, [{pat}]",
+            "mov r14, [{pat}]",
+            "mov r15, [{pat}]",
+            "2:",
+            "cmp r12, [{pat}]",
+            "jne 3f",
+            "cmp r13, [{pat}]",
+            "jne 3f",
+            "cmp r14, [{pat}]",
+            "jne 3f",
+            "cmp r15, [{pat}]",
+            "jne 3f",
+            "dec {it}",
+            "jnz 2b",
+            "jmp 4f",
+            "3:",
+            "mov qword ptr [{mism}], 1",
+            "4:",
+            pat = in(reg) pat_ptr,
+            mism = in(reg) core::ptr::from_mut(&mut mism),
+            it = inout(reg) iters => _,
+            out("r12") _,
+            out("r13") _,
+            out("r14") _,
+            out("r15") _,
+            options(nostack),
+        );
+    }
+    mism
+}
+
+#[cfg(target_arch = "riscv64")]
+fn spin_check(pat_ptr: *const u64) -> u64
+{
+    let mut mism: u64 = 0;
+    let iters: u64 = SPIN_ITERS;
+    // SAFETY: loads the sentinel at `pat_ptr` into s2..s5 (callee-saved), then
+    // re-checks each against the in-memory sentinel every iteration via t0; t1
+    // is the store scratch for the mismatch flag. See the x86-64 sibling.
+    unsafe {
+        core::arch::asm!(
+            "ld s2, 0({pat})",
+            "ld s3, 0({pat})",
+            "ld s4, 0({pat})",
+            "ld s5, 0({pat})",
+            "2:",
+            "ld t0, 0({pat})",
+            "bne s2, t0, 3f",
+            "bne s3, t0, 3f",
+            "bne s4, t0, 3f",
+            "bne s5, t0, 3f",
+            "addi {it}, {it}, -1",
+            "bnez {it}, 2b",
+            "j 4f",
+            "3:",
+            "li t1, 1",
+            "sd t1, 0({mism})",
+            "4:",
+            pat = in(reg) pat_ptr,
+            mism = in(reg) core::ptr::from_mut(&mut mism),
+            it = inout(reg) iters => _,
+            out("s2") _,
+            out("s3") _,
+            out("s4") _,
+            out("s5") _,
+            out("t0") _,
+            out("t1") _,
+            options(nostack),
+        );
+    }
+    mism
+}
+
+fn spinner_entry(id: u64) -> !
+{
+    let idx = usize::from(id & 1 != 0);
+    // PATTERN is a read-only static; the index is 0 or 1.
+    let pat_ptr = core::ptr::addr_of!(PATTERN[idx]);
+    if spin_check(pat_ptr) != 0
+    {
+        MISMATCHES.fetch_add(1, Ordering::AcqRel);
+    }
+    DONE.fetch_add(1, Ordering::AcqRel);
+    thread_exit();
+}
+
+pub fn run(ctx: &TestContext) -> TestResult
+{
+    MISMATCHES.store(0, Ordering::Release);
+    DONE.store(0, Ordering::Release);
+
+    let child0 =
+        spawn::new_child(ctx).map_err(|_| "irq_preserves_user_regs: spawn::new_child(0) failed")?;
+    let child1 =
+        spawn::new_child(ctx).map_err(|_| "irq_preserves_user_regs: spawn::new_child(1) failed")?;
+
+    // Pin both to CPU 0 so the timer round-robins them on one CPU: each
+    // preemption hands the registers to the sibling (with the other sentinel)
+    // and back, exercising the frame save/restore under real clobbering.
+    let top0 = ChildStack::top(core::ptr::addr_of!(STACK0));
+    let top1 = ChildStack::top(core::ptr::addr_of!(STACK1));
+    spawn::configure_and_start_pinned(&child0, spinner_entry, top0, 0, 0)
+        .map_err(|_| "irq_preserves_user_regs: start child0 failed")?;
+    spawn::configure_and_start_pinned(&child1, spinner_entry, top1, 1, 0)
+        .map_err(|_| "irq_preserves_user_regs: start child1 failed")?;
+
+    // Sleep-poll for both spinners to finish. Sleeping yields CPU 0 so the
+    // spinners run; the bound avoids hanging the suite if a spinner wedges.
+    let mut waited_ms = 0u64;
+    while DONE.load(Ordering::Acquire) < 2 && waited_ms < 30_000
+    {
+        let _ = thread_sleep(10); // 10 ms
+        waited_ms += 10;
+    }
+
+    let done = DONE.load(Ordering::Acquire);
+    let mismatches = MISMATCHES.load(Ordering::Acquire);
+
+    cap_delete(child0.th).map_err(|_| "irq_preserves_user_regs: cap_delete child0.th failed")?;
+    cap_delete(child0.cs).map_err(|_| "irq_preserves_user_regs: cap_delete child0.cs failed")?;
+    cap_delete(child1.th).map_err(|_| "irq_preserves_user_regs: cap_delete child1.th failed")?;
+    cap_delete(child1.cs).map_err(|_| "irq_preserves_user_regs: cap_delete child1.cs failed")?;
+
+    if done < 2
+    {
+        return Err("irq_preserves_user_regs: spinners did not finish in time");
+    }
+    crate::log_u64(
+        "integration::irq_preserves_user_regs mismatches=",
+        mismatches,
+    );
+    if mismatches != 0
+    {
+        return Err("callee-saved register corrupted across timer preemption");
+    }
+    Ok(())
+}

--- a/core/ktest/src/integration/irq_preserves_user_regs.rs
+++ b/core/ktest/src/integration/irq_preserves_user_regs.rs
@@ -19,7 +19,8 @@
 
 use core::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 
-use syscall::{cap_delete, thread_exit, thread_sleep};
+use syscall::{cap_delete, system_info, thread_exit, thread_sleep};
+use syscall_abi::SystemInfoType;
 
 use crate::{ChildStack, TestContext, TestResult, spawn};
 
@@ -27,10 +28,20 @@ use crate::{ChildStack, TestContext, TestResult, spawn};
 /// preempting sibling that leaves its own value in a register is detected.
 static PATTERN: [u64; 2] = [0x1111_2222_3333_4444, 0x5555_6666_7777_8888];
 
-/// Iterations each spinner runs. Sized so the round-robin timer fires many times
-/// across the loop; the per-iteration check means a single corrupting preemption
-/// is caught, so the exact count is not load-bearing for correctness.
-const SPIN_ITERS: u64 = 4_000_000;
+/// Iterations per asm chunk. Sized so a chunk spans well under a timer period on
+/// fast emulators yet keeps syscall overhead negligible; the spinner runs chunks
+/// until the time budget elapses, so this is not the loop bound.
+const CHUNK_ITERS: u64 = 200_000;
+
+/// Guest-time each spinner runs, in microseconds. Bounding by elapsed time (not a
+/// host-speed-dependent iteration count) guarantees the spin spans many timer
+/// periods, so the two same-CPU spinners are repeatedly preempted and interleaved
+/// — otherwise a fast host could run the whole spin inside one quantum and never
+/// exercise the IRQ frame path.
+const TIME_BUDGET_US: u64 = 100_000; // 100 ms
+
+/// Backstop chunk cap so the loop terminates even if `ElapsedUs` never advances.
+const MAX_CHUNKS: u64 = 5_000;
 
 /// Set non-zero by any spinner that observes a corrupted callee-saved register.
 static MISMATCHES: AtomicU64 = AtomicU64::new(0);
@@ -38,14 +49,24 @@ static MISMATCHES: AtomicU64 = AtomicU64::new(0);
 /// Incremented by each spinner as it exits its loop. The parent waits for 2.
 static DONE: AtomicU32 = AtomicU32::new(0);
 
+/// Per-spinner chunk progress, published between asm chunks. A spinner that
+/// observes the sibling's value advance while it was itself running proves the
+/// two were time-sliced on the one CPU — i.e. a timer preemption occurred, so
+/// the frame save/restore path was actually exercised (not a no-op pass).
+static PROGRESS: [AtomicU64; 2] = [AtomicU64::new(0), AtomicU64::new(0)];
+
+/// Set to 1 by a spinner that observed the sibling advancing mid-run. If it
+/// stays 0, no preemption interleaved the spinners and the test exercised
+/// nothing — a hard failure, not a silent pass.
+static PREEMPT_OBSERVED: AtomicU32 = AtomicU32::new(0);
+
 static mut STACK0: ChildStack = ChildStack::ZERO;
 static mut STACK1: ChildStack = ChildStack::ZERO;
 
 #[cfg(target_arch = "x86_64")]
-fn spin_check(pat_ptr: *const u64) -> u64
+fn spin_check(pat_ptr: *const u64, iters: u64) -> u64
 {
     let mut mism: u64 = 0;
-    let iters: u64 = SPIN_ITERS;
     // SAFETY: loads the sentinel at `pat_ptr` into r12..r15, then re-checks each
     // against the (stable, in-memory) sentinel every iteration. r12..r15 are
     // callee-saved; a timer preemption that mishandles the entry frame would
@@ -87,10 +108,9 @@ fn spin_check(pat_ptr: *const u64) -> u64
 }
 
 #[cfg(target_arch = "riscv64")]
-fn spin_check(pat_ptr: *const u64) -> u64
+fn spin_check(pat_ptr: *const u64, iters: u64) -> u64
 {
     let mut mism: u64 = 0;
-    let iters: u64 = SPIN_ITERS;
     // SAFETY: loads the sentinel at `pat_ptr` into s2..s5 (callee-saved), then
     // re-checks each against the in-memory sentinel every iteration via t0; t1
     // is the store scratch for the mismatch flag. See the x86-64 sibling.
@@ -131,11 +151,32 @@ fn spin_check(pat_ptr: *const u64) -> u64
 fn spinner_entry(id: u64) -> !
 {
     let idx = usize::from(id & 1 != 0);
+    let other = idx ^ 1;
     // PATTERN is a read-only static; the index is 0 or 1.
     let pat_ptr = core::ptr::addr_of!(PATTERN[idx]);
-    if spin_check(pat_ptr) != 0
+    let start_us = system_info(SystemInfoType::ElapsedUs as u64).unwrap_or(0);
+    let mut c: u64 = 0;
+    while c < MAX_CHUNKS
     {
-        MISMATCHES.fetch_add(1, Ordering::AcqRel);
+        let sibling_before = PROGRESS[other].load(Ordering::Acquire);
+        if spin_check(pat_ptr, CHUNK_ITERS) != 0
+        {
+            MISMATCHES.fetch_add(1, Ordering::AcqRel);
+            break;
+        }
+        c += 1;
+        PROGRESS[idx].store(c, Ordering::Release);
+        // The sibling advanced a chunk while this thread held the CPU ⇒ the timer
+        // time-sliced them on the one CPU ⇒ the ring-3 IRQ frame path ran.
+        if PROGRESS[other].load(Ordering::Acquire) != sibling_before
+        {
+            PREEMPT_OBSERVED.store(1, Ordering::Release);
+        }
+        let now = system_info(SystemInfoType::ElapsedUs as u64).unwrap_or(u64::MAX);
+        if now.saturating_sub(start_us) >= TIME_BUDGET_US
+        {
+            break;
+        }
     }
     DONE.fetch_add(1, Ordering::AcqRel);
     thread_exit();
@@ -145,6 +186,9 @@ pub fn run(ctx: &TestContext) -> TestResult
 {
     MISMATCHES.store(0, Ordering::Release);
     DONE.store(0, Ordering::Release);
+    PREEMPT_OBSERVED.store(0, Ordering::Release);
+    PROGRESS[0].store(0, Ordering::Release);
+    PROGRESS[1].store(0, Ordering::Release);
 
     let child0 =
         spawn::new_child(ctx).map_err(|_| "irq_preserves_user_regs: spawn::new_child(0) failed")?;
@@ -172,6 +216,7 @@ pub fn run(ctx: &TestContext) -> TestResult
 
     let done = DONE.load(Ordering::Acquire);
     let mismatches = MISMATCHES.load(Ordering::Acquire);
+    let preempted = PREEMPT_OBSERVED.load(Ordering::Acquire);
 
     cap_delete(child0.th).map_err(|_| "irq_preserves_user_regs: cap_delete child0.th failed")?;
     cap_delete(child0.cs).map_err(|_| "irq_preserves_user_regs: cap_delete child0.cs failed")?;
@@ -189,6 +234,12 @@ pub fn run(ctx: &TestContext) -> TestResult
     if mismatches != 0
     {
         return Err("callee-saved register corrupted across timer preemption");
+    }
+    // Guard against a vacuous pass: if the timer never preempted, the spinners
+    // ran sequentially and the frame path was never exercised.
+    if preempted == 0
+    {
+        return Err("irq_preserves_user_regs: no timer preemption observed — test was vacuous");
     }
     Ok(())
 }

--- a/core/ktest/src/integration/mod.rs
+++ b/core/ktest/src/integration/mod.rs
@@ -37,6 +37,7 @@
 //! - `fault_handler_declines_kills.rs` — a handler that replies KILL terminates the faulting thread
 //! - `fault_exception_redirect.rs` — a non-page-fault CPU exception is redirected to a handler that resumes the thread at a new PC
 //! - `fault_exception_no_handler_kills.rs` — a non-page-fault CPU exception with no handler bound terminates the thread
+//! - `irq_preserves_user_regs.rs` — a ring-3 thread's callee-saved registers survive a timer preemption (frame-authoritative IRQ path)
 //! - `tlb_widen_retry.rs`        — a permission-widen elides its shootdown; a remote stale-TLB write still completes via spurious-fault retry
 
 pub mod cap_delegation_chain;
@@ -49,6 +50,7 @@ pub mod fault_kills_thread;
 pub mod fault_pager_roundtrip;
 pub mod fault_resume_modifies_pc;
 pub mod fpu_survives_ipc_call;
+pub mod irq_preserves_user_regs;
 pub mod memory_lifecycle;
 pub mod multi_caller_ipc_fifo;
 pub mod priority_preemption;
@@ -128,6 +130,10 @@ pub fn run_all(ctx: &TestContext)
     run_integration_test!(
         "integration::fault_exception_no_handler_kills",
         fault_exception_no_handler_kills::run(ctx)
+    );
+    run_integration_test!(
+        "integration::irq_preserves_user_regs",
+        irq_preserves_user_regs::run(ctx)
     );
     run_integration_test!("integration::tlb_widen_retry", tlb_widen_retry::run(ctx));
 }


### PR DESCRIPTION
Closes #222. Groundwork for #233 (userspace debugger / trap-and-emulate).

## What

Replaces the contained `ExceptionFrame`↔`TrapFrame` copy in the x86-64
fault-redirect path with the one canonical `TrapFrame` on every ring-3 entry at
which a thread can be stopped, making x86-64 symmetric with RISC-V (which already
builds one `TrapFrame` per trap and points `tcb->trap_frame` at the live frame —
no copy).

- **Exception / `#PF` / NMI** trampolines build the canonical `TrapFrame` in place
  (`sub rsp` + explicit `mov`, the `syscall_entry` pattern) via shared
  `tf_build_asm!`/`tf_resume_asm!` fragments; handlers take `(TrapFrame, vector,
  error_code)` args. `cr2` is still read in the handler; `fs_base` is zeroed (TLS
  lives in `SavedState`).
- **`redirect_user_fault`** drops the stack-local copy and points
  `tcb->trap_frame` at the live frame for the block — byte-for-byte the RISC-V form.
- **New `common_irq_trampoline` + `irq_dispatch`**: every device/timer/IPI stub
  pushes a two-word prologue and jumps to it. Ring-3 origin builds the `TrapFrame`
  and returns frame-authoritatively (all GPRs restored from the frame, retiring the
  implicit split-save); ring-0 origin keeps the minimal save. In long mode the CPU
  always pushes the 5-word iret frame, so the branch is on *interrupted ring*, not
  frame size.
- `ExceptionFrame` and the two copy helpers are deleted.

## Scope: #222 vs #233

This PR is the frame **construction** half: every stoppable ring-3 entry now
yields one canonical, live register snapshot. The **consumption** half —
repointing `tcb->trap_frame` on a stop, the debugger register syscalls,
single-step (`#DB`), `#BP`, trap-and-emulate — stays in #233. Unifying the IRQ
path here is exactly the invariant #233 needs: a thread stopped while spinning in
userspace (caught only by a timer IRQ) previously had no `TrapFrame`.

## Acceptance (#222)

- [x] One canonical `TrapFrame` populated on every x86-64 ring-3 entry — annotated
  to **every *stoppable* ring-3 entry** (syscall, exception incl. `#PF`,
  NMI-diagnostic, IRQ). Deliberate deviation: `#NM` (always resolves and
  re-executes) and the spurious vector (no-op) are never stoppable and keep their
  minimal stubs — no `tcb->trap_frame` consumer.
- [x] Fault redirect no longer copies to/from a stack-local frame.
- [x] ktest fault/register tests pass on x86_64 and riscv64; userspace ABI
  unchanged (`TrapFrame` layout, fault-message ABI untouched).

## Test plan

- `cargo xtask build` + `compose-bundle --harness ktest` + `run` on **both**
  x86_64 and riscv64: `[ktest] ALL TESTS PASSED`, **178 passed / 0 failed** each.
- Exercised paths: exception redirect (`fault_*`), register read/write
  (`stop_read_regs`, `write_regs_resume`), handler PC/reg edit + resume
  (`fault_resume_modifies_pc`), TLB-shootdown IPIs and timer preemption (benches).
- New `integration::irq_preserves_user_regs`: two same-CPU spinners load distinct
  callee-saved sentinels and re-check them every iteration; a timer preemption
  that mishandled the frame would surface as a mismatch. `mismatches=0` on both
  arches.
- `cargo xtask test` (host) green.