### PR TITLE
docs: complete Summarized By backlink sweep (#15)

### DIFF
--- a/core/kernel/docs/arch-interface.md
+++ b/core/kernel/docs/arch-interface.md
@@ -460,4 +460,4 @@ equally clearly.
 
 ## Summarized By
 
-None
+[kernel/README.md](../README.md)

--- a/core/kernel/docs/capability-internals.md
+++ b/core/kernel/docs/capability-internals.md
@@ -446,4 +446,4 @@ CSpace. The kernel clears the per-thread reply slot after `SYS_IPC_REPLY`.
 
 ## Summarized By
 
-None
+[kernel/README.md](../README.md)

--- a/core/kernel/docs/initialization.md
+++ b/core/kernel/docs/initialization.md
@@ -473,4 +473,4 @@ that CPU only; the BSP and other CPUs continue.
 
 ## Summarized By
 
-None
+[kernel/README.md](../README.md)

--- a/core/kernel/docs/ipc-internals.md
+++ b/core/kernel/docs/ipc-internals.md
@@ -544,4 +544,4 @@ to userspace.
 
 ## Summarized By
 
-None
+[kernel/README.md](../README.md)

--- a/core/kernel/docs/memory-internals.md
+++ b/core/kernel/docs/memory-internals.md
@@ -453,4 +453,4 @@ by the address space that contains them.
 
 ## Summarized By
 
-None
+[kernel/README.md](../README.md)

--- a/core/kernel/docs/scheduler.md
+++ b/core/kernel/docs/scheduler.md
@@ -528,4 +528,4 @@ optimisation.
 
 ## Summarized By
 
-None
+[kernel/README.md](../README.md)

--- a/core/kernel/docs/scheduling-internals.md
+++ b/core/kernel/docs/scheduling-internals.md
@@ -575,4 +575,4 @@ stuck participants. Zero overhead in healthy paths.
 
 ## Summarized By
 
-None
+[kernel/README.md](../README.md)

--- a/core/kernel/docs/syscalls.md
+++ b/core/kernel/docs/syscalls.md
@@ -1442,4 +1442,4 @@ message capacity against syscall overhead. The exact value becomes stable ABI.
 
 ## Summarized By
 
-None
+[kernel/README.md](../README.md)

--- a/core/kernel/docs/thread-lifecycle-and-sleep.md
+++ b/core/kernel/docs/thread-lifecycle-and-sleep.md
@@ -285,4 +285,4 @@ This section lists ordering invariants specific to the sleep-list + lifecycle su
 
 ## Summarized By
 
-None
+[kernel/README.md](../README.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -162,7 +162,7 @@ live in the component scope:
 Boot modules (procmgr, memmgr, devmgr, vfsd, virtio-blk, fatfs) are packed into
 `\EFI\seraph\bootstrap.bundle` by `cargo xtask build` (see
 [`xtask/README.md`](../xtask/README.md) for the producer side and
-[`abi/boot-protocol/src/bundle.rs`](../abi/boot-protocol/src/bundle.rs) for the
+[`abi/boot-protocol`](../abi/boot-protocol/README.md)'s [`bundle.rs`](../abi/boot-protocol/src/bundle.rs) for the
 wire format); the bootloader exposes each entry as a named `BootModule` and
 init looks them up by `BootModule.name`.
 

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -82,7 +82,7 @@ handover endowment, and exits.
 
 Init runs a second thread, init-logd, that drains the master log endpoint and
 writes lines to serial directly from early boot onward. svcmgr launches and
-supervises the real `logd` post-handover, minting its bootstrap caps from the
+supervises the real [`logd`](../services/logd/README.md) post-handover, minting its bootstrap caps from the
 reserved log-sink sources init endows; the real `logd` then takes the receive
 side of the master log endpoint and pulls init-logd's captured history. The
 kernel endpoint object is unchanged across the transition, so existing badged
@@ -116,7 +116,5 @@ Once init exits, svcmgr is the resident supervisor. See
 ## Summarized By
 
 [README.md](../README.md),
-[abi/boot-protocol/README.md](../abi/boot-protocol/README.md),
 [init/README.md](../services/init/README.md),
-[logd/README.md](../services/logd/README.md),
-[svcmgr/README.md](../services/svcmgr/README.md)
+[logd/README.md](../services/logd/README.md)

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -42,7 +42,7 @@ binary. Components targeting the kernel, bootloader, or std-userspace triples
 must be built via `cargo xtask build` so the correct custom target JSON and
 `-Zbuild-std` flags are passed.
 
-`abi/boot-protocol` is the source of truth for the boot protocol ABI; both
+[`abi/boot-protocol`](../abi/boot-protocol/README.md) is the source of truth for the boot protocol ABI; both
 the bootloader and kernel depend on it. The kernel-entry contract the ABI
 supports is in [`core/boot/docs/kernel-handoff.md`](../core/boot/docs/kernel-handoff.md).
 `abi/syscall` defines syscall numbers, argument layout, and return codes; both

--- a/docs/console-model.md
+++ b/docs/console-model.md
@@ -34,7 +34,7 @@ earlier ones, which remain as fallbacks.
    `services/init/src/logging.rs`) drains the master log endpoint and writes
    lines to the UART directly. It owns console output from the moment init
    spawns it through the entire init → svcmgr handover and svcmgr's reconcile,
-   until the svcmgr-launched real-logd assumes the endpoint's RECV, pulls
+   until the svcmgr-launched [real-logd](../services/logd/README.md) assumes the endpoint's RECV, pulls
    init-logd's captured history via `log_labels::HANDOVER_PULL`, then releases
    it with `log_labels::HANDOVER_RELEASE` — at which point init-logd
    self-terminates. This direct path is **permanent**, not

--- a/docs/device-management.md
+++ b/docs/device-management.md
@@ -149,7 +149,7 @@ devmgr loads driver binaries from one of two places:
   MODULE bootstrap round. devmgr spawns them via
   `procmgr_labels::CREATE_PROCESS` during initial enumeration.
 - **On-disk rootfs** — non-essentials (the per-arch RTC and the
-  virtio-input keyboard driver) live at `/services/drivers/` and are
+  [virtio-input keyboard driver](../services/drivers/virtio/input/README.md)) live at `/services/drivers/` and are
   loaded via `procmgr_labels::CREATE_FROM_FILE`. virtio-input is
   PCI-enumerated during the initial scan — its BAR/IRQ caps are carved
   and stashed then — but its spawn is deferred to this path, since a

--- a/docs/ipc-design.md
+++ b/docs/ipc-design.md
@@ -171,6 +171,4 @@ The kernel does not provide:
 [Architecture Overview](architecture.md),
 [devmgr/README.md](../services/devmgr/README.md),
 [logd/README.md](../services/logd/README.md),
-[memmgr/README.md](../services/memmgr/README.md),
-[procmgr/README.md](../services/procmgr/README.md),
 [vfsd/README.md](../services/vfsd/README.md)

--- a/docs/process-lifecycle.md
+++ b/docs/process-lifecycle.md
@@ -9,7 +9,7 @@ System-wide model of userspace process creation, identity, and destruction from 
 This document is authoritative for:
 
 - The boot ordering of userspace tier-1 services
-  (`init` → `memmgr` → `procmgr` → `svcmgr`).
+  ([`init`](../services/init/README.md) → [`memmgr`](../services/memmgr/README.md) → [`procmgr`](../services/procmgr/README.md) → [`svcmgr`](../services/svcmgr/README.md)).
 - The capability flow at each step — who hands what to whom.
 - The `ProcessInfo` / `InitInfo` handover discipline: which fields are
   parent-chosen runtime values and which are ABI constants.

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -1,7 +1,8 @@
 # Storage
 
-System-scope composition of the Seraph storage stack: how `vfsd`,
-filesystem drivers, and block drivers are linked by capability
+System-scope composition of the Seraph storage stack: how
+[`vfsd`](../services/vfsd/README.md),
+[filesystem drivers](../services/fs/README.md), and block drivers are linked by capability
 delegation and how mounts are established at boot.
 
 ---

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -12,9 +12,9 @@ Three harnesses exercise three surfaces:
 
 | Harness | Surface | Crate | Launch mechanism |
 |---|---|---|---|
-| `ktest` | Kernel | `core/ktest/` | Bootloader-loaded init replacement (`cargo xtask compose-bundle --harness ktest`) |
+| `ktest` | Kernel | [`core/ktest/`](../core/ktest/README.md) | Bootloader-loaded init replacement (`cargo xtask compose-bundle --harness ktest`) |
 | `svctest` | Services | `services/svctest/` | `svcmgr` spawns from `/config/svcmgr/services/` recipe |
-| `usertest` | Programs | `services/usertest/` | `svcmgr` spawns from `/config/svcmgr/services/` recipe; drives binaries under `programs/` through their real I/O surfaces. Also hosts the terminal interactive test (`cargo xtask test-terminal`), which injects keys over QMP through the live virtio-input driver and the autostarted terminal |
+| `usertest` | Programs | [`services/usertest/`](../services/usertest/README.md) | `svcmgr` spawns from `/config/svcmgr/services/` recipe; drives binaries under `programs/` through their real I/O surfaces. Also hosts the terminal interactive test (`cargo xtask test-terminal`), which injects keys over QMP through the live virtio-input driver and the autostarted terminal |
 
 `ktest` and `svctest` are authoritative for their own surface; the harness
 itself owns its phases. `usertest` is an orchestrator that runs per-program

--- a/docs/userspace-memory-model.md
+++ b/docs/userspace-memory-model.md
@@ -232,4 +232,4 @@ yet implemented), not a kernel feature.
 
 ## Summarized By
 
-[README.md](../README.md), [Memory Model](memory-model.md), [Process Lifecycle](process-lifecycle.md), [Architecture Overview](architecture.md), [memmgr/README.md](../services/memmgr/README.md), [procmgr/README.md](../services/procmgr/README.md), [ruststd/README.md](../runtime/ruststd/README.md)
+[README.md](../README.md), [Memory Model](memory-model.md), [Architecture Overview](architecture.md), [memmgr/README.md](../services/memmgr/README.md), [procmgr/README.md](../services/procmgr/README.md), [ruststd/README.md](../runtime/ruststd/README.md)

--- a/programs/echosh/README.md
+++ b/programs/echosh/README.md
@@ -14,3 +14,9 @@ This is a stand-in for the real interactive shell, which lands as
 editing the `argv` line of `terminal.svc`, and `echosh` can be removed.
 
 No capabilities, no IPC — `std::io` over the stdio pipes the terminal provides.
+
+---
+
+## Summarized By
+
+None

--- a/programs/terminal/README.md
+++ b/programs/terminal/README.md
@@ -86,3 +86,9 @@ the `usertest` cell. See [docs/testing.md](../../docs/testing.md).
 [#67]: https://github.com/kottlerg/seraph/issues/67
 [#110]: https://github.com/kottlerg/seraph/issues/110
 [#112]: https://github.com/kottlerg/seraph/issues/112
+
+---
+
+## Summarized By
+
+[Testing](../../docs/testing.md)

--- a/runtime/ruststd/README.md
+++ b/runtime/ruststd/README.md
@@ -146,4 +146,4 @@ require a POSIX layer; it maps directly onto Seraph primitives.
 
 ## Summarized By
 
-[Userspace Memory Model](../../docs/userspace-memory-model.md)
+None

--- a/services/devmgr/README.md
+++ b/services/devmgr/README.md
@@ -143,4 +143,4 @@ MUST NOT be started independently of devmgr. See
 
 ## Summarized By
 
-[docs/device-management.md](../../docs/device-management.md), [docs/storage.md](../../docs/storage.md)
+[docs/device-management.md](../../docs/device-management.md)

--- a/services/devmgr/docs/hotplug.md
+++ b/services/devmgr/docs/hotplug.md
@@ -8,4 +8,4 @@ devices.
 
 ## Summarized By
 
-None
+[devmgr/README.md](../README.md)

--- a/services/drivers/cmos/README.md
+++ b/services/drivers/cmos/README.md
@@ -75,3 +75,9 @@ returns a sensible BCD century (`0x19`, `0x20`, `0x21`) it is used,
 otherwise the year is interpreted as `2000 + yy` (so seraph runs
 cleanly on QEMU CMOS, which leaves register `0x32` zero, through
 the year 2099).
+
+---
+
+## Summarized By
+
+None

--- a/services/drivers/goldfish-rtc/README.md
+++ b/services/drivers/goldfish-rtc/README.md
@@ -102,3 +102,9 @@ Real RISC-V boards diverge from QEMU `virt`. Per-board RTC support
 requires DT parsing infrastructure and per-board drivers; tracked
 as a follow-up. This driver covers the QEMU target seraph currently
 ships.
+
+---
+
+## Summarized By
+
+None

--- a/services/fs/fat/README.md
+++ b/services/fs/fat/README.md
@@ -118,4 +118,4 @@ windows.
 
 ## Summarized By
 
-[services/fs/README.md](../README.md)
+None

--- a/services/init/README.md
+++ b/services/init/README.md
@@ -110,4 +110,4 @@ transfer table.
 
 ## Summarized By
 
-[Architecture Overview](../../docs/architecture.md), [System Bootstrap](../../docs/bootstrap.md), [Process Lifecycle](../../docs/process-lifecycle.md), [logd](../logd/README.md), [memmgr](../memmgr/README.md), [pwrmgr](../pwrmgr/README.md)
+[Architecture Overview](../../docs/architecture.md), [System Bootstrap](../../docs/bootstrap.md), [Process Lifecycle](../../docs/process-lifecycle.md), [logd](../logd/README.md), [memmgr](../memmgr/README.md)

--- a/services/init/docs/bootstrap.md
+++ b/services/init/docs/bootstrap.md
@@ -257,4 +257,4 @@ svcmgr if needed.
 
 ## Summarized By
 
-[init/README.md](../README.md), [docs/bootstrap.md](../../../docs/bootstrap.md), [docs/process-lifecycle.md](../../../docs/process-lifecycle.md)
+[init/README.md](../README.md), [docs/bootstrap.md](../../../docs/bootstrap.md)

--- a/services/logd/docs/handover-protocol.md
+++ b/services/logd/docs/handover-protocol.md
@@ -132,3 +132,9 @@ Wire-format constants are defined in
 [`services/init/src/logging.rs`](../../init/src/logging.rs) (sender
 side) and [`services/logd/src/handover.rs`](../src/handover.rs)
 (receiver side). Both files cross-reference each other.
+
+---
+
+## Summarized By
+
+[logd/README.md](../README.md)

--- a/services/logd/docs/ipc-interface.md
+++ b/services/logd/docs/ipc-interface.md
@@ -129,3 +129,9 @@ logd's drain consumes each event as
 `(process_badge as u32) << 32 | exit_reason` and evicts the
 matching slot from the hash-keyed badge table. Idempotent on
 already-evicted badges.
+
+---
+
+## Summarized By
+
+[logd/README.md](../README.md)

--- a/services/svcmgr/README.md
+++ b/services/svcmgr/README.md
@@ -150,7 +150,9 @@ no init-side `PUBLISH_ENDPOINT` traffic. The first three are published in
 endows svcmgr with at handover; the provider names are published on each
 provider's launch path. Names are FS-driver- and platform-agnostic by
 design; consumers resolve them through their `.svc` `seed = ...` lines or
-via direct `QUERY_ENDPOINT` calls.
+via direct `QUERY_ENDPOINT` calls. The handover endowment and
+`PUBLISH_ENDPOINT` / `QUERY_ENDPOINT` wire format are specified in
+[docs/ipc-interface.md](docs/ipc-interface.md).
 
 | Name | Source | Cap shape |
 |---|---|---|

--- a/services/timed/README.md
+++ b/services/timed/README.md
@@ -76,3 +76,9 @@ exceeds `kernel_us`. `wrapping_add(wrapping_sub(x, y), y) == x`
 holds for unsigned, so the reply value equals `rtc_us` at the
 instant of the original RTC read, plus exactly the elapsed
 monotonic time since.
+
+---
+
+## Summarized By
+
+None

--- a/services/usertest/README.md
+++ b/services/usertest/README.md
@@ -33,4 +33,4 @@ runtime.
 
 ## Summarized By
 
-[Root README](../../README.md), [docs/testing.md](../../docs/testing.md)
+[docs/testing.md](../../docs/testing.md)

--- a/shared/namespace-protocol/README.md
+++ b/shared/namespace-protocol/README.md
@@ -294,4 +294,4 @@ describes vfsd's synthetic-root composition in detail.
 
 ## Summarized By
 
-[shared/README.md](../README.md), [services/vfsd/README.md](../../services/vfsd/README.md), [services/fs/README.md](../../services/fs/README.md), [services/fs/docs/fs-driver-protocol.md](../../services/fs/docs/fs-driver-protocol.md), [services/vfsd/docs/namespace-composition.md](../../services/vfsd/docs/namespace-composition.md), [services/vfsd/docs/vfs-ipc-interface.md](../../services/vfsd/docs/vfs-ipc-interface.md)
+[services/vfsd/README.md](../../services/vfsd/README.md), [services/fs/README.md](../../services/fs/README.md), [services/fs/docs/fs-driver-protocol.md](../../services/fs/docs/fs-driver-protocol.md), [services/vfsd/docs/namespace-composition.md](../../services/vfsd/docs/namespace-composition.md), [services/vfsd/docs/vfs-ipc-interface.md](../../services/vfsd/docs/vfs-ipc-interface.md)


### PR DESCRIPTION
Closes #15.

## Context

The treewide `## Summarized By` sweep was reported "largely done" on 2026-06-05
with one residual gap (two logd docs). Investigation found the issue's acceptance
was still violated, and by more than that update reported — five component READMEs
added since the sweep lacked the section, and the entire `core/kernel/docs/`
subtree carried only `None` despite the kernel README summarizing each doc.

This completes the sweep and reconciles summary reciprocity treewide per
`docs/documentation-standards.md` (§Backlinks, §Authority and Duplication).

## Changes

- **Missing sections added (7):** `services/timed`, `services/drivers/cmos`,
  `services/drivers/goldfish-rtc`, `programs/terminal`, `programs/echosh` READMEs;
  `services/logd/docs/{ipc-interface,handover-protocol}.md`.
- **Parent-README backlinks (10):** all nine `core/kernel/docs/*.md` and
  `services/devmgr/docs/hotplug.md` now backlink their README.
- **Reciprocity reconciliation (24 asymmetries):** added the missing forward link
  where a higher-level doc genuinely summarizes a target (e.g. `testing`→ktest/
  usertest, `bootstrap`/`console-model`→logd, `device-management`→virtio-input,
  `process-lifecycle`→init/memmgr, `build-system`/`architecture`→boot-protocol,
  `storage`→vfsd/fs, `svcmgr`→its ipc-interface doc); removed unsupported or
  reverse-direction backlink entries (`ipc-design`, `bootstrap`,
  `userspace-memory-model`, `init`, `ruststd`, `fat`, `namespace-protocol`,
  `devmgr`). Parent→child-component listings are treated as indexes (no backlink),
  consistent with the `drivers/`→`serial` precedent.

Scope note: this touches more files than the 2026-06-05 update anticipated
(kernel subtree + components added since); a one-line scope expansion, not a
deferral.

## Acceptance (#15)

- [x] Every component README has a current `## Summarized By` section (root README
  exempt as a Routing doc per the standard).
- [x] No `## Summarized By` lists a doc that doesn't link back, and vice versa
  (verified: 0 parent-doc gaps, 0 dangling entries via a dir-aware reciprocity
  audit).
- [x] `grep -rn "Summarized By"` across the tree yields a coherent set.

## Validation

Docs-only. No `.md` is `include_str!`'d into any binary, so the build/boot are
unaffected; CI's both-arch build+run is the gate. Reciprocity and link-resolution
were verified with a dir-aware audit script (0 parent gaps, 0 dangling, 0 real
broken links).