### PR TITLE
vfsd, xtask: auto-mount SERAPH_DATA partition at /data

### DIFF
--- a/abi/boot-protocol/src/role_guids.rs
+++ b/abi/boot-protocol/src/role_guids.rs
@@ -36,8 +36,8 @@ pub const SERAPH_ROOT_RISCV64: [u8; 16] = [
 
 /// Type-GUID for a Seraph data partition (arch-neutral).
 ///
-/// UUID: `036dcef6-d862-4242-93f8-4757a8b333de`. Reserved; no consumer in
-/// the current tree.
+/// UUID: `036dcef6-d862-4242-93f8-4757a8b333de`. Consumed by vfsd's
+/// `/data` auto-mount (DPS-style: the type GUID is the mount point).
 pub const SERAPH_DATA: [u8; 16] = [
     0xf6, 0xce, 0x6d, 0x03, 0x62, 0xd8, 0x42, 0x42, 0x93, 0xf8, 0x47, 0x57, 0xa8, 0xb3, 0x33, 0xde,
 ];

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -167,11 +167,16 @@ The UEFI firmware discovers the bootloader at `EFI/BOOT/BOOT<arch>.EFI`
 services live alongside it under `EFI/seraph/`, the Seraph vendor directory
 within the EFI partition.
 
-Non-ESP directories (`services/`, `programs/`, `tests/`, `config/`,
-`data/`) populate the GPT image's root partition, which userspace
-services mount via vfsd / fatfs after boot. The split mirrors real
-deployments: anything the firmware must reach lives on the ESP;
-everything else lives on the root partition.
+Non-ESP, non-`data` directories (`services/`, `programs/`, `tests/`,
+`config/`) populate the GPT image's root partition, which userspace
+services mount via vfsd / fatfs after boot. `data/` populates a
+dedicated `SERAPH_DATA` partition instead of the root partition; vfsd
+auto-mounts it at `/data`. (vfsd would also serve `/data` from a root-fs
+directory via fall-through, so carrying it on its own partition is a
+disk-authoring choice — see [storage.md](storage.md); the in-tree image
+uses the partition.) The split mirrors real deployments: anything the
+firmware must reach lives on the ESP; everything else lives on the root
+partition, except the discoverable `/data` mountpoint.
 
 The `esp/` and root-partition trees are populated from two sources:
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -99,6 +99,18 @@ or on-disk UUID. The model is:
   `c12a7328-f81f-11d2-ba4b-00a0c93ec93b`. No caller issues a
   `MOUNT` for `/esp`; vfsd does so internally at startup. ESP mount
   is best-effort and failure is non-fatal.
+- **The Seraph data partition is auto-mounted at `/data`** immediately
+  after the ESP, using the arch-neutral `SERAPH_DATA` type GUID. vfsd
+  mounts it internally at startup, like the ESP. The mount is
+  best-effort: when no `SERAPH_DATA` partition is present — or its
+  lookup is ambiguous (duplicate tied priority) — vfsd skips the mount
+  and `/data` falls through to the root partition, serving any `/data`
+  tree present there (or resolving as absent if none). Unlike the root
+  self-mount, an absent or ambiguous data partition is never fatal.
+  Whether `/data` is a dedicated partition or a root-fs directory is
+  therefore a disk-authoring choice, not a vfsd concern; the in-tree
+  image (see [build-system.md](build-system.md)) carries the tree on the
+  partition only.
 - **DPS-style priority tie-break.** Where multiple partitions match
   a role GUID, GPT attribute bits 48–63 are compared as an unsigned
   priority; the highest wins. Tied non-zero priorities are a fatal
@@ -134,10 +146,11 @@ its parsed table, registers the partition bound with virtio-blk,
 spawns the fs driver, sends `FS_MOUNT` to validate the BPB, and
 captures the driver's root cap into the synthetic root (see
 [`services/vfsd/docs/namespace-composition.md`](../services/vfsd/docs/namespace-composition.md)).
-It then auto-mounts the ESP at `/esp`. Both run before any service
-thread serves a request, so `GET_SYSTEM_ROOT_CAP` never observes an
-unmounted root. The runtime `MOUNT` label is retained for explicit /
-foreign-GUID mounts and shares this resolution path.
+It then auto-mounts the ESP at `/esp` and the data partition at
+`/data`. All three run before any service thread serves a request, so
+`GET_SYSTEM_ROOT_CAP` never observes an unmounted root. The runtime
+`MOUNT` label is retained for explicit / foreign-GUID mounts and shares
+this resolution path.
 
 **fs driver** runs as a separate process. After `FS_MOUNT` succeeds,
 it serves the cap-native `NS_*` protocol plus the surviving

--- a/services/svctest/src/phases/namespace.rs
+++ b/services/svctest/src/phases/namespace.rs
@@ -370,10 +370,9 @@ pub fn ns_multi_component_phase(_: &Caps)
     let _ = syscall::cap_delete(esp_cap);
     std::os::seraph::log!("ns_multi_component: NS_LOOKUP /esp/EFI (terminal contents) ok");
 
-    // Root-fs fixture: `/data/test.txt` is a plain rootfs file (the
-    // mount that previously covered the storage path is gone), so the
-    // cap walked from the system root resolves through the root-fs
-    // backend unchanged. Marker check verifies the byte content.
+    // `/data/test.txt` resolves through the SERAPH_DATA partition vfsd
+    // auto-mounts at `/data`; the in-tree image carries the fixture there.
+    // The marker check is content-only.
     let body = std::fs::read_to_string("/data/test.txt")
         .expect("ns_multi_component: std::fs::read_to_string(/data/test.txt) failed");
     assert!(

--- a/services/vfsd/README.md
+++ b/services/vfsd/README.md
@@ -38,18 +38,21 @@ vfsd/
   lookups to the root mount via transparent delegation. See
   [`docs/namespace-composition.md`](docs/namespace-composition.md).
 - **Root self-mount** — at startup, after parsing the GPT, vfsd mounts
-  the Seraph root partition at `/` and the ESP at `/esp` on its own
-  initiative, before any service thread begins serving. The namespace
-  dispatcher is spawned first because the `/esp` mount re-enters vfsd's
-  namespace endpoint to resolve `/services/fs/fatfs`; service threads
-  are spawned only after the mount, so `GET_SYSTEM_ROOT_CAP` is never
-  served against an unmounted root.
+  the Seraph root partition at `/`, the ESP at `/esp`, and the data
+  partition at `/data` on its own initiative, before any service thread
+  begins serving. The namespace dispatcher is spawned first because the
+  `/esp` and `/data` mounts re-enter vfsd's namespace endpoint to
+  resolve `/services/fs/fatfs`; service threads are spawned only after
+  the mounts, so `GET_SYSTEM_ROOT_CAP` is never served against an
+  unmounted root. The `/esp` and `/data` mounts are best-effort: an
+  absent partition is skipped (non-fatal) and the mount point falls
+  through to the root partition.
 - **Service endpoint** — handles `MOUNT` and `GET_SYSTEM_ROOT_CAP` on
   its un-badged service endpoint, with multi-threaded recv so a
   worker-driven `CREATE_FROM_FILE` re-entry cannot deadlock an in-
   flight reply. `MOUNT` is the runtime explicit-mount surface
   (foreign-GUID disks, user-invoked mounts); no in-tree caller issues
-  it, since root and `/esp` are self-mounted. See
+  it, since root, `/esp`, and `/data` are self-mounted. See
   [`docs/vfs-ipc-interface.md`](docs/vfs-ipc-interface.md).
 - **System-root cap delivery** — vfsd does not push a system-root
   cap anywhere at boot. Init pulls one via
@@ -73,8 +76,9 @@ vfsd/
   table from a single scratch memory cap at startup, then resolves the
   arch-conditional root GUID in `src/role_guids.rs` via
   `gpt::lookup_partition_by_type_guid` for the self-mount. The EFI
-  System Partition (matched by its standard type GUID) auto-mounts at
-  `/esp` immediately after root; there is no `mounts.conf` and no
+  System Partition (standard type GUID) and the Seraph data partition
+  (arch-neutral `SERAPH_DATA` GUID) auto-mount at `/esp` and `/data`
+  immediately after root; there is no `mounts.conf` and no
   `INGEST_CONFIG_MOUNTS` IPC. The runtime `MOUNT` handler decodes a
   `MountRole` byte from the wire payload and reuses the same
   resolution path. See

--- a/services/vfsd/docs/namespace-composition.md
+++ b/services/vfsd/docs/namespace-composition.md
@@ -118,8 +118,8 @@ namespace endpoint, both addressing the driver's root at full
 namespace rights:
 
 - `caller_root_cap` is returned to the `MOUNT` caller (or dropped on
-  the internal `auto_mount_esp` path that handles the `/esp` mount
-  without a synchronous caller).
+  the internal `auto_mount_role` path that handles the `/esp` and
+  `/data` mounts without a synchronous caller).
 - `synthetic_root_cap` is captured into [`VfsdRootBackend`] so the
   composition above can `cap_derive` from it on every `NS_LOOKUP`.
 

--- a/services/vfsd/docs/vfs-ipc-interface.md
+++ b/services/vfsd/docs/vfs-ipc-interface.md
@@ -43,13 +43,14 @@ labels live in [`ipc::vfsd_labels`] in `shared/ipc`.
 ## Label 10: `MOUNT`
 
 Runtime explicit-mount surface (foreign-GUID disks, user-invoked
-mounts). vfsd self-mounts root and `/esp` at startup through the same
-resolution path, so no in-tree caller currently issues `MOUNT`; the
-label is retained for runtime mounts.
+mounts). vfsd self-mounts root, `/esp`, and `/data` at startup through
+the same resolution path, so no in-tree caller currently issues
+`MOUNT`; the label is retained for runtime mounts.
 
 Mount the partition identified by a Seraph-minted GPT type GUID at the
-given path. vfsd resolves the role byte to an arch-conditional type
-GUID (see [`services/vfsd/src/role_guids.rs`](../src/role_guids.rs)),
+given path. vfsd resolves the role byte to a type GUID (arch-conditional
+for the root role, arch-neutral for data; see
+[`services/vfsd/src/role_guids.rs`](../src/role_guids.rs)),
 looks the partition up in its parsed GPT table via
 [`gpt::lookup_partition_by_type_guid`](../src/gpt.rs) (DPS-style
 priority tie-break on attribute bits 48-63; tied priorities are
@@ -60,19 +61,22 @@ the new filesystem's namespace endpoint addressing its root. A mount
 on `/` is rejected (`NO_MOUNT`) once root is already mounted.
 
 When the requested role is the rootfs (`MountRole::Root`, byte `0`),
-vfsd additionally auto-mounts the EFI System Partition at `/esp`
-inside the same handler before replying — the same logic the startup
-self-mount uses. The ESP mount is best-effort: failure logs a
-diagnostic but does not propagate into the root mount reply. The ESP
-is identified by the standard EFI System Partition type GUID
-(`c12a7328-f81f-11d2-ba4b-00a0c93ec93b`).
+vfsd additionally auto-mounts the EFI System Partition at `/esp` and
+the data partition at `/data` inside the same handler before replying —
+the same logic the startup self-mount uses. Both auto-mounts are
+best-effort: a missing or duplicate-priority partition logs a
+diagnostic and is skipped (leaving `/esp` / `/data` to resolve through
+the root-fs fall-through) without propagating into the root mount
+reply. The ESP is identified by the standard EFI System Partition type
+GUID (`c12a7328-f81f-11d2-ba4b-00a0c93ec93b`); the data partition by
+the arch-neutral `SERAPH_DATA` GUID.
 
 **Request**
 
 | Field | Value |
 |---|---|
 | `label` | `10` |
-| `data[0]` low byte | `MountRole` discriminant (`0` = `Root`; other roles reserved) |
+| `data[0]` low byte | `MountRole` discriminant (`0` = `Root`; `1` = `Data`; other roles reserved) |
 | `data[1]` | Mount path length (1..=64) |
 | `data[2..]` | Mount path bytes packed little-endian |
 

--- a/services/vfsd/src/main.rs
+++ b/services/vfsd/src/main.rs
@@ -14,8 +14,9 @@
 //! from client to driver.
 //!
 //! vfsd self-mounts the Seraph root partition at `/` (and the ESP at
-//! `/esp`) during startup, before serving any request; the runtime
-//! `MOUNT` IPC remains for explicit/foreign-GUID mounts.
+//! `/esp` and the data partition at `/data`) during startup, before
+//! serving any request; the runtime `MOUNT` IPC remains for
+//! explicit/foreign-GUID mounts.
 //!
 //! See `vfsd/README.md` for the design and `fs/docs/fs-driver-protocol.md`
 //! for the driver-side protocol.
@@ -766,6 +767,9 @@ enum MountRole
 {
     /// Seraph rootfs (`role_guids::SERAPH_ROOT`).
     Root,
+    /// Seraph data partition (`role_guids::SERAPH_DATA`), auto-mounted at
+    /// `/data`.
+    Data,
 }
 
 impl MountRole
@@ -775,6 +779,7 @@ impl MountRole
         match byte
         {
             0 => Some(MountRole::Root),
+            1 => Some(MountRole::Data),
             _ => None,
         }
     }
@@ -784,19 +789,21 @@ impl MountRole
         match self
         {
             MountRole::Root => &role_guids::SERAPH_ROOT,
+            MountRole::Data => &role_guids::SERAPH_DATA,
         }
     }
 }
 
 /// Mount the Seraph root partition at `/`, then auto-mount the ESP at
-/// `/esp`, during vfsd startup.
+/// `/esp` and the data partition at `/data`, during vfsd startup.
 ///
 /// Runs on the main thread before any service handler exists, so a
 /// `GET_SYSTEM_ROOT_CAP` request can never observe an unmounted root.
-/// The namespace dispatcher must already be running: the `/esp` mount
-/// takes the VFS spawn path, which re-enters vfsd's namespace endpoint
-/// to resolve `/services/fs/fatfs`. Returns whether the root mount
-/// succeeded; `/esp` is best-effort and never gates the return value.
+/// The namespace dispatcher must already be running: the `/esp` and
+/// `/data` mounts take the VFS spawn path, which re-enters vfsd's
+/// namespace endpoint to resolve `/services/fs/fatfs`. Returns whether
+/// the root mount succeeded; `/esp` and `/data` are best-effort and never
+/// gate the return value.
 fn self_mount(rt: &VfsdRuntime, ipc_buf: *mut u64) -> bool
 {
     match do_mount_internal(rt, ipc_buf, &role_guids::SERAPH_ROOT, b"/")
@@ -816,14 +823,15 @@ fn self_mount(rt: &VfsdRuntime, ipc_buf: *mut u64) -> bool
         }
     }
 
-    auto_mount_esp(rt, ipc_buf);
+    auto_mount_role(rt, ipc_buf, &role_guids::EFI_SYSTEM_PARTITION, "/esp");
+    auto_mount_role(rt, ipc_buf, &role_guids::SERAPH_DATA, "/data");
     true
 }
 
 /// Handle a runtime MOUNT request from an authorized client.
 ///
-/// vfsd self-mounts root and `/esp` at startup ([`self_mount`]), so no
-/// in-tree caller currently issues MOUNT; it remains the explicit /
+/// vfsd self-mounts root, `/esp`, and `/data` at startup ([`self_mount`]),
+/// so no in-tree caller currently issues MOUNT; it remains the explicit /
 /// runtime-mount surface (foreign-GUID disks, user-invoked mounts).
 ///
 /// IPC data layout (boot protocol v8+):
@@ -833,7 +841,8 @@ fn self_mount(rt: &VfsdRuntime, ipc_buf: *mut u64) -> bool
 ///
 /// Decodes the wire payload and delegates to [`do_mount`] for the
 /// real work. When the requested role is [`MountRole::Root`], vfsd
-/// additionally auto-mounts the EFI System Partition at `/esp`.
+/// additionally auto-mounts the EFI System Partition at `/esp` and the
+/// data partition at `/data`.
 #[allow(clippy::cast_possible_truncation)]
 fn handle_mount_request(recv: &IpcMessage, ipc_buf: *mut u64, rt: &VfsdRuntime)
 {
@@ -879,44 +888,50 @@ fn handle_mount_request(recv: &IpcMessage, ipc_buf: *mut u64, rt: &VfsdRuntime)
         Err(label) => IpcMessage::new(label),
     };
 
-    // Auto-mount the EFI System Partition at /esp once root is up so
-    // userspace can read kernel + bundle + bootloader without a separate
-    // MOUNT call. Best-effort — failure does not propagate into the root
-    // mount's reply.
+    // Auto-mount the EFI System Partition at /esp and the data partition
+    // at /data once root is up, so userspace can read kernel + bundle +
+    // bootloader and the data tree without a separate MOUNT call.
+    // Best-effort — failure does not propagate into the root mount's reply.
     if matches!(role, MountRole::Root) && reply.label == ipc::vfsd_errors::SUCCESS
     {
-        auto_mount_esp(rt, ipc_buf);
+        auto_mount_role(rt, ipc_buf, &role_guids::EFI_SYSTEM_PARTITION, "/esp");
+        auto_mount_role(rt, ipc_buf, &role_guids::SERAPH_DATA, "/data");
     }
 
     // SAFETY: ipc_buf is the registered IPC buffer.
     let _ = unsafe { ipc::ipc_reply(&reply, ipc_buf) };
 }
 
-/// One-shot best-effort mount of the EFI System Partition at `/esp`. Logs
-/// a diagnostic on any failure. Idempotent if invoked twice — the
-/// install attempt against an already-terminal mount path is rejected by
+/// One-shot best-effort mount of the partition tagged `type_guid` at
+/// `mount_path`. Scans the parsed GPT for an active matching partition; if
+/// none is present (or its role lookup is ambiguous), logs a diagnostic
+/// and returns without mounting, leaving `mount_path` to resolve through
+/// the root-fs fall-through. On a match, runs the mount transaction and
+/// logs the outcome. Never fatal — distinct from the root self-mount,
+/// whose failure gates boot. Idempotent if invoked twice: the install
+/// against an already-terminal mount path is rejected by
 /// `root_backend::install_mount`.
-fn auto_mount_esp(rt: &VfsdRuntime, ipc_buf: *mut u64)
+fn auto_mount_role(rt: &VfsdRuntime, ipc_buf: *mut u64, type_guid: &[u8; 16], mount_path: &str)
 {
-    let parts = &rt.gpt_parts;
-    let mut esp_found = false;
-    for p in parts
+    let present = rt
+        .gpt_parts
+        .iter()
+        .any(|p| p.active && &p.type_guid == type_guid);
+    if !present
     {
-        if p.active && p.type_guid == role_guids::EFI_SYSTEM_PARTITION
-        {
-            esp_found = true;
-            break;
-        }
-    }
-    if !esp_found
-    {
-        std::os::seraph::log!("MOUNT: no EFI System Partition found; skipping /esp auto-mount");
+        std::os::seraph::log!("MOUNT: no partition for {mount_path}; skipping auto-mount");
         return;
     }
-    match do_mount_internal(rt, ipc_buf, &role_guids::EFI_SYSTEM_PARTITION, b"/esp")
+    match do_mount_internal(rt, ipc_buf, type_guid, mount_path.as_bytes())
     {
-        Ok(_) => std::os::seraph::log!("MOUNT: /esp auto-mounted"),
-        Err(code) => std::os::seraph::log!("MOUNT: /esp auto-mount failed: code={code:#x}"),
+        Ok(caller_cap) =>
+        {
+            // The auto-mount has no IPC caller for the returned badged SEND;
+            // vfsd reaches the mount through its synthetic backend.
+            log_cap_delete("auto-mount caller cap", caller_cap);
+            std::os::seraph::log!("MOUNT: {mount_path} auto-mounted");
+        }
+        Err(code) => std::os::seraph::log!("MOUNT: {mount_path} auto-mount failed: code={code:#x}"),
     }
 }
 
@@ -966,9 +981,9 @@ pub(crate) fn do_mount(
 }
 
 /// Shared implementation for both role-driven (`do_mount`) and
-/// internally-triggered (`auto_mount_esp`) mounts. Takes a type-GUID
-/// directly so callers without a [`MountRole`] (the ESP auto-mount)
-/// can reuse the transaction body.
+/// internally-triggered (`auto_mount_role`) mounts. Takes a type-GUID
+/// directly so callers without a [`MountRole`] (the `/esp` and `/data`
+/// auto-mounts) can reuse the transaction body.
 #[allow(clippy::too_many_lines)]
 fn do_mount_internal(
     rt: &VfsdRuntime,
@@ -988,8 +1003,11 @@ fn do_mount_internal(
             }
             Err(gpt::GptLookupError::DuplicateTie) =>
             {
+                // Non-fatal here; the caller decides (root self-mount treats
+                // the returned error as fatal, the /esp and /data auto-mounts
+                // skip and fall through).
                 std::os::seraph::log!(
-                    "MOUNT: FATAL — multiple partitions share the role GUID with tied priority"
+                    "MOUNT: role GUID matched by multiple tied-priority partitions; not mounting"
                 );
                 return Err(ipc::vfsd_errors::NO_MOUNT);
             }

--- a/services/vfsd/src/role_guids.rs
+++ b/services/vfsd/src/role_guids.rs
@@ -24,3 +24,8 @@ pub const SERAPH_ROOT: [u8; 16] = boot_protocol::role_guids::SERAPH_ROOT_RISCV64
 pub const EFI_SYSTEM_PARTITION: [u8; 16] = [
     0x28, 0x73, 0x2a, 0xc1, 0x1f, 0xf8, 0xd2, 0x11, 0xba, 0x4b, 0x00, 0xa0, 0xc9, 0x3e, 0xc9, 0x3b,
 ];
+
+/// The Seraph data partition type-GUID (arch-neutral). Used to auto-mount
+/// `/data` after `/esp` when present; otherwise `/data` resolves through
+/// the root-fs fall-through.
+pub const SERAPH_DATA: [u8; 16] = boot_protocol::role_guids::SERAPH_DATA;

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -100,6 +100,17 @@ fails if the bundle is missing. The bundle is composed by
 [`cargo xtask compose-bundle`](#cargo-xtask-compose-bundle) (any
 harness).
 
+`disk.img` carries three GPT partitions: the EFI System Partition
+(from `sysroot/esp/`), the arch-specific Seraph root (from `sysroot/`,
+excluding `esp/` and `data/`), and an arch-neutral `SERAPH_DATA`
+partition (from `sysroot/data/`). The data partition is authored
+unconditionally — there is no flag to toggle it. vfsd auto-mounts it at
+`/data`; the data tree lives only on this partition, not on root.
+(vfsd's fall-through would also serve `/data` from a root-fs directory,
+so a dedicated partition is a disk-authoring choice — the in-tree image
+uses the partition.) This applies to `build`, `mkdisk`, and
+`compose-bundle` alike.
+
 ```
 cargo xtask mkdisk [--arch x86_64|riscv64]
 ```

--- a/xtask/src/disk.rs
+++ b/xtask/src/disk.rs
@@ -3,9 +3,10 @@
 
 //! disk.rs
 //!
-//! Build a GPT disk image from sysroot contents. The image contains two FAT32
-//! partitions: an EFI System Partition (populated from sysroot/) and an empty
-//! root partition for future use.
+//! Build a GPT disk image from sysroot contents. The image contains three
+//! FAT32 partitions: an EFI System Partition (from sysroot/esp/), a Seraph
+//! root partition (from sysroot/), and a Seraph data partition (from
+//! sysroot/data/) that vfsd auto-mounts at /data.
 
 use std::fs::{self, File};
 use std::io::{self, Read, Seek, SeekFrom, Write};
@@ -40,8 +41,17 @@ const ESP_SIZE_LBA: u64 = ESP_PARTITION_SIZE / SECTOR_SIZE;
 const ROOT_START_LBA: u64 = ESP_START_LBA + ESP_SIZE_LBA;
 const ROOT_SIZE_LBA: u64 = ROOT_PARTITION_SIZE / SECTOR_SIZE;
 
+/// Data partition size. Backs the `/data` mountpoint (namespace-marker
+/// fixture plus svctest scratch space); 256 MiB leaves generous headroom
+/// for the test phases' scratch writes.
+const DATA_PARTITION_SIZE: u64 = 256 * 1024 * 1024;
+
+/// Third partition follows immediately after the root partition.
+const DATA_START_LBA: u64 = ROOT_START_LBA + ROOT_SIZE_LBA;
+const DATA_SIZE_LBA: u64 = DATA_PARTITION_SIZE / SECTOR_SIZE;
+
 /// Total image size: partitions + 1 MiB lead-in + 1 MiB trailing GPT backup.
-const IMAGE_SIZE: u64 = (ROOT_START_LBA + ROOT_SIZE_LBA + 2048) * SECTOR_SIZE;
+const IMAGE_SIZE: u64 = (DATA_START_LBA + DATA_SIZE_LBA + 2048) * SECTOR_SIZE;
 
 /// A read/write/seek view into a byte range of an underlying file.
 /// Lets the `fatfs` crate operate on a single partition without knowing
@@ -150,14 +160,19 @@ impl Seek for PartitionSlice
 
 /// Create a GPT disk image at `<project_root>/disk.img`.
 ///
-/// The image contains two FAT32 partitions:
+/// The image contains three FAT32 partitions:
 /// - Partition 1 (ESP, [`ESP_PARTITION_SIZE`]): populated from `sysroot/esp/`
 /// - Partition 2 (ROOT, [`ROOT_PARTITION_SIZE`]): populated from `sysroot/`
-///   excluding `esp/`
+///   excluding `esp/` and `data/`
+/// - Partition 3 (DATA, [`DATA_PARTITION_SIZE`]): populated from `sysroot/data/`
 ///
-/// Partition 2's GPT type-GUID is the arch-specific Seraph root GUID
-/// (see [`boot_protocol::role_guids`]) so vfsd can identify the root by
-/// role without consulting a config file.
+/// Partition 2's GPT type-GUID is the arch-specific Seraph root GUID and
+/// partition 3's is the arch-neutral Seraph data GUID (see
+/// [`boot_protocol::role_guids`]) so vfsd can identify each by role
+/// without consulting a config file. vfsd auto-mounts the data partition
+/// at `/data`. The data tree is placed only on the data partition, not
+/// duplicated onto root; vfsd's fall-through still serves `/data` from
+/// root on images that choose to carry it there instead.
 pub fn create_disk_image(ctx: &BuildContext, arch: Arch) -> Result<()>
 {
     let image_path = ctx.disk_image();
@@ -198,6 +213,16 @@ pub fn create_disk_image(ctx: &BuildContext, arch: Arch) -> Result<()>
         &ctx.sysroot,
     )?;
 
+    // Format and populate the data partition from sysroot/data/. vfsd
+    // auto-mounts it at /data. The tree is not also written to the root
+    // partition (populate_dir skips top-level data/).
+    format_and_populate_partition(
+        &image_path,
+        DATA_START_LBA,
+        DATA_PARTITION_SIZE,
+        &ctx.sysroot.join("data"),
+    )?;
+
     step("Disk image complete");
     Ok(())
 }
@@ -210,6 +235,7 @@ pub fn create_disk_image(ctx: &BuildContext, arch: Arch) -> Result<()>
 /// partition's role; these identify the specific partition instance.
 pub const ESP_UNIQUE_UUID: &str = "a1b2c3d4-e5f6-7890-abcd-ef0123456789";
 pub const ROOT_UNIQUE_UUID: &str = "12345678-abcd-ef01-2345-6789abcdef01";
+pub const DATA_UNIQUE_UUID: &str = "c0ffee01-2345-6789-abcd-ef0123456789";
 
 /// Return the Seraph root partition type-GUID for `arch`, wrapped as a
 /// `gpt::partition_types::Type` ready for `add_partition_at`.
@@ -226,7 +252,18 @@ fn seraph_root_type(arch: Arch) -> gpt::partition_types::Type
     }
 }
 
-/// Write a GPT partition table with two partitions and deterministic UUIDs.
+/// Return the Seraph data partition type-GUID, wrapped as a
+/// `gpt::partition_types::Type` ready for `add_partition_at`. The data
+/// GUID is arch-neutral, so this takes no `arch`.
+fn seraph_data_type() -> gpt::partition_types::Type
+{
+    gpt::partition_types::Type {
+        guid: uuid::Uuid::from_bytes_le(role_guids::SERAPH_DATA),
+        os: gpt::partition_types::OperatingSystem::None,
+    }
+}
+
+/// Write a GPT partition table with three partitions and deterministic UUIDs.
 fn write_gpt(image_path: &Path, arch: Arch) -> Result<()>
 {
     let mut file = fs::OpenOptions::new()
@@ -273,9 +310,22 @@ fn write_gpt(image_path: &Path, arch: Arch) -> Result<()>
     )
     .context("failed to add ROOT partition")?;
 
+    // Partition 3: Seraph data, arch-neutral type-GUID per
+    // `boot_protocol::role_guids`. Flags 0 ⇒ DPS priority 0.
+    disk.add_partition_at(
+        "DATA",
+        3,
+        DATA_START_LBA,
+        DATA_SIZE_LBA,
+        seraph_data_type(),
+        0,
+    )
+    .context("failed to add DATA partition")?;
+
     // Set deterministic per-partition unique GUIDs for reproducible builds.
     let esp_uuid: uuid::Uuid = ESP_UNIQUE_UUID.parse().expect("invalid ESP_UNIQUE_UUID");
     let root_uuid: uuid::Uuid = ROOT_UNIQUE_UUID.parse().expect("invalid ROOT_UNIQUE_UUID");
+    let data_uuid: uuid::Uuid = DATA_UNIQUE_UUID.parse().expect("invalid DATA_UNIQUE_UUID");
 
     let mut parts = disk.take_partitions();
     if let Some(p) = parts.get_mut(&1)
@@ -285,6 +335,10 @@ fn write_gpt(image_path: &Path, arch: Arch) -> Result<()>
     if let Some(p) = parts.get_mut(&2)
     {
         p.part_guid = root_uuid;
+    }
+    if let Some(p) = parts.get_mut(&3)
+    {
+        p.part_guid = data_uuid;
     }
     disk.update_partitions(parts)
         .context("failed to update partition UUIDs")?;
@@ -297,8 +351,9 @@ fn write_gpt(image_path: &Path, arch: Arch) -> Result<()>
 
 /// Format a partition as FAT32 and populate it from a source directory.
 ///
-/// Skips `.arch`, `NvVars`, and the `esp` subdirectory (which is the ESP
-/// mount point, not root content) when populating.
+/// Skips build metadata (`.arch`, `NvVars`) and the top-level `esp` and
+/// `data` subdirectories, each a mount point with its own partition and so
+/// not root content.
 fn format_and_populate_partition(
     image_path: &Path,
     start_lba: u64,
@@ -364,6 +419,15 @@ fn populate_dir<T: Read + Write + Seek>(
 
         // Skip build metadata and the ESP mount point (populated separately).
         if name_str == ".arch" || name_str == "NvVars" || name_str == "esp"
+        {
+            continue;
+        }
+
+        // `data` is a mount point with its own SERAPH_DATA partition, so it
+        // is excluded from the root partition (symmetric with `esp`). Skip
+        // it only at the sysroot top level — a nested `data/` elsewhere in
+        // the tree is still copied.
+        if name_str == "data" && host_dir == sysroot_root
         {
             continue;
         }


### PR DESCRIPTION
## Summary

Wires the `SERAPH_DATA` GPT type-GUID (minted under #123, previously unconsumed) to a canonical `/data` mountpoint, DPS-style: a partition's type GUID *is* its mount point, with no per-system configuration.

- `MountRole::Data` added (wire byte `1`, maps to `SERAPH_DATA`).
- `auto_mount_esp` generalised to `auto_mount_role(rt, ipc_buf, type_guid, mount_path)`; vfsd self-mounts `/esp` then `/data` after the root self-mount, in both `self_mount` (startup) and `handle_mount_request` (runtime).
- Best-effort: an absent or duplicate-tied `SERAPH_DATA` partition is skipped and the mount point falls through to the root partition; never fatal (unlike the root self-mount).
- `cargo xtask` authors a third FAT32 `SERAPH_DATA` partition (from `sysroot/data/`) on every disk image. The data tree is placed **only** on this partition — `populate_dir` skips top-level `data/` on root (symmetric with the existing `esp` skip), so it is not duplicated.
- Fixed a pre-existing caller-cap leak on the auto-mount path.

## Layering note

Two layers, kept distinct:
- **vfsd (general, unchanged):** `/data` = the mounted `SERAPH_DATA` partition if present, else root-fs fall-through. A disk may carry `/data` on its own partition *or* as a root-fs directory — vfsd serves both; the choice is the disk author's.
- **In-tree image (this PR):** carries the data tree on the partition only (no root duplication).

## Partition map

`disk.img` now carries three GPT partitions (512-byte LBAs):

| # | Role | Type GUID | Start LBA | Size | Source |
|---|------|-----------|-----------|------|--------|
| 1 | ESP | `EFI` | 2048 (`0x800`) | 256 MiB | `sysroot/esp/` |
| 2 | ROOT | `SERAPH_ROOT_<arch>` | `0x80800` | 512 MiB | `sysroot/` (excl. `esp/`, `data/`) |
| 3 | DATA | `SERAPH_DATA` (arch-neutral) | `0x180800` | 256 MiB | `sysroot/data/` |

Total image ≈ 1026 MiB (1 MiB lead-in + 256 + 512 + 256 MiB + 1 MiB trailing backup GPT).

## Design decisions

- **Author by default, no flag.** Every disk carries ESP + Root + SERAPH_DATA.
- **Data on the partition only**, not duplicated onto root (de-dup; symmetric with the `esp` skip). The runtime fall-through capability is unaffected — it lives in vfsd, not the image.
- **Best-effort, non-fatal** when the partition is absent (vfsd skips, falls through to root).
- **Multi-instance = existing DPS tie-break** (`gpt::lookup_partition_by_type_guid`, attribute bits 48-63); a duplicate-priority tie is non-fatal for `/data`, fatal for root.

## Acceptance (#156)

- [x] `MountRole::Data` declared with `SERAPH_DATA` GUID mapping.
- [x] vfsd auto-mounts `SERAPH_DATA` at `/data` when present, with documented absent / parse-failed semantics (best-effort skip + fall-through; `docs/storage.md`).
- [x] Multi-instance / duplicate-GUID policy decided and documented (DPS tie-break; non-fatal for `/data`).
- [x] `cargo xtask` flag surface documented in `xtask/README.md` (no flag — authored unconditionally).
- [x] `docs/storage.md` updated to describe `/data` as a discoverable mountpoint.
- [x] Both x86_64 and riscv64 boot with and without a SERAPH_DATA partition (absent -> non-fatal skip; verified by boot log). svctest + usertest pass against the authored image. `/data` is a pure discoverable mountpoint; with no partition it is simply absent (no root fallback content, by design). The vfsd fall-through *mechanism* is unchanged and serves `/data` from root on images that carry it there.

## Test plan

- [x] `cargo xtask build` — x86_64 and riscv64 (fmt + clippy + check gate)
- [x] x86_64 svctest / usertest / ktest reach pass markers
- [x] riscv64 svctest / usertest / ktest reach pass markers
- [x] svctest re-run on both arches after de-dup (data off root) — pass
- [x] `cargo xtask test` (host) — 68 passed, 0 failed
- [x] Verbose boot confirms `[vfsd] MOUNT: /data auto-mounted` at the SERAPH_DATA LBA (`0x180800`)
- [x] `mdir` inspection of the authored image: ROOT carries `config/ programs/ services/ tests/` (no `data`, no `esp`); DATA carries `test.txt` + `svctest/`
- [x] No-partition boot: `[vfsd] MOUNT: no partition for /data; skipping auto-mount`, system boots non-fatally