### PR TITLE
procmgr: default system pager for ordinary processes (#225)

### DIFF
--- a/abi/process-abi/README.md
+++ b/abi/process-abi/README.md
@@ -43,7 +43,7 @@ The struct MUST be `#[repr(C)]` with stable layout. The process MUST check
 The authoritative field list, with per-field doc comments and exact order, is
 [`src/lib.rs`](src/lib.rs) (`struct ProcessInfo`). This README summarises the
 field groups rather than mirroring every field, so the two cannot drift. As of
-`PROCESS_ABI_VERSION` 18 the groups are:
+`PROCESS_ABI_VERSION` 19 the groups are:
 
 - **Process identity** — `version`, `self_thread_cap`, `self_aspace_cap`,
   `self_cspace_cap`, `sched_control_cap`.
@@ -60,12 +60,13 @@ field groups rather than mirroring every field, so the two cannot drift. As of
 - **Namespace** — `system_root_cap`, `current_dir_cap`.
 - **Logging** — `log_send_cap` (deprecated; migrating to `service_registry_cap`).
 - **Main-thread stack envelope** — `stack_top_vaddr`, `stack_pages`.
-- **Demand-paging pager** (v18, #34) — `pager_endpoint_cap`, `pager_badge`. The
-  `Endpoint` cap + badge of the process's pager (memmgr) when the process is
-  created demand-paged (`procmgr_labels::CREATE_DEMAND_PAGED`); both zero
-  otherwise. procmgr binds the main thread's fault handler to this endpoint at
-  creation, and the runtime inherits it onto every thread it spawns. Consumers
-  must tolerate zero.
+- **Demand-paging pager** (v18, #34; default-on v19, #225) — `pager_endpoint_cap`,
+  `pager_badge`. The `Endpoint` cap + badge of the process's pager (memmgr).
+  Demand paging is the system-wide default, so these are nonzero for ordinary
+  processes and zero only for pinned ones (`procmgr_labels::CREATE_PINNED`, e.g.
+  DMA drivers) and the pre-pager bootstrap. procmgr binds the main thread's fault
+  handler to this endpoint at creation, and the runtime inherits it onto every
+  thread it spawns. Consumers must tolerate zero.
 
 Every cap field names a `CSpace` slot (`0` = absent); `*_vaddr` / size / count
 fields are plain values.

--- a/abi/process-abi/src/lib.rs
+++ b/abi/process-abi/src/lib.rs
@@ -45,7 +45,12 @@ use core::prelude::rust_2024::*;
 ///      (#34) — the demand-paging fault handler advertised to the runtime so it
 ///      can inherit the pager onto spawned threads. Both zero when the process
 ///      is not demand-paged.
-pub const PROCESS_ABI_VERSION: u32 = 18;
+/// v19: Demand paging is now the system-wide default (#225). Layout unchanged
+///      from v18, but the field semantics flip: [`ProcessInfo::pager_endpoint_cap`]
+///      / [`ProcessInfo::pager_badge`] are nonzero for default-spawned processes
+///      and zero only for pinned ones (`procmgr_labels::CREATE_PINNED`, e.g. DMA
+///      drivers) and the pre-pager bootstrap (init/memmgr/procmgr).
+pub const PROCESS_ABI_VERSION: u32 = 19;
 
 // ── Address space constants ──────────────────────────────────────────────────
 
@@ -468,8 +473,10 @@ pub struct ProcessInfo
     pub stack_pages: u32,
 
     /// `CSpace` slot of an `Endpoint` cap on the process's demand-paging
-    /// pager (memmgr's service endpoint), or zero when the process is not
-    /// demand-paged.
+    /// pager (memmgr's service endpoint). Nonzero for ordinary processes —
+    /// demand paging is the system-wide default — and zero only for pinned
+    /// processes (`procmgr_labels::CREATE_PINNED`, e.g. DMA drivers) and the
+    /// pre-pager bootstrap (init/memmgr/procmgr).
     ///
     /// procmgr binds the main thread's fault handler to this endpoint at
     /// creation; the runtime reads this slot and `pager_badge` to bind the
@@ -479,7 +486,8 @@ pub struct ProcessInfo
     pub pager_endpoint_cap: u32,
 
     /// Fault-message badge bound with [`Self::pager_endpoint_cap`],
-    /// identifying this process to the pager. Zero when not demand-paged.
+    /// identifying this process to the pager. Zero when the process is pinned
+    /// (no pager).
     pub pager_badge: u64,
 }
 

--- a/core/kernel/src/syscall/ipc.rs
+++ b/core/kernel/src/syscall/ipc.rs
@@ -295,6 +295,58 @@ unsafe fn transfer_caps(
 
 // ── IPC syscall handlers ──────────────────────────────────────────────────────
 
+/// Move the caps carried by a `SYS_IPC_CALL` message from the running caller's
+/// `CSpace` into a server that was already blocked in recv, stashing the
+/// destination slot indices in the server's `ipc_msg` so it publishes them when
+/// it resumes.
+///
+/// Runs in the caller's context: the caller's `CSpace` is live (it is the
+/// running thread) and `server_tcb` is pinned by the `wake_in_flight` claim
+/// `endpoint_call` set under `ep.lock` (not yet enqueued, so it cannot run).
+/// Doing the move here keeps the server's resumed `sys_ipc_recv` off the
+/// hazardous path of re-deriving the caller from `reply_tcb`, which a concurrent
+/// `cancel_ipc_block` / `dealloc_object(Thread)` can clear to null or free. The
+/// server pre-allocated worst-case headroom before blocking, so the move cannot
+/// OOM; on the (practically unreachable) failure the message is delivered
+/// without caps rather than stranding the already-parked caller.
+///
+/// # Safety
+/// `caller_tcb` must be the running thread; `server_tcb` a valid TCB pinned by
+/// `wake_in_flight` and not yet enqueued.
+#[cfg(not(test))]
+unsafe fn deliver_call_caps(
+    caller_tcb: *mut crate::sched::thread::ThreadControlBlock,
+    server_tcb: *mut crate::sched::thread::ThreadControlBlock,
+    msg: &Message,
+)
+{
+    if msg.cap_count == 0
+    {
+        return;
+    }
+    // SAFETY: caller_tcb is the running caller; server_tcb a valid pinned TCB.
+    let caller_cspace = unsafe { (*caller_tcb).cspace };
+    // SAFETY: server_tcb valid and pinned by wake_in_flight.
+    let server_cspace = unsafe { (*server_tcb).cspace };
+    let mut dst_indices = [0u32; MSG_CAP_SLOTS_MAX];
+    // SAFETY: CSpace pointers extracted from valid, live TCBs.
+    let transferred = unsafe {
+        transfer_caps(
+            caller_cspace,
+            &msg.cap_slots[..msg.cap_count],
+            server_cspace,
+            &mut dst_indices,
+        )
+    }
+    .unwrap_or(0);
+    // SAFETY: server_tcb is pinned and not yet enqueued (so it cannot be
+    // running); finalizing its ipc_msg cap results is race-free.
+    unsafe {
+        (*server_tcb).ipc_msg.cap_slots = dst_indices;
+        (*server_tcb).ipc_msg.cap_count = transferred;
+    }
+}
+
 /// `SYS_IPC_CALL` (0): synchronous call on an endpoint.
 ///
 /// arg0 = endpoint cap index, arg1 = label, arg2 = `data_count`,
@@ -402,7 +454,18 @@ pub fn sys_ipc_call(tf: &mut TrapFrame) -> Result<u64, SyscallError>
 
     if let Ok(woken_server) = result
     {
-        // A server was waiting; enqueue it and yield so it can run.
+        // The server was already blocked in recv: endpoint_call completed the
+        // rendezvous. Move any caps in this caller's context before waking the
+        // server, so its resumed recv only publishes the results and never
+        // re-derives this caller from reply_tcb (which a concurrent
+        // cancel/dealloc of the caller can clear to null or free). See
+        // `deliver_call_caps`.
+        // SAFETY: tcb is the running caller; woken_server is a valid TCB pinned
+        // by its wake_in_flight claim until the enqueue_and_wake below.
+        unsafe {
+            deliver_call_caps(tcb, woken_server, &msg);
+        }
+        // Enqueue the server and yield so it can run.
         // SAFETY: woken_server returned by endpoint_call; is valid TCB.
         unsafe {
             debug_assert!((*woken_server).magic == crate::sched::thread::TCB_MAGIC);
@@ -567,43 +630,27 @@ pub fn sys_ipc_recv(tf: &mut TrapFrame) -> Result<u64, SyscallError>
         crate::sched::schedule(false);
     }
 
-    // On resume (caller arrived), deliver message from ipc_msg.
-    // SAFETY: tcb validated above; ipc_msg populated by endpoint_recv on wakeup.
+    // On resume, deliver the message the waking caller copied into ipc_msg.
+    //
+    // The caller-side `sys_ipc_call` already performed any cap move in its own
+    // context (where its CSpace is provably live) and overwrote ipc_msg's
+    // cap_slots/cap_count with the DESTINATION slot indices and the transferred
+    // count. We MUST NOT re-derive the caller from reply_tcb to move caps here:
+    // a concurrent cancel/dealloc of the caller may have cleared the slot to
+    // null or freed the caller, and dereferencing it crashes under SMP load. We
+    // only publish the already-moved results. See the server-was-waiting branch
+    // of `sys_ipc_call`.
+    // SAFETY: tcb validated above; ipc_msg populated by endpoint_call on wakeup.
     let msg = unsafe { (*tcb).ipc_msg };
     // SAFETY: tcb validated above; ipc_buffer is immutable.
     let server_buf = unsafe { (*tcb).ipc_buffer };
 
-    let mut transferred: usize = 0;
-    let mut dst_indices = [0u32; MSG_CAP_SLOTS_MAX];
-    if msg.cap_count > 0
-    {
-        // SAFETY: tcb validated; reply_tcb set by endpoint_recv to caller's TCB.
-        let caller = unsafe { (*tcb).reply_tcb.load(core::sync::atomic::Ordering::Acquire) };
-        // SAFETY: caller is valid TCB from reply_tcb.
-        let caller_cspace = unsafe { (*caller).cspace };
-        // SAFETY: tcb validated above.
-        let server_cspace = unsafe { (*tcb).cspace };
-        // On failure: deliver message data without caps (cap_count=0 in buf).
-        // The caller stays blocked awaiting a reply; the server receives an
-        // incomplete message but is not crashed.
-        // SAFETY: CSpace pointers extracted from valid TCBs.
-        if let Ok(t) = unsafe {
-            transfer_caps(
-                caller_cspace,
-                &msg.cap_slots[..msg.cap_count],
-                server_cspace,
-                &mut dst_indices,
-            )
-        }
-        {
-            transferred = t;
-        }
-    }
-    // Always write cap_count (see immediate-delivery path above for the
-    // rationale).
+    // Always write the cap_count word (including the zero-cap case) so a prior
+    // IPC's cap metadata cannot be mis-read as this delivery's. cap_slots holds
+    // the destination indices written by the caller's transfer.
     // SAFETY: server_buf is user-mapped or 0.
     unsafe {
-        write_cap_results(server_buf, transferred, &dst_indices);
+        write_cap_results(server_buf, msg.cap_count, &msg.cap_slots);
     }
 
     if msg.data_count > 0

--- a/docs/fault-handling.md
+++ b/docs/fault-handling.md
@@ -46,9 +46,10 @@ including register inspection and modification of a fault-blocked thread via
 no handler bound is still terminated, the behavior for all faults absent this mechanism.
 
 The demand-paging consumer is implemented: memmgr acts as the pager, procmgr binds it for
-processes created with the `CREATE_DEMAND_PAGED` flag and delegates the child address space,
-and the `ProcessInfo` pager field (`pager_endpoint_cap` / `pager_badge`, `PROCESS_ABI_VERSION`
-18) advertises it so the runtime inherits the handler onto spawned threads. Userspace reserves
+every ordinary process it creates (demand paging is the default; a process opts out with the
+`CREATE_PINNED` flag) and delegates the child address space, and the `ProcessInfo` pager
+field (`pager_endpoint_cap` / `pager_badge`, `PROCESS_ABI_VERSION` 19) advertises it so the
+runtime inherits the handler onto spawned threads. Userspace reserves
 unbacked VA and registers it via `std::os::seraph::register_demand_paged`; first touch faults,
 memmgr maps a frame and resumes. See
 [memmgr/docs/ipc-interface.md](../services/memmgr/docs/ipc-interface.md) (`REGISTER_REGION`,
@@ -252,15 +253,35 @@ process-death path of [Process Lifecycle](process-lifecycle.md#process-death).
 
 The broadly useful memory policies — lazy and guard-page stack growth, zero-fill-on-demand
 anonymous memory, copy-on-write sharing, swap and overcommit, working-set tracking,
-snapshotting — exist only if a manager sits on the fault path of most processes. The
-mechanism is designed so binding a default pager to all ordinary processes is a userspace
-policy decision (a creator default plus runtime propagation via `ProcessInfo`).
+snapshotting — exist only if a manager sits on the fault path of most processes. Binding a
+default pager to all ordinary processes is a userspace policy decision (a creator default
+plus runtime propagation via `ProcessInfo`), not a kernel one.
 
-Such a default MUST exempt infrastructure that cannot depend on the fault path — init, the
-frame manager, the pager itself, and drivers requiring pinned memory — by leaving them
-without a pager (eager-mapped). A demand-paged pager would otherwise recurse on its own
-faults. A userspace fault round-trip is costlier than a kernel-internal fill; this cost is
-accepted to keep paging policy out of the kernel.
+Demand paging is the **system-wide default**: procmgr binds memmgr (the pager) as the
+fault handler on every process it creates and advertises it in
+[`ProcessInfo`](process-lifecycle.md#processinfo--initinfo-handover-discipline)
+(`pager_endpoint_cap` / `pager_badge`), and the runtime inherits it onto spawned threads.
+It is not a per-tier or per-service decision; a process is demand-paged simply because it is
+a process.
+
+The default MUST exempt only the narrow set that cannot depend on the fault path:
+
+- **init, the frame manager, and the pager itself** — these are pre-pager and are never
+  routed through procmgr's pager-binding path (init is created by the kernel; it creates
+  memmgr and procmgr via raw syscalls), so they are pinned by construction. A demand-paged
+  pager would recurse on its own faults.
+- **Drivers requiring pinned memory (DMA)** — a device may write a process's memory before a
+  demand fault could back it, so DMA-capable drivers must be eager-mapped. The creator opts a
+  process out with `procmgr_labels::CREATE_PINNED`; devmgr sets it for the DMA-capable driver
+  class (PCI devices with BAR + IRQ). The exemption is a capability-flag decision, never a
+  badge-range test.
+
+A userspace fault round-trip is costlier than a kernel-internal fill; this cost is accepted
+to keep paging policy out of the kernel.
+
+A declarative paging key on svcmgr service definitions is a reserved future extension: no
+svcmgr-launched service does DMA or sits on the fault path today, so none needs to opt out.
+It would be added when the first pinned svcmgr-launched service exists.
 
 ---
 

--- a/programs/demandpaged/src/main.rs
+++ b/programs/demandpaged/src/main.rs
@@ -5,9 +5,10 @@
 
 //! Demand-paging fixture for the svctest pager phase.
 //!
-//! Spawned with `std::os::seraph::CommandExt::demand_paged(true)`, so procmgr
-//! binds this process's fault handler to memmgr (the pager). Two modes,
-//! selected by argv:
+//! Demand paging is the system-wide default, so when spawned normally procmgr
+//! binds this process's fault handler to memmgr (the pager). The pager phase
+//! also spawns it `pinned(true)` to prove the opt-out leaves it with no pager.
+//! Two modes, selected by argv:
 //!
 //!   * default — reserve an unbacked region, register it as demand-paged, and
 //!     write a per-page pattern across it. Each first touch faults to memmgr,

--- a/programs/threadstack/src/main.rs
+++ b/programs/threadstack/src/main.rs
@@ -5,7 +5,7 @@
 
 //! Guarded demand-stack fixture for the usertest `threadstack` tester.
 //!
-//! Spawned demand-paged (`CommandExt::demand_paged(true)`), so threads this
+//! Spawned demand-paged (the system default; no opt-in needed), so threads this
 //! process spawns get a guarded demand-paged stack: a large lazily-grown
 //! usable region with an unregistered guard page below it. Two modes, by argv:
 //!

--- a/programs/threadstack/tester/src/main.rs
+++ b/programs/threadstack/tester/src/main.rs
@@ -3,8 +3,9 @@
 
 // programs/threadstack/tester/src/main.rs
 
-//! Per-program tester for `/programs/threadstack`. Spawns it demand-paged in
-//! two modes and asserts, capability-natively (stdout marker is the verdict;
+//! Per-program tester for `/programs/threadstack`. Spawns it in two modes
+//! (demand-paged by the system default) and asserts, capability-natively
+//! (stdout marker is the verdict;
 //! the kernel's fault-class exit reason is corroborating mechanism only):
 //!
 //!   * `grow` — a worker recurses deep into its demand-paged stack and joins;
@@ -19,7 +20,6 @@
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use std::io::Read;
-use std::os::seraph::process::CommandExt;
 use std::process::{Command, Stdio};
 
 /// Base exit reason for a fault-induced death (`abi/syscall` `EXIT_FAULT_BASE`).
@@ -32,13 +32,12 @@ fn fail(msg: &str) -> !
     std::process::exit(1);
 }
 
-/// Spawn `/programs/threadstack <mode>` demand-paged, capture stdout, and
-/// return `(stdout, ExitStatus)`.
+/// Spawn `/programs/threadstack <mode>` (demand-paged by the system default),
+/// capture stdout, and return `(stdout, ExitStatus)`.
 fn run(mode: &str) -> (String, std::process::ExitStatus)
 {
     let mut child = Command::new("/programs/threadstack")
         .arg(mode)
-        .demand_paged(true)
         .stdout(Stdio::piped())
         .spawn()
         .expect("spawn /programs/threadstack");

--- a/runtime/ruststd/src/os/seraph.rs
+++ b/runtime/ruststd/src/os/seraph.rs
@@ -735,8 +735,9 @@ pub use pal_reserve::{ReserveError, ReservedRange, reserve_pages, unreserve_page
 ///
 /// The range maps lazily: the first access to each page faults, the pager
 /// backs it read-write, and the access retries transparently. The process
-/// must be demand-paged (created with `procmgr_labels::CREATE_DEMAND_PAGED`);
-/// otherwise the first fault kills the thread.
+/// must be demand-paged — the system default; not created with
+/// `procmgr_labels::CREATE_PINNED` — otherwise the first fault kills the
+/// thread.
 ///
 /// On any failure the reservation is released. On success the caller owns the
 /// range and must `mem_unmap` any backed pages, then `unreserve_pages`, when
@@ -807,7 +808,8 @@ impl GuardedStack {
 
 /// Reserve a guarded demand-paged stack: `guard_pages` unregistered pages below
 /// `usable_pages` of RW demand-paged stack. The process must be demand-paged
-/// (`CREATE_DEMAND_PAGED`). On any failure the reservation is released.
+/// (the system default; not `CREATE_PINNED`). On any failure the reservation is
+/// released.
 ///
 /// Composes [`register_demand_paged`]'s steps but registers only the upper
 /// `usable_pages`, leaving the guard hole below to fault fatally. Pairs with
@@ -1042,14 +1044,16 @@ pub mod process {
         #[stable(feature = "seraph_ext", since = "1.0.0")]
         fn cwd_dir_cap(&mut self, cap: u32) -> &mut Self;
 
-        /// Create the child as demand-paged: procmgr binds its main thread's
+        /// Create the child *pinned*: eager-mapped, with no system pager.
+        /// By default a child is demand-paged — procmgr binds its main thread's
         /// fault handler to the system pager (memmgr) and delegates the child
         /// address space, and the runtime inherits the pager onto threads the
-        /// child spawns. The child can then back regions lazily via
-        /// [`super::register_demand_paged`]. No effect on infrastructure
-        /// processes. Defaults to off.
+        /// child spawns, so the child can back regions lazily via
+        /// [`super::register_demand_paged`]. Set `pinned(true)` only for a
+        /// child that cannot depend on the fault path — e.g. one doing DMA.
+        /// Defaults to off.
         #[stable(feature = "seraph_ext", since = "1.0.0")]
-        fn demand_paged(&mut self, on: bool) -> &mut Self;
+        fn pinned(&mut self, on: bool) -> &mut Self;
     }
 
     #[stable(feature = "seraph_ext", since = "1.0.0")]
@@ -1064,8 +1068,8 @@ pub mod process {
             self
         }
 
-        fn demand_paged(&mut self, on: bool) -> &mut Command {
-            self.as_inner_mut().set_demand_paged(on);
+        fn pinned(&mut self, on: bool) -> &mut Command {
+            self.as_inner_mut().set_pinned(on);
             self
         }
     }

--- a/runtime/ruststd/src/sys/process/seraph.rs
+++ b/runtime/ruststd/src/sys/process/seraph.rs
@@ -140,10 +140,11 @@ pub struct Command {
     /// then `current_dir_cap()` parent inherit, then zero). Same
     /// ownership contract as `namespace_cap`.
     cwd_dir_cap: u32,
-    /// When set, spawn ORs `procmgr_labels::CREATE_DEMAND_PAGED` into the
-    /// `CREATE_FROM_FILE` label so procmgr binds the child to the system
-    /// pager. Set via `CommandExt::demand_paged`. Defaults to off.
-    demand_paged: bool,
+    /// When set, spawn ORs `procmgr_labels::CREATE_PINNED` into the
+    /// `CREATE_FROM_FILE` label so procmgr leaves the child eager-mapped with
+    /// no system pager. Set via `CommandExt::pinned`. Defaults to off — the
+    /// child is demand-paged by the system default.
+    pinned: bool,
 }
 
 impl Command {
@@ -158,7 +159,7 @@ impl Command {
             stderr: None,
             namespace_cap: 0,
             cwd_dir_cap: 0,
-            demand_paged: false,
+            pinned: false,
         }
     }
 
@@ -176,9 +177,10 @@ impl Command {
         self.cwd_dir_cap = cap;
     }
 
-    /// Request a demand-paged child. Called by `CommandExt::demand_paged`.
-    pub fn set_demand_paged(&mut self, on: bool) {
-        self.demand_paged = on;
+    /// Request a pinned (eager-mapped, no pager) child. Called by
+    /// `CommandExt::pinned`.
+    pub fn set_pinned(&mut self, on: bool) {
+        self.pinned = on;
     }
 
     pub fn arg(&mut self, arg: &OsStr) {
@@ -389,13 +391,13 @@ impl Command {
         let env_len_word_offset = argv_word_offset + argv_words;
         let env_blob_word_offset = env_len_word_offset + 1;
 
-        let demand_paged_flag = if self.demand_paged {
-            procmgr_labels::CREATE_DEMAND_PAGED
+        let pinned_flag = if self.pinned {
+            procmgr_labels::CREATE_PINNED
         } else {
             0
         };
         let builder = ipc::IpcMessage::builder(procmgr_labels::CREATE_FROM_FILE
-            | demand_paged_flag
+            | pinned_flag
             | procmgr_labels::CREATE_DEATH_RELAY
             | ((args_blob.len() as u64) << 32)
             | ((u64::from(args_count)) << 48)

--- a/services/devmgr/src/main.rs
+++ b/services/devmgr/src/main.rs
@@ -1179,6 +1179,14 @@ fn spawn_virtio_blk(
     catalog: &mut DeviceCatalog,
 ) -> bool
 {
+    // Guard the boot module across every retained exit — no virtio device, no
+    // module delivered, or a catalog-serialisation failure — until it is handed
+    // to `spawn_driver`. A retained module cap is a live derivation child of
+    // init's donated pool-run source and pins that run unsplittable. Disarmed
+    // immediately before the spawn, which then owns the cap's lifecycle.
+    let module_cap = caps.module_cap_for_kind(caps::module_kind::VIRTIO_BLK);
+    let mut module_guard = spawn::ModuleCapGuard::new(module_cap);
+
     for pci_dev in devices
     {
         if !pci::is_virtio_blk(pci_dev)
@@ -1227,8 +1235,6 @@ fn spawn_virtio_blk(
         let bar_info = find_virtio_bar_cap(pci_dev, caps);
         let irq_cap = acquire_single_irq_cap(pci_dev, irq_root);
 
-        let module_cap = caps.module_cap_for_kind(caps::module_kind::VIRTIO_BLK);
-
         let config = spawn::DriverSpawnConfig {
             procmgr_ep: caps.procmgr_ep,
             bootstrap_ep: caps.self_bootstrap_ep,
@@ -1245,19 +1251,13 @@ fn spawn_virtio_blk(
         };
         // `spawn_driver` owns the module cap's lifecycle from here (guarded
         // internally: consumed by CREATE_PROCESS, or released on failure).
+        module_guard.disarm();
         spawn::spawn_driver(&config, ipc_buf);
 
         return true;
     }
 
-    // No virtio block device present: the module was never handed to a spawn,
-    // so it is still a live derivation child of init's donated pool-run source.
-    // Release it so that run stays splittable.
-    let module_cap = caps.module_cap_for_kind(caps::module_kind::VIRTIO_BLK);
-    if module_cap != 0
-    {
-        let _ = syscall::cap_delete(module_cap);
-    }
+    // No virtio block device present: `module_guard` releases the module here.
     false
 }
 

--- a/services/devmgr/src/main.rs
+++ b/services/devmgr/src/main.rs
@@ -163,25 +163,6 @@ fn main() -> !
         std::os::seraph::log!("devmgr: framebuffer driver spawned");
     }
 
-    // Boot-module driver caps are single-use: each bootstrap-essential driver is
-    // spawned from its module exactly once above, which moves the cap into
-    // procmgr (`CREATE_PROCESS`). Any module cap still held here — a driver whose
-    // spawn was skipped (e.g. the framebuffer on a headless boot) or failed —
-    // must be released now. init donates every boot-module source to memmgr's
-    // pool at reap; a retained derivation pins that pool run unsplittable, so a
-    // later demand fault landing on it is wrongly killed. `cap_delete` on an
-    // already-moved (empty) slot is an idempotent no-op. No driver is ever
-    // re-spawned from a module after boot — the rootfs/VFS path serves those.
-    for i in 0..caps.driver_module_count
-    {
-        let slot = caps.driver_module_slots[i];
-        if slot != 0
-        {
-            let _ = syscall::cap_delete(slot);
-        }
-        caps.driver_module_slots[i] = 0;
-    }
-
     // On-disk driver state. The RTC binary lives on the rootfs at
     // `/services/drivers/<chip>`, not in the boot bundle — RTC is not
     // bootstrap-essential. svcmgr delivers a `LOOKUP | READ`-attenuated
@@ -1262,11 +1243,21 @@ fn spawn_virtio_blk(
             registry_ep: caps.registry_ep,
             device_badge,
         };
+        // `spawn_driver` owns the module cap's lifecycle from here (guarded
+        // internally: consumed by CREATE_PROCESS, or released on failure).
         spawn::spawn_driver(&config, ipc_buf);
 
         return true;
     }
 
+    // No virtio block device present: the module was never handed to a spawn,
+    // so it is still a live derivation child of init's donated pool-run source.
+    // Release it so that run stays splittable.
+    let module_cap = caps.module_cap_for_kind(caps::module_kind::VIRTIO_BLK);
+    if module_cap != 0
+    {
+        let _ = syscall::cap_delete(module_cap);
+    }
     false
 }
 
@@ -1366,6 +1357,9 @@ fn spawn_serial(caps: &mut caps::DevmgrCaps, ipc_buf: *mut u64) -> (bool, u32)
         std::os::seraph::log!("serial: no serial driver module delivered");
         return (false, 0);
     }
+    // Release the module cap on any exit before it is handed to the spawn (which
+    // then owns its lifecycle); a retained cap pins its donated pool run.
+    let mut module_guard = spawn::ModuleCapGuard::new(module_cap);
 
     // devmgr-owned service endpoint: the driver receives on a RIGHTS_ALL
     // copy; devmgr keeps the original to mint client SEND caps on query.
@@ -1385,6 +1379,7 @@ fn spawn_serial(caps: &mut caps::DevmgrCaps, ipc_buf: *mut u64) -> (bool, u32)
         return (false, serial_ep);
     };
 
+    module_guard.disarm();
     let spawned = spawn::spawn_simple_device(
         caps.procmgr_ep,
         caps.self_bootstrap_ep,
@@ -1420,6 +1415,14 @@ fn spawn_framebuffer(
     ipc_buf: *mut u64,
 ) -> (bool, u32)
 {
+    // Resolve and guard the module cap before the headless check: on a headless
+    // boot (`fb_info == None`) the framebuffer driver is never spawned, so its
+    // module cap would otherwise stay held — a live derivation child pinning
+    // init's donated pool-run source unsplittable. The guard releases it on
+    // every early exit until it is handed to the spawn.
+    let module_cap = caps.module_cap_for_kind(caps::module_kind::FRAMEBUFFER);
+    let mut module_guard = spawn::ModuleCapGuard::new(module_cap);
+
     let Some(fb) = caps.fb_info
     else
     {
@@ -1427,7 +1430,6 @@ fn spawn_framebuffer(
         return (false, 0);
     };
 
-    let module_cap = caps.module_cap_for_kind(caps::module_kind::FRAMEBUFFER);
     if module_cap == 0
     {
         std::os::seraph::log!("framebuffer: no framebuffer driver module delivered");
@@ -1509,6 +1511,7 @@ fn spawn_framebuffer(
         return (false, fb_ep);
     };
 
+    module_guard.disarm();
     let spawned = spawn::spawn_simple_device(
         caps.procmgr_ep,
         caps.self_bootstrap_ep,

--- a/services/devmgr/src/main.rs
+++ b/services/devmgr/src/main.rs
@@ -163,6 +163,25 @@ fn main() -> !
         std::os::seraph::log!("devmgr: framebuffer driver spawned");
     }
 
+    // Boot-module driver caps are single-use: each bootstrap-essential driver is
+    // spawned from its module exactly once above, which moves the cap into
+    // procmgr (`CREATE_PROCESS`). Any module cap still held here — a driver whose
+    // spawn was skipped (e.g. the framebuffer on a headless boot) or failed —
+    // must be released now. init donates every boot-module source to memmgr's
+    // pool at reap; a retained derivation pins that pool run unsplittable, so a
+    // later demand fault landing on it is wrongly killed. `cap_delete` on an
+    // already-moved (empty) slot is an idempotent no-op. No driver is ever
+    // re-spawned from a module after boot — the rootfs/VFS path serves those.
+    for i in 0..caps.driver_module_count
+    {
+        let slot = caps.driver_module_slots[i];
+        if slot != 0
+        {
+            let _ = syscall::cap_delete(slot);
+        }
+        caps.driver_module_slots[i] = 0;
+    }
+
     // On-disk driver state. The RTC binary lives on the rootfs at
     // `/services/drivers/<chip>`, not in the boot bundle — RTC is not
     // bootstrap-essential. svcmgr delivers a `LOOKUP | READ`-attenuated

--- a/services/devmgr/src/spawn.rs
+++ b/services/devmgr/src/spawn.rs
@@ -26,9 +26,11 @@ use ipc::{IpcMessage, procmgr_labels};
 pub enum CreateSource
 {
     /// Memory cap to an in-memory ELF image (`procmgr_labels::CREATE_PROCESS`).
-    /// Caller retains the slot on failure to match the existing
-    /// `spawn_simple_device` contract; kernel transfers ownership on
-    /// successful `CREATE_PROCESS`.
+    /// A `CREATE_PROCESS` `ipc_call` transfers the cap to procmgr (which deletes
+    /// it on both success and failure). On any failure BEFORE that transfer,
+    /// [`spawn_simple_device`] deletes the cap on the caller's behalf — a
+    /// retained boot-module cap is a live derivation child of init's donated
+    /// pool-run source and pins that run unsplittable.
     Module(u32),
     /// vfsd file SEND cap (`procmgr_labels::CREATE_FROM_FILE`). `size` is
     /// the file size hint reported by the resolving `NS_LOOKUP`. On any

--- a/services/devmgr/src/spawn.rs
+++ b/services/devmgr/src/spawn.rs
@@ -125,10 +125,17 @@ pub fn spawn_driver(config: &DriverSpawnConfig, ipc_buf: *mut u64)
     // CREATE_PROCESS via procmgr. Caps [module, creator]. The child has no
     // stdio wired by default — it logs through `seraph::log!` via the
     // discovery cap procmgr installs in `ProcessInfo`.
-    let create_msg = IpcMessage::builder(procmgr_labels::CREATE_PROCESS)
-        .cap(module_cap)
-        .cap(badged_creator)
-        .build();
+    //
+    // CREATE_PINNED: drivers reached through `spawn_driver` are PCI devices
+    // with BAR + IRQ — the DMA-capable class. A device may write driver memory
+    // before a demand fault could back it (the kernel never pins), so these
+    // must be eager-mapped, not demand-paged. Keyed off the spawn path for now;
+    // #165 replaces this with an explicit per-driver DMA attribute.
+    let create_msg =
+        IpcMessage::builder(procmgr_labels::CREATE_PROCESS | procmgr_labels::CREATE_PINNED)
+            .cap(module_cap)
+            .cap(badged_creator)
+            .build();
     // SAFETY: ipc_buf is the registered IPC buffer.
     let Ok(reply) = (unsafe { ipc::ipc_call(procmgr_ep, &create_msg, ipc_buf) })
     else

--- a/services/devmgr/src/spawn.rs
+++ b/services/devmgr/src/spawn.rs
@@ -41,6 +41,46 @@ pub enum CreateSource
     },
 }
 
+/// RAII guard for a boot-module Memory cap not yet consumed by a successful
+/// `CREATE_PROCESS`. While armed, `Drop` `cap_delete`s the slot.
+///
+/// A retained module cap is a live `cap_derive` child of init's donated
+/// pool-run source, so leaving it held pins that run unsplittable (a later
+/// demand fault landing on it is then wrongly killed). Guarding it releases the
+/// cap on every not-consumed exit — a skipped spawn (e.g. headless framebuffer,
+/// absent virtio device) or any failure before `CREATE_PROCESS` moves the cap
+/// to procmgr. Call [`disarm`](Self::disarm) once ownership has moved on (the
+/// `CREATE_PROCESS` `ipc_call` returned, transferring the cap, or an inner spawn
+/// step has taken over its lifecycle) so the cap is not double-freed — the slot
+/// is freed and the kernel's LIFO freelist promptly reuses it for a live cap.
+pub struct ModuleCapGuard(u32);
+
+impl ModuleCapGuard
+{
+    /// Arm a guard over `slot` (0 = nothing to guard).
+    pub fn new(slot: u32) -> Self
+    {
+        Self(slot)
+    }
+
+    /// Disarm: the cap's ownership has moved on; do not delete on drop.
+    pub fn disarm(&mut self)
+    {
+        self.0 = 0;
+    }
+}
+
+impl Drop for ModuleCapGuard
+{
+    fn drop(&mut self)
+    {
+        if self.0 != 0
+        {
+            let _ = syscall::cap_delete(self.0);
+        }
+    }
+}
+
 /// Monotonic counter for driver-child bootstrap badges.
 static NEXT_BOOTSTRAP_BADGE: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(1);
 
@@ -93,6 +133,11 @@ pub fn spawn_driver(config: &DriverSpawnConfig, ipc_buf: *mut u64)
     let _ = config.bars.bases;
     let _ = config.bars.sizes;
 
+    // Release the module cap on every exit before CREATE_PROCESS consumes it
+    // (missing BAR/IRQ, badge-derive failure, ipc_call failure). Disarmed once
+    // the ipc_call returns, which transfers the cap to procmgr.
+    let mut module_guard = ModuleCapGuard::new(config.module_cap);
+
     let Some(bar_cap) = config.bars.caps.first().copied()
     else
     {
@@ -143,6 +188,10 @@ pub fn spawn_driver(config: &DriverSpawnConfig, ipc_buf: *mut u64)
         std::os::seraph::log!("driver CREATE_PROCESS ipc_call failed");
         return;
     };
+    // ipc_call returned: the module cap was transferred to procmgr regardless of
+    // the reply label (procmgr owns its teardown on its own failure). Disarm so
+    // the guard does not free the now-reused slot.
+    module_guard.disarm();
     if reply.label != 0
     {
         std::os::seraph::log!("driver CREATE_PROCESS failed");
@@ -277,14 +326,15 @@ pub fn spawn_simple_device(
 ) -> bool
 {
     // Source-aware cleanup: on any failure before the procmgr ipc_call
-    // completes, `CreateSource::File`'s file_cap is deleted (the
-    // namespace walk just produced it; there is no retry value), while
-    // `CreateSource::Module`'s memory cap stays in the caller's slot
-    // (existing contract — module caps came from bootstrap and the
-    // caller may have other uses for them).
+    // completes (so the source cap was not transferred), the source cap is
+    // deleted. For `File` the namespace walk just produced it; for `Module` a
+    // retained cap is a live derivation child of init's donated pool-run source
+    // and pins that run unsplittable, so it must be freed. The post-ipc_call
+    // failure paths below do NOT run this cleanup — there the source cap is
+    // already owned by procmgr.
     let source_cap_to_clean: u32 = match source
     {
-        CreateSource::Module(_) => 0,
+        CreateSource::Module(m) => m,
         CreateSource::File { file_cap, .. } => file_cap,
     };
     let source_cap_present: bool = match source

--- a/services/init/src/service.rs
+++ b/services/init/src/service.rs
@@ -1194,6 +1194,18 @@ pub fn phase3_svcmgr_handover(
         ipc_buf,
     );
 
+    // Bind procmgr's init-reap death observers on both init threads BEFORE the
+    // svcmgr handover. svcmgr launches real-logd in response to
+    // HANDOVER_COMPLETE, and real-logd's HANDOVER_PULL releases init-logd; if
+    // the observer bind ran after that release it would land on an already
+    // -exited init-logd and silently lose the death — the kernel bind only
+    // appends an observer, it does not fire for a thread that has already
+    // exited — stranding the reap on the liveness backstop. Transferring init's
+    // kernel-object caps here is safe: svcmgr is already created and endowed
+    // (the only consumer of init's own CSpace cap), and the cap handles move
+    // while the underlying objects keep backing init's still-running threads.
+    let reap_bound = register_init_reap_objects(procmgr_ep, info, init_logd_thread_cap, ipc_buf);
+
     let handover_msg = IpcMessage::new(svcmgr_labels::HANDOVER_COMPLETE);
     // SAFETY: ipc_buf is caller's registered IPC buffer.
     match unsafe { ipc::ipc_call(svcmgr_service_ep, &handover_msg, ipc_buf) }
@@ -1202,20 +1214,22 @@ pub fn phase3_svcmgr_handover(
         _ => log("phase 3: handover failed"),
     }
 
-    // Reap-handoff: move init's kernel-object caps + every reclaimable
-    // Memory cap to procmgr. Procmgr binds a death-EQ on both of init's
-    // threads (main + init-logd) and reaps once both have exited — init-logd
-    // outlives this main thread until the svcmgr-launched real-logd pulls
-    // `HANDOVER_PULL`. The reap tears init's AS/CSpace/Threads down and
-    // donates the Memory caps to memmgr's pool.
-    handoff_to_procmgr_reap(
-        info,
-        procmgr_ep,
-        init_logd_thread_cap,
-        ipc_buf,
-        mem_reap_floor,
-        orphan_memory_caps,
-    );
+    // Reap-handoff (donation + arm): stream init's reclaimable Memory caps to
+    // procmgr and notify INIT_TEARDOWN_DONE. The death observers were bound
+    // above; procmgr reaps once both init threads have exited — init-logd when
+    // real-logd pulls the handover, main on the thread_exit below. The Memory
+    // caps land in memmgr's pool at reap. Skipped if the object round failed:
+    // the reap cannot run without it.
+    if reap_bound
+    {
+        finish_init_reap_handoff(
+            info,
+            procmgr_ep,
+            ipc_buf,
+            mem_reap_floor,
+            orphan_memory_caps,
+        );
+    }
 
     log("main thread exiting; init handed off to procmgr for reap");
     syscall::thread_exit();
@@ -1260,26 +1274,27 @@ fn module_spawn_copy(module_memory_cap: u32) -> Option<u32>
     syscall::cap_derive(module_memory_cap, syscall::RIGHTS_ALL).ok()
 }
 
-/// Move init's kernel-object caps + every reclaimable Memory cap to
-/// procmgr via `REGISTER_INIT_TEARDOWN`, then notification
-/// `INIT_TEARDOWN_DONE`. IPC cap-transfer MOVES caps, so after this
-/// returns init's `CSpace` no longer holds the transferred slots.
+/// Round 1 of the reap handoff: transfer init's four kernel-object caps
+/// (aspace, cspace, main thread, init-logd thread) to procmgr, which binds a
+/// death-EQ observer on both threads (`data[0] = 1` distinguishes this from the
+/// later donate-only rounds). IPC cap-transfer MOVES the caps; after this init's
+/// `CSpace` no longer holds those four slots, but its threads keep running in
+/// the underlying objects.
 ///
-/// Failures here are logged but otherwise non-fatal — init still calls
-/// `sys_thread_exit` afterward, just leaving the un-transferred caps
-/// to cascade through `CSpace` teardown to the kernel buddy on eventual
-/// cap death.
-fn handoff_to_procmgr_reap(
-    info: &InitInfo,
+/// MUST run before the svcmgr handover — see the call site. Returns whether the
+/// round succeeded; on failure the caller skips the donation rounds and arming,
+/// since the reap cannot run without the bound observers.
+///
+/// # Safety
+/// `ipc_buf` must be init's registered IPC buffer; `procmgr_ep` must carry
+/// `SEND|GRANT`.
+fn register_init_reap_objects(
     procmgr_ep: u32,
+    info: &InitInfo,
     init_logd_thread_cap: u32,
     ipc_buf: *mut u64,
-    mem_reap_floor: u32,
-    orphan_memory_caps: &[u32],
-)
+) -> bool
 {
-    // Round 1: kernel-object caps. `data[0] = 1` distinguishes from
-    // subsequent donate-only rounds.
     let round1 = IpcMessage::builder(procmgr_labels::REGISTER_INIT_TEARDOWN)
         .word(0, 1)
         .cap(info.aspace_cap)
@@ -1288,20 +1303,40 @@ fn handoff_to_procmgr_reap(
         .cap(init_logd_thread_cap)
         .build();
     // SAFETY: ipc_buf is init's registered IPC buffer; procmgr_ep carries SEND|GRANT.
-    if let Ok(reply) = unsafe { ipc::ipc_call(procmgr_ep, &round1, ipc_buf) }
+    match unsafe { ipc::ipc_call(procmgr_ep, &round1, ipc_buf) }
     {
-        if reply.label != ipc::procmgr_errors::SUCCESS
+        Ok(reply) if reply.label == ipc::procmgr_errors::SUCCESS => true,
+        Ok(_) =>
         {
-            log("reap-handoff: procmgr refused kernel-object round; aborting handoff");
-            return;
+            log("reap-handoff: procmgr refused kernel-object round; skipping reap handoff");
+            false
+        }
+        Err(_) =>
+        {
+            log("reap-handoff: kernel-object round IPC failed; skipping reap handoff");
+            false
         }
     }
-    else
-    {
-        log("reap-handoff: kernel-object round IPC failed; aborting handoff");
-        return;
-    }
+}
 
+/// Donation + arm phase of the reap handoff: stream every reclaimable Memory
+/// cap init solely holds to procmgr, then notify `INIT_TEARDOWN_DONE`. Run after
+/// the svcmgr handover and only when [`register_init_reap_objects`] bound the
+/// death observers. IPC cap-transfer MOVES the donated caps out of init's
+/// `CSpace`.
+///
+/// Failures here are logged but otherwise non-fatal — init still calls
+/// `sys_thread_exit` afterward, just leaving the un-transferred caps
+/// to cascade through `CSpace` teardown to the kernel buddy on eventual
+/// cap death.
+fn finish_init_reap_handoff(
+    info: &InitInfo,
+    procmgr_ep: u32,
+    ipc_buf: *mut u64,
+    mem_reap_floor: u32,
+    orphan_memory_caps: &[u32],
+)
+{
     // Donate every `owns_memory` Memory cap init solely holds, streamed in
     // MSG_CAP_SLOTS_MAX-sized rounds. Three disjoint sources:
     //  - explicit InitInfo ranges (not in the descriptor array): init's ELF

--- a/services/memmgr/src/main.rs
+++ b/services/memmgr/src/main.rs
@@ -1410,13 +1410,17 @@ fn handle_process_died(req: &IpcMessage, ipc_buf: *mut u64, procmgr_badge: u64)
         // allocation, though still owned and accounted).
         pool.coalesce();
 
-        // Drop memmgr's copy of a demand-paged process's delegated address
-        // space, freeing the CSpace slot. The child's own AS is torn down by
-        // procmgr; this only releases memmgr's reference.
-        if record.aspace_cap != 0
-        {
-            let _ = syscall::cap_delete(record.aspace_cap);
-        }
+        // Do NOT delete memmgr's delegated address-space cap here. It is a
+        // `cap_derive` child of the child's AddressSpace cap (procmgr's
+        // `DELEGATE_ASPACE` derivation), so procmgr's `cap_revoke` of that
+        // AddressSpace during child teardown — which runs before this
+        // `PROCESS_DIED` — has already revoked memmgr's copy and freed its
+        // CSpace slot. By this point `record.aspace_cap` is a stale slot index
+        // that memmgr's allocator may have already reused for an unrelated cap
+        // (e.g. a pool-run tail); deleting it would free that unrelated cap and
+        // corrupt the free pool. The delegated copy's teardown is owned by
+        // procmgr's revocation of the parent aspace.
+        record.aspace_cap = 0;
         // Free the slot in place (mark reusable); no by-value move.
         record.badge = 0;
     }

--- a/services/procmgr/docs/ipc-interface.md
+++ b/services/procmgr/docs/ipc-interface.md
@@ -74,15 +74,17 @@ stop/configure the thread.
 | 2 | `OutOfMemory` | Insufficient memory caps to allocate stack, ProcessInfo page, or IPC buffer |
 | 3 | `CSpaceFull` | Cannot allocate kernel objects (address space, CSpace, thread) |
 
-**Demand-paged flag.** The label's bit 16 (`CREATE_DEMAND_PAGED`, in the
-reserved `[16..32]` window shared with `CREATE_FROM_FILE`) requests a
-demand-paged child. At finalize, for non-infrastructure children (badge
-≥ `LOG_BADGE_FIRST_CHILD`), procmgr binds the main thread's fault handler to
-memmgr (the system pager) via `SYS_THREAD_SET_FAULT_HANDLER`, delegates the
-child `AddressSpace` to memmgr via `memmgr_labels::DELEGATE_ASPACE`, and sets
-`ProcessInfo.pager_endpoint_cap` / `pager_badge` so the runtime inherits the
-handler onto spawned threads. The child then backs reserved regions lazily via
-`std::os::seraph::register_demand_paged`. See
+**Pinned flag.** Demand paging is the default: at finalize procmgr binds every
+child's main thread fault handler to memmgr (the system pager) via
+`SYS_THREAD_SET_FAULT_HANDLER`, delegates the child `AddressSpace` to memmgr via
+`memmgr_labels::DELEGATE_ASPACE`, and sets `ProcessInfo.pager_endpoint_cap` /
+`pager_badge` so the runtime inherits the handler onto spawned threads. The
+child then backs reserved regions lazily via
+`std::os::seraph::register_demand_paged`. The label's bit 16 (`CREATE_PINNED`,
+in the reserved `[16..32]` window shared with `CREATE_FROM_FILE`) opts out: the
+child is left eager-mapped with no pager. Set it only for a process that cannot
+depend on the fault path — a DMA driver. init, memmgr, and procmgr are pre-pager
+and never routed through this path, so they are pinned by construction. See
 [docs/fault-handling.md](../../../docs/fault-handling.md). The binding is
 best-effort: a failure degrades to "no pager" (faults kill), never blocking
 creation.

--- a/services/procmgr/src/init_reap.rs
+++ b/services/procmgr/src/init_reap.rs
@@ -247,30 +247,38 @@ pub fn run_reap(memmgr_ep: u32, ipc_buf: *mut u64)
         {
             return;
         };
-        if !s.armed
-        {
-            return;
-        }
+        // Count the death as soon as it is observed, even before
+        // `INIT_TEARDOWN_DONE` arms the reap. The death-EQ observers are bound
+        // (first round) before the svcmgr handover can release init-logd, so
+        // init-logd's exit may fire while init is still streaming donation
+        // rounds — i.e. pre-arm. Dropping a pre-arm death would strand
+        // `pending_deaths` and force the liveness backstop. Anchor the backstop
+        // from the first death regardless. Only the *execution* of the reap
+        // waits for `armed`: init must finish donating its reclaimable caps,
+        // and `do_reap` consumes the kernel-object caps that round delivers.
         s.pending_deaths = s.pending_deaths.saturating_sub(1);
+        if s.first_death_us == 0
+        {
+            s.first_death_us = elapsed_us();
+        }
         if s.pending_deaths > 0
         {
-            // One init thread exited (the main thread); the other still runs
-            // in init's aspace/cspace. Reclaiming now would fault it — wait.
-            // Anchor the liveness backstop from this instant so a wedged
-            // handover (init-logd never released) cannot block the reap
-            // forever; the common path still reaps on init-logd's own exit
-            // below, well before the deadline.
-            if s.first_death_us == 0
-            {
-                s.first_death_us = elapsed_us();
-            }
             std::os::seraph::log!(
                 "init-reap: an init thread exited; {} still running",
                 s.pending_deaths
             );
             return;
         }
-        guard.take().expect("armed init-reap state present")
+        if !s.armed
+        {
+            // Both threads exited before arming. init's main thread sends
+            // `INIT_TEARDOWN_DONE` before its own `thread_exit`, so main's death
+            // is always post-arm and this branch is unreachable in well-formed
+            // teardown; leave the reap for the arming path / backstop rather
+            // than reaping before init has finished donating.
+            return;
+        }
+        guard.take().expect("init-reap state present")
     };
 
     do_reap(state, memmgr_ep, ipc_buf);

--- a/services/procmgr/src/main.rs
+++ b/services/procmgr/src/main.rs
@@ -710,7 +710,8 @@ fn reply_create_result(result: &process::CreateResult, ipc_buf: *mut u64)
 ///
 /// Label layout:
 ///   bits [0..16]  = opcode (`CREATE_PROCESS`)
-///   bits [16..32] = reserved
+///   bit  16       = `CREATE_PINNED` (opt out of the default system pager)
+///   bits [17..32] = reserved (bit 17 = `CREATE_DEATH_RELAY` on `CREATE_FROM_FILE`)
 ///   bits [32..48] = `args_bytes` (total byte length of the argv blob; u16)
 ///   bits [48..56] = `args_count` (number of NUL-terminated strings; u8)
 ///   bits [56..64] = `env_count` (number of NUL-terminated `KEY=VALUE`
@@ -812,7 +813,7 @@ fn handle_create(
         memmgr_badge,
         registry_send_source: ctx.registry_ep,
         sched_baseline: ctx.sched_baseline,
-        demand_paged: label & procmgr_labels::CREATE_DEMAND_PAGED != 0,
+        demand_paged: label & procmgr_labels::CREATE_PINNED == 0,
         self_memmgr_ep: ctx.memmgr_ep,
     };
 
@@ -1007,7 +1008,7 @@ fn handle_create_from_file(
         &args,
         &env,
         ctx.death_eq,
-        label & procmgr_labels::CREATE_DEMAND_PAGED != 0,
+        label & procmgr_labels::CREATE_PINNED == 0,
         parent_relay_cap,
     );
 

--- a/services/procmgr/src/process.rs
+++ b/services/procmgr/src/process.rs
@@ -556,11 +556,12 @@ pub struct UniversalCaps
     /// priorities within the band. Zero when procmgr was given no baseline;
     /// children then receive zero and cannot set any priority.
     pub sched_baseline: u32,
-    /// Whether the caller requested a demand-paged child (the
-    /// `procmgr_labels::CREATE_DEMAND_PAGED` flag). When set and the child is
-    /// not infrastructure, `finalize_creation` binds the child's main-thread
-    /// fault handler to memmgr and delegates the child `AddressSpace`, and
-    /// `populate_child_info` advertises the pager in `ProcessInfo`.
+    /// Whether the child is demand-paged. Demand paging is the default; this
+    /// is false only when the caller set `procmgr_labels::CREATE_PINNED` (a
+    /// DMA driver that must be eager-mapped). When true, `finalize_creation`
+    /// binds the child's main-thread fault handler to memmgr and delegates the
+    /// child `AddressSpace`, and `populate_child_info` advertises the pager in
+    /// `ProcessInfo`.
     pub demand_paged: bool,
     /// Procmgr's own (procmgr-badged) SEND cap on memmgr's endpoint, used to
     /// issue the procmgr-only `DELEGATE_ASPACE`. Distinct from
@@ -1265,13 +1266,12 @@ fn finalize_creation(
     // Demand-paged wiring (best-effort): delegate the child address space to
     // memmgr and bind the main thread's fault handler to it. A failure here
     // degrades to "no pager" (faults kill the thread) rather than failing an
-    // otherwise-complete creation. Infrastructure (badge below
-    // LOG_BADGE_FIRST_CHILD) is never paged; procmgr never spawns it anyway,
-    // but the floor is an explicit guard.
-    if demand_paged
-        && process_badge >= ipc::log_badges::LOG_BADGE_FIRST_CHILD
-        && memmgr_send_cap != 0
-        && self_memmgr_ep != 0
+    // otherwise-complete creation. Demand paging is the system-wide default;
+    // `demand_paged` is false only when the caller set `CREATE_PINNED` (a DMA
+    // driver). init, memmgr, and procmgr are pre-pager and are never routed
+    // through this path, so they are pinned by construction — the exemption is
+    // a capability-flag decision, never a badge-range test.
+    if demand_paged && memmgr_send_cap != 0 && self_memmgr_ep != 0
     {
         // Hand memmgr its own copy of the child AS, keyed by the child's
         // memmgr badge, over procmgr's (procmgr-badged) endpoint so it lands

--- a/services/svcmgr/docs/service-definitions.md
+++ b/services/svcmgr/docs/service-definitions.md
@@ -59,6 +59,13 @@ seed      = rootfs.root pwrmgr.shutdown pwrmgr.deny
 | `provides` | no | Space-separated `name[:auth\|:deny]` entries. svcmgr creates this service's endpoint, serves its RECV as bootstrap `cap[0]`, and publishes one badged SEND per entry into the discovery registry. See [`provides`](#provides). |
 | `log_sink` | no | `yes` or `no` (default `no`). Marks the service as the system log sink (real-logd); svcmgr mints its bootstrap round from the reserved log-sink sources init endows. Mutually exclusive with `seed` and `provides`. See [`log_sink`](#log_sink). |
 
+There is deliberately no paging key. Demand paging is procmgr's system-wide default
+(see [Fault Handling](../../../docs/fault-handling.md#default-system-pager)); every
+svcmgr-launched service is demand-paged. A pinned opt-out
+(`procmgr_labels::CREATE_PINNED`) exists for DMA drivers, which devmgr spawns — not svcmgr.
+A declarative paging key here is a reserved future extension, to be added only when the
+first pinned svcmgr-launched service exists.
+
 ## `restart`
 
 | Value | Semantics |

--- a/services/svctest/src/phases/pager.rs
+++ b/services/svctest/src/phases/pager.rs
@@ -4,18 +4,25 @@
 //! Demand-paging pager surface: memmgr backs reserved anonymous regions on
 //! fault, and declines (kills) faults outside any registered region.
 //!
-//! Drives `/programs/demandpaged`, spawned demand-paged via
-//! `std::os::seraph::CommandExt::demand_paged`:
+//! Drives `/programs/demandpaged`. Demand paging is the system-wide default, so
+//! the first two phases spawn it with no opt-in; the third opts out via
+//! `std::os::seraph::CommandExt::pinned`:
 //!
 //!   * **positive** — the child reserves, registers, touches, and reads back a
 //!     multi-page region; memmgr backs each first touch on fault. A clean exit
 //!     proves the round-trip (touch → fault → map → resume) and that repeat
-//!     access does not re-fault (the read-back pass sees the written pattern).
+//!     access does not re-fault (the read-back pass sees the written pattern) —
+//!     all with no opt-in flag, proving the default binds a pager.
 //!   * **negative** — the child touches an *unregistered* reserved page; memmgr
 //!     declines and the kernel kills it, proving preserved segfault semantics
 //!     under a bound pager.
+//!   * **pinned** — the child is spawned `pinned(true)`, so procmgr binds no
+//!     pager and delegates no address space. Touching its *registered* region
+//!     (which exits cleanly in **positive**) now faults with no handler and the
+//!     kernel kills it, proving the opt-out leaves the process eager-mapped with
+//!     no pager on the fault path.
 //!
-//! After the spawn/die cycle the all-RAM-accounted identity must still hold,
+//! After each spawn/die cycle the all-RAM-accounted identity must still hold,
 //! directly guarding against fault-path accounting drift (a stray
 //! `pool_total` credit on demand allocation would break it).
 
@@ -36,6 +43,10 @@ pub fn phases() -> &'static [Phase]
             name: "demand_paging_segfault",
             run: demand_paging_segfault_phase,
         },
+        Phase {
+            name: "demand_paging_pinned",
+            run: demand_paging_pinned_phase,
+        },
     ]
 }
 
@@ -44,7 +55,6 @@ fn demand_paging_phase(_: &Caps)
     use std::process::Command;
 
     let mut child = Command::new("/programs/demandpaged")
-        .demand_paged(true)
         .spawn()
         .expect("spawn /programs/demandpaged failed");
     let status = child.wait().expect("demandpaged wait failed");
@@ -71,7 +81,6 @@ fn demand_paging_segfault_phase(_: &Caps)
 
     let mut child = Command::new("/programs/demandpaged")
         .arg("oor")
-        .demand_paged(true)
         .spawn()
         .expect("spawn /programs/demandpaged oor failed");
     let status = child.wait().expect("demandpaged oor wait failed");
@@ -86,6 +95,44 @@ fn demand_paging_segfault_phase(_: &Caps)
         "expected a fault/kill exit_reason >= {EXIT_FAULT_BASE:#x}, got {raw:#x}"
     );
     std::os::seraph::log!("demand_paging_segfault phase passed (exit_reason={raw:#x})");
+}
+
+// cast_sign_loss: ExitStatus::code() is i32 but exit reasons are non-negative
+// (fault 0x1000+vec, killed 0x2000); the u64 cast is safe.
+#[allow(clippy::cast_sign_loss)]
+fn demand_paging_pinned_phase(_: &Caps)
+{
+    use std::process::Command;
+
+    const EXIT_FAULT_BASE: u64 = 0x1000;
+
+    // Pinned: procmgr binds no fault handler and delegates no address space.
+    // The child still registers its region (memmgr records it against the badge
+    // minted at REGISTER_PROCESS), but the first touch faults with no handler
+    // bound, so the kernel kills the process. The same registered-region touch
+    // exits cleanly in `demand_paging` — the kill here is the proof that
+    // `pinned(true)` suppressed the default pager.
+    let mut child = Command::new("/programs/demandpaged")
+        .pinned(true)
+        .spawn()
+        .expect("spawn /programs/demandpaged pinned failed");
+    let status = child.wait().expect("demandpaged pinned wait failed");
+    std::os::seraph::log!("demandpaged pinned exited: {status}");
+    assert!(
+        !status.success(),
+        "a pinned child has no pager: touching its registered region must be \
+         killed, not backed: {status}"
+    );
+    let raw = status.code().expect("pinned ExitStatus must carry a code") as u64;
+    assert!(
+        raw >= EXIT_FAULT_BASE,
+        "expected a no-handler fault exit_reason >= {EXIT_FAULT_BASE:#x}, got {raw:#x}"
+    );
+
+    // The child died with no demand frames mapped (no handler ever backed a
+    // page); memmgr reclaims its record on PROCESS_DIED. The identity must hold.
+    assert_ram_identity();
+    std::os::seraph::log!("demand_paging_pinned phase passed (exit_reason={raw:#x})");
 }
 
 /// Assert `system_ram == kernel_reserved + pool_total` via memmgr

--- a/shared/ipc/src/lib.rs
+++ b/shared/ipc/src/lib.rs
@@ -72,7 +72,7 @@ use syscall_abi::{MSG_CAP_SLOTS_MAX, MSG_DATA_WORDS_MAX};
 //     TIMED_LABELS_VERSION
 //     SERIAL_LABELS_VERSION
 
-pub const PROCMGR_LABELS_VERSION: u32 = 1;
+pub const PROCMGR_LABELS_VERSION: u32 = 2;
 /// IPC labels for the process manager (`procmgr`).
 pub mod procmgr_labels
 {
@@ -117,16 +117,19 @@ pub mod procmgr_labels
     /// [`CONFIGURE_PIPE`] calls between create and start.
     pub const CREATE_FROM_FILE: u64 = 13;
     /// Label flag (bit 16) for [`CREATE_PROCESS`] / [`CREATE_FROM_FILE`]:
-    /// create the new process as demand-paged. At finalize procmgr binds
+    /// create the new process *pinned* — eager-mapped, with no system pager.
+    /// Demand paging is the default: when this flag is clear, procmgr binds
     /// the child's main thread fault handler to memmgr (the system pager),
     /// delegates the child `AddressSpace` cap to memmgr via
     /// `memmgr_labels::DELEGATE_ASPACE`, and advertises the pager in
     /// `ProcessInfo` (`pager_endpoint_cap` / `pager_badge`) so the runtime
-    /// inherits it onto spawned threads. Occupies bit 16 of the reserved
-    /// `[16..32]` label window. Infrastructure processes (badge below
-    /// `log_badges::LOG_BADGE_FIRST_CHILD`) are never paged regardless of
-    /// this flag.
-    pub const CREATE_DEMAND_PAGED: u64 = 1 << 16;
+    /// inherits it onto spawned threads. Set this flag only for a process
+    /// that cannot depend on the fault path — a driver doing DMA, whose
+    /// memory a device may write before a demand fault could back it.
+    /// Occupies bit 16 of the reserved `[16..32]` label window. init,
+    /// memmgr, and procmgr are pre-pager and never routed through this
+    /// binding path, so they are pinned by construction regardless.
+    pub const CREATE_PINNED: u64 = 1 << 16;
     /// Label flag (bit 17) for [`CREATE_FROM_FILE`]: the message carries a
     /// trailing death-relay POST-only `EventQueue` cap (the LAST cap in the
     /// message). At finalize procmgr binds it as an `AddressSpace` death
@@ -404,9 +407,10 @@ pub mod memmgr_labels
     /// Procmgr-only: delegate a demand-paged child's `AddressSpace` cap to
     /// memmgr so the pager can map frames into it on fault.
     ///
-    /// Sent at process finalize for processes created with the
-    /// [`CREATE_DEMAND_PAGED`] flag, after the child address space exists
-    /// (so it cannot ride on the earlier [`REGISTER_PROCESS`] handshake).
+    /// Sent at process finalize for demand-paged processes — the default;
+    /// not those created with the [`CREATE_PINNED`] flag — after the child
+    /// address space exists (so it cannot ride on the earlier
+    /// [`REGISTER_PROCESS`] handshake).
     /// memmgr stores the transferred cap against the child's tracking
     /// entry, keyed by the badge minted at [`REGISTER_PROCESS`].
     ///


### PR DESCRIPTION
Closes #225.

Flips the userspace pager protocol (#34 PR4) from opt-in to a **system-wide default**: procmgr binds memmgr (the pager) as the fault handler on every ordinary process it creates and advertises it in `ProcessInfo`; the runtime inherits it onto spawned threads. Demand paging is not a per-tier or per-service decision — a process is demand-paged because it is a process.

## Acceptance (#225)
- [x] **procmgr binds a default pager to ordinary processes by policy.** `demand_paged = (label & CREATE_PINNED) == 0`; the bind/delegate/advertise wiring (already present from #34 PR4) now fires by default.
- [x] **Infrastructure processes are exempt (no pager → fault kills, terminating the chain).** init, memmgr (the frame manager), and procmgr are pre-pager and are never routed through procmgr's pager-binding path, so they are pinned by construction. A fault in an exempt process with no handler is terminal (`EXIT_FAULT_BASE + code`), as before.
- [x] **Exemption set is data-driven (flag), not hard-coded.** Exemption is the `CREATE_PINNED` capability-flag, not a hard-coded name list. devmgr sets it for the DMA-capable driver class (the `spawn_driver` PCI/BAR+IRQ path); a demand-paged DMA buffer could be written by a device before a fault could back it. The badge-range test was removed from the policy (it was a PID-shaped axis and a tautology at the call site).

## Design decisions (resolved during planning)
- **Opt-in → opt-out, bit 16 reused.** `CREATE_DEMAND_PAGED` → `CREATE_PINNED`; `PROCMGR_LABELS_VERSION` bumped (same bit, inverted wire semantics). The opt-in flag had no production consumer.
- **No badge-number policy.** Dropped `process_badge >= LOG_BADGE_FIRST_CHILD` from the exemption; the badge stays only as a capability-stamped client identity / log-attribution namespace base.
- **DMA drivers: interim spawn-path heuristic.** Pin the `spawn_driver` (PCI) class; finer per-driver classification is deferred to #165 (data-driven device/driver binding).
- **`.svc paging` key: deferred (YAGNI).** No svcmgr-launched service does DMA or sits on the fault path today; the field would have no consumer and svcmgr's parser rejects unknown keys. Reserved as a future extension (documented).
- **ABI:** `PROCESS_ABI_VERSION` 18 → 19 (layout unchanged; `pager_endpoint_cap`/`pager_badge` field semantics flip — nonzero by default).

## Init-reap root-cause fix (surfaced by the flip)
A pre-existing ~6% riscv64 flaky: procmgr bound the init-reap death observers *after* the svcmgr handover, so real-logd's `HANDOVER_PULL` could release init-logd before the bind — landing on an exited thread and silently losing the death (the kernel bind only appends; it does not fire for an already-exited thread). The reap stalled on the wake-gated liveness backstop, delaying init's ~110 MiB arena donation past svctest's RAM-identity check. Fixed by binding the observers **before** the handover (`register_init_reap_objects`) and counting deaths as observed in `run_reap` (gating only reap execution on `armed`). No test-side workaround. The backstop's wake-gated nature is orthogonal hardening, tracked by #36.

## Validation (`cargo xtask`, both arches, pass marker `[<h>] ALL TESTS PASSED`)
| | svctest | usertest |
|---|---|---|
| x86_64 | 6/6 | 12/12 |
| riscv64 | **40/40** | 12/12 |

- New `demand_paging_pinned` svctest phase confirmed on both arches (e.g. x86_64 `exit_reason=0x100e` = #PF, riscv64 store page fault) — pinned child killed with no handler.
- Host-side `cargo xtask test`: 68 passed.
- riscv64 40-run soak confirms the init-reap fix eliminates that init-reap flaky (was ~6%, now 0).

### riscv64-release exposure (latent bugs the policy flip surfaced)
The first CI run failed only on `riscv64 release {svctest,usertest}`. Making every
process demand-paged exposed three pre-existing latent bugs, all fixed in this PR
(CI now fully green, 13/13):
- **kernel** fault-IPC cap-transfer SMP race — `sys_ipc_recv` re-derived the caller
  from a nullable/freeable `reply_tcb` (`stval=0x318` null-deref). Fix: move the cap
  transfer into `sys_ipc_call`'s caller context (commit 67d954e).
- **devmgr** retained the headless-skipped framebuffer module cap, a live derivation
  child pinning init's donated pool run unsplittable → demand-stack fault wrongly
  killed. Fix: release retained module caps per-path via an RAII guard (commits
  317238e, d172266, 2cf1e93).
- **memmgr** deleted the procmgr-revoked delegated-aspace cap (a stale, reused slot)
  on `PROCESS_DIED` → free-pool corruption → child `heap_bootstrap` FATAL. Fix: don't
  delete it; procmgr's `cap_revoke` of the parent aspace owns the teardown
  (commit 073d502).
- Re-validated post-fix: riscv64 release svctest 40/40 + usertest 6/6, x86_64 release
  svctest 8/8 + usertest 6/6, host-side 333 passed; full CI matrix green.

## Follow-ups
- #165 — replace devmgr's spawn-path pinning heuristic with a per-driver DMA attribute.
- #36 — timed `ipc_recv`/`wait_set_wait` so the init-reap backstop can fire on a hard deadline (orthogonal hardening).
- #238 — devmgr leaks the `CREATE_PROCESS` reply `process_handle` (pre-merge audit S1).
- #239 — procmgr `load_elf_page` leaks memory caps on OOM error paths.
- #240 — ruststd spawned threads leak `thread_slab`/`thread_cap` until process death.
- #241 — kernel `CSpace::free_slot` double-free guard only catches the current `free_head`.

