### PR TITLE
procmgr: unify ELF page loader; fix memory-cap leak on load error paths

### DIFF
--- a/services/procmgr/src/loader.rs
+++ b/services/procmgr/src/loader.rs
@@ -9,6 +9,7 @@
 //! appropriate protection rights, and loading ELF segment pages from memory
 //! into freshly allocated memory caps.
 
+use ipc::procmgr_errors;
 use std::os::seraph::{ReservedRange, reserve_pages, unreserve_pages};
 use syscall_abi::PAGE_SIZE;
 
@@ -132,11 +133,94 @@ pub fn derive_memory_for_prot(memory_cap: u32, prot: u64) -> Option<u32>
     }
 }
 
-/// Copy one ELF segment page into a fresh memory cap and map it into the child.
+/// Allocate one fresh memory cap, fill its zeroed scratch page via `fill`, then
+/// derive a `prot`-restricted cap and map it into the child at `page_vaddr`.
 ///
 /// Memory caps are allocated against `child_memmgr_send` so memmgr accounts them
-/// to the child from the moment they leave the pool — `PROCESS_DIED`
-/// reclaims the entire set when the child exits.
+/// to the child from the moment they leave the pool — `PROCESS_DIED` reclaims
+/// the entire set when the child exits.
+///
+/// Every error exit deletes the caps it allocated (the `memory_cap`, plus the
+/// `derived` cap once derivation succeeds). The success path drops the same
+/// transient slots: the mapping owns no cap-refcount on the underlying
+/// `MemoryObject` — memmgr's outer pins the page until `PROCESS_DIED` — so the
+/// slots must be released either way or they accumulate across an unbounded
+/// create/destroy loop.
+///
+/// `fill` receives the writable scratch VA of the zeroed page and writes the
+/// segment bytes in (in-memory slice copy or VFS stream); it is infallible — a
+/// short read leaves the page tail zeroed.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn load_elf_page_into_child(
+    page_vaddr: u64,
+    prot: u64,
+    self_aspace: u32,
+    child_aspace: u32,
+    child_memmgr_send: u32,
+    ipc_buf: *mut u64,
+    fill: impl FnOnce(u64),
+) -> Result<(), u64>
+{
+    let Some(memory_cap) = crate::memmgr_alloc_page(child_memmgr_send, ipc_buf)
+    else
+    {
+        std::os::seraph::log!(
+            "procmgr: load_elf_page: alloc None vaddr=0x{:x}",
+            page_vaddr
+        );
+        return Err(procmgr_errors::OUT_OF_MEMORY);
+    };
+
+    let Some(scratch) = ScratchMapping::map(self_aspace, memory_cap, 1, syscall::MAP_WRITABLE)
+    else
+    {
+        std::os::seraph::log!(
+            "procmgr: load_elf_page: scratch map None vaddr=0x{:x}",
+            page_vaddr
+        );
+        let _ = syscall::cap_delete(memory_cap);
+        return Err(procmgr_errors::MAP_FAILED);
+    };
+    let scratch_va = scratch.va();
+    // SAFETY: scratch_va is mapped writable, one page.
+    unsafe { core::ptr::write_bytes(scratch_va as *mut u8, 0, PAGE_SIZE as usize) };
+
+    fill(scratch_va);
+
+    drop(scratch);
+
+    let Some(derived) = derive_memory_for_prot(memory_cap, prot)
+    else
+    {
+        std::os::seraph::log!(
+            "procmgr: load_elf_page: derive None vaddr=0x{:x} prot=0x{:x}",
+            page_vaddr,
+            prot
+        );
+        let _ = syscall::cap_delete(memory_cap);
+        return Err(procmgr_errors::INSUFFICIENT_RIGHTS);
+    };
+    if let Err(e) = syscall::mem_map(derived, child_aspace, page_vaddr, 0, 1, 0)
+    {
+        std::os::seraph::log!(
+            "procmgr: load_elf_page: mem_map err={} vaddr=0x{:x}",
+            e,
+            page_vaddr
+        );
+        let _ = syscall::cap_delete(derived);
+        let _ = syscall::cap_delete(memory_cap);
+        return Err(procmgr_errors::MAP_FAILED);
+    }
+
+    let _ = syscall::cap_delete(derived);
+    let _ = syscall::cap_delete(memory_cap);
+
+    Ok(())
+}
+
+/// Copy one in-memory ELF segment page into a fresh memory cap and map it into
+/// the child. Thin wrapper over [`load_elf_page_into_child`] supplying the
+/// in-memory slice-copy fill.
 #[allow(clippy::too_many_arguments)]
 pub fn load_elf_page(
     page_vaddr: u64,
@@ -149,27 +233,16 @@ pub fn load_elf_page(
     ipc_buf: *mut u64,
 ) -> Option<()>
 {
-    let memory_cap = crate::memmgr_alloc_page(child_memmgr_send, ipc_buf)?;
-
-    let scratch = ScratchMapping::map(self_aspace, memory_cap, 1, syscall::MAP_WRITABLE)?;
-    let scratch_va = scratch.va();
-    // SAFETY: scratch_va is mapped writable, one page.
-    unsafe { core::ptr::write_bytes(scratch_va as *mut u8, 0, PAGE_SIZE as usize) };
-
-    copy_segment_data(scratch_va, page_vaddr, seg_vaddr, file_data);
-
-    drop(scratch);
-
-    let derived = derive_memory_for_prot(memory_cap, prot)?;
-    syscall::mem_map(derived, child_aspace, page_vaddr, 0, 1, 0).ok()?;
-
-    // The mapping owns no cap-refcount on the underlying MemoryObject; memmgr's
-    // outer keeps it alive until PROCESS_DIED. Drop procmgr's transient slots
-    // so they don't accumulate across an unbounded create/destroy loop.
-    let _ = syscall::cap_delete(derived);
-    let _ = syscall::cap_delete(memory_cap);
-
-    Some(())
+    load_elf_page_into_child(
+        page_vaddr,
+        prot,
+        self_aspace,
+        child_aspace,
+        child_memmgr_send,
+        ipc_buf,
+        |scratch_va| copy_segment_data(scratch_va, page_vaddr, seg_vaddr, file_data),
+    )
+    .ok()
 }
 
 /// Copy file data for one segment page into the memory cap mapped at `scratch_va`.

--- a/services/procmgr/src/process.rs
+++ b/services/procmgr/src/process.rs
@@ -1828,8 +1828,9 @@ pub struct ElfLoadCtx
 
 /// Load one ELF segment page by streaming file data from VFS.
 ///
-/// On failure returns a `procmgr_errors::*` code distinguishing
-/// allocation, mapping, and rights-derivation failures.
+/// Thin wrapper over [`loader::load_elf_page_into_child`] supplying the VFS
+/// stream fill. On failure returns the core's `procmgr_errors::*` code
+/// distinguishing allocation, mapping, and rights-derivation failures.
 fn load_elf_page_streaming(
     page_vaddr: u64,
     seg: &elf::LoadSegment,
@@ -1837,62 +1838,15 @@ fn load_elf_page_streaming(
     ctx: &ElfLoadCtx,
 ) -> Result<(), u64>
 {
-    let Some(memory_cap) = crate::memmgr_alloc_page(ctx.child_memmgr_send, ctx.ipc_buf)
-    else
-    {
-        std::os::seraph::log!(
-            "procmgr: load_elf_page_streaming: alloc_page None vaddr=0x{:x}",
-            page_vaddr
-        );
-        return Err(procmgr_errors::OUT_OF_MEMORY);
-    };
-
-    let Some(scratch) = ScratchMapping::map(ctx.self_aspace, memory_cap, 1, syscall::MAP_WRITABLE)
-    else
-    {
-        std::os::seraph::log!(
-            "procmgr: load_elf_page_streaming: ScratchMapping::map None vaddr=0x{:x}",
-            page_vaddr
-        );
-        let _ = syscall::cap_delete(memory_cap);
-        return Err(procmgr_errors::MAP_FAILED);
-    };
-    let scratch_va = scratch.va();
-    // SAFETY: scratch_va mapped writable, one page.
-    unsafe { core::ptr::write_bytes(scratch_va as *mut u8, 0, PAGE_SIZE as usize) };
-
-    stream_segment_to_memory(scratch_va, page_vaddr, seg, ctx);
-
-    drop(scratch);
-
-    let Some(derived) = loader::derive_memory_for_prot(memory_cap, prot)
-    else
-    {
-        std::os::seraph::log!(
-            "procmgr: load_elf_page_streaming: derive_memory_for_prot None vaddr=0x{:x} prot=0x{:x}",
-            page_vaddr,
-            prot
-        );
-        let _ = syscall::cap_delete(memory_cap);
-        return Err(procmgr_errors::INSUFFICIENT_RIGHTS);
-    };
-    if let Err(e) = syscall::mem_map(derived, ctx.child_aspace, page_vaddr, 0, 1, 0)
-    {
-        std::os::seraph::log!(
-            "procmgr: load_elf_page_streaming: mem_map err={} vaddr=0x{:x}",
-            e,
-            page_vaddr
-        );
-        let _ = syscall::cap_delete(derived);
-        let _ = syscall::cap_delete(memory_cap);
-        return Err(procmgr_errors::MAP_FAILED);
-    }
-
-    // See `loader::load_elf_page` for the cap-refcount story.
-    let _ = syscall::cap_delete(derived);
-    let _ = syscall::cap_delete(memory_cap);
-
-    Ok(())
+    loader::load_elf_page_into_child(
+        page_vaddr,
+        prot,
+        ctx.self_aspace,
+        ctx.child_aspace,
+        ctx.child_memmgr_send,
+        ctx.ipc_buf,
+        |scratch_va| stream_segment_to_memory(scratch_va, page_vaddr, seg, ctx),
+    )
 }
 
 /// Stream segment file data from VFS into the memory cap mapped at `scratch_va`.


### PR DESCRIPTION
## Summary

Fixes #239: `load_elf_page` leaked the `memory_cap` (and, past derivation, the `derived` cap) on its three `?` error exits (scratch-map, derive, child-map). Only the success path released them. The leak is latent (OOM-only), but a partially-failed create would leak one inner Memory cap per failed page; each leaked cap is a live derivation of memmgr's outer and pins that pool run unsplittable once the child later dies and memmgr reclaims.

The streaming twin `load_elf_page_streaming` already did the identical alloc/scratch/derive/map sequence with correct per-exit cleanup. Per the agreed approach, both are collapsed onto **one** cleanup-correct core, `loader::load_elf_page_into_child`, parameterized by an infallible page-fill closure (in-memory slice copy vs VFS stream). The buggy in-memory path is fixed by construction; the duplication that let it drift is removed.

## Changes
- `services/procmgr/src/loader.rs` — add `load_elf_page_into_child` (the cleanup-correct core); `load_elf_page` becomes a thin wrapper supplying the in-memory copy fill.
- `services/procmgr/src/process.rs` — `load_elf_page_streaming` collapses to a thin wrapper supplying the VFS stream fill. Returned `procmgr_errors::*` codes are unchanged, so the caller's `?` propagation is preserved.

Net: `+101 / −74`, alloc/derive/map/cleanup logic now lives in exactly one place. The in-memory path additionally gains generic per-failure log lines (it logged nothing before).

## Acceptance (issue #239)
- [x] Every error exit of the shared core deletes the `memory_cap` (and `derived`, if reached); both `load_elf_page` and `load_elf_page_streaming` route through it.
- [x] Verified by structural parity with the already-correct streaming path and by clean QEMU boots exercising both create paths on both arches (below).

## Verification
`cargo xtask build` + svctest `run-parallel --parallel 1 --runs 1 --timeout 180`, both arches:
- **x86_64**: PASS — `[svctest] ALL TESTS PASSED` (8.2s)
- **riscv64**: PASS — `[svctest] ALL TESTS PASSED` (34.4s)

The svctest boot exercises **both** wrappers: early-service bringup via `CREATE_PROCESS` (in-memory → `load_elf_page`) and the `spawn` phase via `Command::spawn` → `CREATE_FROM_FILE` (streaming → `load_elf_page_streaming`).

A test-only failure-injection harness was deliberately not added — see the issue note: the sound observable for this CSpace-slot leak (`cap_info(self_cspace, CAP_INFO_CSPACE_USED)`) is reachable only from inside procmgr, and adding test surface to a production service is disallowed.

## Out of scope (noted, not fixed here)
On the `CREATE_PROCESS` / in-memory path, `create_process_from_bytes` does not guard the child aspace/cspace/thread caps or already-loaded pages when a later `?` fails — a separate, broader partial-child teardown leak (the streaming path already guards these via `ChildKernelObjects`). #239 is scoped to the per-page cap-slot leak; the broader gap should be filed separately if confirmed reachable.

Closes #239
