### PR TITLE
memmgr: reclaim a process's granted Memory caps mid-life (#274)

### DIFF
--- a/docs/userspace-memory-model.md
+++ b/docs/userspace-memory-model.md
@@ -187,9 +187,12 @@ memmgr serves frame requests over IPC. The contract:
 - **Caller maps.** Every returned Memory cap is mapped at a caller-
   chosen VA via `mem_map` (which already accepts a multi-page
   `page_count` argument).
-- **Caller releases.** `RELEASE_MEMORY_CAPS` returns specific caps to the
-  pool. Process death triggers automatic reclamation via procmgr's
-  `PROCESS_DIED` notification to memmgr.
+- **Caller releases.** `RELEASE_MEMORY_CAPS` returns a granted region to the
+  pool mid-life, named by the `phys_base` memmgr reported at grant (the caller
+  need not still hold the cap — it may have retyped the region and dropped its
+  copy). This keeps a per-unit-of-work retype loop (e.g. ruststd's Thread
+  slab per spawn) at a bounded pool footprint. Process death triggers automatic
+  reclamation via procmgr's `PROCESS_DIED` notification to memmgr.
 
 Authoritative wire shape lives in
 [`services/memmgr/docs/ipc-interface.md`](../services/memmgr/docs/ipc-interface.md).

--- a/programs/threadchurn/src/main.rs
+++ b/programs/threadchurn/src/main.rs
@@ -13,13 +13,15 @@
 //! count stays flat. Before the fix it grew ~2-3 slots per spawn and exhausted
 //! the process `CSpace` within a few dozen spawns (`thread cap alloc failed`).
 //!
-//! The iteration counts are kept modest on purpose. memmgr only returns a
-//! process's granted Memory caps to its allocatable pool on `PROCESS_DIED`
-//! (`RELEASE_MEMORY_CAPS` is a documented accounting no-op), so a process that
-//! requests a fresh retype slab per thread cannot run an unbounded thread loop
-//! regardless of `CSpace` reclaim — a separate memmgr limitation tracked apart
-//! from #240. These counts exercise far more thread lifecycles than the
-//! pre-fix `CSpace` ceiling (~50) while staying within that memmgr budget.
+//! The high-count join phase (`JOIN_CHURN`) deliberately runs far past the
+//! pre-#274 ~340-spawn memmgr-pool ceiling. memmgr now returns a process's
+//! granted Memory caps to its pool mid-life (`RELEASE_MEMORY_CAPS`), and
+//! ruststd returns each reclaimed thread's Thread-retype slab on join/reap, so
+//! the pool footprint stays bounded across the churn. The fixture samples
+//! memmgr's free-pool size (`QUERY_POOL_STATUS`) before and after and asserts
+//! the drop stays within `POOL_SLACK_BYTES` — before the fix the pool drained
+//! by `JOIN_CHURN * ~6` pages until the worker's demand-stack fault could no
+//! longer be backed (#274).
 //!
 //! Idiomatic `std` for the threading; only the slot sampling reaches the Seraph
 //! `cap_info` surface.
@@ -29,14 +31,25 @@
 use std::os::seraph::log;
 use std::process::ExitCode;
 
-/// Threads per spawn+join churn phase.
-const JOIN_CHURN: u64 = 50;
+/// Threads per high-count spawn+join churn phase. Runs well past the pre-#274
+/// ~340-spawn memmgr-pool ceiling to prove mid-life slab reclaim keeps the
+/// pool footprint bounded.
+const JOIN_CHURN: u64 = 400;
+/// Threads per reaping churn (detach-burst cleanup). Kept small: its job is to
+/// drive reaper sweeps, not to stress the pool.
+const REAP_CHURN: u64 = 50;
 /// Detached threads spawned in one burst, then reaped by later sweeps.
 const DETACH_BATCH: u64 = 48;
 /// Allowed slot growth between the baseline and the final sample. Absorbs
 /// lazily-created one-time caps (the reaper death `EventQueue`, pooled object
 /// slabs) that may not have settled at the baseline. Steady-state growth is 0.
 const SLACK: u64 = 12;
+/// Allowed memmgr free-pool drop across the churn (#274). With mid-life slab
+/// reclaim the steady-state footprint is flat (~0 drop); the pre-fix leak would
+/// drop free memory by `JOIN_CHURN * ~6` pages (~9 MiB at 400), so this 2-MiB
+/// bound cleanly separates fixed from leaking while absorbing the handful of
+/// pages other services churn during the run.
+const POOL_SLACK_BYTES: u64 = 2 * 1024 * 1024;
 
 fn used_slots(cspace: u32) -> u64
 {
@@ -73,10 +86,13 @@ fn main() -> ExitCode
         spawn_join(i);
     }
     let baseline = used_slots(cspace);
-    log!("baseline slots {baseline}");
+    let baseline_free = std::os::seraph::memmgr_pool_free_bytes();
+    log!("baseline slots {baseline} free {baseline_free:?}");
 
-    // Join churn. Each join reclaims thread_slab + thread_cap + done_notification;
-    // the demand-stack VA (and its page tables) is reused.
+    // High-count join churn. Each join reclaims thread_slab — returned to
+    // memmgr's pool mid-life (#274) — plus thread_cap and done_notification; the
+    // demand-stack VA (and its page tables) is reused. Runs past the pre-#274
+    // pool ceiling, so a per-spawn slab leak would exhaust the pool here.
     for i in 0..JOIN_CHURN
     {
         spawn_join(i);
@@ -95,7 +111,7 @@ fn main() -> ExitCode
     // Yield long enough for the detached workers to run to completion and post
     // their death notifications before the reaping sweeps below.
     std::thread::sleep(std::time::Duration::from_millis(100));
-    for i in 0..JOIN_CHURN
+    for i in 0..REAP_CHURN
     {
         spawn_join(i);
     }
@@ -106,8 +122,10 @@ fn main() -> ExitCode
         spawn_join(i);
     }
     let after_b = used_slots(cspace);
-    log!("after detach-churn slots {after_b}");
+    let after_free = std::os::seraph::memmgr_pool_free_bytes();
+    log!("after detach-churn slots {after_b} free {after_free:?}");
 
+    // CSpace-slot bound (#240): the churn must not grow the populated slot count.
     let peak = after_a.max(after_b);
     let growth = peak.saturating_sub(baseline);
     if growth > SLACK
@@ -116,6 +134,23 @@ fn main() -> ExitCode
         println!("threadchurn: FAIL slot growth {growth} exceeds slack {SLACK}");
         return ExitCode::from(1);
     }
+
+    // memmgr-pool bound (#274): the churn must not have drained the pool. A
+    // missing query (memmgr unreachable) skips the check rather than failing.
+    if let (Some(before), Some(after)) = (baseline_free, after_free)
+    {
+        let drop = before.saturating_sub(after);
+        if drop > POOL_SLACK_BYTES
+        {
+            log!(
+                "FAIL pool drop {drop} > slack {POOL_SLACK_BYTES} (before {before}, after {after})"
+            );
+            println!("threadchurn: FAIL pool free dropped {drop} exceeds slack {POOL_SLACK_BYTES}");
+            return ExitCode::from(1);
+        }
+        log!("pool drop {drop} <= slack {POOL_SLACK_BYTES}");
+    }
+
     log!("PASS growth {growth} <= slack {SLACK}");
     println!("threadchurn: PASS slot growth {growth} within slack {SLACK}");
     ExitCode::SUCCESS

--- a/programs/threadchurn/src/main.rs
+++ b/programs/threadchurn/src/main.rs
@@ -3,38 +3,45 @@
 
 // programs/threadchurn/src/main.rs
 
-//! `CSpace`-slot reclaim fixture for the usertest `threadchurn` tester (#240).
+//! `CSpace`-slot and memmgr-pool reclaim fixture for the usertest
+//! `threadchurn` tester (#240, #274).
 //!
-//! Spawns and joins, then spawns and detaches, batches of threads, sampling the
-//! process's populated `CSpace`-slot count via `CAP_INFO_CSPACE_USED`
-//! before and after. With the reclaim fixes — `thread_slab` deleted on the
-//! `Thread::new` success path, the Thread cap deleted on `join`, and the
-//! detached-thread reaper freeing dropped handles on their death-post — the slot
-//! count stays flat. Before the fix it grew ~2-3 slots per spawn and exhausted
-//! the process `CSpace` within a few dozen spawns (`thread cap alloc failed`).
+//! Spawns and joins, then spawns and detaches, batches of threads, sampling two
+//! quantities before and after: the process's populated `CSpace`-slot count
+//! (`CAP_INFO_CSPACE_USED`) and memmgr's free-pool size (`QUERY_POOL_STATUS`).
 //!
-//! The high-count join phase (`JOIN_CHURN`) deliberately runs far past the
-//! pre-#274 ~340-spawn memmgr-pool ceiling. memmgr now returns a process's
-//! granted Memory caps to its pool mid-life (`RELEASE_MEMORY_CAPS`), and
-//! ruststd returns each reclaimed thread's Thread-retype slab on join/reap, so
-//! the pool footprint stays bounded across the churn. The fixture samples
-//! memmgr's free-pool size (`QUERY_POOL_STATUS`) before and after and asserts
-//! the drop stays within `POOL_SLACK_BYTES` — before the fix the pool drained
-//! by `JOIN_CHURN * ~6` pages until the worker's demand-stack fault could no
-//! longer be backed (#274).
+//! Reclaim runs at three sites — `thread_slab` freed on the `Thread::new`
+//! success path, the Thread cap deleted on `join`, and the detached-thread
+//! reaper freeing dropped handles on their death-post. The slab returns to
+//! memmgr's pool mid-life via `RELEASE_MEMORY_CAPS`; the Thread cap and
+//! demand-stack VA are reused. So across the churn both the slot count and the
+//! pool footprint stay flat.
 //!
-//! Idiomatic `std` for the threading; only the slot sampling reaches the Seraph
-//! `cap_info` surface.
+//! The fixture asserts that flatness: slot growth within `SLACK`, free-pool
+//! drop within `POOL_SLACK_BYTES`. A per-spawn slot leak would grow the slot
+//! count ~2-3 slots per spawn; a per-spawn slab leak would drop the free pool
+//! by `JOIN_CHURN * ~6` pages — either trips its bound. The high `JOIN_CHURN`
+//! also runs past the count at which an unbounded memmgr tracking-anchor
+//! footprint live-locks the service, so completing the run at all proves that
+//! footprint stays bounded (#274); a regression there surfaces as a HANG, which
+//! the periodic heartbeat keeps visible against slow progress.
+//!
+//! Idiomatic `std` for the threading; only the sampling reaches the Seraph
+//! `cap_info` / memmgr surfaces.
 
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use std::os::seraph::log;
 use std::process::ExitCode;
 
-/// Threads per high-count spawn+join churn phase. Runs well past the pre-#274
-/// ~340-spawn memmgr-pool ceiling to prove mid-life slab reclaim keeps the
-/// pool footprint bounded.
-const JOIN_CHURN: u64 = 400;
+/// Threads per spawn+join churn phase. Runs well past the ~250-spawn count at
+/// which an unbounded memmgr tracking-anchor (`CSpace`) footprint live-locks the
+/// service, so completing the run is itself the criterion-2 termination proof
+/// (#274). Also sized so a per-spawn slab RAM leak drops memmgr's free pool
+/// several times past `POOL_SLACK_BYTES` (criterion 1). Completes within the CI
+/// run timeout under TCG (each iteration is a spawn + demand-fault +
+/// REQUEST/RELEASE round-trip).
+const JOIN_CHURN: u64 = 600;
 /// Threads per reaping churn (detach-burst cleanup). Kept small: its job is to
 /// drive reaper sweeps, not to stress the pool.
 const REAP_CHURN: u64 = 50;
@@ -45,11 +52,12 @@ const DETACH_BATCH: u64 = 48;
 /// slabs) that may not have settled at the baseline. Steady-state growth is 0.
 const SLACK: u64 = 12;
 /// Allowed memmgr free-pool drop across the churn (#274). With mid-life slab
-/// reclaim the steady-state footprint is flat (~0 drop); the pre-fix leak would
-/// drop free memory by `JOIN_CHURN * ~6` pages (~9 MiB at 400), so this 2-MiB
-/// bound cleanly separates fixed from leaking while absorbing the handful of
-/// pages other services churn during the run.
-const POOL_SLACK_BYTES: u64 = 2 * 1024 * 1024;
+/// reclaim the steady-state footprint stays flat (a passing run stays far under
+/// this bound); a per-spawn slab RAM leak would drop free memory by
+/// `JOIN_CHURN * ~6` pages (~14 MiB at 600), so this 1-MiB bound cleanly
+/// separates a bounded footprint from a leaking one while absorbing the handful
+/// of pages other services churn during the run.
+const POOL_SLACK_BYTES: u64 = 1024 * 1024;
 
 fn used_slots(cspace: u32) -> u64
 {
@@ -89,13 +97,19 @@ fn main() -> ExitCode
     let baseline_free = std::os::seraph::memmgr_pool_free_bytes();
     log!("baseline slots {baseline} free {baseline_free:?}");
 
-    // High-count join churn. Each join reclaims thread_slab — returned to
-    // memmgr's pool mid-life (#274) — plus thread_cap and done_notification; the
-    // demand-stack VA (and its page tables) is reused. Runs past the pre-#274
-    // pool ceiling, so a per-spawn slab leak would exhaust the pool here.
+    // Join churn. Each join reclaims thread_slab — returned to memmgr's pool
+    // mid-life (#274) — plus thread_cap and done_notification; the demand-stack
+    // VA (and its page tables) is reused. A per-spawn slab leak would surface as
+    // a free-pool drop past POOL_SLACK_BYTES in the assertion below. The
+    // periodic heartbeat keeps a HANG distinguishable from slow progress in the
+    // run-parallel log.
     for i in 0..JOIN_CHURN
     {
         spawn_join(i);
+        if i % 25 == 24
+        {
+            log!("join-churn progress {}/{JOIN_CHURN}", i + 1);
+        }
     }
     let after_a = used_slots(cspace);
     log!("after join-churn slots {after_a}");

--- a/runtime/ruststd/src/os/seraph.rs
+++ b/runtime/ruststd/src/os/seraph.rs
@@ -700,6 +700,15 @@ pub fn object_slab_acquire(min_bytes: u64) -> Option<u32> {
     pal_alloc::object_slab_acquire(min_bytes)
 }
 
+/// memmgr's current free-pool size in bytes, or `None` if memmgr is
+/// unreachable. Thin wrapper over the `QUERY_POOL_STATUS` aggregate query;
+/// used by tests asserting that a churn loop holds a bounded memmgr-pool
+/// footprint.
+#[stable(feature = "seraph_ext", since = "1.0.0")]
+pub fn memmgr_pool_free_bytes() -> Option<u64> {
+    pal_alloc::memmgr_query_free_bytes()
+}
+
 /// Fund `self_aspace`'s page-table growth budget to cover mapping a
 /// `region_pages`-page foreign-memory region (MMIO, DMA) into a
 /// retype-backed `AddressSpace`.

--- a/runtime/ruststd/src/sys/alloc/seraph.rs
+++ b/runtime/ruststd/src/sys/alloc/seraph.rs
@@ -691,7 +691,7 @@ fn slab_acquire_fresh(need: u64, want_pages: u64) -> Option<SlabGrant> {
 
 /// Return a fresh slab's backing run to memmgr's pool, naming it by the `phys`
 /// base recorded in its [`SlabGrant`]. Best-effort: a failed IPC just leaves
-/// the run accounted to this process until it dies (the prior behaviour).
+/// the run accounted to this process until it dies.
 ///
 /// The caller MUST have already deleted every kernel object retyped from the
 /// slab; releasing while a retype is live is correctness-safe (the kernel

--- a/runtime/ruststd/src/sys/alloc/seraph.rs
+++ b/runtime/ruststd/src/sys/alloc/seraph.rs
@@ -33,7 +33,7 @@ use crate::os::seraph::current_ipc_buf;
 use crate::ptr::{NonNull, null_mut};
 use crate::sync::atomic::{AtomicBool, Ordering};
 
-use ipc::memmgr_labels::REQUEST_MEMORY_CAPS;
+use ipc::memmgr_labels::{QUERY_POOL_STATUS, RELEASE_MEMORY_CAPS, REQUEST_MEMORY_CAPS};
 use syscall_abi::{MAP_WRITABLE, PAGE_SIZE};
 
 // Heap-zone VAs are private to the std-overlay allocator. They sit
@@ -378,13 +378,16 @@ impl Heap {
         // Augment: request 1 page from memmgr, feed to cap_create_aspace
         // in augment mode (target = self_aspace). Single page covers
         // ~511 new PT-entries' worth of mappable VA.
-        let Some(aug_memory) = slab_acquire_fresh(PAGE_SIZE, 2) else {
+        let Some(aug) = slab_acquire_fresh(PAGE_SIZE, 2) else {
             return false;
         };
+        let aug_memory = aug.cap;
         if syscall::cap_create_aspace(aug_memory, self.self_aspace, 1).is_err() {
             // Augment-mode returns 0 on success; treat any error as fatal
-            // for this grow. Drop the unused Memory cap.
+            // for this grow. Drop the unused (virgin) Memory cap and return its
+            // run to memmgr's pool.
             let _ = syscall::cap_delete(aug_memory);
+            slab_release_fresh(aug.phys);
             return false;
         }
         // The augment cap is consumed by cap_create_aspace; do not delete.
@@ -571,9 +574,11 @@ fn slab_round_to_class(bytes: u64) -> u64 {
 /// to the first returned cap (any cap unblocks sub-page retypes; a too-small
 /// cap simply means the next page-sized retype request triggers a refresh).
 ///
-/// Returns `Some((slot, pages))` on success, `None` on IPC failure or empty
-/// reply.
-fn slab_request_pages(memmgr_ep: u32, min_pages: u64) -> Option<(u32, u64)> {
+/// Returns `Some((slot, pages, phys))` on success, `None` on IPC failure or
+/// empty reply. `phys` is the chosen cap's physical base, which memmgr reports
+/// at `data[1 + returned + i]`; the caller passes it to [`slab_release_fresh`]
+/// to return the run to memmgr's pool mid-life.
+fn slab_request_pages(memmgr_ep: u32, min_pages: u64) -> Option<(u32, u64, u64)> {
     let ipc_buf = current_ipc_buf();
     if ipc_buf.is_null() {
         return None;
@@ -589,15 +594,16 @@ fn slab_request_pages(memmgr_ep: u32, min_pages: u64) -> Option<(u32, u64)> {
         return None;
     }
     let caps = reply.caps();
+    // Reply layout: data[1+i] = page_count_i, data[1+returned+i] = phys_base_i.
     // Prefer the first cap that already covers `min_pages`.
     for i in 0..returned {
         let pages = reply.word(1 + i);
         if pages >= min_pages {
-            return Some((caps[i], pages));
+            return Some((caps[i], pages, reply.word(1 + returned + i)));
         }
     }
     // Fallback: take the first (smaller) cap so sub-page retypes still work.
-    Some((caps[0], reply.word(1)))
+    Some((caps[0], reply.word(1), reply.word(1 + returned)))
 }
 
 /// Number of pages to request when refilling the object slab.
@@ -628,7 +634,7 @@ fn slab_acquire_pooled(pool: &ObjectSlab, need: u64, want_pages: u64) -> Option<
         if ep == 0 {
             return None;
         }
-        let (new_cap, cap_pages) = slab_request_pages(ep, want_pages)?;
+        let (new_cap, cap_pages, _phys) = slab_request_pages(ep, want_pages)?;
         const ALLOCATOR_METADATA_RESERVE: u64 = 64;
         let total = cap_pages.saturating_mul(PAGE_SIZE);
         let usable = total.saturating_sub(ALLOCATOR_METADATA_RESERVE);
@@ -648,24 +654,61 @@ fn slab_acquire_pooled(pool: &ObjectSlab, need: u64, want_pages: u64) -> Option<
     res
 }
 
+/// A freshly-acquired dedicated Memory cap plus the identity memmgr needs to
+/// reclaim its backing run mid-life. `phys` is the physical base memmgr
+/// reported in the grant reply; pass it to [`slab_release_fresh`] once every
+/// kernel object retyped from `cap` has been deleted.
+#[derive(Clone, Copy)]
+pub struct SlabGrant {
+    pub cap: u32,
+    pub phys: u64,
+}
+
 /// Acquire a fresh, dedicated Memory cap for a page-aligned retype. No
 /// caching — the cap is consumed entirely by the caller's single retype
 /// (or by a few retypes against the leftover sub-page tail, which the
 /// caller manages). Used by variable-size types (`EventQueue`, `Thread`,
 /// `AddressSpace`, `CSpace`) where caching offers no benefit.
-fn slab_acquire_fresh(need: u64, want_pages: u64) -> Option<u32> {
+fn slab_acquire_fresh(need: u64, want_pages: u64) -> Option<SlabGrant> {
     let ep = SLAB_MEMMGR_EP.load(Ordering::Acquire);
     if ep == 0 {
         return None;
     }
-    let (new_cap, cap_pages) = slab_request_pages(ep, want_pages)?;
+    let (new_cap, cap_pages, phys) = slab_request_pages(ep, want_pages)?;
     const ALLOCATOR_METADATA_RESERVE: u64 = 64;
     let total = cap_pages.saturating_mul(PAGE_SIZE);
     if total.saturating_sub(ALLOCATOR_METADATA_RESERVE) < need {
+        // Too small for this request. Delete the inner cap and return the run
+        // to memmgr's pool — the slab is virgin (nothing retyped yet), and
+        // deleting the inner alone would strand the run in memmgr's
+        // per-process accounting until process death.
         let _ = syscall::cap_delete(new_cap);
+        slab_release_fresh(phys);
         return None;
     }
-    Some(new_cap)
+    Some(SlabGrant { cap: new_cap, phys })
+}
+
+/// Return a fresh slab's backing run to memmgr's pool, naming it by the `phys`
+/// base recorded in its [`SlabGrant`]. Best-effort: a failed IPC just leaves
+/// the run accounted to this process until it dies (the prior behaviour).
+///
+/// The caller MUST have already deleted every kernel object retyped from the
+/// slab; releasing while a retype is live is correctness-safe (the kernel
+/// refuses to re-hand-out live bytes) but strands the run until the retype is
+/// freed.
+pub fn slab_release_fresh(phys: u64) {
+    let ep = SLAB_MEMMGR_EP.load(Ordering::Acquire);
+    if ep == 0 {
+        return;
+    }
+    let ipc_buf = current_ipc_buf();
+    if ipc_buf.is_null() {
+        return;
+    }
+    let msg = ipc::IpcMessage::builder(RELEASE_MEMORY_CAPS).word(0, 1).word(1, phys).build();
+    // SAFETY: ipc_buf is the calling thread's registered IPC buffer.
+    let _ = unsafe { ipc::ipc_call(ep, &msg, ipc_buf) };
 }
 
 /// Return a Memory-cap slot with at least `min_bytes` of `available_bytes`
@@ -691,8 +734,41 @@ pub fn object_slab_acquire(min_bytes: u64) -> Option<u32> {
     } else if need <= 512 {
         slab_acquire_pooled(&SLAB_BIN_512, need, want_pages)
     } else {
-        slab_acquire_fresh(need, want_pages)
+        slab_acquire_fresh(need, want_pages).map(|g| g.cap)
     }
+}
+
+/// Like [`object_slab_acquire`] but always takes a fresh, dedicated cap and
+/// returns the [`SlabGrant`] identity, so the caller can return the run to
+/// memmgr's pool mid-life via [`slab_release_fresh`] once every object retyped
+/// from the slab is deleted. For a per-unit-of-work retype (e.g. one Thread
+/// slab per spawn) this keeps the process's memmgr-pool footprint bounded
+/// instead of leaking a run per iteration until process death.
+pub fn object_slab_acquire_fresh(min_bytes: u64) -> Option<SlabGrant> {
+    let need = slab_round_to_class(min_bytes);
+    let want_pages = need.div_ceil(PAGE_SIZE).max(1) + 1;
+    slab_acquire_fresh(need, want_pages)
+}
+
+/// memmgr's current free-pool size in bytes (`QUERY_POOL_STATUS`, reply
+/// `data[3]`). `None` if memmgr is unreachable. A read-only aggregate query;
+/// used by the threadchurn regression to assert a bounded pool footprint.
+pub fn memmgr_query_free_bytes() -> Option<u64> {
+    let ep = SLAB_MEMMGR_EP.load(Ordering::Acquire);
+    if ep == 0 {
+        return None;
+    }
+    let ipc_buf = current_ipc_buf();
+    if ipc_buf.is_null() {
+        return None;
+    }
+    let msg = ipc::IpcMessage::builder(QUERY_POOL_STATUS).build();
+    // SAFETY: ipc_buf is the calling thread's registered IPC buffer.
+    let reply = unsafe { ipc::ipc_call(ep, &msg, ipc_buf) }.ok()?;
+    if reply.label != 0 {
+        return None;
+    }
+    Some(reply.word(3))
 }
 
 /// Fund `self_aspace`'s page-table growth budget to cover mapping a

--- a/runtime/ruststd/src/sys/thread/seraph.rs
+++ b/runtime/ruststd/src/sys/thread/seraph.rs
@@ -56,10 +56,16 @@ struct SpawnArgs {
 /// The reclaimable resources a spawned thread owns. Moved as a unit between the
 /// `Thread` handle (joinable), the reaper registry (detached), and the reclaim
 /// path. Has no `Drop` glue — every field is a cap slot, a raw heap pointer, a
-/// `Copy` `Layout`, or a `StackAlloc` (whose variants own no `Drop` resources) —
-/// so it is freed only via the explicit [`ThreadResources::reclaim`].
+/// `Copy` `Layout`, a `StackAlloc` (whose variants own no `Drop` resources), or
+/// a plain `u64` — so it is freed only via the explicit
+/// [`ThreadResources::reclaim`].
 struct ThreadResources {
     thread_cap: u32,
+    /// Physical base of the Thread-retype slab's backing run, as reported by
+    /// memmgr at grant. Returned to memmgr's pool in `reclaim`, after the
+    /// Thread cap is deleted, so a thread-churn loop holds a bounded
+    /// memmgr-pool footprint (#274).
+    slab_phys: u64,
     done_notification: u32,
     stack: StackAlloc,
     ipc_buf_base: *mut u8,
@@ -81,6 +87,12 @@ impl ThreadResources {
     unsafe fn reclaim(self) {
         let _ = syscall::cap_delete(self.done_notification);
         let _ = syscall::cap_delete(self.thread_cap);
+        // The Thread cap is now gone, so `dealloc_object(Thread)` has returned
+        // the retype slot's bytes to the source MemoryObject. Hand the slab's
+        // run back to memmgr's pool so the footprint stays bounded across a
+        // thread-churn loop, rather than leaking a run per spawn until process
+        // death (#274). Must follow the Thread cap delete above.
+        crate::sys::alloc::seraph::slab_release_fresh(self.slab_phys);
         // SAFETY: the thread has left user-mode; these allocations are no longer
         // read or written from user space.
         unsafe {
@@ -242,9 +254,9 @@ impl Thread {
         // 5-page slab for the Thread retype slot (kstack + wrapper/TCB).
         // Matches `cap::retype::dispatch_for(Thread)` in the kernel.
         const THREAD_RETYPE_BYTES: u64 = 5 * 4096;
-        let thread_slab =
-            match crate::sys::alloc::seraph::object_slab_acquire(THREAD_RETYPE_BYTES) {
-                Some(cap) => cap,
+        let (thread_slab, thread_slab_phys) =
+            match crate::sys::alloc::seraph::object_slab_acquire_fresh(THREAD_RETYPE_BYTES) {
+                Some(g) => (g.cap, g.phys),
                 None => {
                     // SAFETY: `args` was just leaked via `Box::into_raw`.
                     let args_owned = unsafe { Box::from_raw(args) };
@@ -266,6 +278,9 @@ impl Thread {
                 Ok(cap) => cap,
                 Err(_) => {
                     let _ = syscall::cap_delete(thread_slab);
+                    // Retype failed, so the slab is virgin — return its run to
+                    // memmgr's pool instead of leaking it until process death.
+                    crate::sys::alloc::seraph::slab_release_fresh(thread_slab_phys);
                     // SAFETY: `args` was just leaked via `Box::into_raw`.
                     let args_owned = unsafe { Box::from_raw(args) };
                     // SAFETY: `args_owned.init` was just leaked via `Box::into_raw`.
@@ -301,6 +316,9 @@ impl Thread {
             // `dealloc_object(Thread)` (drain gates pass immediately — it never
             // ran) to reclaim the retype slot + ancestor bytes.
             let _ = syscall::cap_delete(thread_cap);
+            // Thread destroyed → its retype bytes are back in the MemoryObject;
+            // return the slab's run to memmgr's pool.
+            crate::sys::alloc::seraph::slab_release_fresh(thread_slab_phys);
             // SAFETY: `args` was just leaked via `Box::into_raw`.
             let args_owned = unsafe { Box::from_raw(args) };
             // SAFETY: `args_owned.init` was just leaked via `Box::into_raw`.
@@ -341,6 +359,8 @@ impl Thread {
             }
             // Never started → safe to reclaim the Thread object immediately.
             let _ = syscall::cap_delete(thread_cap);
+            // Thread destroyed → return the slab's run to memmgr's pool.
+            crate::sys::alloc::seraph::slab_release_fresh(thread_slab_phys);
             // SAFETY: `args` was just leaked via `Box::into_raw`.
             let args_owned = unsafe { Box::from_raw(args) };
             // SAFETY: `args_owned.init` was just leaked via `Box::into_raw`.
@@ -359,6 +379,7 @@ impl Thread {
         Ok(Thread {
             res: ThreadResources {
                 thread_cap,
+                slab_phys: thread_slab_phys,
                 done_notification,
                 stack,
                 ipc_buf_base,

--- a/services/memmgr/README.md
+++ b/services/memmgr/README.md
@@ -44,6 +44,10 @@ address space at virtual addresses they choose themselves.
   caps memmgr has handed out, keyed on a procmgr-minted badge.
 - **Reclamation on process death** — on `PROCESS_DIED` from procmgr,
   reclaim the dead process's memory caps into the free pool.
+- **Mid-life reclamation** — on `RELEASE_MEMORY_CAPS` (or `UNREGISTER_REGION`
+  for a demand-paged region) from a live process, return the named grant to the
+  free pool so a per-unit-of-work retype loop holds a bounded footprint without
+  waiting for process death.
 - **Coalescing** — fold adjacent free pages back into larger contiguous
   Memory caps via reverse-`memory_split`, sustaining the success rate of
   `REQUIRE_CONTIGUOUS` requests as the pool fragments.
@@ -72,7 +76,7 @@ The full memmgr IPC specification is in
 [`docs/ipc-interface.md`](docs/ipc-interface.md). Key operations:
 
 - `REQUEST_MEMORY_CAPS(want_pages, flags) → memory_caps[..]`
-- `RELEASE_MEMORY_CAPS(memory_caps[..])`
+- `RELEASE_MEMORY_CAPS(phys_base[..])` — return granted regions mid-life
 - `REGISTER_PROCESS(...) → badged_endpoint_cap` (procmgr-only)
 - `PROCESS_DIED(badge)` (procmgr-only)
 

--- a/services/memmgr/README.md
+++ b/services/memmgr/README.md
@@ -47,10 +47,18 @@ address space at virtual addresses they choose themselves.
 - **Mid-life reclamation** — on `RELEASE_MEMORY_CAPS` (or `UNREGISTER_REGION`
   for a demand-paged region) from a live process, return the named grant to the
   free pool so a per-unit-of-work retype loop holds a bounded footprint without
-  waiting for process death.
+  waiting for process death. Best-fit best-effort selection (reuse a freed run
+  of the requested size rather than re-split a larger one) plus a coalesce after
+  every reclamation bound this on both sides: the caller's pool footprint *and*
+  memmgr's own per-run tracking-anchor (CSpace) footprint. A high-volume
+  spawn/free churn — e.g. ruststd thread creation, which grants and frees a
+  fresh Thread-retype slab per spawn — therefore cannot drift memmgr's CSpace
+  toward exhaustion even though its RAM stays flat.
 - **Coalescing** — fold adjacent free pages back into larger contiguous
   Memory caps via reverse-`memory_split`, sustaining the success rate of
-  `REQUIRE_CONTIGUOUS` requests as the pool fragments.
+  `REQUIRE_CONTIGUOUS` requests as the pool fragments. Runs after every
+  reclamation (death, release, unregister), so reclaimed runs rejoin their
+  physical neighbours instead of accumulating as discrete parked runs.
 
 ## What memmgr deliberately does NOT do
 

--- a/services/memmgr/docs/ipc-interface.md
+++ b/services/memmgr/docs/ipc-interface.md
@@ -124,18 +124,25 @@ Best-effort replies may use the full reply-side capacity.
 
 ### Label 2: `RELEASE_MEMORY_CAPS`
 
-Voluntarily return Memory caps to the pool. Privilege: universal.
-Typically called by `unreserve_pages` after the caller has unmapped the
-range, or by long-lived services pruning their working set.
+Voluntarily return previously-granted Memory caps to the pool mid-life.
+Privilege: universal. Called by a long-lived process pruning its working
+set — e.g. ruststd releasing a reclaimed thread's Thread-retype slab so a
+bounded thread-churn loop holds a bounded pool footprint.
+
+The caller names each region by the `phys_base` memmgr reported in the
+granting `REQUEST_MEMORY_CAPS` reply, *not* by transferring the cap: a
+caller that has retyped the region (e.g. into a Thread) and dropped the
+inner cap no longer holds a cap to send back. memmgr keeps the outer cap
+as the per-process tracking anchor and uses `phys_base` to find it.
 
 **Request:**
 
 | Field | Value |
 |---|---|
 | label | 2 |
-| data[0] | `cap_count` (u32) |
-| data[1+i] | `page_count_for_cap_i` (u32) for each released cap |
-| cap[0..cap_count] | Memory capabilities being released |
+| data[0] | `count` (u32) |
+| data[1+i] | `phys_base_i` (u64) — physical base of region `i` to release |
+| cap[..] | any inner caps the caller still holds (dropped defensively) |
 
 **Reply (success):**
 
@@ -153,11 +160,16 @@ range, or by long-lived services pruning their working set.
 
 | Code | Name | Meaning |
 |---|---|---|
-| 4 | `InvalidArgument` | `cap_count == 0`, cap not previously issued to this badge, or page-count mismatch |
+| 4 | `InvalidArgument` | caller's badge is unknown |
 
-memmgr removes the listed caps from the per-process tracking entry,
-inserts them back into the appropriate free-pool buckets, and runs
-coalescing on adjacent runs.
+For each `phys_base`, memmgr finds the matching caller-owned grant
+(`FRAME_VA_UNMAPPED`) in the per-process tracking entry, returns its run to
+the free pool (coalescing where possible), and frees the tracking node.
+Bases that match no outstanding grant are ignored — release is idempotent,
+so a racing double-release (join plus reaper) is harmless. The caller MUST
+have already deleted every kernel object retyped from the region; releasing
+a region with a live retype is correctness-safe (the kernel refuses to
+re-hand-out live bytes) but strands the run until that retype is freed.
 
 ### Label 3: `REGISTER_PROCESS`
 

--- a/services/memmgr/docs/memory-pool.md
+++ b/services/memmgr/docs/memory-pool.md
@@ -76,11 +76,17 @@ constraint.
    `OutOfMemory{contiguous}`. memmgr does not migrate live pages to
    produce a contiguous run; coalescing is the only mechanism that
    restores contiguity.
-2. **Best-effort.** Walk buckets to satisfy the request from one or
-   more runs. Prefer larger runs first to minimise the returned-cap
-   count. Bound the returned-cap count by the IPC reply-side cap-slot
-   limit; if the pool cannot satisfy `want_pages` within that bound,
-   return `OutOfMemory{best_effort}`.
+2. **Best-effort.** First try a single best-fit run — the smallest run
+   that covers `want_pages` whole. One run is the fewest possible caps,
+   and best-fit reuses a freed run of the requested size instead of
+   re-splitting a larger one, so a workload that repeatedly frees and
+   re-requests a fixed size (e.g. ruststd's per-thread Thread-retype slab)
+   cycles the same run — and the same tracking anchor — rather than minting
+   a fresh anchor each request. Only when no single run is large enough,
+   fall back to satisfying the request greedily from multiple runs, largest
+   first. Bound the returned-cap count by the IPC reply-side cap-slot limit;
+   if the pool cannot satisfy `want_pages` within that bound, return
+   `OutOfMemory{best_effort}`.
 
 Each Memory cap returned to the caller is a derive-twice copy: memmgr
 retains an intermediary in its own CSpace and hands the second derivation
@@ -173,22 +179,22 @@ longer holds one — so it names each region by the `phys_base` memmgr reported
 at grant. memmgr matches that base against the entry's frame list
 (`FRAME_VA_UNMAPPED` grants only; demand-mapped chunks are reclaimed by
 `UNREGISTER_REGION`), inserts the retained intermediary cap back into the pool,
-and frees the node, leaving the entry's other records untouched. Unmatched
-bases are ignored, so release is idempotent (a racing join-plus-reaper
-double-release is harmless). The caller must have deleted every object retyped
-from the region first; releasing a still-retyped region is correctness-safe
-(the kernel refuses to re-hand-out live bytes) but the run is only re-grantable
-whole — its retype bump pointer blocks `memory_split` — until the retype is
-freed.
+frees the node, and coalesces the freed runs with their physical neighbours,
+leaving the entry's other records untouched. Unmatched bases are ignored, so
+release is idempotent (a racing join-plus-reaper double-release is harmless).
+The caller must have deleted every object retyped from the region first;
+releasing a still-retyped region is correctness-safe (the kernel refuses to
+re-hand-out live bytes) but the run is only re-grantable whole — its retype
+bump pointer blocks `memory_split` — until the retype is freed.
 
 `UNREGISTER_REGION` from a live process is the mid-life counterpart for a
 demand-paged region: memmgr removes the region node, and for each frame it
 backed inside that region **actively unmaps** the page from the delegated
 child `AddressSpace` (the process is still alive, so the mapping must be
 removed before the frame returns to the pool), inserts the cap back into the
-pool, and frees the node. Frames the caller mapped itself are left untouched.
-This is the reclamation path the ruststd guarded-stack consumer uses on
-`join()`.
+pool, frees the node, and coalesces the freed runs with their physical
+neighbours. Frames the caller mapped itself are left untouched. This is the
+reclamation path the ruststd guarded-stack consumer uses on `join()`.
 
 ---
 
@@ -205,15 +211,23 @@ cap. Eligibility:
   the original boot-time ingest guarantees for caps derived from the
   same `BootInfo` Memory cap.
 
-Coalescing runs explicitly after every `PROCESS_DIED` reclamation. The
-mid-life paths (`RELEASE_MEMORY_CAPS`, `UNREGISTER_REGION`) reinsert through a
-coalesce-on-demand push that folds runs only when the free-pool array is full,
-so steady-state churn pays no per-release coalescing cost. A "dirty" released
-run — one whose source `MemoryObject` kept its retype bump pointer advanced —
-declines `memory_merge` (the kernel requires a virgin tail) and stays a
-discrete, re-grantable-whole run. Coalescing is bounded: a single reclamation
-that frees `K` pages can produce at most `K` coalesce operations, each
-O(log pool_size) to update bucket indices.
+Coalescing runs explicitly after every reclamation — `PROCESS_DIED`,
+`RELEASE_MEMORY_CAPS`, and `UNREGISTER_REGION` alike — so a freed run rejoins
+its physical neighbours immediately rather than parking discrete until the
+free-pool array fills. Together with best-fit best-effort selection (above),
+this bounds the pool's run count under long spawn/free/die churn, and with it
+the per-run tracking anchor memmgr holds in its own CSpace: best-fit keeps a
+fixed-size churn cycling one run, and the explicit merge keeps residual
+fragmentation from drifting the run (and anchor) count up over time. Left
+un-coalesced, reclaimed runs park discrete and their anchors persist, slowly
+consuming memmgr's CSpace even while its RAM footprint stays bounded. The
+per-insert push still folds opportunistically when the array is full; the
+explicit pass is what holds the steady state under churn that never fills it. A
+"dirty" released run — one whose source `MemoryObject` kept its retype bump
+pointer advanced — declines `memory_merge` (the kernel requires a virgin tail)
+and stays a discrete, re-grantable-whole run. Coalescing cost scales with the
+live run count, which best-fit and this pass jointly keep small, so the
+per-reclamation merge is negligible.
 
 Coalescing across boot-time ingest boundaries (between two distinct
 `BootInfo` Memory caps) is not attempted — those caps have no common

--- a/services/memmgr/docs/memory-pool.md
+++ b/services/memmgr/docs/memory-pool.md
@@ -166,8 +166,20 @@ caller-side derivation copies of the Memory caps become unreachable as part
 of that teardown; memmgr's intermediary copies remain valid and are what the
 free-pool insertion uses.
 
-`RELEASE_MEMORY_CAPS` from a live process follows the same path for the
-listed slots without touching the per-process entry's other records.
+`RELEASE_MEMORY_CAPS` from a live process is the mid-life counterpart for a
+caller-owned grant. The caller usually cannot transfer the cap back — having
+retyped the region (e.g. into a Thread) and dropped its inner copy, it no
+longer holds one — so it names each region by the `phys_base` memmgr reported
+at grant. memmgr matches that base against the entry's frame list
+(`FRAME_VA_UNMAPPED` grants only; demand-mapped chunks are reclaimed by
+`UNREGISTER_REGION`), inserts the retained intermediary cap back into the pool,
+and frees the node, leaving the entry's other records untouched. Unmatched
+bases are ignored, so release is idempotent (a racing join-plus-reaper
+double-release is harmless). The caller must have deleted every object retyped
+from the region first; releasing a still-retyped region is correctness-safe
+(the kernel refuses to re-hand-out live bytes) but the run is only re-grantable
+whole — its retype bump pointer blocks `memory_split` — until the retype is
+freed.
 
 `UNREGISTER_REGION` from a live process is the mid-life counterpart for a
 demand-paged region: memmgr removes the region node, and for each frame it
@@ -193,10 +205,15 @@ cap. Eligibility:
   the original boot-time ingest guarantees for caps derived from the
   same `BootInfo` Memory cap.
 
-Coalescing runs after every `PROCESS_DIED` reclamation and after every
-`RELEASE_MEMORY_CAPS` whose freed range adjoins another free run. It is
-bounded: a single reclamation that frees `K` pages can produce at most
-`K` coalesce operations, each O(log pool_size) to update bucket indices.
+Coalescing runs explicitly after every `PROCESS_DIED` reclamation. The
+mid-life paths (`RELEASE_MEMORY_CAPS`, `UNREGISTER_REGION`) reinsert through a
+coalesce-on-demand push that folds runs only when the free-pool array is full,
+so steady-state churn pays no per-release coalescing cost. A "dirty" released
+run — one whose source `MemoryObject` kept its retype bump pointer advanced —
+declines `memory_merge` (the kernel requires a virgin tail) and stays a
+discrete, re-grantable-whole run. Coalescing is bounded: a single reclamation
+that frees `K` pages can produce at most `K` coalesce operations, each
+O(log pool_size) to update bucket indices.
 
 Coalescing across boot-time ingest boundaries (between two distinct
 `BootInfo` Memory caps) is not attempted — those caps have no common

--- a/services/memmgr/src/main.rs
+++ b/services/memmgr/src/main.rs
@@ -1215,7 +1215,19 @@ fn select_memory_caps(
         return Ok((granted, 1));
     }
 
-    // Best-effort: greedy, largest-first, bounded by reply slots.
+    // Best-effort: a single best-fit run satisfies the request with the fewest
+    // caps and reuses a freed run of the requested size instead of re-splitting
+    // a larger one, so churn that frees and re-requests a fixed size cycles the
+    // same run (and the same anchor slot) rather than leaking one per request.
+    // Fall back to greedy largest-first only when no single run is large enough.
+    if let Some(idx) = pool.smallest_fit(want_pages)
+        && let Some((outer, phys)) = take_exactly(pool, idx, want_pages)
+    {
+        granted[0] = (outer, want_pages, phys);
+        return Ok((granted, 1));
+    }
+
+    // Fallback: greedy, largest-first across multiple runs, bounded by reply slots.
     let mut count: usize = 0;
     let mut remaining = want_pages;
     while remaining > 0 && count < MAX_REPLY_CAPS
@@ -1405,6 +1417,11 @@ fn handle_release_memory_caps(req: &IpcMessage, ipc_buf: *mut u64)
         let phys = req.word(1 + i);
         let _ = record.release_frame_by_phys(phys, pool);
     }
+    // Restore contiguity across the released runs. As in `handle_unregister_region`,
+    // `push_or_coalesce` only coalesces under slot pressure, so a release-heavy
+    // churn (ruststd returning Thread-retype slabs on join/reap) would otherwise
+    // fragment the pool monotonically.
+    pool.coalesce();
     reply_label(ipc_buf, memmgr_errors::SUCCESS);
 }
 
@@ -1703,6 +1720,12 @@ fn handle_unregister_region(req: &IpcMessage, ipc_buf: *mut u64)
     let end = region.va_base.saturating_add(region.len);
     let aspace_cap = record.aspace_cap;
     record.reclaim_frames_in(region.va_base, end, aspace_cap, pool);
+    // Restore contiguity across the reclaimed runs. The per-frame
+    // `push_or_coalesce` only fires `coalesce` under slot pressure, so a churn
+    // working set that never fills the array would otherwise leave the pool more
+    // fragmented after each register/unregister cycle, drifting the run (and
+    // tracking-anchor) count up monotonically across a long run.
+    pool.coalesce();
     reply_label(ipc_buf, memmgr_errors::SUCCESS);
 }
 

--- a/services/memmgr/src/main.rs
+++ b/services/memmgr/src/main.rs
@@ -588,6 +588,63 @@ impl ProcessRecord
         }
     }
 
+    /// Return a single caller-owned grant — identified by `phys` — to the pool
+    /// mid-life, freeing its tracking node. Matches the first `Node::Frame`
+    /// with `phys_base == phys` and `va == FRAME_VA_UNMAPPED`: only frames
+    /// issued via `REQUEST_MEMORY_CAPS` (caller owns the mapping) are
+    /// releasable this way; demand-mapped chunks (`va != FRAME_VA_UNMAPPED`)
+    /// are reclaimed only via `UNREGISTER_REGION` / `PROCESS_DIED` and are
+    /// skipped. Returns whether a grant matched.
+    ///
+    /// The run may be "dirty": its `MemoryObject` keeps the retype bump pointer
+    /// advanced even after the caller's retype was freed. `push_or_coalesce` is
+    /// sound regardless — `coalesce`'s `memory_merge` guards every join with
+    /// `.is_err()` and the kernel refuses to merge a non-virgin tail
+    /// (`sys_memory_merge`) or split past the bump (`sys_memory_split`), so a
+    /// dirty run is parked discrete and re-granted whole, reusing the kernel's
+    /// retype free-list. A varied-size workload that releases dirty runs may
+    /// see mild fragmentation (no sub-splitting until the run goes virgin);
+    /// same-size churn (the Thread-retype slab) is unaffected.
+    fn release_frame_by_phys(&mut self, phys: u64, pool: &mut FreePool) -> bool
+    {
+        let mut prev = NODE_NULL;
+        let mut cur = self.frame_head;
+        while cur != NODE_NULL
+        {
+            // SAFETY: cur is a live frame node.
+            let s = unsafe { *slot_ptr(cur) };
+            if let Node::Frame {
+                cap_slot,
+                page_count,
+                phys_base,
+                va,
+            } = s.node
+                && va == FRAME_VA_UNMAPPED
+                && phys_base == phys
+            {
+                let _ = pool.push_or_coalesce(FreeRun {
+                    cap_slot,
+                    page_count,
+                    phys_base,
+                });
+                if prev == NODE_NULL
+                {
+                    self.frame_head = s.next;
+                }
+                else
+                {
+                    // SAFETY: prev is a live frame node.
+                    unsafe { (*slot_ptr(prev)).next = s.next };
+                }
+                node_free(cur);
+                return true;
+            }
+            prev = cur;
+            cur = s.next;
+        }
+        false
+    }
+
     /// Reclaim every frame and region node on process death: each frame cap
     /// returns to the pool (the kernel's cspace-revoke cascade, run by procmgr
     /// before this point, already tore down the child's mappings, so no unmap
@@ -1320,15 +1377,33 @@ fn handle_request_memory_caps(req: &IpcMessage, ipc_buf: *mut u64)
 
 fn handle_release_memory_caps(req: &IpcMessage, ipc_buf: *mut u64)
 {
-    // First-cut RELEASE: receive the caller's caps, drop them. Per-process
-    // tracking is not updated; the underlying physical region remains
-    // pinned by memmgr's outer derivation until PROCESS_DIED reclaims the
-    // process. This is correctness-safe (no double-free) and intentionally
-    // conservative until userspace has a way to identify outers from
-    // received inner caps.
+    // Drop any inner caps the caller still holds. The common caller (ruststd
+    // releasing a reclaimed Thread-retype slab) already deleted its inner cap
+    // after retype, so this is usually empty; it is defensive for callers that
+    // hand the cap back too.
     for &slot in req.caps()
     {
         let _ = syscall::cap_delete(slot);
+    }
+
+    let pool = pool_mut();
+    let Some(record) = table_mut().find_mut(req.badge)
+    else
+    {
+        reply_label(ipc_buf, memmgr_errors::INVALID_ARGUMENT);
+        return;
+    };
+
+    // Each word names a previously-granted region by physical base (the value
+    // memmgr reported in the grant reply). Return every match to the pool;
+    // unmatched bases are ignored, so release is idempotent and a racing
+    // double-release (a joined thread plus the detached-thread reaper) is
+    // harmless. Clamp to the words actually present to stay in bounds.
+    let count = (req.word(0) as usize).min(req.word_count().saturating_sub(1));
+    for i in 0..count
+    {
+        let phys = req.word(1 + i);
+        let _ = record.release_frame_by_phys(phys, pool);
     }
     reply_label(ipc_buf, memmgr_errors::SUCCESS);
 }

--- a/shared/ipc/src/lib.rs
+++ b/shared/ipc/src/lib.rs
@@ -303,7 +303,7 @@ pub mod procmgr_labels
     pub const INIT_REAP_CORRELATOR: u32 = u32::MAX;
 }
 
-pub const MEMMGR_LABELS_VERSION: u32 = 4;
+pub const MEMMGR_LABELS_VERSION: u32 = 5;
 /// IPC labels for the memory manager (`memmgr`).
 ///
 /// memmgr owns the userspace RAM frame pool. All std-built processes
@@ -332,10 +332,29 @@ pub mod memmgr_labels
     /// syscalls; memmgr derives reply caps with `RIGHTS_ALL`, which
     /// preserves the RETYPE bit stamped at boot by the kernel.
     pub const REQUEST_MEMORY_CAPS: u64 = 1;
-    /// Voluntarily return Memory caps to the pool. Callable from any
-    /// badged cap. Wire format: `data[0]` = `cap_count`; `data[1+i]` =
-    /// `page_count_for_cap_i`; `caps[0..cap_count]` = Memory caps to release.
-    /// memmgr verifies each cap was previously issued to the caller's badge.
+    /// Voluntarily return previously-granted Memory caps to the pool
+    /// mid-life. Callable from any badged cap. The caller names each region
+    /// by the `phys_base` memmgr reported in the granting
+    /// `REQUEST_MEMORY_CAPS` reply, not by transferring the cap: a caller
+    /// that retyped the region (e.g. into a Thread) and dropped the inner cap
+    /// no longer holds a cap to send back. Wire format:
+    ///
+    /// * `data[0]` — `count: u32`.
+    /// * `data[1+i]` — `phys_base_i: u64`, the physical base of the region to
+    ///   release (the grant reply reports it at `data[1 + cap_count + i]`).
+    /// * `caps[..]` — any inner caps the caller still holds; dropped
+    ///   defensively.
+    ///
+    /// memmgr matches each `phys_base` against the caller's own outstanding
+    /// grants (badge-scoped), returns the backing run to the free pool, and
+    /// credits `free_bytes`. Unmatched bases are ignored (idempotent, like
+    /// `PROCESS_DIED`). The caller MUST have already deleted every kernel
+    /// object retyped from the region; releasing a region with a live retype
+    /// is correctness-safe (the kernel refuses to re-hand-out live bytes) but
+    /// strands the run until that retype is freed.
+    ///
+    /// Reply: `memmgr_errors::SUCCESS`; `INVALID_ARGUMENT` if the caller's
+    /// badge is unknown.
     pub const RELEASE_MEMORY_CAPS: u64 = 2;
     /// Procmgr-only: register a new process. memmgr allocates a per-process
     /// tracking entry and replies with a badged SEND cap on its endpoint
@@ -474,8 +493,9 @@ pub mod memmgr_errors
     /// exhausted. Per-process region and frame counts are otherwise RAM-bound,
     /// not capped by a constant.
     pub const QUOTA: u64 = 3;
-    /// `want_pages == 0`, reserved flag bits set, page-count mismatch on
-    /// `RELEASE_MEMORY_CAPS`, or badge unknown.
+    /// `want_pages == 0`, reserved flag bits set, or badge unknown
+    /// (`REQUEST_MEMORY_CAPS` / `RELEASE_MEMORY_CAPS` from an unregistered
+    /// badge).
     pub const INVALID_ARGUMENT: u64 = 4;
     /// Procmgr-only label called over a non-procmgr badge.
     pub const UNAUTHORIZED: u64 = 5;


### PR DESCRIPTION
Resolves #274.

## Problem
#274 has two acceptance criteria:

1. **Mid-life RAM reclaim** — `RELEASE_MEMORY_CAPS` was an accounting no-op, so a process requesting a fresh retype slab per unit of work (ruststd's per-spawn Thread-retype slot) drained memmgr's pool without bound until it exited.
2. **No hang at high counts** — surfaced by `programs/threadchurn`: at high spawn counts a join blocks forever while a CPU spins (no watchdog).

## Criterion 1 — functional mid-life reclaim (commit `c337297`)
**Keyed by physical base** (the value memmgr already ships in the `REQUEST_MEMORY_CAPS` reply):
- `services/memmgr/src/main.rs` — `RELEASE_MEMORY_CAPS` matches each `phys_base` against the caller's own `FRAME_VA_UNMAPPED` grants (badge-scoped), returns the retained outer run to the pool, frees the node. Idempotent on unmatched bases (a racing join + reaper double-release is harmless). New `ProcessRecord::release_frame_by_phys`.
- `shared/ipc/src/lib.rs` — redefine the `RELEASE_MEMORY_CAPS` wire contract (phys_base list, not transferred caps); bump `MEMMGR_LABELS_VERSION` 4→5.
- `runtime/ruststd/.../alloc/seraph.rs` — fresh-slab path returns `SlabGrant{cap, phys}`; new `slab_release_fresh` and `memmgr_pool_free_bytes` query. Too-small/augment reject paths return their virgin runs instead of leaking.
- `runtime/ruststd/.../thread/seraph.rs` — `ThreadResources` carries `slab_phys`; `reclaim()` returns the Thread retype slab to memmgr after the Thread cap is deleted (join + both reaper paths).

**Soundness:** a released run keeps its retype bump pointer advanced, so it is re-granted *whole* and re-retyped via the kernel's retype free-list. `memory_split`/`memory_merge` refuse dirty/childed objects, so the kernel backstops aliasing even if a caller releases a still-retyped region.

## Criterion 2 — bound memmgr's CSpace anchor footprint (commit `7ff59f7`)
The earlier "demand-fault under exhaustion → terminal-fault escalation (#228)" reading was **wrong**. Live GDB on the deadlocked guest showed the real mechanism: at ~250 spawns **memmgr's own main thread** live-locks in `sys_ipc_recv` → `CSpace::pre_allocate(4)` → `CSpace::grow()` returning `OutOfMemory` every call. memmgr's CSpace growth pool is exhausted (~1735 anchored slots) while its **RAM pool stays bounded** — so the receive loop busy-retries forever and one CPU spins (the watchdog only fires when *every* CPU is idle). The kernel is not at fault and is unchanged.

Why the CSpace grew without bound: memmgr anchors **one outer Memory cap = one CSpace slot per distinct pool run** it tracks. Two coupled defects climbed the anchor count ~per spawn:
- **Best-effort selection never reused freed runs.** The per-spawn Thread-retype slab is requested non-contiguous; `select_memory_caps`' best-effort branch carved the largest run (`largest()`) and never picked a freed slab-sized run, minting a fresh anchor each spawn.
- **Reclaim paths never coalesced.** `handle_release_memory_caps` / `handle_unregister_region` pushed runs back without coalescing (unlike `handle_process_died`), so reclaimed runs parked discrete and their anchors persisted.

Fix (memmgr-internal; **kernel unchanged**):
- `select_memory_caps` best-effort branch tries a single **best-fit** run (`smallest_fit`) before the greedy largest-first fallback. A fixed-size free/re-request churn now cycles the same run and the same anchor; also strictly fewer caps (one run is the fewest), preserving the prefer-fewer-caps contract.
- `handle_release_memory_caps` and `handle_unregister_region` **coalesce after reclaim**, mirroring `handle_process_died`.

## Regression
`programs/threadchurn` runs a high-count join phase (**`JOIN_CHURN = 600`**, well past the ~250 live-lock threshold) with a per-25 heartbeat. **Completing the run is the criterion-2 proof** (pre-fix it froze at ~250 with a spinning CPU). It also asserts memmgr free-pool drop < 1 MiB (criterion 1) and the process CSpace-slot bound ≤ 12 (#240). A per-spawn RAM leak would drop the pool ~14 MiB at 600.

## Acceptance (#274)
- [x] A process can return granted Memory caps to memmgr's pool mid-life (functional `RELEASE_MEMORY_CAPS`), so a bounded-working-set churn loop holds a bounded pool footprint.
- [x] High-count `threadchurn` terminates rather than hangs: memmgr's CSpace anchor footprint is now bounded under per-spawn churn (best-fit reuse + coalesce-on-reclaim), so the `sys_ipc_recv` CSpace-exhaustion live-lock is unreachable for this workload.

## Test plan
Verified on **x86_64** and **riscv64** (`cargo xtask clean` between arches):
- `cargo xtask build` — clean both arches.
- `cargo xtask run` (usertest, headless) — `[usertest] ALL TESTS PASSED`, clean `[pwrmgr] SHUTDOWN requested`, both arches.
- threadchurn (identical both arches): join-churn `25 → 600/600` with **no stall** (pre-fix froze at ~250), `pool drop 90112 <= slack 1048576`, `PASS growth 11 <= slack 12`. `Some(..)` free-bytes confirms the pool query ran.
- Host `cargo xtask test` — **68 passed; 0 failed**.

## Docs
`services/memmgr/{README.md,docs/ipc-interface.md,docs/memory-pool.md}` and `docs/userspace-memory-model.md` describe functional mid-life reclaim (criterion 1); `services/memmgr/{README.md,docs/memory-pool.md}` describe best-fit best-effort selection and coalesce-after-every-reclamation with the resulting bounded anchor footprint (criterion 2).
