### PR TITLE
ci: drop autostarted terminal from burn-in svctest/usertest boots

### DIFF
--- a/.github/workflows/burnin.yml
+++ b/.github/workflows/burnin.yml
@@ -66,22 +66,26 @@ jobs:
       - name: Stage ${{ matrix.tester }} and repack disk
         # Recipe staging: svctest and usertest live in
         # `sysroot/config/svcmgr/tests/` (svcmgr does not scan that
-        # directory); cp into services/ to enable. `cargo xtask mkdisk`
-        # re-mirrors rootfs and repacks the FAT image without invoking
-        # cargo. ktest swaps the bundle's `init` entry via
-        # `cargo xtask compose-bundle --harness ktest`, which repacks
-        # the disk image as part of the compose step.
+        # directory); cp into services/ to enable. These functional harness
+        # boots drop the autostarted `terminal` (a user-facing program, not
+        # part of the services/programs substrate under test) so the boot is
+        # controlled. `--repack-only` makes the removal stick: a normal repack
+        # re-mirrors rootfs, which would restore terminal.svc. ktest swaps the
+        # bundle's `init` entry via `cargo xtask compose-bundle --harness
+        # ktest`, which repacks the disk image as part of the compose step.
         run: |
           case "${{ matrix.tester }}" in
             svctest)
               cp sysroot/config/svcmgr/tests/svctest.svc \
                  sysroot/config/svcmgr/services/
-              cargo xtask mkdisk --arch ${{ matrix.arch }}
+              rm -f sysroot/config/svcmgr/services/terminal.svc
+              cargo xtask mkdisk --arch ${{ matrix.arch }} --repack-only
               ;;
             usertest)
               cp sysroot/config/svcmgr/tests/usertest.svc \
                  sysroot/config/svcmgr/services/
-              cargo xtask mkdisk --arch ${{ matrix.arch }}
+              rm -f sysroot/config/svcmgr/services/terminal.svc
+              cargo xtask mkdisk --arch ${{ matrix.arch }} --repack-only
               ;;
             ktest)
               cargo xtask compose-bundle --arch ${{ matrix.arch }} --harness ktest

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -327,7 +327,7 @@ CI workflows live in `.github/workflows/`. Local equivalents are the
 | Workflow | Trigger | Purpose |
 |---|---|---|
 | `build-test.yml` | push to `master`, PR to `master`, manual dispatch | Light validation: one `host-tests` job runs `cargo xtask test`; the matrix `validate` job builds each `arch × profile` cell, then per-tester either stages a recipe + `mkdisk` (svctest, usertest) or re-composes the bundle via `compose-bundle --harness ktest`, and runs one iteration. |
-| `burnin.yml` | tag push (`v*.*.*`), manual dispatch | Heavy validation: per `arch × profile` cell, builds and runs `4 × 20` svctest iterations against the default bundle, then re-composes with `--harness ktest` and runs `4 × 20` ktest iterations. |
+| `burnin.yml` | tag push (`v*.*.*`), manual dispatch | Heavy validation: the `arch × profile × tester` matrix builds each cell, stages that one harness (svctest/usertest drop the autostarted `terminal` and `mkdisk --repack-only`; ktest via `compose-bundle --harness ktest`), then burns it in with `run-parallel --parallel 2 --runs 20 --timeout 180`. |
 | `release.yml` | tag push (`v*.*.*`), manual dispatch | Builds release-profile disk images per architecture, compresses with zstd, generates `SHA256SUMS`, creates a draft GitHub Release whose body is `docs/releases/<tag>.md`. |
 
 `build-test.yml` cancels stacked runs on the same ref


### PR DESCRIPTION
## Summary
Burn-in's `usertest`/`svctest` cells re-mirrored `rootfs/` during staging, leaving the autostarting `terminal` co-resident with the harness. Under the debug + 2-parallel load these cells run, that deterministically wedged mid-run at the first child-process spawn — `usertest` at `/tests/programs/shell`, `svctest` at `fs_crossover_bench` → `/programs/fsbench` — hanging all 20 iterations (run [27135233537](https://github.com/kottlerg/seraph/actions/runs/27135233537): `pass=0 hang=20` in x86_64+riscv64 debug usertest and x86_64 debug svctest). `build-test.yml` has excluded `terminal` from these functional-harness boots since #111; burn-in never received that isolation. This mirrors it, and corrects the stale burn-in description in `build-system.md`.

## Acceptance
No linked Issue. This PR is the test-isolation/workflow-parity fix only. Scope delivered:
- [x] burn-in `svctest`/`usertest` cells drop `terminal.svc` and repack with `--repack-only`
- [x] matches `build-test.yml`'s terminal isolation for svctest/usertest (crasher co-staging intentionally not added — unrelated to this fix); `ktest` path unchanged (bypasses svcmgr's service scan)
- [x] staging-step comment states present intent (drop user-facing terminal; `--repack-only` makes the removal stick)
- [x] `docs/build-system.md` burn-in row corrected (matrix dims, one-harness-per-cell, `--parallel 2 --runs 20`, terminal drop)

## Test plan
Edits only the burn-in workflow and one doc; builds no code, so standard build/run validation is covered by this PR's own `build-test` CI (host-tests + all 12 `validate` cells — all green on the PR head, run 27140777374).

Burn-in (workflow_dispatch only, not run on PR) was dispatched on this branch — run [27140810608](https://github.com/kottlerg/seraph/actions/runs/27140810608):
- [x] burn-in dispatched on this branch
- [x] usertest riscv64 debug: `pass=20` — was `hang=20` ✓
- [x] svctest x86_64 debug: `pass=20` — was `hang=20` ✓
- [x] usertest x86_64 debug: deterministic terminal hang eliminated — `pass=18` (was `pass=0 hang=20`). The 2 residual hangs are a **separate, intermittent, terminal-independent** kernel missed-wakeup deadlock (`tid46` prio-15 Exited, `SLEEP_LIST=0`, watchdog), filed as #341 — pre-existing, previously masked by the 100% terminal hang.
- [x] no regression from this change: the only other red is svctest x86_64 release `err=1` (`rc=-1`, QEMU failed to launch at 5s — a CI-startup flake, not a hang or test failure)

## Notes
The staging `build-test.yml` has carried since #111 was never mirrored into burn-in — a workflow drift, not a harness bug; `run-parallel` itself is sound (per-slot disk copies, per-slot logs, no shared resource). With the terminal removed, burn-in unmasked a real latent kernel deadlock (missed wakeup on thread exit in the shell-test path), now characterized and tracked in **#341**. #290 documented an earlier form of this class but its diagnosis (`echosh`, bringup) is stale — `echosh` was replaced by `/programs/shell` in #112; #341 reproduces without terminal and in the shell-test path, not bringup.

The branch was rebuilt onto current `master` to contain only these two commits; an earlier push had inadvertently bundled PR #339's `#302` commits (now restored to their own branch).