### PR TITLE
xtask/run-parallel: abort a crashed run early after a --fail grace window

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,7 +2,7 @@
 
 [alias]
 # `cargo xtask <command>` runs the xtask build runner.
-xtask = "run --package xtask --release --"
+xtask = "run --package xtask --"
 
 #
 # build-std flags are passed explicitly by the build scripts rather than here,

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -220,7 +220,8 @@ cargo xtask run-parallel \
     [--timeout SECONDS] \
     [--cpus N] \
     [--pass REGEX] \
-    [--fail REGEX]
+    [--fail REGEX] \
+    [--fail-grace-secs SECONDS]
 ```
 
 | Option | Default | Description |
@@ -232,6 +233,7 @@ cargo xtask run-parallel \
 | `--cpus` | `4` | vCPUs per guest |
 | `--pass` | `ALL TESTS PASSED` | Regex marking a successful run. The default matches the cross-harness terminal marker `[<harness>] ALL TESTS PASSED` standardised in [docs/testing.md](../docs/testing.md). On match the log is discarded and the run is classified `PASS` |
 | `--fail` | `SOME TESTS FAILED\|KERNEL EXCEPTION\|FATAL:\|PANIC( at \|: )` | Regex marking a failed run; the **first** match wins. Matches the cross-harness terminal marker `[<harness>] SOME TESTS FAILED` ([docs/testing.md](../docs/testing.md)) plus the kernel's own death markers (`KERNEL EXCEPTION` + `FATAL:` for a hardware trap, `PANIC at`/`PANIC:` for a Rust `panic!`) so a crash classifies `FAIL` rather than `HANG`. The benign `USERSPACE FAULT` path matches none of these. On match the log is preserved as `FAIL-<run>.log`. Failure takes precedence over success. Override with a never-matching pattern (e.g. `'$.^'`) to disable |
+| `--fail-grace-secs` | `10` | After the first `--fail` match, wait this many seconds (bounded by `--timeout`) before SIGKILL, so the trailing fault dump still lands in the log. A crashed run thus aborts ~grace seconds after the first match instead of idling to `--timeout` |
 
 **Mode-agnostic**: xtask does not know about ktest, svctest, or any other
 rootfs configuration. Pass/fail markers come from the invoker. The default
@@ -253,7 +255,8 @@ non-passing runs are preserved under `target/xtask/run-parallel/` as
 discarded.
 
 **Outcome precedence**:
-1. `--fail` regex matches → `FAIL`
+1. `--fail` regex matches → `FAIL` (a live match also triggers early abort
+   after `--fail-grace-secs`, bounded by `--timeout`; the verdict is unchanged)
 2. `--pass` regex matches → `PASS` (even if QEMU was watchdog-killed,
    which is the normal case for kernels that idle after success)
 3. Watchdog timeout → `HANG`

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -301,4 +301,13 @@ pub struct RunParallelArgs
     /// Override with a never-matching pattern (e.g. `'$.^'`) to disable.
     #[arg(long, default_value = DEFAULT_FAIL_REGEX)]
     pub fail: String,
+
+    /// Grace window, in seconds, after the first `--fail` match before the
+    /// run is SIGKILLed. A kernel fault dump is multi-line and may be
+    /// followed by secondary-CPU faults; killing on the first matching byte
+    /// truncates the diagnostics. The run is killed at whichever is first:
+    /// this window, or the `--timeout` deadline. 0 kills on the next poll
+    /// after the match.
+    #[arg(long, default_value = "10")]
+    pub fail_grace_secs: u64,
 }

--- a/xtask/src/commands/run_parallel.rs
+++ b/xtask/src/commands/run_parallel.rs
@@ -456,9 +456,10 @@ fn wait_with_timeout(
 /// match, when the log is still small, so re-reading is cheap and there is
 /// no split-across-reads boundary to mishandle. The `last_len` guard skips
 /// the read when the file has not grown, bounding cost on a quiescent guest
-/// or a disabled `--fail`. Errors collapse to `false`; the final `classify`
-/// read is authoritative, so a missed live match only forgoes the early
-/// abort, never the verdict.
+/// or a disabled `--fail`. Best-effort: a `read_log` error returns `false`
+/// and a `metadata` failure falls back to length 0 (re-reading unless the
+/// log is still empty). The final `classify` read is authoritative, so a
+/// missed live match only forgoes the early abort, never the verdict.
 fn fail_marker_present(log_path: &Path, last_len: &mut u64, fail_re: &Regex) -> bool
 {
     let len = std::fs::metadata(log_path).map(|m| m.len()).unwrap_or(0);

--- a/xtask/src/commands/run_parallel.rs
+++ b/xtask/src/commands/run_parallel.rs
@@ -157,6 +157,7 @@ pub fn run(ctx: &BuildContext, args: &RunParallelArgs) -> Result<()>
             let arch = args.arch;
             let cpus = args.cpus;
             let timeout = Duration::from_secs(args.timeout);
+            let fail_grace = Duration::from_secs(args.fail_grace_secs);
             let pass_re = pass_re.clone();
             let fail_re = fail_re.clone();
             let workdir = workdir.clone();
@@ -234,7 +235,8 @@ pub fn run(ctx: &BuildContext, args: &RunParallelArgs) -> Result<()>
                     .context("QEMU stdout was piped but unavailable")?;
                 let forwarder = spawn_stdout_forwarder(qemu_stdout, log_file, slot)?;
 
-                let (exit_rc, hung) = wait_with_timeout(&mut child, timeout)?;
+                let (exit_rc, hung) =
+                    wait_with_timeout(&mut child, timeout, &log_path, &fail_re, fail_grace)?;
                 // Drain the forwarder before reading the log so classify()
                 // sees the complete byte stream even when the watchdog
                 // killed QEMU mid-write.
@@ -396,28 +398,79 @@ fn join_forwarder(handle: JoinHandle<Result<()>>, run_id: u32)
     }
 }
 
-/// Block waiting for `child` to exit or `timeout` to elapse.
+/// Block until `child` exits or a watchdog deadline elapses, SIGKILLing it
+/// on the deadline.
 ///
-/// On timeout the child is SIGKILLed and reaped. Returns
-/// `(exit_code, was_hung)`: `exit_code` is the process's reported status
-/// (or 137 on a watchdog kill, matching SIGKILL semantics); `was_hung`
-/// distinguishes a clean exit-by-coincidence from a watchdog-induced kill.
-fn wait_with_timeout(child: &mut Child, timeout: Duration) -> Result<(i32, bool)>
+/// Two deadlines apply, whichever comes first:
+/// - the hard `timeout` (a run still alive here is classified `HANG`);
+/// - a `fail_grace` window armed on the first `--fail` (`fail_re`) match in
+///   the live log. A crashed guest halts without shutting QEMU down, so
+///   without this it would idle to `timeout`; the grace window bounds that
+///   idle while still letting the multi-line fault dump finish landing in
+///   the log before the kill.
+///
+/// Returns `(exit_code, was_hung)`: `exit_code` is the process's reported
+/// status (or 137 on a watchdog kill, matching SIGKILL semantics);
+/// `was_hung` marks any watchdog kill (hard timeout or grace). `classify`
+/// disambiguates — a grace kill carries the `--fail` marker in the final
+/// log read, so it resolves to `FAIL`, not `HANG`.
+fn wait_with_timeout(
+    child: &mut Child,
+    timeout: Duration,
+    log_path: &Path,
+    fail_re: &Regex,
+    fail_grace: Duration,
+) -> Result<(i32, bool)>
 {
     let deadline = Instant::now() + timeout;
+    let mut grace_deadline: Option<Instant> = None;
+    let mut last_log_len: u64 = 0;
     loop
     {
+        // try_wait first: a guest that prints the fail marker then exits
+        // cleanly within the grace window must report its real exit code.
         if let Some(status) = child.try_wait().context("polling child")?
         {
             return Ok((status.code().unwrap_or(-1), false));
         }
-        if Instant::now() >= deadline
+        // Arm the grace window on the first --fail match in the live log.
+        if grace_deadline.is_none() && fail_marker_present(log_path, &mut last_log_len, fail_re)
+        {
+            grace_deadline = Some(Instant::now() + fail_grace);
+        }
+        let effective = grace_deadline.map_or(deadline, |g| g.min(deadline));
+        if Instant::now() >= effective
         {
             let _ = child.kill();
             let status = child.wait().context("reaping killed child")?;
             return Ok((status.code().unwrap_or(137), true));
         }
         thread::sleep(POLL_INTERVAL);
+    }
+}
+
+/// Best-effort live scan of the per-run log for the `--fail` marker.
+///
+/// Reuses the whole-file `read_log` (the verdict authority in `classify`)
+/// rather than incremental tailing: the scan runs only until the first
+/// match, when the log is still small, so re-reading is cheap and there is
+/// no split-across-reads boundary to mishandle. The `last_len` guard skips
+/// the read when the file has not grown, bounding cost on a quiescent guest
+/// or a disabled `--fail`. Errors collapse to `false`; the final `classify`
+/// read is authoritative, so a missed live match only forgoes the early
+/// abort, never the verdict.
+fn fail_marker_present(log_path: &Path, last_len: &mut u64, fail_re: &Regex) -> bool
+{
+    let len = std::fs::metadata(log_path).map(|m| m.len()).unwrap_or(0);
+    if len == *last_len
+    {
+        return false;
+    }
+    *last_len = len;
+    match read_log(log_path)
+    {
+        Ok(text) => fail_re.is_match(&text),
+        Err(_) => false,
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #161.

`run-parallel`'s watchdog previously reaped a run only when QEMU exited or the
`--timeout` deadline elapsed. A crashed guest (kernel `#PF`/`panic!`) halts
without shutting QEMU down, so it idled the **entire** `--timeout` before being
SIGKILLed and classified — ~150s wasted per crash in a 180s burn-in (#160).

The watchdog now scans the growing per-run log for the `--fail` regex on its
existing poll cadence. On the first match it arms a grace window
(`--fail-grace-secs`, default 10) and kills at `min(timeout, match + grace)`, so
the multi-line fault dump (register dumps, secondary-CPU faults) still lands in
the log before the kill.

## Design notes

- **`classify()` is unchanged.** The live scan only triggers the early kill; the
  final whole-file `read_log` after the forwarder drains stays the verdict
  authority. `fail` beats everything in `classify`, so a grace kill (which
  reports `was_hung = true`) resolves to `FAIL`, never `HANG`.
- **`try_wait` stays first in the poll loop**, so a guest that prints the marker
  then exits cleanly within the grace window still reports its real exit code.
- **Scan is best-effort and cheap:** it reuses `read_log` behind a
  `metadata().len()` size-guard and runs only until the first match (when the log
  is still small), then stops. No incremental-tailing boundary surface.
- **`--fail`-only.** A live `--pass` early-exit is intentionally omitted; the
  existing "pass beats watchdog" rule already covers a guest that prints PASS then
  idles.

## Bundled change (outside #161 scope)

Per discussion, this PR also drops `--release` from the `cargo xtask` alias
(`.cargo/config.toml`, second commit). That flag compiled only the xtask *host
tool* (the kernel/sysroot profile is selected independently by xtask's own
`--release` CLI flag); the release profile (`lto=true`, `codegen-units=1`,
`opt-level="s"`) is the workspace's slowest to compile, paid on every xtask change
for negligible runtime gain. Building under `profile.dev` is faster to recompile
and keeps debug-assertions/overflow-checks on. No behaviour change to any
`cargo xtask` command.

## Validation

`cargo xtask test` → 68/68 host tests pass (incl. the `classify` suite). End-to-end
on both arches via `cargo xtask build` + `run-parallel` against the ktest harness:

| Arch | Build | Healthy ktest (no regression) | Early-abort |
|---|---|---|---|
| x86_64 | ✅ | 4/4 PASS, `[ktest] ALL TESTS PASSED`, clean exit ~12s, no false-trigger | `--fail` match → FAIL @ **5.17s** vs `--timeout 45` |
| riscv64 | ✅ | 2/2 PASS, `[ktest] ALL TESTS PASSED`, clean exit 16–26s, no false-trigger | `--fail 'ktest'` → FAIL @ **10.10s** vs `--timeout 180` (matched `ktest: starting`) |

The healthy runs confirm the per-poll scan does not false-trigger on a passing
boot and that normal PASS classification + the terminal pass marker are intact on
both arches.

## Follow-ups (filed)

- #318 — `run_parallel.rs:179` uses `.expect()` in a production path
  (coding-standards.md § error handling). Pre-existing; deferred out of this PR.
- #319 — the host `xtask` crate is never `cargo clippy`'d in CI, so the workspace
  `unwrap_used`/`expect_used` denies are enforced on the sysroot build but not on
  xtask — which is why #318 sits on green master.
