### PR TITLE
xtask, treewide: unify opt-level at 2; opt-in debuginfo via --debug; fix Z-milestone convention

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,12 +96,21 @@ syscall = { path = "abi/syscall", package = "syscall-abi" }
 syscall-abi = { path = "abi/syscall" }
 virtio-core = { path = "services/drivers/virtio/core" }
 
+# opt-level = 2 and debug = 0 are unified across both profiles; debuginfo is
+# opt-in per-package via `cargo xtask build --debug <comp>`. dev and release
+# differ only in {debug-assertions, overflow-checks} (iterate) and
+# {lto, codegen-units} (ship). LTO has no per-package form, so two profiles
+# must persist.
 [profile.dev]
 panic = "abort"
-opt-level = 1
+opt-level = 2
+debug = 0
+debug-assertions = true
+overflow-checks = true
 
 [profile.release]
 panic = "abort"
+opt-level = 2
+debug = 0
 lto = true
 codegen-units = 1
-opt-level = "s"

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ requirements, sysroot layout, and QEMU / firmware configuration are in
 ```sh
 cargo xtask build                            # build (defaults: x86_64, debug)
 cargo xtask build --arch riscv64             # build for RISC-V
+cargo xtask build --debug kernel             # build all; debuginfo for kernel only
 cargo xtask mkdisk                           # repack disk.img after rootfs/ edits
 cargo xtask compose-bundle --harness ktest   # swap boot bundle to ktest harness
 cargo xtask run                              # launch existing sysroot under QEMU

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -106,6 +106,47 @@ opt-in.
 
 ---
 
+## Build Profiles
+
+Two Cargo profiles are defined at the workspace root (`Cargo.toml`): `dev`
+(the default) and `release` (selected by `--release`). Both share
+`opt-level = 2` and `debug = 0`; they differ only in two key pairs:
+
+| Concern | `dev` | `release` |
+|---|---|---|
+| Iterate (runtime checks) | `debug-assertions`, `overflow-checks` on | off |
+| Ship (codegen) | — | `lto = true`, `codegen-units = 1` |
+
+Both set `panic = "abort"`. LTO has no per-package form, which is the only
+reason two profiles persist rather than one. Cargo names the profiles `dev`
+and `release` but writes their output to `target/<triple>/debug/` and
+`target/<triple>/release/`; the CI cells and branch-protection status checks
+use the directory names `debug`/`release`.
+
+### Debuginfo is opt-in
+
+`debug = 0` means a plain `cargo xtask build` (or `--release`) emits no
+per-binary DWARF — every installed binary is symbol-free. To debug specific
+components, opt them in:
+
+```
+cargo xtask build --debug <component>[,<component>…]
+```
+
+This injects `--config profile.<active>.package."<pkg>".debug=2` plus
+`opt-level=1` for the named package(s) only, leaving every other binary
+symbol-free. `<active>` is `dev` by default, `release` under `--release`.
+The debugged crate drops to `opt-level = 1` (not `0`): opt-0 inflates stack
+frames and risks overflowing the tight kernel/thread stacks.
+
+Limits: under `--release`, fat LTO reoptimizes at the profile opt-level and
+partially overrides the per-package `opt-level=1`, so step fidelity is
+degraded — the normal debug flow uses the default (`dev`) profile. No `strip`
+is configured: debuginfo is already absent by default, and stripping would
+risk panic/fault backtrace symbolization.
+
+---
+
 ## Build Output: the Sysroot
 
 Build artifacts are staged in `sysroot/`, which is then packaged into the

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -58,7 +58,7 @@ Every Issue MUST carry at least one **Subsystem** label and at least one **Class
 
 ### Milestones
 
-Each `Y` bump (`v0.1.0`, `v0.2.0`, …) has a GitHub milestone. Issues blocking a milestone MUST be assigned to it; everything else MUST stay unassigned.
+Each `Y` bump (`v0.1.0`, `v0.2.0`, …) and each shipped `Z` patch (`v0.1.1`, …) has a GitHub milestone. Issues blocking a milestone MUST be assigned to it; everything else MUST stay unassigned.
 
 ### Commit and PR cross-references
 

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -11,7 +11,7 @@ Build task runner for Seraph. Invoke via `cargo xtask <command>`.
 Build Seraph components and populate `sysroot/`.
 
 ```
-cargo xtask build [--arch x86_64|riscv64] [--release] [--component boot|kernel|init|all]
+cargo xtask build [--arch x86_64|riscv64] [--release] [--component boot|kernel|init|all] [--debug <comp>[,...]]
 ```
 
 | Option | Default | Description |
@@ -19,6 +19,7 @@ cargo xtask build [--arch x86_64|riscv64] [--release] [--component boot|kernel|i
 | `--arch` | `x86_64` | Target architecture |
 | `--release` | off | Build in release mode |
 | `--component` | `all` | Build a single component (`boot`, `kernel`, `init`, or `all`) |
+| `--debug` | (none) | Emit debuginfo (`debug=2`, `opt-level=1`) for the named component(s) only, e.g. `--debug kernel,procmgr`; applies within the active profile. See [Build Profiles](../docs/build-system.md#build-profiles). |
 
 The sysroot is architecture-specific. Building for a different arch than the
 existing sysroot is an error — run `cargo xtask clean` first.

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -86,6 +86,13 @@ pub struct BuildArgs
     #[arg(long, default_value = "all")]
     pub component: BuildComponent,
 
+    /// Emit debuginfo (`debug = 2`, `opt-level = 1`) for the named
+    /// component(s) only, within the active profile (default or `--release`).
+    /// Comma-separated, e.g. `--debug kernel,procmgr`; names match
+    /// `--component`. Only components in the current build are affected.
+    #[arg(long, value_delimiter = ',')]
+    pub debug: Vec<BuildComponent>,
+
     /// Skip `cargo fmt` and per-component `cargo check` (clippy). `cargo
     /// xtask run` sets this internally to keep the tight edit → rebuild →
     /// launch loop responsive — an unchanged tree would otherwise pay for

--- a/xtask/src/commands/build.rs
+++ b/xtask/src/commands/build.rs
@@ -509,6 +509,7 @@ fn build_boot(ctx: &BuildContext, args: &BuildArgs) -> Result<()>
 
     let mut cmd = cargo(&ctx.root);
     cmd.arg("build").args(&flags);
+    cmd.args(debug_config_flags(args, "boot"));
     run_cmd(&mut cmd)?;
 
     let efi_boot_dir = ctx.sysroot_efi_boot();
@@ -666,6 +667,10 @@ fn build_group(
 
     let mut cmd = cargo(&ctx.root);
     cmd.arg("build").args(&flags_ref);
+    for &pkg in &names
+    {
+        cmd.args(debug_config_flags(args, pkg));
+    }
     if let Some(s) = seraph.as_ref()
     {
         s.apply_env(&mut cmd);
@@ -755,6 +760,7 @@ fn build_spec(ctx: &BuildContext, args: &BuildArgs, spec: &Spec) -> Result<()>
 
     let mut cmd = cargo(&ctx.root);
     cmd.arg("build").args(&flags_ref);
+    cmd.args(debug_config_flags(args, spec.name));
     if let Some(s) = seraph.as_ref()
     {
         // Routes RUSTC + RUSTC_WORKSPACE_WRAPPER through the shim,
@@ -920,4 +926,48 @@ fn copy_file(src: &Path, dst: &Path) -> Result<()>
 fn profile_name(release: bool) -> &'static str
 {
     if release { "release" } else { "debug" }
+}
+
+/// Cargo profile *selector* name (`dev`/`release`) for `--config` keys.
+///
+/// Distinct from [`profile_name`], which returns the output-directory name
+/// (`debug`/`release`). The cargo profile is literally named `dev`; no profile
+/// is named `debug`, so a per-package `--config` key MUST use this name —
+/// `profile.debug.package.*` would be a silent no-op. Do not fold this into
+/// [`profile_name`].
+fn active_profile(release: bool) -> &'static str
+{
+    if release { "release" } else { "dev" }
+}
+
+/// Whether `--debug` selected `pkg` for debuginfo. [`BuildComponent::All`]
+/// selects every package; [`BuildComponent::Boot`] selects only `boot` (which
+/// has no [`Spec`], hence the explicit arm).
+fn debug_includes(args: &BuildArgs, pkg: &str) -> bool
+{
+    args.debug.iter().any(|c| match c
+    {
+        BuildComponent::All => true,
+        BuildComponent::Boot => pkg == "boot",
+        other => spec_for(*other).is_some_and(|s| s.name == pkg),
+    })
+}
+
+/// `--config` flags opting `pkg` into debuginfo (`debug = 2`, `opt-level = 1`)
+/// within the active profile. Empty unless `--debug` named `pkg`. The package
+/// segment is quoted so hyphenated names (`virtio-blk`, `cmos-rtc`, `*-tester`)
+/// parse as a single TOML key.
+fn debug_config_flags(args: &BuildArgs, pkg: &str) -> Vec<String>
+{
+    if !debug_includes(args, pkg)
+    {
+        return Vec::new();
+    }
+    let profile = active_profile(args.release);
+    vec![
+        "--config".into(),
+        format!("profile.{profile}.package.\"{pkg}\".debug=2"),
+        "--config".into(),
+        format!("profile.{profile}.package.\"{pkg}\".opt-level=1"),
+    ]
 }

--- a/xtask/src/disk.rs
+++ b/xtask/src/disk.rs
@@ -21,15 +21,16 @@ use crate::util::step;
 
 const SECTOR_SIZE: u64 = 512;
 
-/// ESP partition size. The ESP holds just kernel + bundle + bootloader EFI
-/// (init and modules live inside the bundle); 256 MiB leaves comfortable
-/// headroom for additional bundle modules.
-const ESP_PARTITION_SIZE: u64 = 256 * 1024 * 1024;
+/// ESP partition size. Holds the kernel, the boot bundle (init + modules),
+/// and the bootloader EFI. 64 MiB covers these with headroom for `--debug`
+/// debuginfo and future bundle modules.
+const ESP_PARTITION_SIZE: u64 = 64 * 1024 * 1024;
 
 /// Root partition size. Holds every installed userspace binary under
-/// `/services/` and `/programs/` plus the `/tests/` harness binaries;
-/// 512 MiB leaves generous headroom.
-const ROOT_PARTITION_SIZE: u64 = 512 * 1024 * 1024;
+/// `/services/` and `/programs/` plus the `/tests/` harness binaries. With
+/// debuginfo off by default the tree is ~10 MiB; 192 MiB covers a full
+/// `--debug` rebuild and ample future components.
+const ROOT_PARTITION_SIZE: u64 = 192 * 1024 * 1024;
 
 /// First partition starts at LBA 2048 (1 MiB alignment, standard GPT practice).
 const ESP_START_LBA: u64 = 2048;

--- a/xtask/src/disk.rs
+++ b/xtask/src/disk.rs
@@ -4,7 +4,7 @@
 //! disk.rs
 //!
 //! Build a GPT disk image from sysroot contents. The image contains three
-//! FAT32 partitions: an EFI System Partition (from sysroot/esp/), a Seraph
+//! FAT partitions: an EFI System Partition (from sysroot/esp/), a Seraph
 //! root partition (from sysroot/), and a Seraph data partition (from
 //! sysroot/data/) that vfsd auto-mounts at /data.
 
@@ -159,7 +159,7 @@ impl Seek for PartitionSlice
 
 /// Create a GPT disk image at `<project_root>/disk.img`.
 ///
-/// The image contains three FAT32 partitions:
+/// The image contains three FAT partitions:
 /// - Partition 1 (ESP, [`ESP_PARTITION_SIZE`]): populated from `sysroot/esp/`
 /// - Partition 2 (ROOT, [`ROOT_PARTITION_SIZE`]): populated from `sysroot/`
 ///   excluding `esp/` and `data/`
@@ -348,7 +348,7 @@ fn write_gpt(image_path: &Path, arch: Arch) -> Result<()>
     Ok(())
 }
 
-/// Format a partition as FAT32 and populate it from a source directory.
+/// Format a partition as FAT and populate it from a source directory.
 ///
 /// Skips build metadata (`.arch`, `NvVars`) and the top-level `esp` and
 /// `data` subdirectories, each a mount point with its own partition and so
@@ -378,7 +378,7 @@ fn format_and_populate_partition(
         let opts = fatfs::FormatVolumeOptions::new()
             .bytes_per_cluster(4096)
             .fat_type(fatfs::FatType::Fat32);
-        fatfs::format_volume(&mut slice, opts).context("failed to format partition as FAT32")?;
+        fatfs::format_volume(&mut slice, opts).context("failed to format partition as FAT")?;
     }
 
     // Populate (if source directory exists).

--- a/xtask/src/disk.rs
+++ b/xtask/src/disk.rs
@@ -26,10 +26,9 @@ const SECTOR_SIZE: u64 = 512;
 /// headroom for additional bundle modules.
 const ESP_PARTITION_SIZE: u64 = 256 * 1024 * 1024;
 
-/// Root partition size. Sized at 512 MiB to comfortably hold every
-/// debug-build userspace binary under `/services/` and `/programs/`
-/// alongside the harness binaries under `/tests/`. Release builds remain
-/// comfortable well under half of this.
+/// Root partition size. Holds every installed userspace binary under
+/// `/services/` and `/programs/` plus the `/tests/` harness binaries;
+/// 512 MiB leaves generous headroom.
 const ROOT_PARTITION_SIZE: u64 = 512 * 1024 * 1024;
 
 /// First partition starts at LBA 2048 (1 MiB alignment, standard GPT practice).

--- a/xtask/src/disk.rs
+++ b/xtask/src/disk.rs
@@ -21,10 +21,9 @@ use crate::util::step;
 
 const SECTOR_SIZE: u64 = 512;
 
-/// ESP partition size. Debug binaries weigh ~14 MiB each; the ESP now holds
-/// just kernel + bundle + bootloader EFI (init and modules live inside the
-/// bundle), so 256 MiB leaves comfortable headroom for additional bundle
-/// modules.
+/// ESP partition size. The ESP holds just kernel + bundle + bootloader EFI
+/// (init and modules live inside the bundle); 256 MiB leaves comfortable
+/// headroom for additional bundle modules.
 const ESP_PARTITION_SIZE: u64 = 256 * 1024 * 1024;
 
 /// Root partition size. Sized at 512 MiB to comfortably hold every


### PR DESCRIPTION
Closes #320.

## Summary

Unifies the two Cargo profiles on `opt-level = 2` and `debug = 0`, making per-binary debuginfo opt-in via a new `cargo xtask build --debug <comp>[,...]` flag. Corrects the stale Z-milestone convention and documents the new profile semantics. Profile **names** (`dev`/`release`, output dirs `debug`/`release`) are unchanged, so the branch-protection check names stay valid. With debuginfo off by default, the over-provisioned disk partitions are also right-sized (ESP 256→64 MiB, root 512→192 MiB), halving the disk image.

## Profile delta

Shared: `panic=abort`, `opt-level=2`, `debug=0`. Distinguishing keys only:

| | dev | release |
|---|---|---|
| debug-assertions / overflow-checks | on | off |
| lto / codegen-units | — | `true` / `1` |

## `--debug`

`cargo xtask build --debug kernel,procmgr` injects `--config profile.<active>.package."<pkg>".debug=2` + `opt-level=1` for the named packages only (active = `dev`, or `release` under `--release`). The package segment is quoted so hyphenated crate names (`virtio-blk`, …) parse. `opt-level=1` (not `0`) keeps stack frames tight for the kernel/thread-stack tests. Limits documented in build-system.md (LTO degrades step fidelity under `--release`; no `strip`).

## Size (x86_64 debug, vs current debug build)

| Metric | before (debug=2) | after (debug=0) | Δ |
|---|---|---|---|
| installed sysroot | 487 MiB | 11.2 MiB | −97.7% |
| disk.img (sparse/actual blocks) | 488 MiB | 12.9 MiB | −97.4% |
| kernel | 7.57 MiB | 0.63 MiB | −92% |
| init | 4.80 MiB | 0.09 MiB | −98% |
| svcmgr | 12.8 MiB | 0.43 MiB | −97% |

0/37 installed binaries carry `.debug_info` after a plain build. (`target/` is build cache that also shrinks but isn't cleanly isolatable here — it transiently holds both old and new fingerprints across the profile change.)

### Partition right-sizing (in this PR)

With debuginfo off by default the installed tree is ~9 MiB (was ~487 MiB), so the disk partitions — sized for the old fat-debug binaries — were grossly over-provisioned. This PR right-sizes them:

| Partition | before | after | default content | `--debug all` content |
|---|---|---|---|---|
| ESP | 256 MiB | 64 MiB | 2.4 MiB | 8.2 MiB |
| root | 512 MiB | 192 MiB | 8.7 MiB | 23.5 MiB |
| data (scratch, unchanged) | 256 MiB | 256 MiB | — | — |

`disk.img` apparent size drops **1026 MiB → 514 MiB (−50%)**. The caps still clear the worst case — a full `cargo xtask build --debug all`, every binary carrying its own per-package debuginfo — by ≥5× on both arches (root use: x86_64 23.5 MiB, riscv64 32.7 MiB, vs the 192 MiB cap), leaving ample room for future components. Per-package `--debug` debuginfo stays small because std/core are not rebuilt with it. The data partition (256 MiB) is intentionally left unchanged — it backs runtime `/data` test scratch, not binaries, so its sizing is orthogonal to the debuginfo change.

## Validation

`cargo xtask test` (host) green. Boot matrix — `cargo xtask build` then `run-parallel --runs 1 --timeout 180` per cell, each reaching its harness pass marker:

| | svctest | usertest | ktest |
|---|---|---|---|
| x86_64 debug | ✓ | ✓ | ✓ |
| x86_64 release | ✓ | ✓ | ✓ |
| riscv64 debug | ✓ | ✓ | ✓ |
| riscv64 release | ✓ | ✓ | ✓ |

svctest exercises `stackoverflow` (guard-page fault); usertest exercises `threadstack`/`threadchurn` (demand-fault stack growth) — both opt-level-sensitive paths, green on both arches and profiles.

`--debug` injection: `--debug kernel` → kernel carries `.debug_info`, siblings symbol-free; `--debug virtio-blk` → hyphenated quoted key accepted on the StdUser/build-std path; comma-list parses.

Partition right-size re-validated on both arches: the default build and `cargo xtask build --debug all` both fit the new geometry with ≥5× headroom (no overflow), and the smaller disk boots (svctest + ktest pass).

## Acceptance (#320)

- [x] `opt-level = 2` in both profiles; delta reduced to `{lto, codegen-units, debug-assertions, overflow-checks}`.
- [x] `debug = 0` default; plain `build`/`build --release` emit no per-binary debuginfo (0/37 carry `.debug_info`).
- [x] `build --debug <comp>` emits debuginfo for the named component(s) only; `--config` injection accepted by the pinned toolchain (cargo 1.96-nightly).
- [x] CI `debug` cells still exercise `debug-assertions`/`overflow-checks`; required-check names unchanged (no workflow or profile-name change).
- [x] `target/` and `disk.img` size reduction quantified (above); partitions additionally right-sized in-PR so the apparent image halves (1026→514 MiB).
- [x] x86_64 + riscv64, both profiles: `cargo xtask build` then `cargo xtask run` reach the pass marker.
- [x] `docs/conventions.md` §Milestones corrected to cover `Z` milestones.
- [x] `docs/build-system.md`, `xtask/README.md`, `README.md` updated to current behavior.
