### PR TITLE
procmgr: remove init-reap liveness backstop that wedged the logd handover

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -108,10 +108,10 @@ jobs:
         #
         # The functional harness boots also drop the autostarted `terminal`
         # (a user-facing program, not part of the services/programs substrate
-        # under test) so the boot is controlled and to avoid a flaky bringup
-        # deadlock under load (#290). `--repack-only` makes the removal stick:
-        # a normal repack re-mirrors rootfs, which would restore terminal.svc.
-        # The terminal is exercised in its own boot (test-terminal, below).
+        # under test) so the boot is controlled. `--repack-only` makes the
+        # removal stick: a normal repack re-mirrors rootfs, which would restore
+        # terminal.svc. The terminal is exercised in its own boot
+        # (test-terminal, below).
         run: |
           case "${{ matrix.tester }}" in
             svctest)

--- a/services/init/README.md
+++ b/services/init/README.md
@@ -54,9 +54,10 @@ Init runs three stages between `_start` and `sys_thread_exit`:
    supervise real-logd. Notification `HANDOVER_COMPLETE`; hand init's own kernel
    objects + reclaimable Memory caps to procmgr via `REGISTER_INIT_TEARDOWN`;
    call `sys_thread_exit`. Procmgr binds a death-EQ on both init threads
-   (main + init-logd) and runs the reap path once both have exited; a
-   liveness backstop force-stops a never-released init-logd so a dropped
-   log handover cannot pin init's memory caps.
+   (main + init-logd) and runs the reap path once both have exited — purely
+   death-driven, with no force-stop; a handover that never completes leaves
+   init-logd serving and init's memory caps held until shutdown (a benign
+   hold, not a wedge).
    svcmgr publishes the well-known names it now owns (`rootfs.root`,
    `svcmgr`, `devmgr.registry`) and installs devmgr's `/services/drivers/`
    cap via `SET_DRIVERS_DIR` from the endowment; it then launches the

--- a/services/init/src/service.rs
+++ b/services/init/src/service.rs
@@ -1200,7 +1200,8 @@ pub fn phase3_svcmgr_handover(
     // the observer bind ran after that release it would land on an already
     // -exited init-logd and silently lose the death — the kernel bind only
     // appends an observer, it does not fire for a thread that has already
-    // exited — stranding the reap on the liveness backstop. Transferring init's
+    // exited — so the reap's death countdown would wait forever for an exit it
+    // already missed, and init would never be reaped. Transferring init's
     // kernel-object caps here is safe: svcmgr is already created and endowed
     // (the only consumer of init's own CSpace cap), and the cap handles move
     // while the underlying objects keep backing init's still-running threads.

--- a/services/logd/docs/handover-protocol.md
+++ b/services/logd/docs/handover-protocol.md
@@ -123,7 +123,7 @@ loop.
 | Symptom | Cause | Recovery |
 |---|---|---|
 | `HANDOVER_PULL` IPC returns error mid-drain | A kernel IPC rendezvous race on the shared endpoint, or an invalid `log_ep_handover_send` | `pull_all` returns; logd still issues `HANDOVER_RELEASE`, so init-logd is released. At most some pre-handover history is lost. |
-| `HANDOVER_RELEASE` never delivered (cap is `0`, e.g. a logd restart; or logd never launches) | No init-logd→logd channel exists | init-logd would otherwise run forever. procmgr's reap backstop force-stops it after a bounded grace and reaps init regardless (see `services/procmgr/src/init_reap.rs`). |
+| `HANDOVER_RELEASE` never delivered (cap is `0`, e.g. a logd restart; or logd never launches) | No init-logd→logd channel exists | init-logd keeps serving and procmgr never reaps init; init's memory caps stay held until shutdown — a benign hold, not a wedge. procmgr does not force-stop init-logd (see `services/procmgr/src/init_reap.rs`). |
 | Reply with unknown `word(0)` kind | Wire-format drift; one side built against an out-of-sync `shared/ipc` revision | Real-logd skips the chunk and continues. A bounded iteration cap (`MAX_ITERS`) in `pull_all` guarantees termination on a malformed reply stream. |
 
 ## Reference

--- a/services/logd/src/handover.rs
+++ b/services/logd/src/handover.rs
@@ -134,7 +134,8 @@ pub unsafe fn pull_all(handover_send_cap: u32, ipc_buf: *mut u64, table: &mut Sl
 /// call is acknowledged and returns `Ok`. The retry recovers a `RELEASE`
 /// whose request was dropped (init-logd never saw it, so it is still
 /// serving). The cap bounds the loop; a genuinely unreachable init-logd is
-/// covered by procmgr's reap backstop, never by an unbounded spin here.
+/// left serving (procmgr reaps init only on init-logd's natural exit), never
+/// wedged by an unbounded spin here.
 ///
 /// # Safety
 /// `ipc_buf` must be the calling thread's registered IPC buffer.

--- a/services/procmgr/README.md
+++ b/services/procmgr/README.md
@@ -73,9 +73,12 @@ init's Phase 3: init's own `AddressSpace` / `CSpace` / `Thread` caps
 plus every reclaimable Memory cap. Procmgr binds a death-EQ observer on
 **both** init threads (main + init-logd) with `INIT_REAP_CORRELATOR` and
 reaps once both have exited — init-logd outlives main until the
-svcmgr-launched real-logd releases it via `HANDOVER_RELEASE`. A liveness
-backstop force-stops a never-released init-logd past a grace, so a
-dropped log handover cannot pin init's memory caps. The reap path tears down
+svcmgr-launched real-logd releases it via `HANDOVER_RELEASE`. The reap is
+purely death-driven: procmgr waits for that natural exit and never force-stops
+init-logd. If a handover never completes (real-logd crashes mid-pull or never
+launches), init-logd serves on and init's memory caps stay held until shutdown
+— a benign hold, not a wedge; the all-RAM-accounted identity correspondingly
+closes only once the handover completes. The reap path tears down
 init's kernel objects in order — Threads → AddressSpace → donate Memory
 caps to memmgr via `DONATE_MEMORY_CAPS` → CSpace cascade — leaving zero init
 residue. Implementation in [`src/init_reap.rs`](src/init_reap.rs).

--- a/services/procmgr/src/init_reap.rs
+++ b/services/procmgr/src/init_reap.rs
@@ -25,18 +25,20 @@
 //!   │  INIT_TEARDOWN_DONE
 //!   ▼
 //! Armed   (pending_deaths = 2; waiting for both threads' INIT_REAP_CORRELATOR
-//!          death events — run_reap counts down, reaping on the last. The
-//!          first death stamps first_death_us, arming the liveness backstop.)
+//!          death events — run_reap counts down, reaping on the last.)
 //!   │
-//!   ├─▼  dispatch_death sees correlator == INIT_REAP_CORRELATOR (×2)
-//!   │  Reaping (run_reap, last death) → do_reap
-//!   │
-//!   └─▼  init-logd never released (dropped HANDOVER_RELEASE) and
-//!        now - first_death_us > BACKSTOP_GRACE_US
-//!      Reaping (check_backstop): thread_stop(logd_thread) → do_reap
+//!   └─▼  dispatch_death sees correlator == INIT_REAP_CORRELATOR (×2)
+//!      Reaping (run_reap, last death) → do_reap
 //!
-//! do_reap (both entry paths):
-//!   1. cap_delete(logd_thread)                — Exited, or Stopped→Exited
+//! init-logd outlives init's main thread until svcmgr-launched real-logd pulls
+//! its handover and releases it (`HANDOVER_RELEASE` → init-logd `thread_exit`).
+//! The reap is purely death-driven: procmgr waits for init-logd's natural exit
+//! and never force-stops it. If a handover genuinely never completes (real-logd
+//! crashes mid-pull or never launches), init-logd serves on and init's memory
+//! caps stay held — a benign hold, not a wedge — until shutdown.
+//!
+//! do_reap:
+//!   1. cap_delete(logd_thread)                — Exited
 //!   2. cap_delete(main_thread)
 //!   3. cap_revoke + cap_delete(aspace)        — mappings gone
 //!   4. DONATE_MEMORY_CAPS(caps[..]) → memmgr       — safe; no aliasing
@@ -80,24 +82,7 @@ pub struct InitReapState
     /// and reaps on the last. init-logd outlives the main thread until the
     /// svcmgr-launched real-logd pulls its handover and releases it.
     pending_deaths: u8,
-    /// Boot-microsecond timestamp of the first init-thread death (the main
-    /// thread, in practice), recorded when `pending_deaths` drops to 1. Zero
-    /// until then. Anchors the liveness backstop: if init-logd has not exited
-    /// within [`BACKSTOP_GRACE_US`] of this instant — because a dropped
-    /// `HANDOVER_RELEASE` (e.g. a logd restart with no handover source, or
-    /// logd never launching) left it serving forever — `check_backstop`
-    /// force-stops it and reaps anyway, so a wedged handover can never
-    /// permanently block reclamation of init's memory caps.
-    first_death_us: u64,
 }
-
-/// Liveness deadline: how long after the first init-thread death the reap will
-/// wait for init-logd to exit on its own before force-stopping it. A liveness
-/// bound (sized like the kernel's idle watchdog), NOT a capacity constant —
-/// the normal handover releases init-logd in well under a second, and the
-/// bound stays far below the point at which svctest first queries the
-/// all-RAM-accounted identity, so the forced donation always lands first.
-const BACKSTOP_GRACE_US: u64 = 3_000_000;
 
 /// State machine slot. `None` until init's first
 /// `REGISTER_INIT_TEARDOWN`; populated and progressively filled by
@@ -184,7 +169,6 @@ pub fn handle_register(req: &IpcMessage, ipc_buf: *mut u64, death_eq: u32)
             donate_caps: Vec::with_capacity(32),
             armed: false,
             pending_deaths: 2,
-            first_death_us: 0,
         });
         reply(ipc_buf, procmgr_errors::SUCCESS);
         return;
@@ -252,15 +236,11 @@ pub fn run_reap(memmgr_ep: u32, ipc_buf: *mut u64)
         // (first round) before the svcmgr handover can release init-logd, so
         // init-logd's exit may fire while init is still streaming donation
         // rounds — i.e. pre-arm. Dropping a pre-arm death would strand
-        // `pending_deaths` and force the liveness backstop. Anchor the backstop
-        // from the first death regardless. Only the *execution* of the reap
-        // waits for `armed`: init must finish donating its reclaimable caps,
-        // and `do_reap` consumes the kernel-object caps that round delivers.
+        // `pending_deaths` and the reap would never fire. Only the *execution*
+        // of the reap waits for `armed`: init must finish donating its
+        // reclaimable caps, and `do_reap` consumes the kernel-object caps that
+        // round delivers.
         s.pending_deaths = s.pending_deaths.saturating_sub(1);
-        if s.first_death_us == 0
-        {
-            s.first_death_us = elapsed_us();
-        }
         if s.pending_deaths > 0
         {
             std::os::seraph::log!(
@@ -274,8 +254,8 @@ pub fn run_reap(memmgr_ep: u32, ipc_buf: *mut u64)
             // Both threads exited before arming. init's main thread sends
             // `INIT_TEARDOWN_DONE` before its own `thread_exit`, so main's death
             // is always post-arm and this branch is unreachable in well-formed
-            // teardown; leave the reap for the arming path / backstop rather
-            // than reaping before init has finished donating.
+            // teardown; leave the reap for the arming path rather than reaping
+            // before init has finished donating.
             return;
         }
         guard.take().expect("init-reap state present")
@@ -284,63 +264,9 @@ pub fn run_reap(memmgr_ep: u32, ipc_buf: *mut u64)
     do_reap(state, memmgr_ep, ipc_buf);
 }
 
-/// Liveness backstop, called from procmgr's main loop. If the main thread has
-/// exited but init-logd has not within [`BACKSTOP_GRACE_US`] — a dropped
-/// `HANDOVER_RELEASE` (a logd restart with no handover source, or logd never
-/// launching) left it serving forever — force-stop it and reap anyway.
-///
-/// `thread_stop` transitions a `Blocked`-in-`ipc_recv` init-logd to `Stopped`;
-/// it posts no death notification, which is why this path reaps directly
-/// rather than waiting for the death count. The `cap_delete` in `do_reap` then
-/// drives the `Stopped` TCB to `Exited` and wakes any thread blocked on a
-/// reply from it (a real-logd stuck mid-pull).
-///
-/// Best-effort scheduling: this only runs when procmgr's main loop is already
-/// awake for some other event. The cases it covers coincide with boot-time
-/// process-death and service traffic that keeps procmgr scheduled, so the
-/// deadline is observed well before svctest first queries the identity. A hard
-/// wall-clock guarantee would require a timed `wait_set` primitive the kernel
-/// does not expose today.
-pub fn check_backstop(memmgr_ep: u32, ipc_buf: *mut u64)
-{
-    let state = {
-        let mut guard = STATE.lock().expect("init-reap state poisoned");
-        let Some(s) = guard.as_mut()
-        else
-        {
-            return;
-        };
-        if !s.armed || s.pending_deaths != 1 || s.first_death_us == 0
-        {
-            return;
-        }
-        if elapsed_us().saturating_sub(s.first_death_us) < BACKSTOP_GRACE_US
-        {
-            return;
-        }
-        // The lagging init thread (init-logd in practice; main is straight-line
-        // to thread_exit) is still alive. Force BOTH off-CPU before reaping —
-        // thread_stop is a harmless InvalidState no-op on whichever already
-        // exited — so do_reap's cap_delete never frees a TCB still running on a
-        // CPU, regardless of which thread lagged. The cap_delete then drives a
-        // Stopped TCB to Exited and wakes any real-logd stuck on init-logd's
-        // reply.
-        let _ = syscall::thread_stop(s.main_thread);
-        let _ = syscall::thread_stop(s.logd_thread);
-        std::os::seraph::log!(
-            "init-reap: handover-release backstop fired; force-stopped init after \
-             {} ms grace",
-            BACKSTOP_GRACE_US / 1000
-        );
-        guard.take().expect("armed init-reap state present")
-    };
-
-    do_reap(state, memmgr_ep, ipc_buf);
-}
-
-/// Tear init down once it is threadless: both threads `Exited` (normal path),
-/// or init-logd forced `Stopped` by [`check_backstop`]. Ordering matters — see
-/// the inline steps.
+/// Tear init down once it is threadless: both threads `Exited` via the normal
+/// handover path (init-logd exits on real-logd's `HANDOVER_RELEASE`). Ordering
+/// matters — see the inline steps.
 fn do_reap(state: InitReapState, memmgr_ep: u32, ipc_buf: *mut u64)
 {
     // Consume the teardown state — this reap is one-shot.
@@ -353,10 +279,9 @@ fn do_reap(state: InitReapState, memmgr_ep: u32, ipc_buf: *mut u64)
         ..
     } = state;
 
-    // 1. Reap init-logd's TCB. It is `Exited` (it released and exited) or
-    //    `Stopped` (forced by the backstop); `dealloc_object` drives either to
-    //    `Exited`, removes it from scheduler queues, and wakes any reply-bound
-    //    client (a real-logd blocked mid-handover) with `Interrupted`.
+    // 1. Reap init-logd's TCB. It is `Exited` (it released on real-logd's
+    //    `HANDOVER_RELEASE` and exited); `dealloc_object` removes it from
+    //    scheduler queues and frees the slot.
     let _ = syscall::cap_delete(logd_thread);
 
     // 2. Reap init's main thread TCB; it exited earlier in the countdown, so
@@ -396,13 +321,6 @@ fn do_reap(state: InitReapState, memmgr_ep: u32, ipc_buf: *mut u64)
         donated_pages * 4,
         pool_total,
     );
-}
-
-/// Boot-microsecond clock via `SYS_SYSTEM_INFO(ElapsedUs)`; never errors
-/// (`unwrap_or(0)` matches the kernel handler's infallible contract).
-fn elapsed_us() -> u64
-{
-    syscall::system_info(syscall_abi::SystemInfoType::ElapsedUs as u64).unwrap_or(0)
 }
 
 fn donate_to_memmgr(memmgr_ep: u32, caps: &[u32], ipc_buf: *mut u64) -> (u32, u64, u64)

--- a/services/procmgr/src/main.rs
+++ b/services/procmgr/src/main.rs
@@ -172,12 +172,6 @@ fn main() -> !
             &mut recent,
         );
 
-        // Liveness backstop: if init's main thread has exited but init-logd is
-        // still wedged past the grace (a dropped HANDOVER_RELEASE), force-stop
-        // it and reap so init's memory caps cannot be pinned indefinitely. No-op
-        // until the deadline, and once init is reaped.
-        init_reap::check_backstop(ctx.memmgr_ep, ipc_buf);
-
         match badge
         {
             WS_BADGE_SERVICE =>


### PR DESCRIPTION
## Summary

Fixes the riscv64 flaky bringup deadlock where a user-facing program (the terminal) co-resident with a heavy service load (`svctest` + `crasher`) intermittently wedges the system: all CPUs idle, `SLEEP_LIST count=0`, every userspace thread blocked, softlockup watchdog fires.

## Root cause

Not a kernel lost-wakeup — a userspace handover/backstop ordering bug. Traced with a temporary live-thread census (stripped before this PR):

1. svcmgr launches **real-logd**, which drains **init-logd**'s boot-log history via repeated blocking `ipc_call(HANDOVER_PULL)` on the shared master log endpoint, then `HANDOVER_RELEASE`.
2. procmgr's **init-reap backstop** force-stops init-logd on a fixed **3 s** wall-clock grace (`BACKSTOP_GRACE_US`) when it hasn't exited within that window of init's main-thread death — a liveness failsafe sized for a sub-second handover.
3. Under the reproducing load the handover legitimately exceeds 3 s, so the backstop stops init-logd **mid-handover**. real-logd's next `ipc_call` then blocks `BlockedOnSend` **forever** on the now-receiverless endpoint — uninterruptible by the death-EQ it registered, and not woken by `do_reap`'s `cap_delete` (which wakes only a *reply-bound* client, not a send-blocked one).
4. Everything logging through real-logd cascade-blocks → procmgr can't service `START_PROCESS` → the next service hangs `Created` → all idle → watchdog.

## Fix

Delete the backstop. procmgr's init-reap is already death-driven — it waits for init-logd's `INIT_REAP_CORRELATOR` death event, which the normal handover delivers when real-logd's `HANDOVER_RELEASE` makes init-logd `thread_exit`. With the backstop gone, a slow handover completes instead of being interrupted, so real-logd is never stranded. procmgr no longer force-kills init-logd and no longer cares what real-logd is doing.

**Trade-off:** if a handover genuinely never completes (real-logd crashes mid-pull or never launches), init-logd serves on and init's reclaimable memory stays held until shutdown — a benign hold (system fully functional, still logging via init-logd), not a wedge. That is a logging-subsystem robustness concern, not something to paper over with a force-kill that can deadlock the whole system.

Net change: **+43 / −125** across 8 files — the `procmgr` deletion (+24 / −112, two files) plus doc/comment sync to the death-driven model: the procmgr / init / logd READMEs, the handover-protocol failure-modes table, the init-reap bind-ordering comment, and the CI terminal-exclusion note (none describe the removed backstop any longer).

## Validation

riscv64 (the affected arch), reproducing config (default boot incl. terminal + `svctest` + `crasher`):

- **0 / 300** watchdog wedges (was ~4 %; ~12 expected if unchanged → p < 1e-5).
- **30 / 30** boots reach `[svctest] ALL TESTS PASSED` (median 68.8 s).

Both arches, clean build (scaffolding stripped):

- `cargo xtask build` — x86_64 ✓, riscv64 ✓
- `cargo xtask test-terminal` — x86_64 ✓, riscv64 ✓; both still reap init and donate its memory to memmgr via the natural-death path (no backstop)
- `cargo xtask` ktest (`[ktest] ALL TESTS PASSED`) — x86_64 ✓, riscv64 ✓

## Acceptance (#290)

- [x] Root-cause the deadlock.
- [x] A user-facing program MUST NOT be able to wedge the system under load — eliminated (0/300).
- [x] Decide terminal-defer/retry vs kernel/procmgr fix — it is a procmgr handover-backstop bug; no terminal or kernel change is needed.

## Notes

- A distinct latent scheduler race found incidentally during diagnosis (`timer_tick` preempting a thread mid-voluntary-block → run-queue double-enqueue) is tracked separately in #299; it is not #290 and is not in this PR.
- The #111 test-isolation workaround (terminal excluded from the `svctest`/`usertest` substrate harnesses) is unrelated to the fix; its #290-flakiness rationale is now resolved, but whether to re-include the terminal there is a test-design call left to the maintainer.

Fixes #290.
