### PR TITLE
docs, kernel: document the off-stack ceiling-sized-scratch invariant

### DIFF
--- a/core/kernel/docs/scheduling-internals.md
+++ b/core/kernel/docs/scheduling-internals.md
@@ -469,6 +469,38 @@ The kernel does not auto-cascade IPC unblock on process exit. The contract:
 
 ---
 
+## Off-Stack Scratch for Ceiling-Sized Arrays
+
+Kernel scratch whose length is a compile-time ceiling (`MAX_CPUS`,
+`MAX_SLEEPING`) MUST NOT be allocated as a stack-local array in either context
+below. It MUST live off-stack via one of the two idioms in the table.
+
+- **Timer-ISR-reachable paths.** `sleep_check_wakeups` is inlined into
+  `timer_tick`, which runs in the timer ISR (`isr_timer`, IST=0) on the kernel
+  stack of whatever thread the tick interrupted. A `[_; MAX_SLEEPING]` frame
+  there overruns that borrowed stack.
+- **All-CPU-locks lifecycle paths.** `set_state_under_all_locks`,
+  `sys_thread_set_priority`, and `dealloc_object(Thread)` each save one
+  interrupt-flag word per CPU across the all-CPU-locks region (Lock Hierarchy
+  rule 4). A `[u64; MAX_CPUS]` frame on the caller's syscall stack scales with
+  the CPU ceiling — 4 KiB at `MAX_CPUS = 512`.
+
+The failure mode is silent and not size-checked by the compiler: the oversized
+frame clobbers a saved return-address chain and the next `ret` faults with
+`#PF rip=0` (reproduced for the timer-ISR case at ~5 % on x86_64 TCG-SMP;
+PR #167).
+
+| Off-stack idiom | Use when | Why no extra synchronisation | Site |
+|---|---|---|---|
+| CPU0-owned `static mut` singleton | The path runs in exactly one non-reentrant context — a CPU0-gated ISR path behind an interrupt gate (IF=0). | The path is non-reentrant, so the single buffer needs no lock. | `EXPIRED_SCRATCH` (`core/kernel/src/sched/mod.rs`) — `sleep_check_wakeups` expired-TCB snapshot (PR #167). |
+| Per-CPU field on `PerCpuScheduler`, written under that CPU's own `scheduler.lock` | Several CPUs run the path serially and each needs its own slot. | Each CPU writes only its own slot, only while holding that CPU's `scheduler.lock`; the all-CPU-locks region serialises every writer of a given slot, so the field needs no atomicity. | `saved_lock_flags` (`core/kernel/src/sched/run_queue.rs`) — per-CPU flag word for all three all-CPU-locks sites above (issue #168). |
+
+No `[_; MAX_CPUS]` or `[_; MAX_SLEEPING]` stack scratch remains in the kernel;
+CPU-set state at the ceiling is carried as bitvectors
+(`core/kernel/src/cpu_mask.rs`), not per-CPU stack arrays.
+
+---
+
 ## Softlockup Watchdog
 
 Permanent kernel feature. Detects "every CPU stalled in kernel mode" — the

--- a/core/kernel/src/sched/mod.rs
+++ b/core/kernel/src/sched/mod.rs
@@ -471,14 +471,12 @@ static mut SLEEP_COUNT: usize = 0;
 /// Scratch buffer holding the TCBs `sleep_check_wakeups` collects between
 /// dropping `SLEEP_LIST_LOCK` and waking them.
 ///
-/// Kept off the stack deliberately: at `MAX_SLEEPING * 8 = 1 KiB` a
-/// stack-local snapshot inflated the frame of `timer_tick` (which inlines
-/// `sleep_check_wakeups`). `timer_tick` runs in the timer ISR (`isr_timer`,
-/// IST=0) on the kernel stack of whatever thread the tick interrupted; the
-/// oversized frame overran that stack's saved return-address chain, faulting
-/// with `rip=0` on the next `ret`. `sleep_check_wakeups` runs only on CPU0
-/// (see `timer_tick`'s `cpu == 0` gate) behind an interrupt gate (IF=0), so it
-/// is non-reentrant and this single buffer needs no lock of its own.
+/// Off-stack via the CPU0-static idiom of docs/scheduling-internals.md
+/// § Off-Stack Scratch for Ceiling-Sized Arrays: a `[_; MAX_SLEEPING]` frame in
+/// `timer_tick` (which inlines `sleep_check_wakeups`) would overrun the timer
+/// ISR's borrowed kernel stack. `sleep_check_wakeups` runs only on CPU0 (see
+/// `timer_tick`'s `cpu == 0` gate) behind an interrupt gate (IF=0), so it is
+/// non-reentrant and this single buffer needs no lock of its own.
 #[cfg(not(test))]
 static mut EXPIRED_SCRATCH: [*mut ThreadControlBlock; MAX_SLEEPING] =
     [core::ptr::null_mut(); MAX_SLEEPING];

--- a/core/kernel/src/sched/run_queue.rs
+++ b/core/kernel/src/sched/run_queue.rs
@@ -216,8 +216,8 @@ pub struct PerCpuScheduler
     /// as part of an all-CPU-locks operation (`set_state_under_all_locks`,
     /// `sys_thread_set_priority`, `dealloc_object(Thread)`); read back at the
     /// matching `unlock_raw`. Written only under this scheduler's own lock, so
-    /// it needs no atomicity. Lives here rather than in a `MAX_CPUS`-wide stack
-    /// array that would scale with the CPU ceiling.
+    /// it needs no atomicity. Off-stack per the per-CPU-field idiom of
+    /// docs/scheduling-internals.md § Off-Stack Scratch for Ceiling-Sized Arrays.
     pub saved_lock_flags: u64,
 }
 


### PR DESCRIPTION
## Summary
Adds the same-class stack-scratch audit note to `core/kernel/docs/scheduling-internals.md` — the sole open acceptance item on #168. A new "Off-Stack Scratch for Ceiling-Sized Arrays" section records the invariant (no `MAX_CPUS`/`MAX_SLEEPING`-length scratch on a timer-ISR-shared or all-CPU-locks path's stack), the two sanctioned off-stack idioms, and ties `EXPIRED_SCRATCH` (PR #167) and `saved_lock_flags` (this class) to it.

The issue's first acceptance item (move `saved_flags` off-stack) already shipped with the `MAX_CPUS` 64→512 bitvector change: all three all-CPU-locks sites (`set_state_under_all_locks`, `sys_thread_set_priority`, `dealloc_object(Thread)`) use the per-CPU `saved_lock_flags` field; no `[u64; MAX_CPUS]` stack scratch remains in the kernel. That change did not reference #168, which is why the issue stayed open.

Closes #168

## Acceptance
- [x] Move `saved_flags` off the syscall stack (per-CPU static indexed by `current_cpu()` is the natural fit; the all-CPU-locks region is serialized by the locks themselves, so no two callers race for the same per-CPU slot). — implemented as a per-CPU `PerCpuScheduler.saved_lock_flags` field written under each CPU's own `scheduler.lock`; functionally the proposed design. Shipped with the MAX_CPUS bitvector change, not this PR.
- [x] No regression on the standard x86_64 + riscv64 svctest amplifier + ktest burn-in. — covered by the required `validate (…, svctest)` and `validate (…, ktest)` CI checks on both arches, debug + release; all green on this PR.
- [x] Same-class audit notes in `core/kernel/docs/scheduling-internals.md` mention this pattern alongside the `EXPIRED_SCRATCH` rationale. — this PR.

## Test plan
- [x] `cargo xtask build` (x86_64)
- [x] `cargo xtask build --arch riscv64`
- `cargo xtask run` (x86_64 / riscv64): not run locally — the change is comment/doc-only (no codegen impact). The boot/run matrix is exercised by the required CI checks `validate (x86_64|riscv64, debug|release, ktest|svctest|usertest)`, all green on this PR.

## Notes
- Code changes are comment-only: the `EXPIRED_SCRATCH` and `saved_lock_flags` doc comments are trimmed to reference the new doc section rather than restate the invariant inline, per `documentation-standards.md` (comments reference, not duplicate, documented invariants). The local soundness facts justifying no-lock / no-atomicity are retained.
- Same-class audit result: clean. No remaining `[_; MAX_CPUS]` or `[_; MAX_SLEEPING]` stack scratch; CPU-set state at the ceiling is carried as bitvectors (`core/kernel/src/cpu_mask.rs`).
- CI note: `validate (riscv64, debug, svctest)` failed once on the first run with a pre-existing, unrelated flaky scheduler panic (`run_queue::enqueue … already this queue's tail`); it passed on re-run. Not introduced by this comment/doc-only diff. Recommend filing a separate `bug,kernel` issue for that residual run-queue double-enqueue race.