### PR TITLE
kernel/sched: enforce single-link run-queue invariant at the enqueue chokepoint (#244)

### DIFF
--- a/core/kernel/docs/scheduling-internals.md
+++ b/core/kernel/docs/scheduling-internals.md
@@ -192,6 +192,29 @@ affinity recheck rather than at dispatch). This is the same eventual-
 consistency window as for any other `enqueue_and_wake` racing
 `sys_thread_set_affinity`; see issue #116.
 
+**Enqueue-chokepoint enforcement (issue #244).** Every run-queue insertion —
+`enqueue_and_wake`, `schedule()`'s outgoing requeue, `sys_thread_set_priority`'s
+re-enqueue, and `migrate_ready_thread`'s destination link — funnels through
+`PerCpuScheduler::enqueue`. That chokepoint refuses a double-link: if `tcb` is
+already linked on a run queue (`run_queue_next.is_some()`, or it is the target
+priority queue's tail), re-linking it would self-cycle the intrusive list
+(`tail.next = Some(tail)`, the `head=tail=tcb` corruption #244 reported). The
+condition is read under the owning `scheduler.lock` — the same state and lock
+the `RunQueue::enqueue` tripwire asserts on, so it identifies only genuine
+double-links. Debug builds panic via that tripwire, naming the racing call
+sites through the debug-only `last_enqueue` breadcrumb; release builds skip the
+redundant link so the "Ready ⇒ linked on exactly one queue" invariant holds by
+construction rather than corrupting. The skip is lossless: the target TCB is
+already `Ready` and linked, so it is dispatched and consumes its wakeup payload
+from where it is already queued. The guard precedes `increment_load`, so a
+skipped link leaves the load counter exact. The legitimate Ready-on-entry
+callers (the cross-CPU outgoing branch, `sys_thread_start`) reach
+`PerCpuScheduler::enqueue` with the TCB *unlinked* (it was just `current`, or
+`Created`/`Stopped`), so the guard never fires on them. This makes the
+invariant self-enforcing at the single insertion chokepoint, closing the
+double-link class (#22/#116/#117/#122/#142/#144/#244) against any residual
+racing path.
+
 ---
 
 ## Cross-CPU TCB Ownership

--- a/core/kernel/src/main.rs
+++ b/core/kernel/src/main.rs
@@ -1049,6 +1049,8 @@ unsafe fn kernel_entry_post_rebase(
                         cpu_affinity: sched::AFFINITY_ANY,
                         preferred_cpu: 0,
                         run_queue_next: None,
+                        #[cfg(debug_assertions)]
+                        last_enqueue: None,
                         ipc_state: sched::thread::IpcThreadState::None,
                         ipc_msg: ipc::message::Message::default(),
                         reply_tcb: core::sync::atomic::AtomicPtr::new(core::ptr::null_mut()),

--- a/core/kernel/src/sched/mod.rs
+++ b/core/kernel/src/sched/mod.rs
@@ -951,6 +951,8 @@ pub fn init(cpu_count: u32) -> u32
                     cpu_affinity: cpu as u32,
                     preferred_cpu: cpu as u32,
                     run_queue_next: None,
+                    #[cfg(debug_assertions)]
+                    last_enqueue: None,
                     ipc_state: IpcThreadState::None,
                     ipc_msg: crate::ipc::message::Message::default(),
                     reply_tcb: core::sync::atomic::AtomicPtr::new(core::ptr::null_mut()),

--- a/core/kernel/src/sched/run_queue.rs
+++ b/core/kernel/src/sched/run_queue.rs
@@ -48,30 +48,43 @@ impl RunQueue
     /// A non-`None` `tcb.run_queue_next` on entry or `tail == Some(tcb)`
     /// indicates the caller is attempting a double-enqueue of a thread
     /// that is already linked — the intrusive list would become a
-    /// self-cycle (`tail.next = Some(tail)`). The two debug-only
-    /// `debug_assert!`s below are tripwires for issue #117 family races;
-    /// the original site reproduced as `head=tail=tcb` (single-element
-    /// queue, second enqueue from a duplicate wake source).
-    /// `#[track_caller]` propagates the panic location to the kernel's
-    /// panic handler (`core/kernel/src/main.rs:1186-1198`), so the panic
-    /// banner names the call site (e.g. `sched/mod.rs:1607` for
-    /// `enqueue_and_wake`).
+    /// self-cycle (`tail.next = Some(tail)`). The debug-only tripwire
+    /// below catches issue #117/#244 family races; the original site
+    /// reproduced as `head=tail=tcb` (single-element queue, second enqueue
+    /// from a duplicate wake source). It reports the prior link's breadcrumb
+    /// (recorded by [`PerCpuScheduler::enqueue`]) so the racing call site is
+    /// named alongside the current one. `#[track_caller]` propagates the
+    /// panic location to the kernel's panic handler
+    /// (`core/kernel/src/main.rs:1186-1198`), so the panic banner names the
+    /// current call site (e.g. `sched/mod.rs:1806` for `enqueue_and_wake`).
     #[track_caller]
     fn enqueue(&mut self, tcb: *mut ThreadControlBlock)
     {
-        // SAFETY: tcb is a valid heap-allocated TCB pointer; caller holds
-        // the owning scheduler.lock so run_queue_next/thread_id are stable.
-        // Both reads are debug-only inputs to the assertions below.
-        let (already_linked, tid) = unsafe { ((*tcb).run_queue_next.is_some(), (*tcb).thread_id) };
-        debug_assert!(
-            !already_linked,
-            "run_queue::enqueue: tcb {tcb:p} tid={tid} already linked (run_queue_next != None) — double-enqueue",
-        );
-        debug_assert!(
-            self.tail != Some(tcb),
-            "run_queue::enqueue: tcb {tcb:p} tid={tid} is already this queue's tail (head={:?}) — double-enqueue or stale tail",
-            self.head,
-        );
+        // Double-enqueue tripwire (issue #244). Gated on `debug_assertions`
+        // rather than `debug_assert!` so it can read the debug-only
+        // `last_enqueue` breadcrumb field, which is absent in release.
+        #[cfg(debug_assertions)]
+        // SAFETY: tcb is a valid heap-allocated TCB pointer; the caller holds
+        // the owning scheduler.lock so these fields are stable.
+        unsafe {
+            let tid = (*tcb).thread_id;
+            let prior = (*tcb).last_enqueue;
+            let cur_ipc = (*tcb).ipc_state;
+            let cur_pref = (*tcb).preferred_cpu;
+            assert!(
+                (*tcb).run_queue_next.is_none(),
+                "run_queue::enqueue: tcb {tcb:p} tid={tid} already linked \
+                 (run_queue_next != None) — double-enqueue; \
+                 prior={prior:?}; now ipc={cur_ipc:?} pref={cur_pref}",
+            );
+            assert!(
+                self.tail != Some(tcb),
+                "run_queue::enqueue: tcb {tcb:p} tid={tid} is already this \
+                 queue's tail (head={head:?}) — double-enqueue or stale tail; \
+                 prior={prior:?}; now ipc={cur_ipc:?} pref={cur_pref}",
+                head = self.head,
+            );
+        }
         // SAFETY: tcb is a valid heap-allocated TCB pointer.
         unsafe { (*tcb).run_queue_next = None };
 
@@ -109,6 +122,17 @@ impl RunQueue
     fn is_empty(&self) -> bool
     {
         self.head.is_none()
+    }
+
+    /// True iff `tcb` is this queue's tail. Used only by the release-safe
+    /// double-link guard in [`PerCpuScheduler::enqueue`]; in debug builds the
+    /// `RunQueue::enqueue` tripwire checks `self.tail` directly, so this
+    /// accessor is release-only. Reads only this queue's own `tail`, so it is
+    /// sound under the owning scheduler.lock.
+    #[cfg(not(debug_assertions))]
+    fn is_tail(&self, tcb: *mut ThreadControlBlock) -> bool
+    {
+        self.tail == Some(tcb)
     }
 
     /// Find the first TCB in this queue satisfying `pred`. Returns the TCB
@@ -257,7 +281,13 @@ impl PerCpuScheduler
 
     /// Enqueue `tcb` at the given `priority` level.
     ///
-    /// Sets bit `priority` in `non_empty` and increments load counter.
+    /// Sets bit `priority` in `non_empty` and increments the load counter.
+    ///
+    /// Enforces the "Ready ⇒ linked on exactly one queue" invariant at this
+    /// chokepoint (issue #244): a `tcb` already linked on a run queue is a
+    /// double-link that would self-cycle the intrusive list. Debug builds panic
+    /// (the `RunQueue::enqueue` tripwire); release builds skip the redundant
+    /// link. See the guard below.
     #[track_caller]
     pub fn enqueue(&mut self, tcb: *mut ThreadControlBlock, priority: u8)
     {
@@ -276,8 +306,46 @@ impl PerCpuScheduler
             p < NUM_PRIORITY_LEVELS,
             "priority {p} out of range [0, {NUM_PRIORITY_LEVELS})"
         );
+
+        // Release-safe double-link guard (issue #244). A non-`None`
+        // `run_queue_next`, or `tcb` already being this priority queue's tail,
+        // means `tcb` is already linked on a run queue; re-linking it would
+        // self-cycle the intrusive list (`tail.next = Some(tail)`) and corrupt
+        // it. This is the exact condition the `RunQueue::enqueue` tripwire
+        // asserts on, read under the same owning scheduler.lock — so it
+        // identifies only genuine double-links. In debug the tripwire still
+        // panics below (naming the racing pair via the `last_enqueue`
+        // breadcrumb); in release, skip the link so the "Ready ⇒ linked on
+        // exactly one queue" invariant holds by construction instead of
+        // corrupting. The skip is lossless: `tcb` is already Ready and linked,
+        // so it is dispatched and consumes its wakeup payload from where it is
+        // already queued; no wake is lost. Placed before `increment_load` so a
+        // skipped link leaves the load counter exact.
+        #[cfg(not(debug_assertions))]
+        // SAFETY: tcb is valid; the caller holds this scheduler's lock, so
+        // run_queue_next is stable for this read.
+        if unsafe { (*tcb).run_queue_next.is_some() } || self.queues[p].is_tail(tcb)
+        {
+            return;
+        }
+
         self.increment_load();
         self.queues[p].enqueue(tcb);
+        // Record the link breadcrumb (issue #244 diagnosis) under the owning
+        // scheduler.lock, after the inner enqueue so a tripping case still
+        // observes the *prior* breadcrumb. `Location::caller()` resolves
+        // through the `#[track_caller]` chain to the wake/requeue call site.
+        // Stripped in release; skipped in host tests (no per-CPU arch context).
+        #[cfg(all(debug_assertions, not(test)))]
+        // SAFETY: tcb is valid; the caller holds this scheduler's lock.
+        unsafe {
+            (*tcb).last_enqueue = Some(super::thread::EnqueueBreadcrumb {
+                site: core::panic::Location::caller(),
+                cpu: crate::arch::current::cpu::current_cpu(),
+                ipc_state: (*tcb).ipc_state,
+                preferred_cpu: (*tcb).preferred_cpu,
+            });
+        }
         // Release: publishes the queue write and the increment_load store to any
         // CPU that observes this bit via Acquire in `has_runnable`. The idle
         // loop relies on this: it is lockless, so the Acquire load of
@@ -484,8 +552,11 @@ mod tests
 
     /// Allocate a zero-initialized TCB for tests with magic cookie set.
     ///
-    /// SAFETY: only `run_queue_next` and `magic` are accessed by
-    /// RunQueue/PerCpuScheduler; all other TCB fields remain zero/null.
+    /// SAFETY: only `run_queue_next`, `last_enqueue`, `ipc_state`,
+    /// `preferred_cpu`, and `magic` are accessed by RunQueue/PerCpuScheduler;
+    /// all other TCB fields remain zero/null. The debug-only `last_enqueue:
+    /// Option<EnqueueBreadcrumb>` field zeroes to `None` via the null-pointer
+    /// niche of its `&'static Location`, so the tripwire reads a valid `None`.
     fn make_tcb() -> Box<ThreadControlBlock>
     {
         let mut tcb: ThreadControlBlock = unsafe { core::mem::zeroed() };

--- a/core/kernel/src/sched/thread.rs
+++ b/core/kernel/src/sched/thread.rs
@@ -180,6 +180,29 @@ pub enum ThreadState
     Exited,
 }
 
+// ── EnqueueBreadcrumb ─────────────────────────────────────────────────────────
+
+/// Debug-only record of the most recent run-queue link of a TCB.
+///
+/// Captured under the owning `PerCpuScheduler.lock` after each successful
+/// enqueue so the `RunQueue::enqueue` double-enqueue tripwires can name the
+/// *prior* link site (the panic banner names only the current caller). Used to
+/// pin the racing pair behind the issue #244 "Ready ⇒ linked on exactly one
+/// queue" double-enqueue. Stripped entirely in release builds.
+#[cfg(debug_assertions)]
+#[derive(Clone, Copy, Debug)]
+pub struct EnqueueBreadcrumb
+{
+    /// Call site that performed the prior enqueue (`#[track_caller]` location).
+    pub site: &'static core::panic::Location<'static>,
+    /// CPU whose run queue linked the TCB.
+    pub cpu: u32,
+    /// `ipc_state` observed at the prior enqueue.
+    pub ipc_state: IpcThreadState,
+    /// `preferred_cpu` observed at the prior enqueue.
+    pub preferred_cpu: u32,
+}
+
 // ── ThreadControlBlock ────────────────────────────────────────────────────────
 
 /// Per-thread kernel state.
@@ -214,6 +237,13 @@ pub struct ThreadControlBlock
     /// Intrusive run-queue link — next TCB at the same priority.
     /// `None` when not on any run queue.
     pub run_queue_next: Option<*mut ThreadControlBlock>,
+
+    /// Debug-only breadcrumb of the most recent run-queue link, recorded under
+    /// the owning `PerCpuScheduler.lock` in `PerCpuScheduler::enqueue`. Read by
+    /// the `RunQueue::enqueue` double-enqueue tripwires to name the prior link
+    /// site (issue #244). Stripped in release builds.
+    #[cfg(debug_assertions)]
+    pub last_enqueue: Option<EnqueueBreadcrumb>,
 
     // === IPC state ===
     /// Current IPC blocking reason (None when not blocked on IPC).

--- a/core/kernel/src/syscall/cap.rs
+++ b/core/kernel/src/syscall/cap.rs
@@ -900,6 +900,8 @@ pub fn sys_cap_create_thread(tf: &mut TrapFrame) -> Result<u64, SyscallError>
                 cpu_affinity: AFFINITY_ANY,
                 preferred_cpu: 0,
                 run_queue_next: None,
+                #[cfg(debug_assertions)]
+                last_enqueue: None,
                 ipc_state: IpcThreadState::None,
                 ipc_msg: Message::default(),
                 reply_tcb: core::sync::atomic::AtomicPtr::new(core::ptr::null_mut()),

--- a/core/ktest/src/stress/double_enqueue_storm.rs
+++ b/core/ktest/src/stress/double_enqueue_storm.rs
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// ktest/src/stress/double_enqueue_storm.rs
+
+//! Stress: regression test for the run-queue double-link guard (issue #244).
+//!
+//! The "Ready ⇒ linked on exactly one queue" invariant is enforced at the
+//! `PerCpuScheduler::enqueue` chokepoint: a TCB already linked on a run queue
+//! must never be re-linked (that would self-cycle the intrusive list,
+//! `tail.next = Some(tail)` — the `head=tail=tcb` corruption #244 reported).
+//! Debug builds panic via the `RunQueue::enqueue` tripwire (naming the racing
+//! call sites through the `last_enqueue` breadcrumb); release builds skip the
+//! redundant link.
+//!
+//! This test exercises that chokepoint under the dense, concurrent scheduler
+//! transitions most likely to drive a double-link, so a regression that
+//! reintroduces one trips the debug tripwire here:
+//!
+//!   * **Phase 1 — wake + churn storm.** Each worker parks on its own
+//!     notification; the controller storms `notification_send` (the wake that
+//!     drives `enqueue_and_wake` while the hosting CPU is in the idle path)
+//!     interleaved with `thread_set_priority` (the #122 remove-and-re-enqueue
+//!     under all-CPU locks) and periodic `thread_set_affinity` flips (the
+//!     `migrate_ready_thread` / cross-CPU `schedule()` outgoing-branch
+//!     re-enqueue). The wake lands while the queue entry is being relocated.
+//!   * **Phase 2 — wake racing dealloc.** For each worker the controller
+//!     issues a wake and *immediately* `cap_delete(Thread)` with no intervening
+//!     yield, so the notification's `enqueue_and_wake` races the dealloc
+//!     all-CPU-locks walk, its `Stopped|Exited` wake-abort, and the
+//!     `BlockedOnNotification` waiter-unlink + wake-in-flight gate.
+//!
+//! Pass criterion is structural: the harness boots clean to
+//! `[ktest] ALL TESTS PASSED`. A reintroduced double-link trips the
+//! `RunQueue::enqueue` tripwire (debug builds), reported as FAIL with the
+//! racing call sites named via the `last_enqueue` breadcrumb.
+//!
+//! Requires ≥ 2 CPUs for the cross-CPU windows; on UP it still exercises the
+//! local wake + churn + dealloc paths.
+
+use syscall::{
+    cap_copy, cap_create_notification, cap_delete, notification_send, thread_set_affinity,
+    thread_set_priority, thread_yield,
+};
+use syscall_abi::SystemInfoType;
+
+use crate::{ChildStack, TestContext, TestResult, spawn};
+
+/// Concurrent parked workers. 32 keeps cross-CPU contention high while staying
+/// within `MAX_STRESS_THREADS` and the shared `STRESS_STACKS` slab.
+const NUM_WORKERS: usize = 32;
+
+/// Wake + churn cycles in Phase 1. Each cycle issues one wake + one priority
+/// write per worker; 600 cycles is a few hundred thousand scheduler
+/// transitions exercising the enqueue chokepoint, well under a second on a
+/// healthy kernel.
+const CYCLES: usize = 600;
+
+/// Notification bit the controller wakes workers with (any non-zero value;
+/// `notification_send` rejects zero-bit sends).
+const BIT_GO: u64 = 0x1;
+
+/// Notify + wait rights, mirroring the other notification stress tests.
+const RIGHTS_NOTIFY_WAIT: u64 = (1 << 7) | (1 << 8);
+
+pub fn run(ctx: &TestContext) -> TestResult
+{
+    let cpus = syscall::system_info(SystemInfoType::CpuCount as u64)
+        .map_err(|_| "stress::double_enqueue_storm: system_info(CpuCount) failed")?;
+    let cpu_mod = u32::try_from(cpus).unwrap_or(1).max(1);
+
+    let mut threads = [0u32; NUM_WORKERS];
+    let mut cspaces = [0u32; NUM_WORKERS];
+    // Parent-side notification caps used to wake each worker.
+    let mut p2c = [0u32; NUM_WORKERS];
+
+    for i in 0..NUM_WORKERS
+    {
+        let notif = cap_create_notification(ctx.memory_base)
+            .map_err(|_| "stress::double_enqueue_storm: cap_create_notification failed")?;
+        let child = spawn::new_child(ctx)
+            .map_err(|_| "stress::double_enqueue_storm: spawn::new_child failed")?;
+        let child_notif = cap_copy(notif, child.cs, RIGHTS_NOTIFY_WAIT)
+            .map_err(|_| "stress::double_enqueue_storm: cap_copy notification failed")?;
+        // SAFETY: stress tests run sequentially; only this test uses these
+        // STRESS_STACKS slots during its run.
+        let stack_top = ChildStack::top(unsafe { core::ptr::addr_of!(super::STRESS_STACKS[i]) });
+        spawn::configure_and_start(&child, worker_entry, stack_top, u64::from(child_notif))
+            .map_err(|_| "stress::double_enqueue_storm: configure_and_start failed")?;
+        threads[i] = child.th;
+        cspaces[i] = child.cs;
+        p2c[i] = notif;
+    }
+
+    // Let every worker reach its `notification_wait` park before the storm —
+    // a wake only drives `enqueue_and_wake` once the target is Blocked.
+    for _ in 0..(NUM_WORKERS * 2)
+    {
+        let _ = thread_yield();
+    }
+
+    // ── Phase 1: wake + priority churn ± affinity flips. ─────────────────────
+    //
+    // Each cycle wakes every worker (enqueue_and_wake) and rewrites its
+    // priority (remove-and-re-enqueue under all-CPU locks). Affinity flips
+    // every 4 cycles relocate the queue entry across CPUs via
+    // migrate_ready_thread / the cross-CPU outgoing branch — so a wake can land
+    // on a TCB mid-relocation, the transient window the #244 class lives in.
+    for cycle in 0..CYCLES
+    {
+        // CYCLES and NUM_WORKERS are compile-time constants well below
+        // u32::MAX; `try_from` keeps the narrow casts clippy-clean.
+        let cycle_u32 = u32::try_from(cycle).unwrap_or(0);
+        for i in 0..NUM_WORKERS
+        {
+            let _ = notification_send(p2c[i], BIT_GO);
+            let prio: u8 = if (cycle + i) & 1 == 0 { 3 } else { 9 };
+            let _ = thread_set_priority(threads[i], prio, ctx.sched_control_cap);
+            if cycle % 4 == 0
+            {
+                let i_u32 = u32::try_from(i).unwrap_or(0);
+                let target_cpu = (i_u32 + cycle_u32) % cpu_mod;
+                let _ = thread_set_affinity(threads[i], target_cpu);
+            }
+        }
+        // Periodically yield so workers actually run and re-park, keeping the
+        // wake path hot instead of saturating each notification's pending mask.
+        if cycle % 8 == 0
+        {
+            let _ = thread_yield();
+        }
+    }
+
+    // ── Phase 2: wake racing dealloc. ────────────────────────────────────────
+    //
+    // Wake the worker and immediately delete it with no intervening yield, so
+    // the notification's enqueue_and_wake races dealloc_object(Thread): its
+    // all-CPU-locks Exited commit, the Stopped|Exited wake-abort in
+    // enqueue_and_wake, and the BlockedOnNotification waiter-unlink + the
+    // wake-in-flight gate. An affinity flip first spreads the target CPU.
+    for i in 0..NUM_WORKERS
+    {
+        let i_u32 = u32::try_from(i).unwrap_or(0);
+        let _ = thread_set_affinity(threads[i], (i_u32 + 1) % cpu_mod);
+        let _ = notification_send(p2c[i], BIT_GO);
+        let _ = thread_set_priority(threads[i], 5, ctx.sched_control_cap);
+        cap_delete(threads[i])
+            .map_err(|_| "stress::double_enqueue_storm: cap_delete thread failed")?;
+        cap_delete(cspaces[i])
+            .map_err(|_| "stress::double_enqueue_storm: cap_delete cspace failed")?;
+        cap_delete(p2c[i])
+            .map_err(|_| "stress::double_enqueue_storm: cap_delete notification failed")?;
+    }
+
+    Ok(())
+}
+
+/// Worker entry: park on the notification and re-park on every wake. The
+/// controller tears the worker down with `cap_delete(Thread)` (Phase 2), so a
+/// clean exit handshake is unnecessary — a delete while parked is itself one of
+/// the raced teardown paths.
+fn worker_entry(notif_slot: u64) -> !
+{
+    // notification_wait returns on each wake; loop forever re-parking. A delete
+    // while parked unblocks via the dealloc waiter-unlink rather than a return.
+    #[allow(clippy::cast_possible_truncation)]
+    let notif = notif_slot as u32;
+    loop
+    {
+        let _ = syscall::notification_wait(notif);
+    }
+}

--- a/core/ktest/src/stress/mod.rs
+++ b/core/ktest/src/stress/mod.rs
@@ -25,6 +25,7 @@ mod concurrent_ipc;
 mod concurrent_map_unmap;
 mod concurrent_notification;
 mod cspace_recycle;
+mod double_enqueue_storm;
 mod event_queue_fill_drain;
 mod fpu_migration_churn;
 mod idle_wake_race;
@@ -65,6 +66,10 @@ pub fn run_all(ctx: &TestContext)
     run_integration_test!(
         "stress::priority_dealloc_race",
         priority_dealloc_race::run(ctx)
+    );
+    run_integration_test!(
+        "stress::double_enqueue_storm",
+        double_enqueue_storm::run(ctx)
     );
     run_integration_test!(
         "stress::concurrent_notification",


### PR DESCRIPTION
## Summary

Closes #244 by enforcing the "Ready ⇒ linked on exactly one queue" invariant at the single run-queue insertion chokepoint, `PerCpuScheduler::enqueue`.

A TCB already linked on a run queue (`run_queue_next` set, or already the target priority queue's tail) can no longer be re-linked into a `tail.next = Some(tail)` self-cycle — the `head=tail=tcb` corruption #244 reported. Same condition the existing tripwire asserts on, same owning `scheduler.lock`. Debug builds panic (now naming the racing pair via a debug-only `last_enqueue` breadcrumb); release builds skip the redundant link. The skip is lossless and precedes `increment_load`, so the load counter stays exact.

## Disposition — please read (acceptance items diverge)

This was a **repro-gated investigation that did not reproduce.** Static analysis confirmed every visible wake path is correctly source-arbitrated; I then built amplifiers + debug instrumentation and ran 100+ amplified riscv64 TCG-SMP boots (ktest + svctest). **Zero reproductions.** The original was a single occurrence in the entire CI history, and the implicated wake/enqueue code is byte-identical to the version that flaked — `git log 2401c79..HEAD` (the #243 merge → HEAD) shows no commit touching `sched/`, `ipc/`, `cap/object.rs`, or `syscall/{thread,ipc}.rs`. So it is **not fixed, just vanishingly rare.**

Against the issue's Acceptance checklist:
- **Reproduce deterministically** — NOT met. Not reproducible at the available burn-in budget (above).
- **Identify the racing path** — NOT met. The debug breadcrumb + enriched tripwire will name it on any future debug-build hit; it could not be observed locally.
- **Fix so the invariant holds** — met, and strengthened: rather than fix one implicated path, the invariant is enforced *by construction* at the single chokepoint every enqueue funnels through, so no residual racing path can corrupt the run queue. Release self-heals; debug still asserts.
- **Update docs** — met (`scheduling-internals.md`).

This trades "identify + fix one path" for "neutralize the consequence for the whole double-link class." The scope change was reviewed and approved with the maintainer; it is the honest disposition for a non-reproducible latent race that would otherwise sit open indefinitely (blocking the v0.1.0 milestone).

## Provable, no-downside

The guard reuses the exact condition the existing debug tripwire already trusts (and panics on) under the same lock, changing only the **release** action from "undefined list corruption" to "skip a redundant link." A skipped enqueue is correct because the TCB is already Ready and linked — it is dispatched from where it sits and consumes its payload, so no wake is lost. The two legitimate Ready-on-entry callers (the cross-CPU outgoing requeue and `sys_thread_start`) reach the chokepoint with the TCB unlinked, so the guard never fires on them. No new TCB state, no new atomic, no cross-lock reasoning beyond the trusted tripwire.

## Test plan

- Host unit tests: `cargo xtask test --component kernel` → **212 passed**.
- x86_64 + riscv64, debug + release: `cargo xtask build` clean (guard compiles in release, breadcrumb strips out).
- x86_64 + riscv64 ktest: `stress::double_enqueue_storm` PASS, `[ktest] ALL TESTS PASSED`.
- x86_64 + riscv64 svctest (with co-staged crasher): `[svctest] ALL TESTS PASSED`.
