### PR TITLE
svctest: widen timed SystemTime-vs-Instant tracking band for SMP oversubscription (#297)

### DIFF
--- a/services/svctest/src/phases/timed.rs
+++ b/services/svctest/src/phases/timed.rs
@@ -69,15 +69,18 @@ pub fn system_time_phase(_: &Caps)
     let mono_min = i_pre1.duration_since(i_post0);
     let mono_max = i_post1.duration_since(i_pre0);
 
-    // Wall (SystemTime, RTC-backed via `timed`) and monotonic (Instant, kernel
-    // elapsed counter) are independent clock sources; under SMP oversubscription
-    // host descheduling perturbs them unequally, so the wall delta drifts from
-    // the tight Instant bracket (~2 ms on a 50 ms window observed under
-    // contention). Compare with a coarse slack band: wide enough to absorb that
-    // divergence, still tight enough to catch a stalled or grossly-misrated wall
-    // clock (the offset wiring itself is covered by the 2024/2100 bounds above).
-    // The lower bound is additive (`sys_delta + slack >= mono_min`) so it cannot
-    // underflow Duration subtraction.
+    // Wall (SystemTime, served by `timed`) and monotonic (Instant) both derive
+    // from the kernel `ElapsedUs` counter, but `timed` reads it across an IPC
+    // round-trip; under SMP oversubscription host descheduling lands that read
+    // at a different point than the local `Instant` reads, so the wall delta
+    // skews from the tight bracket (~2 ms on a 50 ms window observed under
+    // contention). Compare with a coarse slack of half the monotonic interval
+    // (10 ms floor for short windows): it admits a wall delta within ~±50% of
+    // the elapsed interval — enough to absorb the skew, while still failing a
+    // stalled clock or one misrated by more than ~50%. Offset wiring is covered
+    // by the 2024/2100 bounds above; the lower bound is additive
+    // (`sys_delta + slack >= mono_min`) so it cannot underflow Duration
+    // subtraction.
     let slack = (mono_max / 2).max(Duration::from_millis(10));
     assert!(
         sys_delta + slack >= mono_min && sys_delta <= mono_max + slack,

--- a/services/svctest/src/phases/timed.rs
+++ b/services/svctest/src/phases/timed.rs
@@ -68,14 +68,25 @@ pub fn system_time_phase(_: &Caps)
 
     let mono_min = i_pre1.duration_since(i_post0);
     let mono_max = i_post1.duration_since(i_pre0);
+
+    // Wall (SystemTime, RTC-backed via `timed`) and monotonic (Instant, kernel
+    // elapsed counter) are independent clock sources; under SMP oversubscription
+    // host descheduling perturbs them unequally, so the wall delta drifts from
+    // the tight Instant bracket (~2 ms on a 50 ms window observed under
+    // contention). Compare with a coarse slack band: wide enough to absorb that
+    // divergence, still tight enough to catch a stalled or grossly-misrated wall
+    // clock (the offset wiring itself is covered by the 2024/2100 bounds above).
+    // The lower bound is additive (`sys_delta + slack >= mono_min`) so it cannot
+    // underflow Duration subtraction.
+    let slack = (mono_max / 2).max(Duration::from_millis(10));
     assert!(
-        sys_delta >= mono_min && sys_delta <= mono_max,
-        "SystemTime delta {sys_delta:?} outside Instant-bracketed bounds \
-         [{mono_min:?}, {mono_max:?}] — clocks not tracking",
+        sys_delta + slack >= mono_min && sys_delta <= mono_max + slack,
+        "SystemTime delta {sys_delta:?} outside Instant bracket \
+         [{mono_min:?}, {mono_max:?}] ±{slack:?} — clocks not tracking",
     );
 
     let (y, mo, dd, hh, mm, ss) = epoch_to_ymdhms(secs);
     std::os::seraph::log!(
-        "SystemTime phase passed ({y:04}-{mo:02}-{dd:02}T{hh:02}:{mm:02}:{ss:02}Z, sys_delta={sys_delta:?}, mono_bounds=[{mono_min:?}, {mono_max:?}])"
+        "SystemTime phase passed ({y:04}-{mo:02}-{dd:02}T{hh:02}:{mm:02}:{ss:02}Z, sys_delta={sys_delta:?}, mono_bounds=[{mono_min:?}, {mono_max:?}], slack={slack:?})"
     );
 }


### PR DESCRIPTION
Closes #297.

## Problem

`services/svctest/src/phases/timed.rs` bracketed a wall-clock (`SystemTime`)
delta against a monotonic (`Instant`) bracket only as wide as two
`GET_WALL_TIME` IPC round-trips (~tens of µs). The two clocks are independent
sources — `Instant` is the kernel monotonic counter (`SYS_SYSTEM_INFO(ElapsedUs)`),
`SystemTime` is the RTC-backed wall clock via `timed`. Under SMP oversubscription,
host descheduling of the guest vCPU perturbs them unequally; the wall delta
drifts a few ms from the bracket (~2 ms on a 50 ms window observed). The assert
fired, svctest aborted (`panic=abort` → `#UD`), the one-shot harness never
reached `pwrmgr` shutdown, and the softlockup watchdog fired downstream — the
same false-positive class as #285, from a different trigger.

## Fix

Replace the tight bracket with a coarse slack band:

```
slack = max(mono_max / 2, 10 ms)
assert sys_delta + slack >= mono_min && sys_delta <= mono_max + slack
```

- Lower bound is **additive** (`sys_delta + slack >= mono_min`), not
  `mono_min - slack`, so it cannot underflow `Duration` subtraction.
- The band absorbs oversubscription divergence while still catching a stalled or
  grossly-misrated wall clock. Offset wiring stays covered by the existing
  2024/2100 bounds; the wall-monotonicity `expect` is unchanged.
- Pass-log now emits `slack` for observability.

Single-function change; no ABI/runtime/doc-authority impact (no svctest `docs/`,
no doc states the old bracket width).

## Test plan

Burn-in amplified via **TCG** (`SERAPH_ACCEL=tcg`) and pinned to 2 cores
(`taskset -c 0,1`) — TCG software emulation reproduces the descheduling-induced
clock skew that KVM's virtualized TSC masks. Marker: `clocks not tracking` fired
**0 times** in every run below.

**Acceptance runs (realistic SMP oversubscription):**

| Arch | Mode | Config | Result |
|---|---|---|---|
| x86_64 | single-shot | KVM | `ALL TESTS PASSED` |
| x86_64 | single-shot | TCG, 2-core | `ALL TESTS PASSED` |
| x86_64 | burn-in | TCG, 2× oversub (1×4 vCPU / 2 cores), 32 runs | **32/32 PASS** |
| riscv64 | single-shot | TCG, 2-core | `ALL TESTS PASSED` |
| riscv64 | burn-in | TCG, 2× oversub (2×2 vCPU / 2 cores), 20 runs | **20/20 PASS** |

Representative pass-log (riscv64): `sys_delta=50.493ms, mono_bounds=[50.094ms, 52.776ms], slack=26.388ms`.

**Calibration note:** an initial 8× over-stress run (4 guests × 4 vCPU on 2 cores)
located the harness ceiling, not a product condition — at that ratio the TCG guest
starves below the kernel's own liveness thresholds (a vCPU descheduled ~17 s,
tripping the IPI/softlockup watchdogs before svctest even ran). The timed fix held
there too (30/30 runs that reached svctest passed); the burn-in was dialed back to
the realistic 2× ratio above for acceptance. The starvation is a property of the
over-stress and does not recur at 2×.

## Acceptance (#297)

- [x] `system_time` clock-tracking check made robust under SMP oversubscription — svctest no longer spuriously aborts.
- [x] Confirmed via oversubscribed burn-in (both arches).
