### PR TITLE
kernel/cap: detect any CSpace slot double-free via free-list marker

### DIFF
--- a/core/kernel/docs/capability-internals.md
+++ b/core/kernel/docs/capability-internals.md
@@ -67,20 +67,36 @@ permanently locked to the null capability, enforced at the lookup level.
 
 ### Free Slot Tracking
 
-A free list of available slot indices is maintained separately:
+A free list of available slot indices is maintained intrusively, with its head in
+kernel memory:
 
 ```rust
 pub struct CSpace
 {
     // ... (above fields)
-    free_head: Option<usize>,  // head of intrusive free list of slot indices
+    free_head: Option<NonZeroU32>, // head of the intrusive free list (None = empty)
+    free_count: usize,             // slots currently on the free list (O(1) queries)
 }
 ```
 
-Free slots store their `next` index in their `CapabilitySlot.tag` field (repurposed
-when the slot is empty). Allocation pops from the free list; deallocation pushes. If
-the free list is empty and more slots are needed, the next L2 page is allocated and
-all its slots are pushed onto the free list.
+A free slot is `CapTag::Null` and encodes its successor's index in the `deriv_parent`
+field (the derivation parent is meaningless on an empty slot); `None` marks the list
+tail. The encoded `SlotId` carries `epoch == 0`, which a live derivation link never
+does, so the two uses of `deriv_parent` stay distinguishable. Allocation pops
+`free_head` and clears the slot; deallocation pushes onto the head. When the list is
+empty and more slots are needed, the next L2 page is allocated and all its usable
+slots are threaded onto the list.
+
+A `Null` tag alone cannot tell a slot that is *linked on the free list* from one that
+was just allocated and not yet populated, and the list tail is byte-identical to a
+cleared slot. Each linked slot therefore also carries an on-free-list marker in
+`CapabilitySlot.pad[0]`; `is_on_free_list()` reports membership in O(1) from
+`tag == Null && pad[0] == marker`. `free_slot` consults it to reject a double-free of
+any slot — re-pushing a slot already on the list would splice it in twice and cycle
+the list, after which allocation could hand back an occupied slot. The marker is set
+when a slot is linked (`set_next_free`) and cleared when it leaves the list (on
+allocation, and when `remove_from_free_list` unlinks a specific index);
+`allocate_slot` debug-asserts the popped slot was a genuine member.
 
 This gives amortised O(1) allocation and O(1) deallocation.
 

--- a/core/kernel/src/cap/cspace.rs
+++ b/core/kernel/src/cap/cspace.rs
@@ -204,6 +204,13 @@ impl CSpace
         // mutable borrow so the borrow checker is satisfied.
         let next = {
             let slot = self.slot(idx.get()).ok_or(CapError::InvalidIndex)?;
+            // The free-time guard prevents an occupied slot from ever entering
+            // the list; this catches any other corruption source before we hand
+            // the slot out, so `allocate_slot` never returns an occupied slot.
+            debug_assert!(
+                slot.is_on_free_list(),
+                "allocate_slot popped a slot not on the free list"
+            );
             slot.next_free()
         };
 
@@ -344,12 +351,14 @@ impl CSpace
     ///
     /// Silently ignores an out-of-range, unmapped, or zero index.
     ///
-    /// Rejects re-freeing the current `free_head`: pushing it again would
-    /// set `slot.next_free = slot`, a self-loop that turns the next
-    /// `allocate_slot` into an unbounded spin under IRQs-off cspace.lock.
-    /// A Null tag alone is not a "double-free" notification — `allocate_slot`
-    /// clears the slot on pop, so a freshly-allocated, not-yet-populated
-    /// slot is also Null-tagged but legitimately off the list.
+    /// Rejects a double-free of any slot: [`CapabilitySlot::is_on_free_list`]
+    /// is true for every slot currently linked on the list (head, interior, or
+    /// tail), so re-freeing one is detected and dropped. Pushing an already-on-
+    /// list slot would splice it in a second time, creating a cycle the next
+    /// `allocate_slot` would walk into — handing out an occupied slot. A Null
+    /// tag alone is not enough to detect this (`allocate_slot` clears the slot
+    /// on pop, so a freshly-allocated, not-yet-populated slot is also Null);
+    /// the free-list marker is the discriminator.
     pub fn free_slot(&mut self, index: u32)
     {
         let Some(nz_index) = NonZeroU32::new(index)
@@ -357,22 +366,24 @@ impl CSpace
         {
             return;
         };
-        if self.free_head == Some(nz_index)
+        let old_head = self.free_head;
+        let Some(slot) = self.slot_mut(index)
+        else
+        {
+            return;
+        };
+        if slot.is_on_free_list()
         {
             #[cfg(not(test))]
             crate::kprintln!(
-                "free_slot: double-free index={} ignored (already free-list head)",
+                "free_slot: double-free index={} ignored (already on free list)",
                 index
             );
             return;
         }
-        let old_head = self.free_head;
-        if let Some(slot) = self.slot_mut(index)
-        {
-            slot.set_next_free(old_head);
-            self.free_head = Some(nz_index);
-            self.free_count += 1;
-        }
+        slot.set_next_free(old_head);
+        self.free_head = Some(nz_index);
+        self.free_count += 1;
     }
 
     /// Allocate a slot, populate it with the given capability, and return the
@@ -434,6 +445,12 @@ impl CSpace
                 .and_then(super::slot::CapabilitySlot::next_free);
             self.free_head = next;
             self.free_count -= 1;
+            // Drop the free-list marker so the unlinked slot is canonical
+            // off-list (same state as an `allocate_slot` pop).
+            if let Some(slot) = self.slot_mut(target)
+            {
+                slot.clear();
+            }
             return true;
         }
         // Walk the list looking for the predecessor.
@@ -464,6 +481,11 @@ impl CSpace
                 };
                 cur_slot.set_next_free(after);
                 self.free_count -= 1;
+                // Drop the free-list marker on the spliced-out slot.
+                if let Some(slot) = self.slot_mut(target)
+                {
+                    slot.clear();
+                }
                 return true;
             }
             cur_idx = next_idx;
@@ -799,5 +821,49 @@ mod tests
                 expected
             );
         }
+    }
+
+    #[test]
+    fn double_free_non_head_does_not_corrupt_freelist()
+    {
+        // Small CSpace so the entire free list fits in one page and the drain
+        // below is bounded.
+        let mut cs = CSpace::new(0, 5);
+        let a = cs.allocate_slot().unwrap();
+        let b = cs.allocate_slot().unwrap();
+        let c = cs.allocate_slot().unwrap();
+
+        // Build a multi-entry free list: head = a -> b -> c -> (rest).
+        cs.free_slot(c.get());
+        cs.free_slot(b.get());
+        cs.free_slot(a.get());
+        assert_eq!(cs.free_head, Some(a), "a should be the free-list head");
+
+        let free_before = cs.free_count;
+        // Double-free a NON-head slot (b; the head is a). The old head-only
+        // guard missed this and spliced b in a second time, cycling the list.
+        cs.free_slot(b.get());
+        assert_eq!(
+            cs.free_count, free_before,
+            "non-head double-free must be rejected, not re-pushed"
+        );
+
+        // Drain the whole free list. A cycle would hand out a duplicate index
+        // (and inflate the count); every popped index must be unique.
+        let mut seen = Vec::new();
+        while let Ok(idx) = cs.allocate_slot()
+        {
+            assert!(
+                !seen.contains(&idx),
+                "allocate_slot returned duplicate index {} — free list corrupted",
+                idx.get()
+            );
+            seen.push(idx);
+        }
+        assert_eq!(
+            seen.len(),
+            free_before,
+            "drain must recover every free slot exactly once"
+        );
     }
 }

--- a/core/kernel/src/cap/slot.rs
+++ b/core/kernel/src/cap/slot.rs
@@ -324,7 +324,7 @@ pub fn violates_wx(rights: Rights) -> bool
 /// ```text
 ///  offset  size  field
 ///       0     1  tag
-///       1     3  pad   (aligns rights to offset 4)
+///       1     3  pad   (aligns rights to offset 4; pad[0] = free-list marker)
 ///       4     4  rights
 ///       8     8  badge  (caller-identifying label; 0 = unbadged)
 ///      16     8  object (naturally 8-byte aligned at offset 16)
@@ -347,6 +347,9 @@ pub struct CapabilitySlot
     /// Capability type; `Null` means the slot is empty.
     pub tag: CapTag,
     /// Explicit padding: aligns `rights` to offset 4 and `badge` to offset 8.
+    /// `pad[0]` doubles as the intrusive free-list membership marker
+    /// ([`FREE_LIST_MARKER`] when the Null slot is linked on a `CSpace` free
+    /// list); `pad[1..]` are always zero.
     pad: [u8; 3],
     /// Rights bitmask (type-specific).
     pub rights: Rights,
@@ -374,6 +377,13 @@ pub struct CapabilitySlot
 unsafe impl Send for CapabilitySlot {}
 // SAFETY: CapabilitySlot is accessed only under CSpace lock; no Sync violation.
 unsafe impl Sync for CapabilitySlot {}
+
+/// Value stamped into `CapabilitySlot::pad[0]` while a Null slot is linked on a
+/// `CSpace` intrusive free list. A free-list **tail** slot has `deriv_parent ==
+/// None`, identical to a freshly-allocated-but-unpopulated Null slot; this
+/// marker is the O(1) discriminator that lets `free_slot` reject a double-free
+/// of any slot, not just the current free-list head.
+const FREE_LIST_MARKER: u8 = 1;
 
 impl CapabilitySlot
 {
@@ -420,10 +430,16 @@ impl CapabilitySlot
     /// the free-list reader only consults `index`. A live derivation link is
     /// always stamped with the registry's non-zero epoch, so `epoch == 0`
     /// unambiguously distinguishes the two encodings.
+    ///
+    /// Stamps the [`FREE_LIST_MARKER`] into `pad[0]` so [`is_on_free_list`]
+    /// can recognise this slot as a free-list member regardless of whether it
+    /// is the list tail.
+    ///
+    /// [`is_on_free_list`]: Self::is_on_free_list
     pub fn set_next_free(&mut self, next: Option<NonZeroU32>)
     {
         self.tag = CapTag::Null;
-        self.pad = [0; 3];
+        self.pad = [FREE_LIST_MARKER, 0, 0];
         self.rights = Rights::NONE;
         self.badge = 0;
         self.object = None;
@@ -447,6 +463,20 @@ impl CapabilitySlot
             "next_free called on occupied slot"
         );
         self.deriv_parent.map(|s| s.index)
+    }
+
+    /// Return `true` if this slot is currently linked on a `CSpace` free list.
+    ///
+    /// True iff the slot is Null-tagged with [`FREE_LIST_MARKER`] set by
+    /// [`set_next_free`]. The tag gate keeps a stale marker on a repopulated
+    /// slot from reading as on-list. Used by `free_slot` to reject a
+    /// double-free of any slot and by `allocate_slot` to assert the popped
+    /// slot was a genuine free-list member.
+    ///
+    /// [`set_next_free`]: Self::set_next_free
+    pub fn is_on_free_list(&self) -> bool
+    {
+        self.tag == CapTag::Null && self.pad[0] == FREE_LIST_MARKER
     }
 }
 
@@ -555,6 +585,7 @@ mod tests
         s.set_next_free(Some(next));
         assert_eq!(s.next_free(), Some(next));
         assert_eq!(s.tag, CapTag::Null);
+        assert!(s.is_on_free_list());
     }
 
     #[test]
@@ -563,6 +594,25 @@ mod tests
         let mut s = CapabilitySlot::null();
         s.set_next_free(None);
         assert_eq!(s.next_free(), None);
+        // The list tail is byte-identical to a cleared slot except for the
+        // marker — that is the whole point of the marker.
+        assert!(s.is_on_free_list());
+    }
+
+    #[test]
+    fn free_list_marker_distinguishes_membership()
+    {
+        // A canonical null slot is off the list.
+        let mut s = CapabilitySlot::null();
+        assert!(!s.is_on_free_list());
+
+        // Linking sets the marker even at the list tail (next == None).
+        s.set_next_free(None);
+        assert!(s.is_on_free_list());
+
+        // clear() (the allocate-on-pop path) drops the marker.
+        s.clear();
+        assert!(!s.is_on_free_list());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
`CSpace::free_slot` only rejected re-freeing the current `free_head`, so a double-free of any *non-head* slot silently spliced it onto the intrusive free list a second time, cycling the list — a later `allocate_slot` could then return an already-occupied slot (silent CSpace corruption). Adds an O(1) on-free-list marker in the previously-zero `CapabilitySlot::pad[0]`, so `free_slot` rejects a double-free of any slot; `allocate_slot` debug-asserts the popped slot was on the list. Slot size (72 B) and `repr(C)` layout are unchanged.

Closes #241

## Acceptance
- [x] A non-head double-free is detected/rejected (debug assert or hard guard), not silently corrupting the freelist.
- [x] `allocate_slot` never returns an occupied slot under any free/alloc sequence.

## Test plan
- [x] `cargo xtask build` (x86_64)
- [x] `cargo xtask run` (x86_64), terminal pass marker observed — ktest `passed=178, failed=0, [ktest] ALL TESTS PASSED`
- [x] `cargo xtask build --arch riscv64`
- [x] `cargo xtask run --arch riscv64`, terminal pass marker observed — ktest `passed=178, failed=0, [ktest] ALL TESTS PASSED`
- [x] additional component-specific checks: `cargo xtask test` host suite green, incl. new `double_free_non_head_does_not_corrupt_freelist` and the three slot-marker tests; `capability_slot_is_72_bytes` still passes (size invariant)

## Notes
- Detection is O(1): a one-byte marker in `pad[0]` (pure alignment padding, never read for semantics). Considered and rejected: an O(free_count) already-on-list walk (issue's "weigh the per-free cost"), and an end-of-list sentinel index (more invasive, no benefit).
- Free-time guard is fail-soft (logs `kprintln!` in non-test, returns; no spurious `free_count` increment), matching the prior convention; `allocate_slot` carries the `debug_assert` as the loud net for any other corruption source.
- `remove_from_free_list` now clears the marker on unlink so the invariant `is_on_free_list() ⟺ (tag==Null && pad[0]==marker)` holds exactly.
- Unrelated observability finding surfaced while validating: the test harnesses don't actually mirror to the framebuffer (ktest's renderer is dead — it probes for an SFBD page nothing produces). Filed as #276; not addressed here.