### PR TITLE
devmgr: tear down orphaned child on mid-bootstrap spawn failure (#176, #238)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -970,6 +970,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-orphan"
+version = "0.1.0"
+dependencies = [
+ "ipc",
+ "syscall",
+]
+
+[[package]]
 name = "text"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "services/drivers/framebuffer",
     "services/drivers/goldfish-rtc",
     "services/drivers/serial",
+    "services/drivers/test-orphan",
     "services/drivers/virtio/core",
     "services/drivers/virtio/blk",
     "services/fs/fat",

--- a/rootfs/config/svcmgr/tests/svctest.svc
+++ b/rootfs/config/svcmgr/tests/svctest.svc
@@ -3,7 +3,9 @@
 # One-shot: exits cleanly on completion; svcmgr never restarts it.
 # Seeds resolve through svcmgr's discovery registry: rootfs.root is
 # the FS-driver-agnostic root-mount cap; pwrmgr.shutdown/pwrmgr.deny
-# are the SHUTDOWN_AUTHORITY-tokened SEND and its no-auth twin.
+# are the SHUTDOWN_AUTHORITY-tokened SEND and its no-auth twin;
+# devmgr.registry is the REGISTRY_QUERY_AUTHORITY SEND that drives the
+# devmgr orphan-teardown phase's TEST_SPAWN_ORPHAN shim (TODO(#165)).
 #
 # Recipe lives under /config/svcmgr/tests/, which svcmgr does NOT
 # scan. To enable in a boot, copy this file into
@@ -16,4 +18,4 @@ restart   = never
 critical  = no
 namespace = universal
 cwd       = /data
-seed      = rootfs.root pwrmgr.shutdown pwrmgr.deny
+seed      = rootfs.root pwrmgr.shutdown pwrmgr.deny devmgr.registry

--- a/services/devmgr/src/main.rs
+++ b/services/devmgr/src/main.rs
@@ -179,6 +179,12 @@ fn main() -> !
     let mut rtc_ep: u32 = 0;
     let mut rtc_spawn_attempted: bool = false;
 
+    // TODO(#165): remove with the devmgr enumeration redesign. Outcome of the
+    // last TEST_SPAWN_ORPHAN trigger, reported by TEST_ORPHAN_RESULT. 0=not
+    // run, 1=spawn failed as expected (#176 unwind fired), 2=unexpected
+    // success, 3=shim setup error.
+    let mut orphan_test_result: u64 = 0;
+
     if caps.registry_ep == 0
     {
         std::os::seraph::log!("no registry endpoint injected, halting");
@@ -531,6 +537,32 @@ fn main() -> !
                     // SAFETY: ipc_buf is the registered IPC buffer.
                     let _ = unsafe { ipc::ipc_reply(&reply, ipc_buf) };
                 }
+            }
+            // TODO(#165): remove with the devmgr enumeration redesign.
+            // Test-only fault injection for #176. The forced-failure spawn
+            // does nested `ipc_call`s that would clobber the implicit reply
+            // context, so ack first (mirroring SET_DRIVERS_DIR), then run the
+            // spawn and stash the outcome for TEST_ORPHAN_RESULT.
+            ipc::devmgr_labels::TEST_SPAWN_ORPHAN =>
+            {
+                let reply = IpcMessage::new(ipc::devmgr_errors::SUCCESS);
+                // SAFETY: ipc_buf is the registered IPC buffer.
+                let _ = unsafe { ipc::ipc_reply(&reply, ipc_buf) };
+                orphan_test_result = match test_spawn_orphan(&mut caps, drivers_dir_cap, ipc_buf)
+                {
+                    Some(false) => 1,
+                    Some(true) => 2,
+                    None => 3,
+                };
+            }
+            // TODO(#165): report the stashed test-orphan outcome (no nested IPC).
+            ipc::devmgr_labels::TEST_ORPHAN_RESULT =>
+            {
+                let reply = IpcMessage::builder(ipc::devmgr_errors::SUCCESS)
+                    .word(0, orphan_test_result)
+                    .build();
+                // SAFETY: ipc_buf is the registered IPC buffer.
+                let _ = unsafe { ipc::ipc_reply(&reply, ipc_buf) };
             }
             _ =>
             {
@@ -1609,6 +1641,82 @@ fn spawn_rtc_from_disk(
         let _ = syscall::cap_delete(rtc_ep);
         None
     }
+}
+
+/// TODO(#165): remove with the devmgr enumeration redesign.
+///
+/// Fault-injection shim for #176: spawn the on-disk `test-orphan` driver via
+/// the normal [`spawn::spawn_simple_device`] path with a non-zero query
+/// endpoint (forcing the two-round protocol), where the driver deliberately
+/// fails its round-2 request. The spawn helper's orphan-teardown then destroys
+/// the child, returning its pages to memmgr.
+///
+/// Returns `Some(false)` when the spawn failed as designed (the unwind ran),
+/// `Some(true)` if it unexpectedly succeeded, and `None` if the shim could not
+/// be set up (driver binary absent, or endpoint/cap minting failed).
+fn test_spawn_orphan(
+    caps: &mut caps::DevmgrCaps,
+    drivers_dir_cap: u32,
+    ipc_buf: *mut u64,
+) -> Option<bool>
+{
+    /// Arbitrary non-zero badge for the forced two-round query endpoint; the
+    /// round-2 failure means it is never delivered.
+    const QUERY_BADGE: u64 = 0x7E57;
+
+    let requested_rights = u64::from(namespace_protocol::rights::READ);
+    let walked =
+        ns_client::walk_to_file(drivers_dir_cap, b"test-orphan", requested_rights, ipc_buf)?;
+
+    // Throwaway service + hw endpoints handed to the child in round 1. Ownership
+    // of `hw_cap` transfers to `spawn_simple_device` (moved into the child or
+    // deleted on failure); `service_ep` is retained here and released below.
+    let service_ep = std::os::seraph::object_slab_acquire(88)
+        .and_then(|slab| syscall::cap_create_endpoint(slab).ok())
+        .unwrap_or(0);
+    let hw_cap = std::os::seraph::object_slab_acquire(88)
+        .and_then(|slab| syscall::cap_create_endpoint(slab).ok())
+        .unwrap_or(0);
+    // Non-zero query endpoint forces the two-round protocol so round 2 is reached.
+    let query_ep =
+        syscall::cap_derive_badge(caps.registry_ep, syscall::RIGHTS_SEND, QUERY_BADGE).unwrap_or(0);
+    if service_ep == 0 || hw_cap == 0 || query_ep == 0
+    {
+        std::os::seraph::log!("test-orphan: failed to mint shim caps");
+        let _ = syscall::cap_delete(walked.file_cap);
+        if service_ep != 0
+        {
+            let _ = syscall::cap_delete(service_ep);
+        }
+        if hw_cap != 0
+        {
+            let _ = syscall::cap_delete(hw_cap);
+        }
+        if query_ep != 0
+        {
+            let _ = syscall::cap_delete(query_ep);
+        }
+        return None;
+    }
+
+    let spawned = spawn::spawn_simple_device(
+        caps.procmgr_ep,
+        caps.self_bootstrap_ep,
+        spawn::CreateSource::File {
+            file_cap: walked.file_cap,
+            size: walked.size,
+        },
+        service_ep,
+        hw_cap,
+        query_ep,
+        ipc_buf,
+    );
+
+    // `spawn_simple_device` owns `hw_cap` and `query_ep` (moved into the child
+    // or released on failure). devmgr still holds the original `service_ep` —
+    // there is no live driver to keep it for, so release it.
+    let _ = syscall::cap_delete(service_ep);
+    Some(spawned)
 }
 
 /// Carve the COM1 `IoPort` (`0x3F8`..=`0x3FF`) out of the root

--- a/services/devmgr/src/spawn.rs
+++ b/services/devmgr/src/spawn.rs
@@ -83,6 +83,65 @@ impl Drop for ModuleCapGuard
     }
 }
 
+/// RAII guard for a child created via `CREATE_PROCESS` whose bootstrap has not
+/// yet reached its final `done` round. `Drop` always releases the caller-side
+/// `process_handle` and `thread_cap` slots delivered in the `CREATE_PROCESS`
+/// reply — devmgr retains no per-child handle past a spawn, so leaving them
+/// held leaks devmgr `CSpace` slots for its resident lifetime. While still armed,
+/// `Drop` additionally sends `DESTROY_PROCESS` over the badged `process_handle`
+/// first, so procmgr reaps the orphan (thread, cspace, aspace torn down; pages
+/// returned to memmgr) instead of leaving it hung in `request_round`.
+///
+/// Call [`disarm`](Self::disarm) once the final round's `done` reply has been
+/// served and the child owns its full cap set: the slots are still freed, but
+/// the now-live child is left running.
+struct ChildGuard
+{
+    process_handle: u32,
+    thread_cap: u32,
+    ipc_buf: *mut u64,
+    destroy: bool,
+}
+
+impl ChildGuard
+{
+    /// Arm a guard over a freshly-created child's reply caps.
+    fn new(process_handle: u32, thread_cap: u32, ipc_buf: *mut u64) -> Self
+    {
+        Self {
+            process_handle,
+            thread_cap,
+            ipc_buf,
+            destroy: true,
+        }
+    }
+
+    /// Bootstrap completed: keep the child alive. `Drop` still frees devmgr's
+    /// handles to it but no longer destroys it.
+    fn disarm(&mut self)
+    {
+        self.destroy = false;
+    }
+}
+
+impl Drop for ChildGuard
+{
+    fn drop(&mut self)
+    {
+        if self.destroy
+        {
+            let destroy_msg = IpcMessage::new(procmgr_labels::DESTROY_PROCESS);
+            // SAFETY: ipc_buf is the registered IPC buffer.
+            let _ = unsafe { ipc::ipc_call(self.process_handle, &destroy_msg, self.ipc_buf) };
+        }
+        let _ = syscall::cap_delete(self.process_handle);
+        if self.thread_cap != 0
+        {
+            let _ = syscall::cap_delete(self.thread_cap);
+        }
+    }
+}
+
 /// Monotonic counter for driver-child bootstrap badges.
 static NEXT_BOOTSTRAP_BADGE: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(1);
 
@@ -207,16 +266,25 @@ pub fn spawn_driver(config: &DriverSpawnConfig, ipc_buf: *mut u64)
         return;
     }
     let process_handle = reply_caps[0];
+    let thread_cap = reply_caps[1];
+    // Tear down the child (and free its reply-cap slots) on any failure before
+    // the final bootstrap round completes; disarmed on success.
+    let mut child_guard = ChildGuard::new(process_handle, thread_cap, ipc_buf);
 
-    // Derive all per-child caps for delivery via bootstrap.
+    // Derive all per-child caps for delivery via bootstrap. Each derivation
+    // owns a devmgr slot that must be released on later failure paths so devmgr
+    // does not leak it; the child itself is reaped by `child_guard`.
     let Ok(bar_copy) = syscall::cap_derive(bar_cap, syscall::RIGHTS_ALL)
     else
     {
+        std::os::seraph::log!("driver bar cap derivation failed");
         return;
     };
     let Ok(irq_copy) = syscall::cap_derive(irq_slot, syscall::RIGHTS_ALL)
     else
     {
+        std::os::seraph::log!("driver irq cap derivation failed");
+        let _ = syscall::cap_delete(bar_copy);
         return;
     };
     let service_copy = if service_ep != 0
@@ -231,7 +299,27 @@ pub fn spawn_driver(config: &DriverSpawnConfig, ipc_buf: *mut u64)
         syscall::cap_derive_badge(registry_ep, syscall::RIGHTS_SEND, device_badge)
     else
     {
+        std::os::seraph::log!("driver devmgr query cap derivation failed");
+        let _ = syscall::cap_delete(bar_copy);
+        let _ = syscall::cap_delete(irq_copy);
+        if service_copy != 0
+        {
+            let _ = syscall::cap_delete(service_copy);
+        }
         return;
+    };
+
+    // Best-effort release of every derived per-child cap. Deleting a slot a
+    // serve_round transfer already consumed is a no-op, so it is safe on any
+    // post-derive failure arm.
+    let drop_derived = || {
+        let _ = syscall::cap_delete(bar_copy);
+        let _ = syscall::cap_delete(irq_copy);
+        if service_copy != 0
+        {
+            let _ = syscall::cap_delete(service_copy);
+        }
+        let _ = syscall::cap_delete(devmgr_copy);
     };
 
     // START_PROCESS.
@@ -244,6 +332,7 @@ pub fn spawn_driver(config: &DriverSpawnConfig, ipc_buf: *mut u64)
     if !start_ok
     {
         std::os::seraph::log!("driver START_PROCESS failed");
+        drop_derived();
         return;
     }
 
@@ -262,6 +351,7 @@ pub fn spawn_driver(config: &DriverSpawnConfig, ipc_buf: *mut u64)
     .is_err()
     {
         std::os::seraph::log!("driver bootstrap round 1 failed");
+        drop_derived();
         return;
     }
 
@@ -280,9 +370,12 @@ pub fn spawn_driver(config: &DriverSpawnConfig, ipc_buf: *mut u64)
     .is_err()
     {
         std::os::seraph::log!("driver bootstrap round 2 failed");
+        drop_derived();
         return;
     }
 
+    // Child owns its full cap set: keep it alive, but release devmgr's handles.
+    child_guard.disarm();
     std::os::seraph::log!("driver started");
 }
 
@@ -414,6 +507,9 @@ pub fn spawn_simple_device(
     let reply_caps = reply.caps();
     if reply_caps.is_empty()
     {
+        // CREATE reported success but delivered no handle, so there is no badge
+        // to tear the child down with. Defensive — procmgr returns two caps on
+        // success.
         std::os::seraph::log!("simple-device CREATE_PROCESS reply missing caps");
         let _ = syscall::cap_delete(hw_cap);
         if devmgr_query_ep != 0
@@ -423,6 +519,12 @@ pub fn spawn_simple_device(
         return false;
     }
     let process_handle = reply_caps[0];
+    let thread_cap = reply_caps.get(1).copied().unwrap_or(0);
+    // Tear down the child (and free its reply-cap slots) on any failure before
+    // the final bootstrap round completes; disarmed on success. The source cap
+    // is already owned by procmgr (the CREATE ipc_call transferred it), so the
+    // guard never touches it.
+    let mut child_guard = ChildGuard::new(process_handle, thread_cap, ipc_buf);
 
     // RECV-rights copy of the service endpoint for the child; devmgr keeps
     // the original to mint client SEND caps on query.
@@ -506,6 +608,8 @@ pub fn spawn_simple_device(
         }
     }
 
+    // Child owns its full cap set: keep it alive, but release devmgr's handles.
+    child_guard.disarm();
     std::os::seraph::log!("simple-device driver started");
     true
 }

--- a/services/drivers/test-orphan/Cargo.toml
+++ b/services/drivers/test-orphan/Cargo.toml
@@ -1,0 +1,20 @@
+# TODO(#165): remove with the devmgr enumeration redesign. Test-only
+# fault-injection driver that forces a mid-bootstrap spawn failure so
+# devmgr's #176 orphan-teardown path can be exercised by svctest.
+[package]
+name = "test-orphan"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[[bin]]
+name = "test-orphan"
+path = "src/main.rs"
+test = false
+
+[dependencies]
+ipc = { path = "../../../shared/ipc" }
+syscall = { path = "../../../shared/syscall" }
+
+[lints]
+workspace = true

--- a/services/drivers/test-orphan/src/main.rs
+++ b/services/drivers/test-orphan/src/main.rs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// drivers/test-orphan/src/main.rs
+
+//! Test-only fault-injection driver for devmgr's spawn-orphan unwind (#176).
+//!
+//! Spawned on demand by devmgr's `TEST_SPAWN_ORPHAN` shim. It completes
+//! bootstrap round 1 normally, reserves a known block of memory, then
+//! deliberately violates the round-2 protocol so devmgr's `serve_round`
+//! rejects it and the spawn-orphan unwind runs. It then blocks forever —
+//! it never `thread_exit`s — so procmgr's exit-reap cannot mask a missing
+//! `DESTROY_PROCESS`: the reserved pages return to memmgr's free pool only
+//! if devmgr's #176 teardown destroys this process.
+//!
+//! TODO(#165): remove with the devmgr enumeration redesign.
+
+use ipc::IpcMessage;
+use std::os::seraph::startup_info;
+
+/// Bytes reserved and touched before the forced failure so the reclamation
+/// delta clears boot-time allocator noise (1 MiB = 256 pages).
+const RESERVE_BYTES: usize = 1 << 20;
+
+/// A round-2 message whose low 16 label bits are not `bootstrap::REQUEST`
+/// (`1`), so devmgr's `serve_round` rejects it with `INVALID` and unwinds.
+const BAD_ROUND_LABEL: u64 = 0x7E57_0000;
+
+fn main() -> !
+{
+    std::os::seraph::log::register_name(b"test-orphan");
+    let info = startup_info();
+    // cast_ptr_alignment: IPC buffer page is 4 KiB-aligned.
+    #[allow(clippy::cast_ptr_alignment)]
+    let ipc_buf = info.ipc_buffer.cast::<u64>();
+
+    let creator = info.creator_endpoint;
+    if creator == 0
+    {
+        std::os::seraph::log!("test-orphan: no creator endpoint");
+        syscall::thread_exit();
+    }
+
+    // Round 1: accept the [service, hw] caps normally. `service_ep` is the
+    // endpoint we block on after forcing the failure.
+    // SAFETY: ipc_buf is the registered IPC buffer page.
+    let service_ep = match unsafe { ipc::bootstrap::request_round(creator, ipc_buf) }
+    {
+        Ok(round) if round.cap_count >= 1 => round.caps[0],
+        _ =>
+        {
+            std::os::seraph::log!("test-orphan: round 1 did not deliver a service endpoint");
+            syscall::thread_exit();
+        }
+    };
+
+    // Reserve and touch a known block so the process's footprint is large
+    // enough to observe in memmgr's free total. `vec!` writes every byte,
+    // faulting the pages in; `reserved` stays live across the block below.
+    let reserved = std::vec![0xAB_u8; RESERVE_BYTES];
+    // Defeat dead-store elimination with a volatile read of the first byte.
+    // SAFETY: `reserved` owns RESERVE_BYTES bytes; offset 0 is in bounds.
+    let probe = unsafe { core::ptr::read_volatile(reserved.as_ptr()) };
+    std::os::seraph::log!(
+        "test-orphan: reserved {} bytes (probe={:#x})",
+        RESERVE_BYTES,
+        u64::from(probe)
+    );
+
+    // Round 2: violate the protocol. devmgr's `serve_round` sees a
+    // non-`REQUEST` label, replies `INVALID`, and returns `Err`, so the
+    // spawn-orphan unwind runs. We ignore the reply.
+    let bad = IpcMessage::new(BAD_ROUND_LABEL);
+    // SAFETY: ipc_buf is the registered IPC buffer page.
+    let _ = unsafe { ipc::ipc_call(creator, &bad, ipc_buf) };
+    std::os::seraph::log!("test-orphan: forced round-2 failure; blocking until destroyed");
+
+    // Block forever without exiting. Nothing sends on `service_ep`, so this
+    // never returns; the process is reaped only when devmgr's #176 teardown
+    // sends `DESTROY_PROCESS`. `reserved` is held live for the whole wait.
+    loop
+    {
+        // SAFETY: ipc_buf is the registered IPC buffer page.
+        let _ = unsafe { ipc::ipc_recv(service_ep, ipc_buf) };
+    }
+}

--- a/services/memmgr/docs/ipc-interface.md
+++ b/services/memmgr/docs/ipc-interface.md
@@ -243,6 +243,34 @@ IPC. Idempotent on stale badges (already-reaped or never-registered).
 `PROCESS_DIED` for an unknown badge is not an error — memmgr returns
 success. Reclamation is idempotent.
 
+### Label 6: `QUERY_POOL_STATUS`
+
+Read-only query of the all-RAM-accounted identity plus the current free
+total. Privilege: universal — returns aggregate counts only, no caps and no
+state change.
+
+**Request:** label 6, no words, no caps.
+
+**Reply (success):**
+
+| Field | Value |
+|---|---|
+| label | 0 (success) |
+| data[0] | `system_ram_bytes` — total installed RAM the kernel computed at boot |
+| data[1] | `kernel_reserved_bytes` — the fixed kernel reserve |
+| data[2] | `pool_total_bytes` — every page memmgr owns (free runs, in-use arenas, reap donations); monotonic |
+| data[3] | `free_bytes` — subset of `pool_total_bytes` parked in free runs, lent to no process |
+
+The all-RAM-accounted identity is `data[0] == data[1] + data[2]`: every page
+is either fixed kernel reserve or in memmgr's pool. `pool_total` counts owned
+RAM and is invariant across a process's lifetime, so it cannot witness
+reclamation. `free_bytes` (`data[3]`) is the page count currently in free
+runs: it falls as `REQUEST_MEMORY_CAPS` lends pages and rises as
+`PROCESS_DIED`, `RELEASE_MEMORY_CAPS`, and `UNREGISTER_REGION` return them.
+A caller asserting that a dead process's pages were reclaimed polls `data[3]`
+back to its pre-spawn baseline. `data[3]` is appended after the identity
+terms; readers needing only the identity may ignore it.
+
 ### Label 7: `REGISTER_REGION`
 
 A demand-paged process registers an anonymous region it has reserved (but

--- a/services/memmgr/src/main.rs
+++ b/services/memmgr/src/main.rs
@@ -647,6 +647,21 @@ impl FreePool
         }
     }
 
+    /// Pages currently parked in free runs — owned by memmgr but lent to no
+    /// process. Unlike `pool_total` (monotonic owned-RAM), this falls as pages
+    /// are allocated and rises as they are reclaimed (`PROCESS_DIED`,
+    /// `RELEASE_MEMORY_CAPS`, `UNREGISTER_REGION`), so it is the observable a
+    /// caller polls to confirm a dead process's pages came back.
+    fn free_pages(&self) -> u64
+    {
+        let mut total: u64 = 0;
+        for run in self.runs.iter().flatten()
+        {
+            total = total.saturating_add(u64::from(run.page_count));
+        }
+        total
+    }
+
     fn push(&mut self, run: FreeRun) -> Result<(), ()>
     {
         for slot in &mut self.runs
@@ -1523,17 +1538,22 @@ fn handle_donate_memory_caps(req: &IpcMessage, ipc_buf: *mut u64)
     let _ = unsafe { ipc::ipc_reply(&reply, ipc_buf) };
 }
 
-/// Reply with the all-RAM-accounted identity terms (all in bytes):
-/// `system_ram`, `kernel_reserved`, `pool_total`. Read-only; the caller asserts
-/// `system_ram == kernel_reserved + pool_total`. `pool_total` is the page
-/// counter scaled to bytes; the facts arrive verbatim from the kernel.
+/// Reply with the all-RAM-accounted identity terms plus the current free total
+/// (all in bytes): `system_ram`, `kernel_reserved`, `pool_total`, `free`.
+/// Read-only; the caller asserts `system_ram == kernel_reserved + pool_total`.
+/// `pool_total` is the monotonic owned-RAM counter scaled to bytes; `free` is
+/// the subset currently parked in free runs (lent to no process), which falls
+/// on allocation and rises on reclamation. The identity facts arrive verbatim
+/// from the kernel.
 fn handle_query_pool_status(ipc_buf: *mut u64, boot: &InitBootstrap)
 {
     let pool_total_bytes = pool_total_pages().saturating_mul(PAGE_SIZE);
+    let free_bytes = pool_mut().free_pages().saturating_mul(PAGE_SIZE);
     let reply = IpcMessage::builder(memmgr_errors::SUCCESS)
         .word(0, boot.system_ram_bytes)
         .word(1, boot.kernel_reserved_bytes)
         .word(2, pool_total_bytes)
+        .word(3, free_bytes)
         .build();
     // SAFETY: ipc_buf is the registered IPC buffer page.
     let _ = unsafe { ipc::ipc_reply(&reply, ipc_buf) };

--- a/services/svctest/src/bootstrap.rs
+++ b/services/svctest/src/bootstrap.rs
@@ -14,6 +14,10 @@
 //!     service endpoint (zero when pwrmgr is absent)
 //!   * `caps[2]`: SEND on pwrmgr's service endpoint without the
 //!     `SHUTDOWN_AUTHORITY` badge bit (zero when pwrmgr is absent)
+//!   * `caps[3]`: `REGISTRY_QUERY_AUTHORITY`-badged SEND on devmgr's
+//!     registry endpoint (zero when devmgr is absent). Drives the
+//!     `TEST_SPAWN_ORPHAN` fault-injection shim in the devmgr
+//!     orphan-teardown phase. TODO(#165): retire with that shim.
 //!
 //! The launcher requests the round from `info.creator_endpoint`; if no
 //! creator endpoint is present (`== 0`), every slot stays zero and
@@ -31,6 +35,9 @@ pub struct Caps
     pub root_fs: u32,
     pub pwrmgr_auth: u32,
     pub pwrmgr_noauth: u32,
+    /// `REGISTRY_QUERY_AUTHORITY`-badged SEND on devmgr's registry
+    /// endpoint. TODO(#165): retire with the `TEST_SPAWN_ORPHAN` shim.
+    pub devmgr_registry: u32,
 }
 
 /// Drain the bootstrap round from `creator_endpoint` and pull caps out.
@@ -66,6 +73,10 @@ pub fn request() -> Caps
     if round.cap_count >= 3
     {
         caps.pwrmgr_noauth = round.caps[2];
+    }
+    if round.cap_count >= 4
+    {
+        caps.devmgr_registry = round.caps[3];
     }
 
     caps

--- a/services/svctest/src/phases/devmgr.rs
+++ b/services/svctest/src/phases/devmgr.rs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+//! devmgr surface — driver-spawn orphan teardown (#176).
+//!
+//! Drives devmgr's temporary `TEST_SPAWN_ORPHAN` shim to force a round-2
+//! bootstrap failure in a fault-injection driver that hangs (never exits),
+//! then asserts both that devmgr reports the spawn failed and that the
+//! child's reserved pages return to memmgr's free pool. Free-pool recovery is
+//! the observable that distinguishes #176's `DESTROY_PROCESS` teardown from a
+//! leak: a hung child is never reaped by procmgr's exit path, so without
+//! teardown its pages stay pinned and `free` never recovers.
+//!
+//! TODO(#165): retire with the devmgr enumeration redesign and its shim.
+
+use std::os::seraph::startup_info;
+
+use crate::bootstrap::Caps;
+use crate::runner::Phase;
+
+pub fn phases() -> &'static [Phase]
+{
+    &[Phase {
+        name: "devmgr_orphan_teardown",
+        run: orphan_teardown_phase,
+    }]
+}
+
+/// Read memmgr's current free-pool total (`QUERY_POOL_STATUS` `data[3]`).
+fn free_bytes(memmgr_ep: u32, ipc_buf: *mut u64) -> u64
+{
+    let req = ipc::IpcMessage::builder(ipc::memmgr_labels::QUERY_POOL_STATUS).build();
+    // SAFETY: ipc_buf is the kernel-registered IPC buffer page.
+    let reply = unsafe { ipc::ipc_call(memmgr_ep, &req, ipc_buf) }
+        .expect("memmgr QUERY_POOL_STATUS ipc_call failed");
+    assert_eq!(
+        reply.label,
+        ipc::memmgr_errors::SUCCESS,
+        "QUERY_POOL_STATUS status"
+    );
+    reply.word(3)
+}
+
+fn orphan_teardown_phase(caps: &Caps)
+{
+    // The child reserves ~1 MiB before hanging; the margin absorbs unrelated
+    // allocator noise in the sampling window.
+    const MARGIN_BYTES: u64 = 128 * 1024;
+    const MAX_POLL: u32 = 4096;
+
+    let devmgr = caps.devmgr_registry;
+    assert!(devmgr != 0, "devmgr_orphan: no devmgr registry cap seeded");
+
+    let info = startup_info();
+    // cast_ptr_alignment: IPC buffer is page-aligned (4 KiB).
+    #[allow(clippy::cast_ptr_alignment)]
+    let ipc_buf = info.ipc_buffer.cast::<u64>();
+    let memmgr = info.memmgr_endpoint;
+
+    let free_before = free_bytes(memmgr, ipc_buf);
+
+    // Trigger the forced-failure spawn. devmgr acks immediately, then runs the
+    // spawn (which fails, unwinds, and DESTROYs the child) before it services
+    // the result query below.
+    let trigger = ipc::IpcMessage::new(ipc::devmgr_labels::TEST_SPAWN_ORPHAN);
+    // SAFETY: ipc_buf is the kernel-registered IPC buffer page.
+    let ack = unsafe { ipc::ipc_call(devmgr, &trigger, ipc_buf) }
+        .expect("TEST_SPAWN_ORPHAN ipc_call failed");
+    assert_eq!(
+        ack.label,
+        ipc::devmgr_errors::SUCCESS,
+        "TEST_SPAWN_ORPHAN ack"
+    );
+
+    // Serviced only after devmgr returns to its loop — i.e. after the spawn and
+    // its synchronous teardown completed.
+    let query = ipc::IpcMessage::new(ipc::devmgr_labels::TEST_ORPHAN_RESULT);
+    // SAFETY: ipc_buf is the kernel-registered IPC buffer page.
+    let res = unsafe { ipc::ipc_call(devmgr, &query, ipc_buf) }
+        .expect("TEST_ORPHAN_RESULT ipc_call failed");
+    assert_eq!(
+        res.label,
+        ipc::devmgr_errors::SUCCESS,
+        "TEST_ORPHAN_RESULT status"
+    );
+    let outcome = res.word(0);
+    assert_eq!(
+        outcome, 1,
+        "devmgr_orphan: expected spawn-failed/unwind (1), got outcome={outcome} \
+         (2=unexpected success, 3=shim setup error)"
+    );
+
+    // With #176's teardown the child's reserved pages are reclaimed
+    // synchronously, so `free` returns to baseline; without it the hung child
+    // stays pinned and `free` stays ~1 MiB low. Poll to bound any incidental lag.
+    let mut free_after = free_bytes(memmgr, ipc_buf);
+    for _ in 0..MAX_POLL
+    {
+        if free_after + MARGIN_BYTES >= free_before
+        {
+            break;
+        }
+        let _ = syscall::thread_yield();
+        free_after = free_bytes(memmgr, ipc_buf);
+    }
+    assert!(
+        free_after + MARGIN_BYTES >= free_before,
+        "devmgr_orphan: orphan pages not reclaimed: free_before={free_before} free_after={free_after}"
+    );
+
+    std::os::seraph::log!(
+        "devmgr_orphan_teardown passed: spawn unwound, free reclaimed (before={free_before} after={free_after})"
+    );
+}

--- a/services/svctest/src/phases/mod.rs
+++ b/services/svctest/src/phases/mod.rs
@@ -32,6 +32,7 @@
 
 use crate::runner::Phase;
 
+pub mod devmgr;
 pub mod fs_ipc;
 pub mod fs_std;
 pub mod memmgr;
@@ -56,6 +57,7 @@ pub fn all() -> Vec<Phase>
     out.extend_from_slice(threading::phases());
     out.extend_from_slice(procmgr::spawn_only());
     out.extend_from_slice(process_faults::phases());
+    out.extend_from_slice(devmgr::phases());
     out.extend_from_slice(pager::phases());
     out.extend_from_slice(shmem::phases());
     out.extend_from_slice(pipes::phases());

--- a/shared/ipc/src/lib.rs
+++ b/shared/ipc/src/lib.rs
@@ -375,11 +375,17 @@ pub mod memmgr_labels
     ///   (`system_ram_bytes` minus every `owns_memory` page minted to init).
     /// * `data[2]` — `pool_total_bytes`: every page memmgr owns, across free
     ///   runs, in-use bootstrap arenas, and reap donations.
+    /// * `data[3]` — `free_bytes`: the subset of `pool_total_bytes` currently
+    ///   parked in free runs (owned by memmgr, lent to no process). Unlike
+    ///   `pool_total` it falls on allocation and rises on reclamation
+    ///   (`PROCESS_DIED`, `RELEASE_MEMORY_CAPS`, `UNREGISTER_REGION`), so a
+    ///   caller polls it to confirm a dead process's pages were reclaimed.
     ///
     /// The all-RAM-accounted identity is `data[0] == data[1] + data[2]`: every
     /// page of RAM is either fixed kernel reserve or in memmgr's pool, with no
     /// invisible residue. A nonzero `data[0] - data[1] - data[2]` is leaked
-    /// "dark" memory.
+    /// "dark" memory. `data[3]` is an appended field — readers needing only the
+    /// identity may ignore it.
     pub const QUERY_POOL_STATUS: u64 = 6;
     /// Register a demand-paged anonymous region for the calling process.
     ///
@@ -1248,6 +1254,19 @@ pub mod devmgr_labels
     /// Replies [`super::devmgr_errors::NO_DEVICE`] when the carve fails or
     /// the platform authority cap is absent.
     pub const QUERY_SHUTDOWN_DEVICE: u64 = 8;
+
+    /// TODO(#165): remove with the devmgr enumeration redesign. Test-only
+    /// label: trigger devmgr's spawn-orphan fault-injection shim (#176). The
+    /// handler replies `SUCCESS` immediately (the forced-failure spawn does
+    /// nested `ipc_call`s that would clobber the reply context), then forces a
+    /// round-2 bootstrap failure and stashes the outcome for
+    /// [`TEST_ORPHAN_RESULT`].
+    pub const TEST_SPAWN_ORPHAN: u64 = 9;
+    /// TODO(#165): remove with the devmgr enumeration redesign. Test-only
+    /// label: report the last [`TEST_SPAWN_ORPHAN`] outcome in reply `data[0]`
+    /// — `0` not run, `1` spawn failed as expected (unwind fired), `2`
+    /// unexpected success, `3` shim setup error.
+    pub const TEST_ORPHAN_RESULT: u64 = 10;
 
     /// Authority bit in the devmgr-registry-endpoint badge's high
     /// u64 bit. Set on caps minted for consumers permitted to call

--- a/xtask/src/commands/build.rs
+++ b/xtask/src/commands/build.rs
@@ -205,6 +205,17 @@ const SPECS: &[Spec] = &[
         dest: InstallDest::ServicesDrivers,
         arch_only: Some(Arch::Riscv64),
     },
+    // TODO(#165): remove with the devmgr enumeration redesign. Test-only
+    // fault-injection driver exercising devmgr's #176 orphan teardown; it
+    // ships on the rootfs and is spawned only by devmgr's TEST_SPAWN_ORPHAN
+    // shim under svctest.
+    Spec {
+        name: "test-orphan",
+        install_name: None,
+        profile: BuildProfile::StdUser,
+        dest: InstallDest::ServicesDrivers,
+        arch_only: None,
+    },
     Spec {
         name: "fatfs",
         install_name: None,


### PR DESCRIPTION
## Summary

Resolves the `spawn_simple_device` / `spawn_driver` orphan window (finding
**S4** of the PR #172 review, #67) and the inseparable reply-cap leak (#238).

On any failure after `CREATE_PROCESS` but before the final bootstrap round,
both helpers returned with no `DESTROY_PROCESS` follow-up — the child was left
hung in `request_round` with its thread/aspace/cspace and touched pages
unreclaimed. The same paths also never freed the reply caps (`process_handle`
+ `thread_cap`), leaking devmgr CSpace slots on every spawn, **success
included** — exactly #238.

A `ChildGuard` RAII (mirroring `ModuleCapGuard`) is armed after `CREATE`:
on any early return it sends `DESTROY_PROCESS` over the badged `process_handle`
and frees both reply slots; disarmed on success, it still frees the slots but
keeps the now-live child. `spawn_driver`'s derived-cap leak gaps are closed
alongside.

## Why the reclamation assertion is required (not nice-to-have)

The fix changes exactly one observable: on a post-`CREATE` failure devmgr now
destroys the child + frees its slots. The spawn-failed return is **identical**
with and without the fix, so a reply-only test cannot regression-guard #176.
The effect is observable only as child-destroyed → pages-reclaimed, and the
child must **hang** (procmgr auto-reaps any child that `thread_exit`s, masking
the bug). `pool_total` is monotonic and the all-RAM identity holds whether
pages leaked or not, so a new free-pool observable is needed.

## Changes

- **`spawn.rs`** — `ChildGuard`; integrated into both helpers; `spawn_driver`
  derived-cap gaps closed.
- **memmgr** — `QUERY_POOL_STATUS` reply gains `data[3] = free_bytes`
  (appended; identity readers ignore it). Doc + `ipc-interface.md` updated.
- **test-orphan** — new fault-injection driver: round 1 OK → reserve 1 MiB →
  forced round-2 violation → block forever.
- **devmgr** — temporary `TEST_SPAWN_ORPHAN` / `TEST_ORPHAN_RESULT` shim
  (reply-before-spawn, since the nested `ipc_call`s clobber the reply context).
- **svctest** — `devmgr_orphan_teardown` phase: sample `free_bytes`, trigger,
  assert spawn-failed outcome, poll `free_bytes` back to baseline.

The shim, driver, label constants, and seed wiring are tagged **`TODO(#165)`**
for removal with the devmgr enumeration redesign (the real on-demand spawn
path). Coordinates with #258.

## Test plan

- `cargo xtask build` + svctest green on **x86_64** and **riscv64**.
- New phase runs on both arches (logs: child reserves 1 MiB → `devmgr:
  simple-device bootstrap round 2 failed` → `free reclaimed (before==after)`).
- **Negative control**: with the `ChildGuard` teardown neutered, the phase
  panics — `orphan pages not reclaimed: free_before=463663104
  free_after=461225984` — proving the test fails without the fix.
- Happy-path driver spawns (virtio-blk / serial / framebuffer / rtc) intact on
  both arches.
- Host-side `cargo xtask test` green (68 passed).

Closes #176
Closes #238