### PR TITLE
docs: complete fs/fat and procmgr README source layouts

### DIFF
--- a/services/fs/fat/README.md
+++ b/services/fs/fat/README.md
@@ -10,6 +10,7 @@ Seraph FAT16 / FAT32 filesystem driver, one process per mount.
 fat/
 ├── Cargo.toml
 ├── README.md
+├── fat-parse/                  # `fatfs-parse` crate: pure host-tested BPB + directory decoders
 ├── docs/
 │   └── crash-safety.md         # Per-op write ordering and post-crash visible states
 └── src/

--- a/services/procmgr/README.md
+++ b/services/procmgr/README.md
@@ -23,7 +23,9 @@ procmgr/
 ├── src/
 │   ├── main.rs                 # _start() entry point, IPC dispatch loop
 │   ├── loader.rs               # ELF load pipeline
-│   └── process.rs              # Per-process state, kernel-object allocation
+│   ├── process.rs              # Per-process state, kernel-object allocation
+│   ├── init_reap.rs            # Init-reap: tears down init's residue after handover
+│   └── arch/                   # Arch-specific helpers
 └── docs/
     └── ipc-interface.md        # procmgr IPC interface specification
 ```


### PR DESCRIPTION
## Summary
Complete two component README Source Layout sections after the host-test extraction series (#304–#308): list the `fatfs-parse` sub-crate under `services/fs/fat`, and the pre-existing-but-unlisted `init_reap.rs` + `arch/` under `services/procmgr`. Documentation-only; no code change.

## Test plan
- [x] docs-only change; no `cargo xtask build`/`run` behaviour affected (CI confirms the build/validate matrix)

## Notes
Surfaced by the `pr-reviewer`/`pr-auditor` passes on #332 (#305) and #335 (#306): the `fatfs-parse` entry was missed when the crate was added in #305; the `init_reap.rs`/`arch/` entries predate this series. No linked issue (incidental docs completeness).