### PR TITLE
ruststd: reclaim spawned-thread CSpace slots and RAM on join/detach

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,6 +985,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "threadchurn"
+version = "0.1.0"
+dependencies = [
+ "syscall",
+ "syscall-abi",
+]
+
+[[package]]
+name = "threadchurn-tester"
+version = "0.1.0"
+
+[[package]]
 name = "threadstack"
 version = "0.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,8 @@ members = [
     "programs/stackoverflow",
     "programs/stdiotest",
     "programs/stdiotest/tester",
+    "programs/threadchurn",
+    "programs/threadchurn/tester",
     "programs/threadstack",
     "programs/threadstack/tester",
     "xtask",

--- a/programs/threadchurn/Cargo.toml
+++ b/programs/threadchurn/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "threadchurn"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[[bin]]
+name = "threadchurn"
+path = "src/main.rs"
+test = false
+
+[dependencies]
+syscall = { path = "../../shared/syscall" }
+syscall-abi = { path = "../../abi/syscall" }
+
+[lints]
+workspace = true

--- a/programs/threadchurn/src/main.rs
+++ b/programs/threadchurn/src/main.rs
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// programs/threadchurn/src/main.rs
+
+//! `CSpace`-slot reclaim fixture for the usertest `threadchurn` tester (#240).
+//!
+//! Spawns and joins, then spawns and detaches, batches of threads, sampling the
+//! process's populated `CSpace`-slot count via `CAP_INFO_CSPACE_USED`
+//! before and after. With the reclaim fixes — `thread_slab` deleted on the
+//! `Thread::new` success path, the Thread cap deleted on `join`, and the
+//! detached-thread reaper freeing dropped handles on their death-post — the slot
+//! count stays flat. Before the fix it grew ~2-3 slots per spawn and exhausted
+//! the process `CSpace` within a few dozen spawns (`thread cap alloc failed`).
+//!
+//! The iteration counts are kept modest on purpose. memmgr only returns a
+//! process's granted Memory caps to its allocatable pool on `PROCESS_DIED`
+//! (`RELEASE_MEMORY_CAPS` is a documented accounting no-op), so a process that
+//! requests a fresh retype slab per thread cannot run an unbounded thread loop
+//! regardless of `CSpace` reclaim — a separate memmgr limitation tracked apart
+//! from #240. These counts exercise far more thread lifecycles than the
+//! pre-fix `CSpace` ceiling (~50) while staying within that memmgr budget.
+//!
+//! Idiomatic `std` for the threading; only the slot sampling reaches the Seraph
+//! `cap_info` surface.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::os::seraph::log;
+use std::process::ExitCode;
+
+/// Threads per spawn+join churn phase.
+const JOIN_CHURN: u64 = 50;
+/// Detached threads spawned in one burst, then reaped by later sweeps.
+const DETACH_BATCH: u64 = 48;
+/// Allowed slot growth between the baseline and the final sample. Absorbs
+/// lazily-created one-time caps (the reaper death `EventQueue`, pooled object
+/// slabs) that may not have settled at the baseline. Steady-state growth is 0.
+const SLACK: u64 = 12;
+
+fn used_slots(cspace: u32) -> u64
+{
+    syscall::cap_info(cspace, syscall_abi::CAP_INFO_CSPACE_USED)
+        .expect("cap_info(CSPACE_USED) on self_cspace")
+}
+
+/// A trivial worker that touches TLS-adjacent state through a `black_box`, so
+/// the spawn is a real thread rather than an elided no-op.
+fn work(seed: u64) -> u64
+{
+    std::hint::black_box(seed)
+        .wrapping_mul(2_654_435_761)
+        .rotate_left(13)
+}
+
+fn spawn_join(i: u64)
+{
+    let h = std::thread::spawn(move || work(i));
+    let v = h.join().expect("worker panicked");
+    std::hint::black_box(v);
+}
+
+fn main() -> ExitCode
+{
+    log::register_name(b"threadchurn");
+    let info = std::os::seraph::startup_info();
+    let cspace = info.self_cspace;
+
+    // Warm up so the reaper death EventQueue, pooled object slabs, and PT budget
+    // reach steady state before the baseline sample.
+    for i in 0..8
+    {
+        spawn_join(i);
+    }
+    let baseline = used_slots(cspace);
+    log!("baseline slots {baseline}");
+
+    // Join churn. Each join reclaims thread_slab + thread_cap + done_notification;
+    // the demand-stack VA (and its page tables) is reused.
+    for i in 0..JOIN_CHURN
+    {
+        spawn_join(i);
+    }
+    let after_a = used_slots(cspace);
+    log!("after join-churn slots {after_a}");
+
+    // Detach churn — detach a burst, let them die, then churn so sweeps reap them.
+    for i in 0..DETACH_BATCH
+    {
+        // Dropping the handle immediately detaches the worker.
+        let _ = std::thread::spawn(move || {
+            std::hint::black_box(work(i));
+        });
+    }
+    // Yield long enough for the detached workers to run to completion and post
+    // their death notifications before the reaping sweeps below.
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    for i in 0..JOIN_CHURN
+    {
+        spawn_join(i);
+    }
+    // Final drain: a short sleep plus a few more sweeps to reap any stragglers.
+    std::thread::sleep(std::time::Duration::from_millis(50));
+    for i in 0..16
+    {
+        spawn_join(i);
+    }
+    let after_b = used_slots(cspace);
+    log!("after detach-churn slots {after_b}");
+
+    let peak = after_a.max(after_b);
+    let growth = peak.saturating_sub(baseline);
+    if growth > SLACK
+    {
+        log!("FAIL growth {growth} > slack {SLACK} (baseline {baseline}, peak {peak})");
+        println!("threadchurn: FAIL slot growth {growth} exceeds slack {SLACK}");
+        return ExitCode::from(1);
+    }
+    log!("PASS growth {growth} <= slack {SLACK}");
+    println!("threadchurn: PASS slot growth {growth} within slack {SLACK}");
+    ExitCode::SUCCESS
+}

--- a/programs/threadchurn/tester/Cargo.toml
+++ b/programs/threadchurn/tester/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "threadchurn-tester"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[[bin]]
+name = "threadchurn-tester"
+path = "src/main.rs"
+test = false
+
+[lints]
+workspace = true

--- a/programs/threadchurn/tester/src/main.rs
+++ b/programs/threadchurn/tester/src/main.rs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// programs/threadchurn/tester/src/main.rs
+
+//! Per-program tester for `/programs/threadchurn` (#240). Runs the fixture with
+//! a piped stdout and asserts it reports bounded CSpace-slot growth and exits
+//! cleanly. The exit code is the verdict; the `[threadchurn-tester]` line is
+//! advisory.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::io::Read;
+use std::process::{Command, Stdio};
+
+fn fail(msg: &str) -> !
+{
+    println!("[threadchurn-tester] FAIL {msg}");
+    std::process::exit(1);
+}
+
+fn main()
+{
+    let mut child = Command::new("/programs/threadchurn")
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn /programs/threadchurn");
+
+    let mut out = String::new();
+    child
+        .stdout
+        .take()
+        .expect("piped stdout")
+        .read_to_string(&mut out)
+        .expect("read stdout");
+    let status = child.wait().expect("wait");
+
+    if out.lines().any(|l| l.contains("threadchurn: FAIL"))
+    {
+        fail("fixture reported FAIL");
+    }
+    if !out.lines().any(|l| l.contains("threadchurn: PASS"))
+    {
+        fail("PASS marker missing");
+    }
+    if !status.success()
+    {
+        fail(&format!("fixture exited non-zero: {:?}", status.code()));
+    }
+
+    println!("[threadchurn-tester] PASS");
+}

--- a/runtime/ruststd/src/sys/alloc/seraph.rs
+++ b/runtime/ruststd/src/sys/alloc/seraph.rs
@@ -717,16 +717,33 @@ pub fn fund_aspace_pt_budget(self_aspace: u32, region_pages: u64) -> bool {
     // `region_pages`: one last-level table per 512 pages plus a boundary
     // span, and the upper levels (PD/PDPT/root) with their spans (+4).
     let pt_pages = region_pages.div_ceil(512) + 4;
-    let Some(frame) = object_slab_acquire(pt_pages * PAGE_SIZE) else {
+    let need_bytes = pt_pages * PAGE_SIZE;
+
+    // Reuse the existing PT growth budget. Demand-stack VAs are reused — the
+    // reserve allocator coalesces and re-hands a freed range — so a reused
+    // stack's intermediate page tables persist and the budget stabilises after
+    // the first few spawns. Funding only the shortfall (and nothing once the
+    // budget already covers the region) keeps a spawn/join loop from leaking a
+    // CSpace slot + PT pages on every spawn.
+    let have = syscall::cap_info(self_aspace, syscall_abi::CAP_INFO_ASPACE_PT_BUDGET).unwrap_or(0);
+    if have >= need_bytes {
+        return true;
+    }
+    let shortfall_pages = (need_bytes - have).div_ceil(PAGE_SIZE).max(1);
+
+    let Some(frame) = object_slab_acquire(shortfall_pages * PAGE_SIZE) else {
         return false;
     };
-    if syscall::cap_create_aspace(frame, self_aspace, pt_pages).is_err() {
+    if syscall::cap_create_aspace(frame, self_aspace, shortfall_pages).is_err() {
         let _ = syscall::cap_delete(frame);
         return false;
     }
-    // The augment retypes the budget out of `frame`; the AS chunk holds its
-    // own reference, so the cap is not deleted (mirrors the heap augment
-    // path). The sub-page tail is reclaimed when the process dies.
+    // The augment bumped the source MemoryObject's refcount into the AS's PT
+    // chunk (`add_chunk` in `sys_cap_create_aspace`), so the chunk keeps the
+    // backing alive on its own — the `frame` cap slot is now dead weight.
+    // Delete it to reclaim the slot; the bytes are reclaimed with the AS at
+    // process death.
+    let _ = syscall::cap_delete(frame);
     true
 }
 

--- a/runtime/ruststd/src/sys/thread/seraph.rs
+++ b/runtime/ruststd/src/sys/thread/seraph.rs
@@ -4,7 +4,10 @@
 // Stacks and per-thread IPC buffers are allocated from the process heap
 // (page-aligned, no guard pages for now — deferred polish). Join
 // synchronises on a Notification cap; the child thread signals just before
-// calling SYS_THREAD_EXIT.
+// calling SYS_THREAD_EXIT, and join then reclaims the child's kernel object,
+// caps, and heap/VA resources. A detached handle (dropped without join) hands
+// its resources to the in-module `reaper`, which reclaims them once the child's
+// kernel death notification lands (see the `reaper` module).
 //
 // Native ELF TLS is live: `SYS_THREAD_CONFIGURE` accepts `tls_base`, the
 // kernel context switch saves/restores `IA32_FS_BASE` (x86-64) / `tp`
@@ -50,7 +53,12 @@ struct SpawnArgs {
     done_notification: u32,
 }
 
-pub struct Thread {
+/// The reclaimable resources a spawned thread owns. Moved as a unit between the
+/// `Thread` handle (joinable), the reaper registry (detached), and the reclaim
+/// path. Has no `Drop` glue — every field is a cap slot, a raw heap pointer, a
+/// `Copy` `Layout`, or a `StackAlloc` (whose variants own no `Drop` resources) —
+/// so it is freed only via the explicit [`ThreadResources::reclaim`].
+struct ThreadResources {
     thread_cap: u32,
     done_notification: u32,
     stack: StackAlloc,
@@ -60,12 +68,45 @@ pub struct Thread {
     tls_layout: Option<Layout>,
 }
 
-// SAFETY: every field of Thread is either a plain integer (thread_cap,
-// done_notification), an owned pointer to a distinct heap allocation, or an
-// owned stack allocation — none shared with any other thread.
+impl ThreadResources {
+    /// Reclaim every owned resource: delete the Thread cap (drives
+    /// `dealloc_object(Thread)` — drain + `retype_free` + ancestor `dec_ref`),
+    /// delete the done-notification cap, free the TLS block and IPC buffer, and
+    /// release the stack.
+    ///
+    /// # Safety
+    /// The owning thread MUST have left user-mode (joined, or its kernel death
+    /// notification observed). Reclaiming a still-running thread's stack/IPC/TLS
+    /// is a use-after-free.
+    unsafe fn reclaim(self) {
+        let _ = syscall::cap_delete(self.done_notification);
+        let _ = syscall::cap_delete(self.thread_cap);
+        // SAFETY: the thread has left user-mode; these allocations are no longer
+        // read or written from user space.
+        unsafe {
+            if let Some(l) = self.tls_layout {
+                dealloc(self.tls_block, l);
+            }
+            dealloc(self.ipc_buf_base, self.ipc_buf_layout);
+        }
+        free_stack(self.stack);
+    }
+}
+
+pub struct Thread {
+    res: ThreadResources,
+    /// `Some((slot, generation))` when a kernel death observer is bound and a
+    /// reaper-registry slot reserves this thread (the common case). `None` is
+    /// the fallback when the reaper was unavailable at spawn — then a detached
+    /// (un-joined) handle leaks its resources until process death, as before.
+    reaper: Option<(usize, u32)>,
+}
+
+// SAFETY: every resource is a plain cap slot, an owned pointer to a distinct
+// heap allocation, or an owned stack allocation — none shared with any other
+// thread; `reaper` is a plain index pair.
 unsafe impl Send for Thread {}
-// SAFETY: &Thread hands out only integer field copies through `join`; no
-// interior mutability is exposed.
+// SAFETY: &Thread exposes no interior mutability; `join` consumes by value.
 unsafe impl Sync for Thread {}
 
 /// How a spawned thread's stack is backed.
@@ -141,6 +182,10 @@ impl Thread {
         let info = crate::os::seraph::try_startup_info().ok_or_else(|| {
             io::Error::other("std::os::seraph::_start has not initialised startup state")
         })?;
+
+        // Reap any detached threads that have since died, freeing their CSpace
+        // slots and RAM before this spawn reserves its own.
+        reaper::sweep();
 
         let stack = alloc_stack(info, stack_bytes)?;
 
@@ -237,6 +282,13 @@ impl Thread {
                 }
             };
 
+        // The kernel bumped the source MemoryObject's refcount into the Thread
+        // (`ancestor.inc_ref()` in `sys_cap_create_thread`), so the Thread keeps
+        // the retype slot's backing alive on its own. The `thread_slab` cap slot
+        // is now dead weight — delete it to reclaim the slot. The slot is freed
+        // immediately; the MemoryObject's bytes are reclaimed when the Thread is.
+        let _ = syscall::cap_delete(thread_slab);
+
         // SP at the top of the usable stack region, 16-byte aligned for SysV
         // ABI; the stack grows down toward the guard page (demand) or heap base.
         let sp = stack.sp();
@@ -245,6 +297,10 @@ impl Thread {
         if let Err(_) =
             syscall::thread_configure_with_tls(thread_cap, entry_addr, sp, args as u64, tls_base)
         {
+            // The thread was created but never started; deleting its cap drives
+            // `dealloc_object(Thread)` (drain gates pass immediately — it never
+            // ran) to reclaim the retype slot + ancestor bytes.
+            let _ = syscall::cap_delete(thread_cap);
             // SAFETY: `args` was just leaked via `Box::into_raw`.
             let args_owned = unsafe { Box::from_raw(args) };
             // SAFETY: `args_owned.init` was just leaked via `Box::into_raw`.
@@ -272,7 +328,19 @@ impl Thread {
             );
         }
 
+        // Bind a kernel death observer so a detached (un-joined) handle's
+        // resources can be reclaimed by `reaper::sweep` once this thread leaves
+        // user-mode. MUST be done before `thread_start` (binding a running
+        // thread races the kernel's lock-free death-post reader). Best-effort:
+        // if the reaper is unavailable, fall back to leak-on-detach (`None`).
+        let reaper = reaper::register(thread_cap);
+
         if let Err(_) = syscall::thread_start(thread_cap) {
+            if let Some((slot, generation)) = reaper {
+                reaper::release(slot, generation);
+            }
+            // Never started → safe to reclaim the Thread object immediately.
+            let _ = syscall::cap_delete(thread_cap);
             // SAFETY: `args` was just leaked via `Box::into_raw`.
             let args_owned = unsafe { Box::from_raw(args) };
             // SAFETY: `args_owned.init` was just leaked via `Box::into_raw`.
@@ -289,73 +357,387 @@ impl Thread {
         }
 
         Ok(Thread {
-            thread_cap,
-            done_notification,
-            stack,
-            ipc_buf_base,
-            ipc_buf_layout,
-            tls_block,
-            tls_layout,
+            res: ThreadResources {
+                thread_cap,
+                done_notification,
+                stack,
+                ipc_buf_base,
+                ipc_buf_layout,
+                tls_block,
+                tls_layout,
+            },
+            reaper,
         })
     }
 
     pub fn join(self) {
-        // Wait for the child to signal completion of its rust_start and
-        // reach `notification_send`. After this point the child's next action is
-        // `syscall::thread_exit` — its stack, IPC buffer, and TLS block
-        // are safe to reclaim because control has left user-mode and will
-        // never return. A spurious wake on another bit is fine — we just
-        // observed the thread finishing.
-        let _ = syscall::notification_wait(self.done_notification);
-        let _ = syscall::cap_delete(self.done_notification);
-        // SAFETY: child reached notification_send, so its remaining execution is
-        // strictly inside the kernel (thread_exit); the allocations we own
-        // are no longer read or written from user space.
-        unsafe {
-            if let Some(l) = self.tls_layout {
-                dealloc(self.tls_block, l);
-            }
-            dealloc(self.ipc_buf_base, self.ipc_buf_layout);
-        }
-        // Reclaim the stack per its kind: a heap stack is freed; a demand stack
-        // is UNREGISTER_REGION'd (memmgr unmaps and returns its frames to the
-        // pool) and its VA released.
-        // SAFETY: `self.stack` is a valid initialised field; `forget(self)`
-        // below suppresses its destructor, so this read is not a double-free.
-        let stack = unsafe { core::ptr::read(&self.stack) };
-        free_stack(stack);
-        // Prevent Drop from running the leak path below; we already
-        // reclaimed everything.
+        // Move the resources out and suppress the Drop path; this handle is
+        // joined, not detached.
+        // SAFETY: `res`/`reaper` are valid initialised fields; `forget(self)`
+        // below suppresses the destructor, so these reads are not double-frees.
+        let res = unsafe { core::ptr::read(&self.res) };
+        let reaper = self.reaper;
         core::mem::forget(self);
+
+        // Wait for the child to signal completion of its rust_start and reach
+        // `notification_send`. After this its only remaining action is
+        // `thread_exit` (in-kernel), so its stack, IPC buffer, and TLS block are
+        // safe to reclaim. `reclaim` then deletes the done-notification cap, the
+        // Thread cap (driving `dealloc_object(Thread)` — the drain gates pass
+        // without spinning since the child has already exited), and frees the
+        // memory. A spurious early wake only makes the cap delete briefly spin
+        // in the kernel drain protocol — correct, never a use-after-free.
+        let _ = syscall::notification_wait(res.done_notification);
+        // SAFETY: the child has left user-mode (it signalled done_notification).
+        unsafe { res.reclaim() };
+
+        // Release this thread's reaper slot so its (eventual) death-post is a
+        // no-op, then opportunistically reap any detached threads that have died.
+        if let Some((slot, generation)) = reaper {
+            reaper::release(slot, generation);
+        }
+        reaper::sweep();
     }
 }
 
 impl Drop for Thread {
     fn drop(&mut self) {
-        // Dropping a `Thread` without `join()` means the caller detached
-        // the child and no longer has a synchronisation point to know
-        // when the child has left user-mode. Freeing the stack, IPC
-        // buffer, or TLS block now would be a use-after-free from the
-        // child's perspective — the memory would re-enter the heap's
-        // free list, get split via `Heap::insert`, and the FreeNode
-        // metadata (size at [0..8], next ptr at [8..16]) would clobber
-        // whatever TLS variable happens to sit at those offsets
-        // (`DTORS.borrow` in std::sys::thread_local::destructors::list),
-        // breaking all subsequent `RefCell::try_borrow_mut` calls on that
-        // thread. The only correct choice for a detached child on seraph
-        // is to leak everything this handle owns.
+        // Dropping a `Thread` without `join()` is a detach: the child runs on
+        // independently and the caller has no synchronisation point to know
+        // when it leaves user-mode. Freeing the stack, IPC buffer, or TLS block
+        // here would be a use-after-free — the memory would re-enter the heap's
+        // free list and the `FreeNode` metadata would clobber the child's live
+        // TLS/stack data.
         //
-        // `thread_cap` was already leaked by design; the stack, IPC buffer,
-        // and TLS block join it here until Seraph has a thread-detach syscall
-        // that reclaims memory on thread_exit. The `stack` field drops as a
-        // no-op (its variants own no `Drop` resources), so a demand stack's VA
-        // reservation and registered region also leak — the same detach
-        // semantics as the heap path.
-        let _ = self.thread_cap;
-        let _ = self.done_notification;
-        let _ = &self.stack;
-        let _ = self.ipc_buf_base;
-        let _ = self.tls_block;
+        // Instead, hand ownership to the reaper registry: a kernel death
+        // observer (bound in `new`) posts to the process death `EventQueue`
+        // when the child exits or faults, and `reaper::sweep` (run on every
+        // spawn/join) reclaims the resources then. If the child has already
+        // died, `detach` returns the resources to reclaim now.
+        //
+        // SAFETY: `res` is a valid initialised field; `ThreadResources` has no
+        // `Drop` glue, so the field's automatic drop after this returns is a
+        // no-op — no double-free of the bytes read out here.
+        let res = unsafe { core::ptr::read(&self.res) };
+        match self.reaper {
+            Some((slot, generation)) => {
+                if let Some(res) = reaper::detach(slot, generation, res) {
+                    // SAFETY: the child already exited (its death-post was
+                    // observed while still Reserved); reclaiming now is safe.
+                    unsafe { res.reclaim() };
+                }
+                reaper::sweep();
+            }
+            None => {
+                // No death observer was bound (the reaper was unavailable at
+                // spawn): no signal will tell us when the child leaves
+                // user-mode, so reclaiming now would be a use-after-free. Leak
+                // the resources until process death (the pre-reaper fallback).
+                core::mem::forget(res);
+            }
+        }
+    }
+}
+
+/// Detached-thread reaper.
+///
+/// `std::thread` detach (dropping a `JoinHandle`) leaves a running child the
+/// parent can no longer synchronise with. Reclaiming the child's kernel object
+/// and heap/VA resources needs a surviving thread to act *after* the child
+/// leaves user-mode. The kernel already provides that signal —
+/// `SYS_THREAD_BIND_NOTIFICATION` posts a thread's death (exit or fault) to a
+/// bound `EventQueue` — so no new syscall is required; this mirrors how
+/// `std::process::Child` reaps child processes.
+///
+/// Every spawned thread binds a death observer (before `thread_start`) to one
+/// process-global death `EventQueue`, with a generation-tagged correlator that
+/// names a registry slot. A joined thread reclaims its own resources directly
+/// and frees its slot; a detached thread leaves its resources in the slot.
+/// `sweep` drains the `EventQueue` on every spawn/join and reclaims any detached
+/// thread whose death-post has landed. The generation tag makes a stale post
+/// for an already-joined or reused slot a no-op.
+mod reaper {
+    use super::ThreadResources;
+    use crate::cell::UnsafeCell;
+    use crate::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+
+    /// Max concurrently-bound spawned threads. A spawn beyond this falls back to
+    /// leak-on-detach (join still reclaims directly). 64 covers realistic
+    /// thread fan-out; raising it only costs registry static size.
+    const REAPER_SLOTS: usize = 64;
+    /// Death `EventQueue` capacity. Drained on every spawn/join, so overflow
+    /// needs >128 detached threads dying between two thread ops — pathological;
+    /// the overflow remainder leaks only until process exit (kernel silently
+    /// drops a post to a full queue).
+    const EQ_CAPACITY: u32 = 128;
+    /// Correlator bit split: low `GEN_BITS` are the generation, the rest the
+    /// slot index (6 bits → 64 slots).
+    const GEN_BITS: u32 = 26;
+    const GEN_MASK: u32 = (1 << GEN_BITS) - 1;
+
+    fn correlator(slot: usize, generation: u32) -> u32 {
+        ((slot as u32) << GEN_BITS) | (generation & GEN_MASK)
+    }
+    fn split(correlator: u32) -> (usize, u32) {
+        ((correlator >> GEN_BITS) as usize, correlator & GEN_MASK)
+    }
+
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum SlotState {
+        /// No occupant.
+        Vacant,
+        /// Bound, handle still held (joinable). Resources live in the `Thread`.
+        Reserved,
+        /// Handle dropped (detached). Resources live in `res`, awaiting the
+        /// child's death-post.
+        Detached,
+    }
+
+    struct Slot {
+        state: SlotState,
+        generation: u32,
+        /// Set when a death-post arrives while still `Reserved` (child died
+        /// before the handle was joined/detached). `detach` consults it to
+        /// reclaim immediately instead of waiting for a post that already fired.
+        died: bool,
+        res: Option<ThreadResources>,
+    }
+
+    const fn vacant_slot() -> Slot {
+        Slot { state: SlotState::Vacant, generation: 0, died: false, res: None }
+    }
+
+    struct Registry {
+        next_gen: u32,
+        slots: [Slot; REAPER_SLOTS],
+    }
+
+    struct Reaper {
+        lock: SpinLock,
+        inner: UnsafeCell<Registry>,
+    }
+    // SAFETY: all access to `inner` is serialised by `lock`; the resources held
+    // in slots are owned (not shared) and reclaimed exactly once.
+    unsafe impl Sync for Reaper {}
+
+    static REAPER: Reaper = Reaper {
+        lock: SpinLock::new(),
+        inner: UnsafeCell::new(Registry {
+            next_gen: 1,
+            slots: [const { vacant_slot() }; REAPER_SLOTS],
+        }),
+    };
+
+    /// Process death `EventQueue` cap, lazily created on first spawn. `0` = not
+    /// yet created or unavailable.
+    static DEATH_EQ: AtomicU32 = AtomicU32::new(0);
+
+    /// Minimal spinlock (mirrors the alloc module's; that one is private).
+    struct SpinLock {
+        locked: AtomicBool,
+    }
+    impl SpinLock {
+        const fn new() -> Self {
+            Self { locked: AtomicBool::new(false) }
+        }
+        fn lock(&self) {
+            while self
+                .locked
+                .compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed)
+                .is_err()
+            {
+                core::hint::spin_loop();
+            }
+        }
+        fn unlock(&self) {
+            self.locked.store(false, Ordering::Release);
+        }
+    }
+
+    /// Return the process death `EventQueue` cap, creating it on first use.
+    /// `0` if the reaper is unavailable (then callers fall back to leak-on-detach).
+    fn death_eq() -> u32 {
+        let cur = DEATH_EQ.load(Ordering::Acquire);
+        if cur != 0 {
+            return cur;
+        }
+        // EventQueue retype size = 80 + (capacity + 1) * 8 bytes; over-request a
+        // little so the slab definitely covers it (fresh dedicated cap path).
+        let want = (u64::from(EQ_CAPACITY) + 1) * 8 + 256;
+        let made = match crate::sys::alloc::seraph::object_slab_acquire(want) {
+            Some(slab) => match syscall::event_queue_create(slab, EQ_CAPACITY) {
+                // The EventQueue holds its own ancestor ref on the slab's
+                // MemoryObject, so the slab cap slot is now dead weight.
+                Ok(eq) => {
+                    let _ = syscall::cap_delete(slab);
+                    Some(eq)
+                }
+                // create failed without consuming the slab — reclaim its slot.
+                Err(_) => {
+                    let _ = syscall::cap_delete(slab);
+                    None
+                }
+            },
+            None => None,
+        };
+        let Some(eq) = made else {
+            return 0;
+        };
+        match DEATH_EQ.compare_exchange(0, eq, Ordering::AcqRel, Ordering::Acquire) {
+            Ok(_) => eq,
+            // Lost the race: another thread installed one. Delete our duplicate.
+            Err(existing) => {
+                let _ = syscall::cap_delete(eq);
+                existing
+            }
+        }
+    }
+
+    /// Reserve a registry slot and bind a kernel death observer on `thread_cap`.
+    /// Returns `Some((slot, generation))` on success, `None` if the reaper is
+    /// unavailable or full (caller then leaks on detach). Call before
+    /// `thread_start`.
+    pub(super) fn register(thread_cap: u32) -> Option<(usize, u32)> {
+        let eq = death_eq();
+        if eq == 0 {
+            return None;
+        }
+
+        // Reserve a vacant slot.
+        REAPER.lock.lock();
+        // SAFETY: lock held; single mutator.
+        let reg = unsafe { &mut *REAPER.inner.get() };
+        let reserved = (|| {
+            for (i, slot) in reg.slots.iter_mut().enumerate() {
+                if slot.state == SlotState::Vacant {
+                    let generation = reg.next_gen & GEN_MASK;
+                    reg.next_gen = reg.next_gen.wrapping_add(1);
+                    slot.state = SlotState::Reserved;
+                    slot.generation = generation;
+                    slot.died = false;
+                    slot.res = None;
+                    return Some((i, generation));
+                }
+            }
+            None
+        })();
+        REAPER.lock.unlock();
+
+        let (slot, generation) = reserved?;
+        // Bind the observer. On failure, release the slot and fall back.
+        if syscall::thread_bind_notification(thread_cap, eq, correlator(slot, generation)).is_err()
+        {
+            release(slot, generation);
+            return None;
+        }
+        Some((slot, generation))
+    }
+
+    /// Release a slot on join (resources reclaimed directly by the caller). A
+    /// later death-post for this slot is ignored (state `Vacant` / generation
+    /// mismatch).
+    pub(super) fn release(slot: usize, generation: u32) {
+        if slot >= REAPER_SLOTS {
+            return;
+        }
+        REAPER.lock.lock();
+        // SAFETY: lock held; single mutator.
+        let reg = unsafe { &mut *REAPER.inner.get() };
+        let s = &mut reg.slots[slot];
+        if s.generation == generation && s.state != SlotState::Vacant {
+            *s = vacant_slot();
+        }
+        REAPER.lock.unlock();
+    }
+
+    /// Hand a detached thread's resources to the registry. If the child already
+    /// died (its death-post was observed while `Reserved`), returns the
+    /// resources for the caller to reclaim immediately; otherwise stores them
+    /// for `sweep` and returns `None`.
+    pub(super) fn detach(
+        slot: usize,
+        generation: u32,
+        res: ThreadResources,
+    ) -> Option<ThreadResources> {
+        if slot >= REAPER_SLOTS {
+            // Out-of-range slot index can't be reclaimed safely (no death
+            // signal we can trust) — leak rather than risk a UAF.
+            core::mem::forget(res);
+            return None;
+        }
+        REAPER.lock.lock();
+        // SAFETY: lock held; single mutator.
+        let reg = unsafe { &mut *REAPER.inner.get() };
+        let s = &mut reg.slots[slot];
+        let outcome = if s.generation == generation && s.state == SlotState::Reserved {
+            if s.died {
+                // Child already dead, post already drained — reclaim now.
+                *s = vacant_slot();
+                Some(res)
+            } else {
+                s.state = SlotState::Detached;
+                s.res = Some(res);
+                None
+            }
+        } else {
+            // Unexpected (slot reused/vacated under us). Leak rather than risk a
+            // UAF on a possibly-live thread.
+            core::mem::forget(res);
+            None
+        };
+        REAPER.lock.unlock();
+        outcome
+    }
+
+    /// Drain the death `EventQueue` (non-blocking) and reclaim any detached
+    /// thread whose death-post has landed. Called on every spawn and join.
+    pub(super) fn sweep() {
+        let eq = DEATH_EQ.load(Ordering::Acquire);
+        if eq == 0 {
+            return;
+        }
+        loop {
+            let payload = match syscall::event_try_recv(eq) {
+                Ok(p) => p,
+                // WouldBlock (empty) or the queue is gone — nothing more to do.
+                Err(_) => break,
+            };
+            let (slot, generation) = split((payload >> 32) as u32);
+
+            REAPER.lock.lock();
+            // SAFETY: lock held; single mutator.
+            let reg = unsafe { &mut *REAPER.inner.get() };
+            let to_reclaim = if slot < REAPER_SLOTS {
+                let s = &mut reg.slots[slot];
+                if s.generation == generation {
+                    match s.state {
+                        SlotState::Detached => {
+                            let res = s.res.take();
+                            *s = vacant_slot();
+                            res
+                        }
+                        SlotState::Reserved => {
+                            // Child died but the handle is still held; mark it so
+                            // `detach`/`release` reclaims when it runs.
+                            s.died = true;
+                            None
+                        }
+                        SlotState::Vacant => None,
+                    }
+                } else {
+                    None // stale post for a reused slot
+                }
+            } else {
+                None
+            };
+            REAPER.lock.unlock();
+
+            if let Some(res) = to_reclaim {
+                // SAFETY: the death-post fired, so the thread has left user-mode;
+                // its stack/IPC/TLS and Thread cap are safe to reclaim.
+                unsafe { res.reclaim() };
+            }
+        }
     }
 }
 

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -122,6 +122,8 @@ pub enum BuildComponent
     StdiotestTester,
     Threadstack,
     ThreadstackTester,
+    Threadchurn,
+    ThreadchurnTester,
     All,
 }
 

--- a/xtask/src/commands/build.rs
+++ b/xtask/src/commands/build.rs
@@ -349,6 +349,20 @@ const SPECS: &[Spec] = &[
         dest: InstallDest::TestsPrograms,
         arch_only: None,
     },
+    Spec {
+        name: "threadchurn",
+        install_name: None,
+        profile: BuildProfile::StdUser,
+        dest: InstallDest::Programs,
+        arch_only: None,
+    },
+    Spec {
+        name: "threadchurn-tester",
+        install_name: Some("threadchurn"),
+        profile: BuildProfile::StdUser,
+        dest: InstallDest::TestsPrograms,
+        arch_only: None,
+    },
 ];
 
 fn spec_for(component: BuildComponent) -> Option<&'static Spec>
@@ -386,6 +400,8 @@ fn spec_for(component: BuildComponent) -> Option<&'static Spec>
         BuildComponent::StdiotestTester => "stdiotest-tester",
         BuildComponent::Threadstack => "threadstack",
         BuildComponent::ThreadstackTester => "threadstack-tester",
+        BuildComponent::Threadchurn => "threadchurn",
+        BuildComponent::ThreadchurnTester => "threadchurn-tester",
     };
     SPECS.iter().find(|s| s.name == name)
 }


### PR DESCRIPTION
## Summary

`Thread::new`/`join`/`Drop` leaked per spawned thread until process death, so a
process that spawned and joined many threads accumulated CSpace slots toward its
fixed limit and exhausted it within a few dozen spawns (`thread cap alloc
failed`). This reclaims those leaks using only existing kernel primitives — **no
new syscall** — and adds a usertest fixture.

### ruststd (`runtime/ruststd/src/sys/thread/seraph.rs`, `.../alloc/seraph.rs`)
- **`thread_slab` deleted on the `Thread::new` success path.** `cap_create_thread`
  bumps the source MemoryObject's refcount into the Thread (`ancestor.inc_ref`),
  so the slab slot is dead weight; deleting it reclaims a slot per spawn. The
  `thread_configure`/`thread_start` error paths now also delete the Thread cap
  (drain gates pass immediately — the thread never ran).
- **Thread cap deleted on `join`**, driving `dealloc_object(Thread)` (drain +
  `retype_free` + ancestor `dec_ref`) after the child signals completion. Safe on
  UP and SMP — the drain gates pass without spinning since the child has exited.
- **Detached threads reclaimed by a process-global reaper** (no new syscall):
  every spawned thread binds a kernel death observer (`SYS_THREAD_BIND_NOTIFICATION`)
  to one death `EventQueue` before start, with a generation-tagged correlator
  naming a registry slot. `join` reclaims directly and frees its slot; `Drop`
  hands resources to the slot; an opportunistic sweep (`event_try_recv`) on every
  spawn/join reclaims any detached thread whose death-post has landed. Mirrors how
  `std::process::Child` reaps child processes.
- **`fund_aspace_pt_budget` funds only the shortfall and deletes the augment cap**
  (the AS chunk holds the ancestor ref), so a spawn/join loop with reused stack
  VAs stops leaking a CSpace slot per spawn.

### Test (`programs/threadchurn` + tester)
Cap-aware fixture: spawn/join churn and spawn/detach + sweep,
sampling `CAP_INFO_CSPACE_USED`. Asserts the populated-slot count stays within a
small slack. Discovered by usertest under `/tests/programs`.

## Verification
Cross-arch, both via `cargo xtask` under the usertest harness:

| arch | result |
|---|---|
| x86_64 | `threadchurn`: baseline 16 → join-churn 16 (flat) → detach-churn 18; `PASS`. `threadstack` regression `PASS`. `[usertest] ALL TESTS PASSED` |
| riscv64 | identical: 16 → 16 → 18; `PASS`. `ALL TESTS PASSED` |

Before the fix the same loop exhausts the CSpace at ~50 spawns (`thread cap alloc
failed`); after it, the join churn is flat (growth 0) and the detached batch is
fully reaped.

## Scope / follow-ups
The CSpace-slot leaks #240 enumerates (`thread_slab`, `thread_cap`, detached
stack/ipc/tls) are fixed and the slot footprint is bounded. Two orthogonal,
deeper limitations surfaced and are tracked separately (not regressions; only
reachable now that the CSpace no longer exhausts first):
- **#273** — kernel/memmgr: reclaim demand-region intermediate page tables on
  unmap (peak-concurrency PT retention; the higher-risk half of the demand-stack
  PT-budget fix, deferred from #240).
- **#274** — memmgr: reclaim a process's granted Memory caps mid-life, and make
  demand-fault-under-pool-exhaustion fail cleanly instead of hanging. This bounds
  the per-thread-retype memmgr-pool footprint (the threadchurn counts are kept
  modest because of it).

Closes #240.
