### PR TITLE
boot, xtask: fixed 1280x720 GOP mode; riscv64 std-VGA for cross-arch parity

### DIFF
--- a/core/boot/README.md
+++ b/core/boot/README.md
@@ -1,7 +1,8 @@
 # boot
 
-UEFI bootloader for Seraph. Reads boot configuration from `\EFI\seraph\boot.conf`,
-loads the kernel ELF and boot modules, parses init's ELF into `InitImage`, establishes
+UEFI bootloader for Seraph. Loads the kernel ELF and the
+`\EFI\seraph\bootstrap.bundle` (init plus boot modules) from hardcoded ESP paths,
+parses init's ELF into `InitImage`, establishes
 initial page tables with W^X enforcement, discovers firmware table addresses (ACPI
 RSDP / Device Tree blob) for passthrough to userspace, and jumps to the kernel entry
 point.
@@ -24,7 +25,6 @@ boot/
 │   └── riscv64-uefi.ld         # Linker script for RISC-V PE/COFF pipeline
 └── src/
     ├── main.rs                 # efi_main — boot sequence orchestrator
-    ├── config.rs               # Boot configuration file parser (boot.conf)
     ├── uefi.rs                 # UEFI protocol wrappers and memory services
     ├── elf.rs                  # UEFI-allocation layer over `shared/elf` + InitImage construction
     ├── firmware.rs             # ACPI / Device Tree address discovery (dispatch)
@@ -143,8 +143,8 @@ The CPU state established at the kernel entry point is specified in
   with firmware-advertised PCI windows. No per-device descriptors, no
   IRQ descriptors, no PCI enumeration. Namespace evaluation and
   device-level assignment are userspace's responsibility.
-- **No boot menu or interactive UI.** File paths come from `boot.conf`; the kernel
-  command line is an opaque string passed through to `BootInfo`.
+- **No boot menu or interactive UI.** The kernel and bundle ESP paths are
+  hardcoded; there is no boot configuration file and no kernel command line.
 - **No permanent page tables.** The initial tables are minimal and temporary; the
   kernel replaces them during Phase 3 of its initialisation sequence.
 

--- a/core/boot/docs/uefi-environment.md
+++ b/core/boot/docs/uefi-environment.md
@@ -16,7 +16,7 @@ acquisition, `ExitBootServices`, and error handling.
 |---|---|---|---|
 | `EFI_LOADED_IMAGE_PROTOCOL` | `HandleProtocol(image_handle)` | Obtain device handle for the boot volume | Yes |
 | `EFI_SIMPLE_FILE_SYSTEM_PROTOCOL` | `HandleProtocol(device_handle)` | Open the ESP root directory | Yes |
-| `EFI_GRAPHICS_OUTPUT_PROTOCOL` | `LocateProtocol(NULL)` | Record framebuffer address, dimensions, format | No |
+| `EFI_GRAPHICS_OUTPUT_PROTOCOL` | `LocateHandleBuffer(ByProtocol)` | Select a fixed mode; record framebuffer address, dimensions, format | No |
 | `EFI_GET_MEMORY_MAP` | `BootServices->GetMemoryMap` | Query physical memory layout | Yes |
 | `EFI_ALLOCATE_PAGES` | `BootServices->AllocatePages` | Allocate physical memory for all loaded data | Yes |
 | `EFI_CONFIGURATION_TABLE` | `SystemTable->ConfigurationTable` | Locate ACPI RSDP or Device Tree blob | Arch-specific |
@@ -24,6 +24,14 @@ acquisition, `ExitBootServices`, and error handling.
 `EFI_GRAPHICS_OUTPUT_PROTOCOL` is optional — its absence is handled gracefully by
 zeroing the `framebuffer.physical_base` field in `BootInfo`. A headless system or a
 virtual machine without a GOP framebuffer is a valid configuration.
+
+When GOP is present, the bootloader requests a fixed 1024x768 mode via `SetMode`
+before recording the active mode for handoff (`TARGET_FB_WIDTH` /
+`TARGET_FB_HEIGHT` in [`boot/src/uefi.rs`](../src/uefi.rs)). Both architectures
+acquire the framebuffer through this same GOP path, so the fixed request yields a
+consistent framebuffer size across x86-64 and RISC-V rather than one dependent on
+per-firmware or per-QEMU defaults. The request is best-effort: if the firmware's
+GOP does not offer the target mode, the active mode is left unchanged.
 
 `EFI_CONFIGURATION_TABLE` entries are needed for firmware table parsing: on x86-64
 the ACPI `EFI_ACPI_20_TABLE_GUID` entry locates the RSDP; on RISC-V the

--- a/core/boot/docs/uefi-environment.md
+++ b/core/boot/docs/uefi-environment.md
@@ -25,7 +25,7 @@ acquisition, `ExitBootServices`, and error handling.
 zeroing the `framebuffer.physical_base` field in `BootInfo`. A headless system or a
 virtual machine without a GOP framebuffer is a valid configuration.
 
-When GOP is present, the bootloader requests a fixed 1024x768 mode via `SetMode`
+When GOP is present, the bootloader requests a fixed 1280x720 mode via `SetMode`
 before recording the active mode for handoff (`TARGET_FB_WIDTH` /
 `TARGET_FB_HEIGHT` in [`boot/src/uefi.rs`](../src/uefi.rs)). Both architectures
 acquire the framebuffer through this same GOP path, so the fixed request yields a

--- a/core/boot/src/main.rs
+++ b/core/boot/src/main.rs
@@ -326,7 +326,15 @@ unsafe fn step1_locate_uefi_protocols(
     }
     if framebuffer.physical_base != 0
     {
-        bprintln!("[--------] boot: GOP: present");
+        // SAFETY: the serial console backend is initialized before this step,
+        // so direct console writes are valid here.
+        unsafe {
+            crate::console::console_write_str("[--------] boot: GOP: present ");
+            crate::console::console_write_dec32(framebuffer.width);
+            crate::console::console_write_str("x");
+            crate::console::console_write_dec32(framebuffer.height);
+            crate::console::console_write_str("\r\n");
+        }
     }
     else
     {

--- a/core/boot/src/uefi.rs
+++ b/core/boot/src/uefi.rs
@@ -884,10 +884,11 @@ pub unsafe fn exit_boot_services(
 /// Both architectures acquire the framebuffer through the same UEFI GOP path,
 /// so issuing one `SetMode` request here gives a consistent framebuffer — and
 /// QEMU window — size across x86-64 and RISC-V, independent of firmware or
-/// QEMU-version defaults. 1024x768 is the largest mode QEMU's RISC-V `ramfb`
-/// GOP (`QemuRamfbDxe`) offers and is also present in x86-64 OVMF's mode list;
-/// when a firmware does not offer it, `set_target_mode` leaves the active mode
-/// untouched and boot proceeds at whatever resolution firmware selected.
+/// QEMU-version defaults. 1024x768 is a near-universal VESA mode offered by
+/// both arches' GOP (under QEMU both run std VGA, same `QemuVideoDxe` mode
+/// table). When a firmware does not offer it, `set_target_mode` leaves the
+/// active mode untouched and boot proceeds at whatever resolution firmware
+/// selected.
 const TARGET_FB_WIDTH: u32 = 1024;
 const TARGET_FB_HEIGHT: u32 = 768;
 

--- a/core/boot/src/uefi.rs
+++ b/core/boot/src/uefi.rs
@@ -434,7 +434,7 @@ pub struct EfiGraphicsOutputProtocol
         size_of_info: *mut usize,
         info: *mut *mut EfiGopModeInfo,
     ) -> EfiStatus,
-    pub set_mode: usize,
+    pub set_mode: unsafe extern "efiapi" fn(this: *mut Self, mode_number: u32) -> EfiStatus,
     pub blt: usize,
     pub mode: *mut EfiGopMode,
 }
@@ -879,6 +879,119 @@ pub unsafe fn exit_boot_services(
     }
 }
 
+/// Framebuffer resolution the bootloader requests from GOP at boot.
+///
+/// Both architectures acquire the framebuffer through the same UEFI GOP path,
+/// so issuing one `SetMode` request here gives a consistent framebuffer — and
+/// QEMU window — size across x86-64 and RISC-V, independent of firmware or
+/// QEMU-version defaults. 1024x768 is the largest mode QEMU's RISC-V `ramfb`
+/// GOP (`QemuRamfbDxe`) offers and is also present in x86-64 OVMF's mode list;
+/// when a firmware does not offer it, `set_target_mode` leaves the active mode
+/// untouched and boot proceeds at whatever resolution firmware selected.
+const TARGET_FB_WIDTH: u32 = 1024;
+const TARGET_FB_HEIGHT: u32 = 768;
+
+/// Classify a GOP mode's pixel layout as a supported [`PixelFormat`].
+///
+/// Returns `None` for layouts the framebuffer console cannot consume:
+/// `PixelBltOnly` (no linear buffer) or a `PixelBitMask` whose channel masks
+/// are neither of the two standard 8bpc RGBX / BGRX layouts.
+fn classify_pixel_format(info: &EfiGopModeInfo) -> Option<PixelFormat>
+{
+    if info.pixel_format == GOP_PIXEL_RED_GREEN_BLUE_RESERVED_8BIT_PER_COLOR
+    {
+        Some(PixelFormat::Rgbx8)
+    }
+    else if info.pixel_format == GOP_PIXEL_BLUE_GREEN_RED_RESERVED_8BIT_PER_COLOR
+    {
+        Some(PixelFormat::Bgrx8)
+    }
+    else if info.pixel_format == GOP_PIXEL_BIT_MASK
+    {
+        let masks = info.pixel_information;
+        if masks == BITMASK_RGBX8
+        {
+            Some(PixelFormat::Rgbx8)
+        }
+        else if masks == BITMASK_BGRX8
+        {
+            Some(PixelFormat::Bgrx8)
+        }
+        else
+        {
+            None
+        }
+    }
+    else
+    {
+        None
+    }
+}
+
+/// Request [`TARGET_FB_WIDTH`]×[`TARGET_FB_HEIGHT`] on `gop`, best-effort.
+///
+/// Scans the GOP mode list; on the first mode that matches the target
+/// resolution with a console-supported pixel format, issues `SetMode` unless
+/// it is already active. Any `QueryMode` / `SetMode` failure — or no match —
+/// leaves the firmware's current mode in place; the caller then hands off
+/// whatever mode is active. `QueryMode` allocates each info buffer from pool,
+/// so every successful query is paired with a `FreePool`.
+///
+/// # Safety
+/// `bs` must be valid boot services; `gop` must point to a valid
+/// `EFI_GRAPHICS_OUTPUT_PROTOCOL` whose `mode` is populated by firmware.
+unsafe fn set_target_mode(bs: *mut EfiBootServices, gop: *mut EfiGraphicsOutputProtocol)
+{
+    // SAFETY: gop is valid; mode is populated by firmware.
+    let max_mode = unsafe { (*(*gop).mode).max_mode };
+    // SAFETY: gop is valid; mode is populated by firmware.
+    let current = unsafe { (*(*gop).mode).mode };
+
+    for i in 0..max_mode
+    {
+        let mut size: usize = 0;
+        let mut info: *mut EfiGopModeInfo = core::ptr::null_mut();
+        // SAFETY: gop is valid; query_mode writes size/info on success.
+        let status = unsafe {
+            ((*gop).query_mode)(
+                gop,
+                i,
+                core::ptr::addr_of_mut!(size),
+                core::ptr::addr_of_mut!(info),
+            )
+        };
+        if status != EFI_SUCCESS || info.is_null()
+        {
+            continue;
+        }
+
+        let is_target = {
+            // SAFETY: query_mode populated info on success.
+            let mode_info = unsafe { &*info };
+            mode_info.horizontal_resolution == TARGET_FB_WIDTH
+                && mode_info.vertical_resolution == TARGET_FB_HEIGHT
+                && classify_pixel_format(mode_info).is_some()
+        };
+
+        // QueryMode allocated the info buffer from pool; release it before the
+        // next iteration regardless of match.
+        // SAFETY: info came from query_mode and is unused after this point.
+        unsafe {
+            ((*bs).free_pool)(info.cast::<core::ffi::c_void>());
+        }
+
+        if is_target
+        {
+            if i != current
+            {
+                // SAFETY: gop is valid; i < max_mode is a valid mode number.
+                let _ = unsafe { ((*gop).set_mode)(gop, i) };
+            }
+            return;
+        }
+    }
+}
+
 /// Locate a usable `EFI_GRAPHICS_OUTPUT_PROTOCOL` and return framebuffer information.
 ///
 /// Enumerates all handles supporting GOP via `LocateHandleBuffer(ByProtocol)` and
@@ -931,38 +1044,21 @@ pub unsafe fn query_gop(bs: *mut EfiBootServices) -> Option<FramebufferInfo>
             continue;
         }
         let gop = iface.cast::<EfiGraphicsOutputProtocol>();
-        // SAFETY: gop is a valid protocol pointer; mode is populated by firmware.
+        // Request the target mode before reading the active one, so the
+        // framebuffer (and the QEMU window) is the same size on both arches.
+        // Best-effort: on failure the firmware's current mode is kept.
+        // SAFETY: bs is valid; gop is a valid GOP protocol pointer.
+        unsafe {
+            set_target_mode(bs, gop);
+        }
+
+        // SAFETY: gop is a valid protocol pointer; mode/info are populated by
+        // firmware and reflect the now-active mode.
         let mode = unsafe { &*(*gop).mode };
         // SAFETY: mode.info is populated by firmware.
         let info = unsafe { &*mode.info };
 
-        // Skip PixelBltOnly (format 3) — no linear framebuffer exists.
-        // For PixelBitMask (format 2), accept only the two standard 8bpc layouts
-        // that map exactly to our Rgbx8 / Bgrx8 variants; skip all others.
-        let pixel_format = if info.pixel_format == GOP_PIXEL_RED_GREEN_BLUE_RESERVED_8BIT_PER_COLOR
-        {
-            PixelFormat::Rgbx8
-        }
-        else if info.pixel_format == GOP_PIXEL_BLUE_GREEN_RED_RESERVED_8BIT_PER_COLOR
-        {
-            PixelFormat::Bgrx8
-        }
-        else if info.pixel_format == GOP_PIXEL_BIT_MASK
-        {
-            let masks = info.pixel_information;
-            if masks == BITMASK_RGBX8
-            {
-                PixelFormat::Rgbx8
-            }
-            else if masks == BITMASK_BGRX8
-            {
-                PixelFormat::Bgrx8
-            }
-            else
-            {
-                continue; // non-standard bitmask layout; skip
-            }
-        }
+        let Some(pixel_format) = classify_pixel_format(info)
         else
         {
             continue;

--- a/core/boot/src/uefi.rs
+++ b/core/boot/src/uefi.rs
@@ -884,13 +884,12 @@ pub unsafe fn exit_boot_services(
 /// Both architectures acquire the framebuffer through the same UEFI GOP path,
 /// so issuing one `SetMode` request here gives a consistent framebuffer — and
 /// QEMU window — size across x86-64 and RISC-V, independent of firmware or
-/// QEMU-version defaults. 1024x768 is a near-universal VESA mode offered by
-/// both arches' GOP (under QEMU both run std VGA, same `QemuVideoDxe` mode
-/// table). When a firmware does not offer it, `set_target_mode` leaves the
-/// active mode untouched and boot proceeds at whatever resolution firmware
-/// selected.
-const TARGET_FB_WIDTH: u32 = 1024;
-const TARGET_FB_HEIGHT: u32 = 768;
+/// QEMU-version defaults. 1280x720 (720p) is present in both arches' std VGA
+/// GOP mode table (`QemuVideoDxe`). When a firmware does not offer it,
+/// `set_target_mode` leaves the active mode untouched and boot proceeds at
+/// whatever resolution firmware selected.
+const TARGET_FB_WIDTH: u32 = 1280;
+const TARGET_FB_HEIGHT: u32 = 720;
 
 /// Classify a GOP mode's pixel layout as a supported [`PixelFormat`].
 ///
@@ -998,7 +997,8 @@ unsafe fn set_target_mode(bs: *mut EfiBootServices, gop: *mut EfiGraphicsOutputP
 /// Enumerates all handles supporting GOP via `LocateHandleBuffer(ByProtocol)` and
 /// returns the first that exposes a linear framebuffer with a supported pixel format
 /// (RGBX or BGRX). Handles reporting `PixelBltOnly` (format 3, no physical address)
-/// or `PixelBitMask` (format 2, custom layout) are skipped.
+/// are skipped, as are `PixelBitMask` (format 2) layouts other than the standard
+/// 8bpc RGBX / BGRX masks (see `classify_pixel_format`).
 ///
 /// Returns `None` if no usable GOP handle exists. This is not an error — the boot
 /// proceeds with `framebuffer.physical_base == 0`.

--- a/services/drivers/framebuffer/src/arch/riscv64/mod.rs
+++ b/services/drivers/framebuffer/src/arch/riscv64/mod.rs
@@ -7,8 +7,9 @@
 //!
 //! Reserves a contiguous VA range and maps the bootloader-discovered
 //! GOP linear-framebuffer `Mmio` cap into it. On QEMU virt the
-//! framebuffer comes from `-device ramfb`; the bootloader captured its
-//! base via UEFI GOP before `ExitBootServices`.
+//! framebuffer comes from `-device VGA` (QEMU std VGA, matching x86-64's
+//! default adapter); the bootloader captured its base via UEFI GOP before
+//! `ExitBootServices`.
 
 use std::os::seraph::{fund_aspace_pt_budget, reserve_pages};
 

--- a/xtask/src/fs_compat.rs
+++ b/xtask/src/fs_compat.rs
@@ -175,13 +175,17 @@ mod tests
 
     fn tmpdir() -> std::path::PathBuf
     {
+        // Per-call atomic counter guarantees a unique path even when two
+        // parallel test threads sample the same nanosecond.
+        static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
         let dir = std::env::temp_dir().join(format!(
-            "seraph-xtask-fs_compat-{}-{}",
+            "seraph-xtask-fs_compat-{}-{}-{}",
             std::process::id(),
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()
                 .as_nanos(),
+            SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
         ));
         fs::create_dir_all(&dir).unwrap();
         dir

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -150,6 +150,9 @@ fn extend_x86(args: &mut Vec<String>, spec: &QemuLaunchSpec, accel: Accel)
         ),
     ]);
 
+    // Non-headless x86-64 uses the q35 default adapter (QEMU std VGA) — the
+    // same device riscv64 selects explicitly via `-device VGA`. Headless drops
+    // it so no framebuffer is advertised.
     if spec.headless
     {
         args.extend(["-vga".into(), "none".into()]);
@@ -190,15 +193,16 @@ fn extend_riscv(args: &mut Vec<String>, spec: &QemuLaunchSpec)
 
     if !spec.headless
     {
-        // The virt machine has no built-in display. ramfb provides a
-        // framebuffer, but without a graphical display backend QEMU falls back
-        // to VNC. Only add display devices when a graphical backend is
-        // available.
+        // The virt machine has no built-in display. Use QEMU std VGA — the
+        // same adapter q35 gives x86-64 by default — so both arches present an
+        // identical UEFI GOP (`QemuVideoDxe`, same mode table). Without a
+        // graphical display backend QEMU falls back to VNC, so only add the
+        // display devices when a backend is available.
         if let Some(backend) = preferred_display_backend(spec.arch.qemu_binary())
         {
             args.extend([
                 "-device".into(),
-                "ramfb".into(),
+                "VGA".into(),
                 "-device".into(),
                 "qemu-xhci".into(),
                 "-device".into(),


### PR DESCRIPTION
## Summary

Three related changes that make the framebuffer consistent across architectures, then lift it to a 720p default:

1. **`boot`** — the bootloader was a passive observer of the firmware's active GOP mode, so non-headless QEMU windows differed between arches and could drift across QEMU versions. `query_gop` now requests a fixed mode via GOP `SetMode` before reading the active mode for handoff (compile-time constant).
2. **`xtask`** — riscv64's display is switched from `-device ramfb` (fixed 3-mode table, capped at 1024x768) to `-device VGA`, the same std VGA adapter x86_64 uses by default. Both arches now present the identical OVMF/edk2 GOP (`QemuVideoDxe`, same 30-mode table) and share one linear-framebuffer model.
3. **`boot`** — with both arches on the same mode table, the default is set to **1280x720** (720p, mode 10 on both).

Closes #280

## Acceptance
- [x] Bootloader requests 1280x720 via GOP `SetMode` on the selected handle, before reading the framebuffer for kernel handoff.
- [x] Consistent 1280x720 verified on both x86_64 and riscv64 (non-headless) — serial reports `GOP: present 1280x720` on both.
- [x] Graceful fallback: if a firmware does not offer the target mode, the firmware's current mode is kept (no regression on headless / no-GOP). *(By construction; see Notes — the no-match branch was not runtime-exercised because both firmware GOPs offer the mode.)*
- [x] `QueryMode` info buffers are freed (no boot-services pool leak).
- [x] Active resolution is surfaced in the boot log.
- [x] Boot docs document the fixed-mode request (uefi-environment.md).
- [x] riscv64 uses QEMU std VGA (`-device VGA`) so both arches share one GOP mode set; userspace framebuffer driver verified against the resulting MMIO framebuffer.

## Test plan
- [x] `cargo xtask build` (x86_64) — clean lint build
- [x] `cargo xtask run` (x86_64), terminal pass marker observed — `GOP: present 1280x720`; `[ktest] ALL TESTS PASSED`
- [x] `cargo xtask build --arch riscv64` — clean lint build
- [x] `cargo xtask run --arch riscv64`, terminal pass marker observed — `GOP: present 1280x720`; `[ktest] ALL TESTS PASSED`
- [x] riscv64 non-headless default boot (VGA) — `GOP: present` over a linear framebuffer at `0x40000000`, `[devmgr] framebuffer driver spawned`, `[fb-charset] done`, zero faults (MMIO-framebuffer path validated end-to-end)
- [x] x86_64 non-headless default boot — `GOP: present 1280x720`, userspace (svcmgr + fb-charset) clean
- [x] `cargo xtask test` — host tests green, including the formerly-flaky `fs_compat::copy_dir_recursive` (now fixed)

## Notes

- **Why VGA, not bochs-display or virtio-gpu.** Runtime GOP enumeration on this host: riscv64 `ramfb` exposes only `{640x480, 800x600, 1024x768}`; x86_64 std VGA exposes 30 modes (incl. 1280x720). `bochs-display` also yields a linear-FB GOP with the full table on riscv64, but it is a *different* device from x86's default (would only be symmetric if x86 migrated too). `virtio-gpu` is `PixelBltOnly` (no linear framebuffer; needs a userspace GPU driver to scan out) and is incompatible with the current direct-linear-FB model. `-device VGA` is the same adapter x86 already uses → maximal symmetry, x86 untouched. Both arches' VGA GOP were confirmed to expose the identical 30-mode table.
- **720p ceiling note.** 1280x720 is present in QEMU's std VGA table on both arches. On real hardware 1024x768 is the more universally-guaranteed VESA fallback; the best-effort `set_target_mode` keeps the firmware's current mode if 720p is absent, so off-QEMU firmware degrades gracefully. Multiple or runtime-selectable resolutions are out of scope for this change.
- **Fallback not runtime-exercised.** Both firmware GOP tables offer 1280x720, so the no-match path was not triggered. The headless / no-GOP early-return path is preserved and exercised by CI's headless validate jobs.
- **Review fixes folded in.** (a) `query_gop` rustdoc corrected — standard 8bpc RGBX/BGRX PixelBitMask layouts are accepted, not skipped (pr-reviewer nit, on the refactored function). (b) `xtask fs_compat::tmpdir()` now appends a process-static atomic counter so two parallel test threads cannot collide on the same nanosecond — fixes the pre-existing `copy_dir_recursive` `AlreadyExists` flake (pr-auditor finding); validated green via `cargo xtask test`.
- **Unrelated kernel bug, filed separately (#282).** A flaky `x86_64 debug svctest` CI run hit a pre-existing kernel panic — `core/kernel/src/cap/retype.rs:762` subtract-overflow reached via a `#GP` userspace fault in svctest's `env` phase — which passed on re-run (and on x86_64 release + both riscv64 svctest the same run). Different surface (kernel cap subsystem), not touched by this PR; tracked in #282, not fixed here.
- **Incidental doc drift fixed on this surface.** Stale `core/boot/README.md` references to the removed `boot.conf` parser / `config.rs` / kernel command line (BOOT_PROTOCOL v8) corrected; GOP locate-method entry in `uefi-environment.md` fixed (`LocateProtocol(NULL)` → `LocateHandleBuffer(ByProtocol)`).
- **`docs/console-model.md` deliberately untouched.** Resolution selection is boot-component-owned (authoritative in `uefi-environment.md`); `documentation-standards.md` §Authority forbids a system-scope doc restating component-owned behavior, and no existing statement there is invalidated.
