### PR TITLE
cleanup: reconcile #[cfg(target_arch)] guards in arch-neutral kernel code with §C (#200)

### DIFF
--- a/core/kernel/docs/arch-interface.md
+++ b/core/kernel/docs/arch-interface.md
@@ -56,10 +56,13 @@ pub mod current;
 pub mod current;
 ```
 
-The sections below document the **cross-architecture contract surface** — the functions and
-types architecture-neutral code depends on. Some submodules are arch-private support code
-(`gdt`, `idt`, `ioapic`/`sbi`, `fpu`, `platform`, `ap_trampoline`) whose internals are not
-part of the cross-architecture contract and are not documented here.
+The sections below document the **cross-architecture contract surface** — the functions,
+types, and module-level constants architecture-neutral code depends on. Some submodules are
+mostly arch-private support code (`gdt`, `idt`, `ioapic`/`sbi`, `fpu`, `platform`,
+`ap_trampoline`) whose internals are not part of the contract; the few items neutral code
+does call — `gdt::{load_iopb, permit_port_range_u32, IOPB_SIZE}` and `platform::console_mmio`
+— are listed in the module-level section below and are contract surface (both `gdt` helpers
+are no-ops on RISC-V).
 
 Addresses cross this boundary as raw `u64`. Page-permission and page-table-rewrite types
 (`PageFlags`, `MapOutcome`, `PagingError`) are architecture-neutral and defined in
@@ -207,6 +210,10 @@ pub fn new_state(entry: u64, stack_top: u64, arg: u64, is_user: bool) -> SavedSt
 /// Seed the thread-local-storage base in a `SavedState` before first run.
 pub fn seed_tls_base(saved: &mut SavedState, tls_base: u64);
 
+/// Round a user-supplied stack pointer to the entry point's `extern "C"` ABI
+/// alignment (x86-64 SysV `rsp ≡ 8 (mod 16)`; RISC-V LP64D `sp ≡ 0 (mod 16)`).
+pub fn align_initial_stack(sp: u64) -> u64;
+
 /// Switch from `current` to `next`, saving callee-saved registers into `current`
 /// and restoring them from `next`. `save_flag` is published once `current`'s
 /// state is fully saved, so another CPU may observe the thread as switched-out.
@@ -262,6 +269,11 @@ pub fn acknowledge(irq: u32);
 pub fn mask(irq: u32);
 pub fn unmask(irq: u32);
 
+/// Route a device IRQ to the BSP and leave it masked at the controller; the
+/// driver unmasks via `SYS_IRQ_ACK`. x86-64 installs an IOAPIC redirection
+/// entry; RISC-V enables then masks the PLIC source.
+pub unsafe fn route_device_irq(irq: u32);
+
 /// Send a TLB-shootdown or wakeup IPI to the CPU with the given hardware id
 /// (APIC id on x86-64; hart id on RISC-V).
 pub unsafe fn send_tlb_shootdown_ipi(target_hw_id: u32);
@@ -272,10 +284,11 @@ pub unsafe fn send_wakeup_ipi(target_hw_id: u32);
 pub unsafe fn wait_for_ack(cond: impl FnMut() -> bool, ctx: &IpiWaitCtx<'_>);
 ```
 
-External-IRQ routing is performed through arch-private modules (`ioapic::route` on x86-64;
-the PLIC path on RISC-V) and is not part of the cross-architecture contract surface.
-NMI-backtrace storage allocation (`init_nmi_backtrace_storage`) is likewise x86-64-private
-(no RISC-V counterpart; its caller is `#[cfg(target_arch = "x86_64")]`-gated).
+External-IRQ routing is reached through the `route_device_irq` surface function above; the
+underlying controller programming (`ioapic::route` on x86-64; the PLIC enable path on
+RISC-V) remains arch-private. Per-CPU table allocation that exists only on x86-64 (GDT/TSS,
+AP IST stacks, NMI-backtrace storage) is reached through the `init_ap_percpu_storage`
+module-level surface function (a no-op on RISC-V), not a `cfg(target_arch)`-gated call.
 
 ---
 
@@ -325,6 +338,10 @@ storage is architecture-managed (GS-base on x86-64; `sscratch` on RISC-V).
 /// index used by arch-neutral code).
 pub fn current_id() -> u32;
 pub fn current_cpu() -> u32;
+
+/// Read the current stack pointer (`rsp` / `sp`). Used by the panic-path
+/// backtrace scanner to bound the kernel-stack walk.
+pub fn current_stack_pointer() -> u64;
 
 /// Install the current CPU's per-CPU data block at `addr`. Call once per CPU
 /// before any per-CPU access.
@@ -386,6 +403,14 @@ impl TrapFrame {
     pub fn syscall_nr(&self) -> u64;
     pub fn set_return(&mut self, val: i64);
 
+    /// User-mode instruction pointer (rip / sepc).
+    pub fn instruction_pointer(&self) -> u64;
+
+    /// Validate and sanitize a user-supplied register snapshot before resuming
+    /// it in user mode: reject a non-canonical/non-user PC or SP and force safe
+    /// privilege state. `Err(())` maps to `SyscallError::InvalidArgument`.
+    pub fn sanitize_for_user_resume(&mut self) -> Result<(), ()>;
+
     /// Read syscall argument `n` (rdi/rsi/rdx/r10/r8/r9 or a0..a5); 0 for n >= 6.
     pub fn arg(&self, n: usize) -> u64;
 
@@ -402,6 +427,66 @@ impl TrapFrame {
     pub fn set_arg0(&mut self, val: u64);
     pub fn set_tls_base(&mut self, tls_base: u64);
 }
+```
+
+---
+
+## Module-level constants and free functions — `arch::current::*`
+
+Cross-architecture items that live directly on the arch module rather than in a per-concern
+submodule:
+
+```rust
+/// Diagnostic architecture name ("x86_64" / "riscv64").
+pub const ARCH_NAME: &str;
+
+/// Valid external-interrupt id range (0..=255 GSIs on x86-64; PLIC sources
+/// 1..=127 on RISC-V).
+pub const MIN_IRQ_ID: u32;
+pub const MAX_IRQ_ID: u32;
+
+/// Width of the root `Interrupt` range capability minted at Phase 7 (256 on
+/// x86-64; 1024 on RISC-V, the PLIC spec maximum). Oversizing is safe — arch
+/// helpers reject out-of-range ids.
+pub const ROOT_IRQ_COUNT: u32;
+
+/// Whether the architecture has an I/O port space — `IoPort` capabilities and
+/// the `sys_ioport_*` syscalls are meaningful. true on x86-64; false on RISC-V.
+pub const HAS_IO_PORTS: bool;
+
+/// Whether the architecture exposes SBI firmware — a root `SbiControl`
+/// capability is minted and `SYS_SBI_CALL` is forwardable. false on x86-64;
+/// true on RISC-V.
+pub const HAS_SBI: bool;
+
+/// Size in bytes of the per-thread I/O Permission Bitmap (8192 on x86-64; 0 on
+/// RISC-V). Sizes the `iopb` field in `ThreadControlBlock` uniformly.
+pub const IOPB_SIZE: usize;
+
+/// Forward a sanctioned SBI call to firmware, mapping SBI errors to `Err(())`
+/// (and always `Err(())` on x86-64, which has no SBI). The neutral
+/// `syscall::sbi` handler enforces the required `SbiControl` right and gates on
+/// `HAS_SBI` before calling.
+pub fn sbi_forward(extension: u64, function: u64, a0: u64, a1: u64, a2: u64) -> Result<u64, ()>;
+
+/// Allocate architecture-specific per-CPU tables during SMP bring-up: x86-64
+/// per-AP GDT/TSS, AP IST stacks, and NMI-backtrace storage; a no-op on RISC-V.
+pub fn init_ap_percpu_storage(cpu_count: usize, allocator: &mut mm::BuddyAllocator);
+```
+
+Two `gdt` helpers and one `platform` accessor are also contract surface (the rest of those
+modules is arch-private):
+
+```rust
+/// Load a thread's IOPB into the TSS, or clear it (x86-64); no-op on RISC-V.
+pub unsafe fn gdt::load_iopb(iopb: Option<&[u8; IOPB_SIZE]>);
+/// Permit an I/O port range in a thread's IOPB (x86-64); no-op on RISC-V.
+pub fn gdt::permit_port_range_u32(iopb: &mut [u8; IOPB_SIZE], base: u32, count: u32);
+
+/// Physical (base, size) of a boot console UART needing a dedicated `Mmio`
+/// capability at Phase 7: `Some` on RISC-V (ns16550, outside the aperture list);
+/// `None` on x86-64 (legacy I/O-port COM1).
+pub fn platform::console_mmio() -> Option<(u64, u64)>;
 ```
 
 ---

--- a/core/kernel/src/arch/riscv64/context.rs
+++ b/core/kernel/src/arch/riscv64/context.rs
@@ -100,6 +100,15 @@ impl SavedState
 #[inline]
 pub fn seed_tls_base(_saved: &mut SavedState, _tls_base: u64) {}
 
+/// Round a user-supplied stack pointer to the ABI alignment expected at an
+/// `extern "C"` entry point. On RISC-V `LP64D` the return address lives in `ra`,
+/// not on the stack, so function entry expects `sp` ≡ 0 (mod 16).
+#[inline]
+pub fn align_initial_stack(sp: u64) -> u64
+{
+    sp & !0xF
+}
+
 // ── new_state ─────────────────────────────────────────────────────────────────
 
 /// Construct the initial [`SavedState`] for a new thread.

--- a/core/kernel/src/arch/riscv64/cpu.rs
+++ b/core/kernel/src/arch/riscv64/cpu.rs
@@ -50,6 +50,20 @@ pub fn halt_until_interrupt()
     }
 }
 
+/// Read the current stack pointer (`sp`, x2).
+///
+/// Used by the panic-path backtrace scanner to bound the kernel-stack walk.
+#[cfg(not(test))]
+pub fn current_stack_pointer() -> u64
+{
+    let sp: u64;
+    // SAFETY: reads the stack pointer register only; no memory access, no clobbers.
+    unsafe {
+        core::arch::asm!("mv {}, sp", out(reg) sp, options(nomem, nostack, preserves_flags));
+    }
+    sp
+}
+
 /// Return the current hart ID.
 ///
 /// Phase 5: only the BSP is running; returns 0.

--- a/core/kernel/src/arch/riscv64/gdt.rs
+++ b/core/kernel/src/arch/riscv64/gdt.rs
@@ -30,3 +30,21 @@ pub fn bsp_tss_ptr() -> u64
 #[cfg(not(test))]
 #[allow(unused_variables)]
 pub unsafe fn init_ap(_cpu_id: u32, _rsp0: u64, _ist1_top: u64, _ist2_top: u64) {}
+
+/// Load the per-thread IOPB into the TSS — no-op on RISC-V.
+///
+/// RISC-V has no TSS or I/O permission bitmap (no I/O port space). Present so
+/// the context-switch path calls it unconditionally on both arches.
+///
+/// # Safety
+/// No preconditions — the body is empty. The `unsafe` qualifier exists only to
+/// match the x86-64 surface signature.
+#[cfg(not(test))]
+pub unsafe fn load_iopb(_iopb: Option<&[u8; IOPB_SIZE]>) {}
+
+/// Permit an I/O port range in a thread's IOPB — no-op on RISC-V.
+///
+/// RISC-V has no I/O port space, so there is nothing to permit. Present so
+/// `sys_ioport_bind` compiles on both arches; the `HAS_IO_PORTS` gate makes
+/// this unreachable on RISC-V.
+pub fn permit_port_range_u32(_iopb: &mut [u8; IOPB_SIZE], _base: u32, _count: u32) {}

--- a/core/kernel/src/arch/riscv64/interrupts.rs
+++ b/core/kernel/src/arch/riscv64/interrupts.rs
@@ -827,6 +827,25 @@ pub fn unmask(irq: u32)
     let _ = irq;
 }
 
+/// Route device IRQ (PLIC source) `irq` to the BSP, leaving it masked at the
+/// controller. The driver unmasks via `SYS_IRQ_ACK` once it has registered a
+/// handler.
+///
+/// # Safety
+/// Must be called after PLIC init with a valid source id.
+#[cfg(not(test))]
+pub unsafe fn route_device_irq(irq: u32)
+{
+    // Enable at the PLIC, then immediately mask until the driver ACKs — the
+    // x86-64 IOAPIC path leaves the line masked the same way.
+    plic_enable(irq);
+    mask(irq);
+}
+
+/// No-op test stub.
+#[cfg(test)]
+pub unsafe fn route_device_irq(_irq: u32) {}
+
 /// Dispatch an external interrupt from the PLIC to its registered notification.
 ///
 /// Called from `trap_dispatch` after claiming the interrupt. Routing is

--- a/core/kernel/src/arch/riscv64/mod.rs
+++ b/core/kernel/src/arch/riscv64/mod.rs
@@ -36,12 +36,39 @@ pub const MAX_IRQ_ID: u32 = 127;
 pub const MIN_IRQ_ID: u32 = 1;
 
 /// RISC-V has no I/O port space; `IoPort` resources are silently skipped.
-#[allow(dead_code)]
 pub const HAS_IO_PORTS: bool = false;
+
+/// RISC-V exposes SBI firmware; one root `SbiControl` capability is minted.
+pub const HAS_SBI: bool = true;
+
+/// Width of the root `Interrupt` range capability minted at Phase 7. The PLIC
+/// spec maximum is 1024 sources; most platforms expose far fewer. Oversizing
+/// is safe — `plic_enable` rejects out-of-range ids.
+pub const ROOT_IRQ_COUNT: u32 = 1024;
 
 /// Size of the I/O Permission Bitmap. Zero on RISC-V (no I/O port concept).
 /// Used to size the `iopb` field in `ThreadControlBlock` uniformly across arches.
 pub const IOPB_SIZE: usize = 0;
+
+/// Forward a sanctioned SBI call to M-mode firmware, mapping any SBI error to a
+/// generic failure. Cap-rights enforcement happens in the neutral
+/// `syscall::sbi` handler before this is reached.
+#[cfg(not(test))]
+pub fn sbi_forward(extension: u64, function: u64, a0: u64, a1: u64, a2: u64) -> Result<u64, ()>
+{
+    let ret = sbi::sbi_call(extension, function, a0, a1, a2);
+    if ret.error != 0
+    {
+        return Err(());
+    }
+    Ok(ret.value)
+}
+
+/// No-op on RISC-V: there are no per-CPU GDT/TSS/IST tables or NMI-backtrace
+/// slab — those are x86-64 concepts. Present so the SMP bring-up path calls it
+/// unconditionally on both arches.
+#[cfg(not(test))]
+pub fn init_ap_percpu_storage(_cpu_count: usize, _allocator: &mut crate::mm::BuddyAllocator) {}
 
 // MMIO regions that must be direct-mapped during Phase 3 page-table setup
 // are supplied by [`platform::collect_mmio_direct_map_regions`], which always

--- a/core/kernel/src/arch/riscv64/platform.rs
+++ b/core/kernel/src/arch/riscv64/platform.rs
@@ -42,6 +42,18 @@ fn page_round_up(n: u64) -> u64
     (n + 0xFFF) & !0xFFF
 }
 
+/// Physical `(base, size)` of the boot console UART that needs a dedicated
+/// `Mmio` capability minted at Phase 7. On RISC-V the `ns16550` UART sits outside
+/// the coarse aperture list, so it is surfaced here for init.
+// unnecessary_wraps: the Option is part of the cross-arch contract — x86-64's
+// `console_mmio` returns None (its console is a legacy I/O-port UART).
+#[allow(clippy::unnecessary_wraps)]
+#[must_use]
+pub fn console_mmio() -> Option<(u64, u64)>
+{
+    Some((uart_base(), uart_size()))
+}
+
 /// UART physical base. Returns the bootloader-discovered value when non-zero,
 /// otherwise [`DEFAULT_UART_BASE`].
 #[must_use]

--- a/core/kernel/src/arch/riscv64/trap_frame.rs
+++ b/core/kernel/src/arch/riscv64/trap_frame.rs
@@ -178,6 +178,37 @@ impl TrapFrame
     {
         self.tp = tls_base;
     }
+
+    /// User-mode instruction pointer (`sepc`). Used by diagnostics that report
+    /// where a thread last entered the kernel.
+    pub fn instruction_pointer(&self) -> u64
+    {
+        self.sepc
+    }
+
+    /// Validate and sanitize a user-supplied register snapshot before it is
+    /// resumed in user mode: reject a non-user `sepc` and clear the
+    /// kernel-internal trap-cause fields.
+    ///
+    /// Returns `Err(())` if `sepc` is not a user address; the caller maps this
+    /// to `SyscallError::InvalidArgument`.
+    pub fn sanitize_for_user_resume(&mut self) -> Result<(), ()>
+    {
+        // sepc must be a valid user address. On RV64, virtual addresses in the
+        // supervisor range start at 0xFFFF_FFC0_0000_0000 (sv39). Any address
+        // >= 0x8000_0000_0000_0000 is non-user.
+        const USER_ADDR_LIMIT: u64 = 0x8000_0000_0000_0000;
+        if self.sepc >= USER_ADDR_LIMIT
+        {
+            return Err(());
+        }
+
+        // scause and stval are kernel-internal; zero them out to prevent
+        // spurious fault handling on resume.
+        self.scause = 0;
+        self.stval = 0;
+        Ok(())
+    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/core/kernel/src/arch/x86_64/context.rs
+++ b/core/kernel/src/arch/x86_64/context.rs
@@ -91,6 +91,17 @@ pub fn seed_tls_base(saved: &mut SavedState, tls_base: u64)
     saved.fs_base = tls_base;
 }
 
+/// Round a user-supplied stack pointer to the ABI alignment expected at an
+/// `extern "C"` entry point. On x86-64 `SysV`, `rsp` ≡ 8 (mod 16) at function
+/// entry — the 8 accounts for the return address a normal `call` would have
+/// pushed — so the first 16-byte-aligned SSE/AVX access in the callee (e.g. a
+/// compiler-emitted `vmovaps (%rsp)`) does not `#GP`.
+#[inline]
+pub fn align_initial_stack(sp: u64) -> u64
+{
+    (sp & !0xF).wrapping_sub(8)
+}
+
 // ── new_state ─────────────────────────────────────────────────────────────────
 
 /// Construct the initial [`SavedState`] for a new thread.

--- a/core/kernel/src/arch/x86_64/cpu.rs
+++ b/core/kernel/src/arch/x86_64/cpu.rs
@@ -45,6 +45,22 @@ pub fn cpuid(leaf: u32) -> (u32, u32, u32, u32)
     (eax, ebx, ecx, edx)
 }
 
+// ── Stack pointer ───────────────────────────────────────────────────────────────
+
+/// Read the current stack pointer (`rsp`).
+///
+/// Used by the panic-path backtrace scanner to bound the kernel-stack walk.
+#[cfg(not(test))]
+pub fn current_stack_pointer() -> u64
+{
+    let sp: u64;
+    // SAFETY: reads the stack pointer register only; no memory access, no clobbers.
+    unsafe {
+        core::arch::asm!("mov {}, rsp", out(reg) sp, options(nomem, nostack, preserves_flags));
+    }
+    sp
+}
+
 // ── CR4 ───────────────────────────────────────────────────────────────────────
 
 /// Read the current value of CR4.

--- a/core/kernel/src/arch/x86_64/interrupts.rs
+++ b/core/kernel/src/arch/x86_64/interrupts.rs
@@ -780,6 +780,29 @@ pub fn unmask(irq: u32)
 #[cfg(test)]
 pub fn unmask(_irq: u32) {}
 
+/// Route device IRQ (GSI) `irq` to the BSP's local APIC, leaving the line
+/// masked at the I/O APIC. The driver unmasks via `SYS_IRQ_ACK` once it has
+/// registered a handler.
+///
+/// # Safety
+/// Must be called after Phase 5 init (IOAPIC initialised) with a valid GSI.
+// cast_possible_truncation: device GSIs are < 256, so the u32→u8 narrowing of
+// the vector offset is exact.
+#[allow(clippy::cast_possible_truncation)]
+#[cfg(not(test))]
+pub unsafe fn route_device_irq(irq: u32)
+{
+    // SAFETY: caller guarantees a valid GSI and post-Phase-5 IOAPIC. route()
+    // installs the redirection entry masked; the driver unmasks via SYS_IRQ_ACK.
+    unsafe {
+        super::ioapic::route(irq, super::ioapic::DEVICE_VECTOR_BASE + irq as u8);
+    }
+}
+
+/// No-op test stub.
+#[cfg(test)]
+pub unsafe fn route_device_irq(_irq: u32) {}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]

--- a/core/kernel/src/arch/x86_64/mod.rs
+++ b/core/kernel/src/arch/x86_64/mod.rs
@@ -36,12 +36,40 @@ pub const MAX_IRQ_ID: u32 = 255;
 pub const MIN_IRQ_ID: u32 = 0;
 
 /// x86-64 has I/O port space; `IoPort` resources are valid here.
-#[allow(dead_code)]
 pub const HAS_IO_PORTS: bool = true;
+
+/// x86-64 has no SBI firmware interface; `SbiControl` is a RISC-V-only concept.
+pub const HAS_SBI: bool = false;
+
+/// Width of the root `Interrupt` range capability minted at Phase 7. x86-64
+/// I/O APICs cover GSI 0..256.
+pub const ROOT_IRQ_COUNT: u32 = 256;
 
 /// Size of the I/O Permission Bitmap in bytes (re-exported from gdt for use
 /// in architecture-independent code such as `ThreadControlBlock`).
 pub use gdt::IOPB_SIZE;
+
+/// Forward a sanctioned SBI call — unsupported on x86-64.
+///
+/// x86-64 has no SBI firmware interface, so this always fails. Unreachable in
+/// practice: `syscall::sbi::sys_sbi_call` gates on [`HAS_SBI`] before calling.
+#[cfg(not(test))]
+pub fn sbi_forward(_extension: u64, _function: u64, _a0: u64, _a1: u64, _a2: u64)
+-> Result<u64, ()>
+{
+    Err(())
+}
+
+/// Allocate the x86-64 per-CPU tables (per-AP GDT/TSS, AP IST stacks, and the
+/// NMI-backtrace request slab) for `cpu_count` CPUs. Called once on the BSP
+/// during SMP bring-up.
+#[cfg(not(test))]
+pub fn init_ap_percpu_storage(cpu_count: usize, allocator: &mut crate::mm::BuddyAllocator)
+{
+    gdt::init_ap_storage(cpu_count, allocator);
+    ap_trampoline::init_ap_ist_storage(cpu_count, allocator);
+    interrupts::init_nmi_backtrace_storage(cpu_count, allocator);
+}
 
 // MMIO regions that must be direct-mapped during Phase 3 page-table setup are
 // supplied by [`platform::collect_mmio_direct_map_regions`], which reads

--- a/core/kernel/src/arch/x86_64/platform.rs
+++ b/core/kernel/src/arch/x86_64/platform.rs
@@ -94,6 +94,16 @@ pub fn uart_base_for_boot_info(_km: &KernelMmio) -> u64
     0
 }
 
+/// Physical `(base, size)` of a boot console UART needing a dedicated `Mmio`
+/// capability at Phase 7. Returns `None` on x86-64: the boot console is the
+/// legacy COM1 I/O-port UART (`0x3F8`), reached via an `IoPort` capability, not
+/// MMIO.
+#[must_use]
+pub fn console_mmio() -> Option<(u64, u64)>
+{
+    None
+}
+
 /// Fill `out` with all kernel-internal MMIO regions that must be direct-mapped
 /// during Phase 3 page-table setup. Returns the number of populated entries.
 ///

--- a/core/kernel/src/arch/x86_64/trap_frame.rs
+++ b/core/kernel/src/arch/x86_64/trap_frame.rs
@@ -205,6 +205,40 @@ impl TrapFrame
     {
         self.fs_base = tls_base;
     }
+
+    /// User-mode instruction pointer (`rip`). Used by diagnostics that report
+    /// where a thread last entered the kernel.
+    pub fn instruction_pointer(&self) -> u64
+    {
+        self.rip
+    }
+
+    /// Validate and sanitize a user-supplied register snapshot before it is
+    /// resumed in user mode: reject a non-canonical instruction or stack
+    /// pointer, force ring-3 segment selectors, and clear privilege bits from
+    /// RFLAGS.
+    ///
+    /// Returns `Err(())` if `rip` or `rsp` is non-canonical; the caller maps
+    /// this to `SyscallError::InvalidArgument`.
+    pub fn sanitize_for_user_resume(&mut self) -> Result<(), ()>
+    {
+        // Canonical user address: bits [63:47] must all be zero.
+        const USER_ADDR_MASK: u64 = 0xFFFF_8000_0000_0000;
+        if self.rip & USER_ADDR_MASK != 0 || self.rsp & USER_ADDR_MASK != 0
+        {
+            return Err(());
+        }
+
+        // Force segment selectors to user-mode values (ring 3, RPL=3).
+        self.cs = super::gdt::USER_CS as u64;
+        self.ss = super::gdt::USER_DS as u64;
+
+        // rflags: must have IF (bit 9) set. Clear IOPL (bits 12-13), VM (bit
+        // 17), VIF (bit 19), VIP (bit 20) — none of which should be set in
+        // user mode. Bit 1 (reserved) must be 1 per the x86 spec.
+        self.rflags = (self.rflags | 0x202) & !0x0013_F000;
+        Ok(())
+    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/core/kernel/src/cap/mod.rs
+++ b/core/kernel/src/cap/mod.rs
@@ -1390,14 +1390,11 @@ fn populate_cspace(
 {
     use init_protocol::CapType;
 
-    /// Width of the root `Interrupt` range cap minted at Phase 7.
-    /// x86-64 IOAPICs cover GSI 0..256; RISC-V PLIC spec max is 1024
-    /// sources. Sized at the per-arch spec max — arch helpers reject
+    /// Width of the root `Interrupt` range cap minted at Phase 7 — the per-arch
+    /// interrupt-controller spec maximum (`arch::current::ROOT_IRQ_COUNT`: 256
+    /// GSIs on x86-64, 1024 PLIC sources on RISC-V). Arch helpers reject
     /// out-of-range ids, so oversizing is safe.
-    #[cfg(target_arch = "x86_64")]
-    const ROOT_IRQ_COUNT: u32 = 256;
-    #[cfg(target_arch = "riscv64")]
-    const ROOT_IRQ_COUNT: u32 = 1024;
+    const ROOT_IRQ_COUNT: u32 = crate::arch::current::ROOT_IRQ_COUNT;
 
     /// Maximum number of `AcpiReclaimable` regions to mint caps for.
     /// Real firmware reports 1–2; the cap guards against pathological
@@ -1547,10 +1544,8 @@ fn populate_cspace(
     let mut hw_cap_base: u32 = 0;
     let mut hw_cap_count: u32 = 0;
 
-    #[cfg(target_arch = "riscv64")]
+    if let Some((uart_base, uart_size)) = crate::arch::current::platform::console_mmio()
     {
-        let uart_base = crate::arch::current::platform::uart_base();
-        let uart_size = crate::arch::current::platform::uart_size();
         let ptr = mint_phase7_body(MmioObject {
             header: KernelObjectHeader::with_ancestor(ObjectType::Mmio, seed_header_nn()),
             base: uart_base,
@@ -1828,10 +1823,10 @@ fn populate_cspace(
         0
     };
 
-    // x86-64: root IoPort covering the full 64K I/O port space.
-    // This is a static architectural fact, not derived from any bootloader
-    // field. Init subdivides and delegates sub-ranges to services as needed.
-    #[cfg(target_arch = "x86_64")]
+    // Root IoPort covering the full 64K I/O port space (x86-64 only). This is
+    // a static architectural fact, not derived from any bootloader field. Init
+    // subdivides and delegates sub-ranges to services as needed.
+    if crate::arch::current::HAS_IO_PORTS
     {
         let ptr = mint_phase7_body(IoPortObject {
             header: KernelObjectHeader::with_ancestor(ObjectType::IoPort, seed_header_nn()),
@@ -1861,8 +1856,8 @@ fn populate_cspace(
     // RISC-V: one SbiControl capability — the root forwarding authority. It
     // carries every sanctioned SBI right; init attenuates per-consumer copies
     // (devmgr serves pwrmgr a `SBI_RESET`-only derivative).
-    #[cfg(target_arch = "riscv64")]
-    let sbi_control_slot = {
+    let sbi_control_slot = if crate::arch::current::HAS_SBI
+    {
         let ptr = mint_phase7_body(SbiControlObject {
             header: KernelObjectHeader::with_ancestor(ObjectType::SbiControl, seed_header_nn()),
         });
@@ -1889,9 +1884,11 @@ fn populate_cspace(
             },
         );
         slot
+    }
+    else
+    {
+        0u32
     };
-    #[cfg(not(target_arch = "riscv64"))]
-    let sbi_control_slot = 0u32;
 
     CSpaceLayout {
         memory_base,

--- a/core/kernel/src/cap/object.rs
+++ b/core/kernel/src/cap/object.rs
@@ -1792,23 +1792,21 @@ unsafe fn dealloc_object_one(
                 unsafe { crate::arch::current::cpu::restore_interrupts(wake_saved_int) };
                 crate::percpu::preempt_enable();
 
-                // x86-64: release the per-thread IOPB to SEED if one was
-                // bound via `sys_iopb_set`. RISC-V threads never set this
-                // field; it stays null and the cleanup is a no-op.
-                #[cfg(target_arch = "x86_64")]
+                // Release the per-thread IOPB to SEED if one was bound via
+                // `sys_ioport_bind` (x86-64 only). RISC-V threads never set this
+                // field — there is no I/O port space — so `iopb` is always null
+                // and this is a no-op there.
+                // SAFETY: tcb validated non-null; iopb field always valid.
+                let iopb_ptr = unsafe { (*tcb).iopb };
+                if !iopb_ptr.is_null()
                 {
-                    // SAFETY: tcb validated non-null; iopb field always valid.
-                    let iopb_ptr = unsafe { (*tcb).iopb };
-                    if !iopb_ptr.is_null()
-                    {
-                        crate::cap::retype::free_seed_scratch(
-                            iopb_ptr.cast::<u8>(),
-                            crate::arch::current::gdt::IOPB_SIZE as u64,
-                        );
-                        // SAFETY: tcb validated non-null.
-                        unsafe {
-                            (*tcb).iopb = core::ptr::null_mut();
-                        }
+                    crate::cap::retype::free_seed_scratch(
+                        iopb_ptr.cast::<u8>(),
+                        crate::arch::current::IOPB_SIZE as u64,
+                    );
+                    // SAFETY: tcb validated non-null.
+                    unsafe {
+                        (*tcb).iopb = core::ptr::null_mut();
                     }
                 }
 

--- a/core/kernel/src/cap/retype.rs
+++ b/core/kernel/src/cap/retype.rs
@@ -229,9 +229,8 @@ fn subpage_link_ok(link: u64, memory_size: u64) -> bool
 /// or a span whose top exceeds `base + size`.
 ///
 /// Pure and `cfg`-independent (mirrors [`subpage_link_ok`]) so the host
-/// `#[cfg(test)]` suite can exercise it even though its sole runtime caller
-/// `free_seed_scratch` is `cfg(target_arch = "x86_64")`-gated.
-#[cfg_attr(target_arch = "riscv64", allow(dead_code))]
+/// `#[cfg(test)]` suite can exercise it directly. Its sole runtime caller is
+/// `free_seed_scratch` (IOPB teardown, meaningful only on x86-64).
 fn seed_scratch_offset(phys: u64, base: u64, size: u64, bytes: u64) -> Option<u64>
 {
     let need = round_to_class(bytes);
@@ -772,13 +771,14 @@ pub fn alloc_in_seed<T>(body: T) -> Result<NonNull<KernelObjectHeader>, SyscallE
 /// Unlike [`alloc_in_seed`], no `KernelObjectHeader` is written and the
 /// region does not enter any `CSpace`; the returned pointer is opaque.
 ///
-/// Gated `cfg(target_arch = "x86_64")` because the only consumer is the
-/// IOPB allocation in `sys_iopb_set`. RISC-V has no I/O port permission
-/// bitmap and never calls this. The per-thread FPU/SIMD/V save area is
-/// not allocated through this path — it is carved as part of the Thread
-/// retype slot (an extra page beyond kstack + wrapper) so its memory
-/// comes from the user's Memory cap rather than the SEED bootstrap reserve.
-#[cfg(all(not(test), target_arch = "x86_64"))]
+/// Compiled on every architecture but only exercised on x86-64 (per-thread
+/// IOPB pages); RISC-V has no I/O permission bitmap, so the only caller
+/// (`sys_ioport_bind`) is `HAS_IO_PORTS`-gated and never reaches this on that
+/// arch. The per-thread FPU/SIMD/V save area is not allocated through this
+/// path — it is carved as part of the Thread retype slot (an extra page beyond
+/// kstack + wrapper) so its memory comes from the user's Memory cap rather than
+/// the SEED bootstrap reserve.
+#[cfg(not(test))]
 pub fn alloc_seed_scratch(bytes: u64) -> Result<*mut u8, SyscallError>
 {
     let seed = crate::cap::seed_memory_ref();
@@ -794,7 +794,7 @@ pub fn alloc_seed_scratch(bytes: u64) -> Result<*mut u8, SyscallError>
 /// SEED is statically pinned (initial refcount 1 + Phase-7 `inc_ref` pin),
 /// so its refcount can never drop to zero in normal operation; the
 /// `dec_ref` here is bookkeeping for the scratch lease.
-#[cfg(all(not(test), target_arch = "x86_64"))]
+#[cfg(not(test))]
 pub fn free_seed_scratch(ptr: *mut u8, bytes: u64)
 {
     let seed = crate::cap::seed_memory_ref();

--- a/core/kernel/src/main.rs
+++ b/core/kernel/src/main.rs
@@ -1433,17 +1433,10 @@ unsafe fn backtrace_scan(stack_top: u64)
     const MAX_BYTES: usize = 8 * 1024;
     const MAX_HITS: usize = 24;
 
-    let mut sp: usize;
-    // SAFETY: reads the stack pointer register only.
-    #[cfg(target_arch = "x86_64")]
-    unsafe {
-        core::arch::asm!("mov {}, rsp", out(reg) sp, options(nomem, nostack, preserves_flags));
-    }
-    // SAFETY: reads the stack pointer register only.
-    #[cfg(target_arch = "riscv64")]
-    unsafe {
-        core::arch::asm!("mv {}, sp", out(reg) sp, options(nomem, nostack, preserves_flags));
-    }
+    // cast_possible_truncation: usize is 64-bit on every Seraph target, so the
+    // stack-pointer value always fits.
+    #[allow(clippy::cast_possible_truncation)]
+    let sp = crate::arch::current::cpu::current_stack_pointer() as usize;
 
     let text_start = core::ptr::addr_of!(__text_start) as usize;
     let text_end = core::ptr::addr_of!(__text_end) as usize;

--- a/core/kernel/src/percpu.rs
+++ b/core/kernel/src/percpu.rs
@@ -378,7 +378,11 @@ pub fn preemption_disabled() -> bool
 /// `cpu` must be < [`MAX_CPUS`]. The returned reference is `'static` because
 /// `PER_CPU` outlives any conceivable caller; concurrent access is safe via
 /// the [`AtomicPtr`] interior mutability.
-#[cfg(all(not(test), target_arch = "x86_64"))]
+// dead_code: consumed only by arch/x86_64 (lazy-FPU owner cache + #NM handler);
+// present unconditionally so no architecture cfg-gate is needed here. RISC-V
+// uses eager FS/VS-dirty FPU tracking and never reads this slot.
+#[allow(dead_code)]
+#[cfg(not(test))]
 pub fn fpu_owner_for(cpu: usize) -> &'static AtomicPtr<ThreadControlBlock>
 {
     // SAFETY: cpu < CPU_COUNT by caller contract; AtomicPtr permits concurrent

--- a/core/kernel/src/sched/mod.rs
+++ b/core/kernel/src/sched/mod.rs
@@ -366,7 +366,7 @@ fn watchdog_tick_and_check()
         // SAFETY: trap_frame is set by every userspace-syscall entry and
         // cleared on userspace return; reading the pointed-to TrapFrame
         // races benignly with concurrent writes (we're already in stall).
-        let (tf_present, tf_rip, tf_rax) = unsafe {
+        let (tf_present, tf_ip, tf_syscall_nr) = unsafe {
             let s = scheduler_for(cpu);
             let cur = s.current;
             if cur.is_null()
@@ -382,20 +382,13 @@ fn watchdog_tick_and_check()
                 }
                 else
                 {
-                    #[cfg(target_arch = "x86_64")]
-                    {
-                        (true, (*tf).rip, (*tf).rax)
-                    }
-                    #[cfg(target_arch = "riscv64")]
-                    {
-                        (true, (*tf).sepc, (*tf).a7)
-                    }
+                    (true, (*tf).instruction_pointer(), (*tf).syscall_nr())
                 }
             }
         };
         if tf_present
         {
-            crate::kprintln!("    user_rip=0x{:x} syscall_nr={}", tf_rip, tf_rax);
+            crate::kprintln!("    user_pc=0x{:x} syscall_nr={}", tf_ip, tf_syscall_nr);
         }
     }
     // Dump sleep list.
@@ -1166,13 +1159,9 @@ fn init_per_cpu_storage(cpu_count: u32, allocator: &mut BuddyAllocator)
     // Per-CPU arch data (PerCpuData) and APIC-ID slabs.
     crate::percpu::init_storage(n, allocator);
 
-    // Arch-specific per-CPU tables. x86_64 only.
-    #[cfg(target_arch = "x86_64")]
-    {
-        crate::arch::current::gdt::init_ap_storage(n, allocator);
-        crate::arch::current::ap_trampoline::init_ap_ist_storage(n, allocator);
-        crate::arch::current::interrupts::init_nmi_backtrace_storage(n, allocator);
-    }
+    // Arch-specific per-CPU tables (x86-64 per-AP GDT/TSS, AP IST stacks, and
+    // NMI-backtrace storage; a no-op on RISC-V).
+    crate::arch::current::init_ap_percpu_storage(n, allocator);
 }
 
 /// Allocate `bytes` of contiguous physical pages, zero-fill, return a
@@ -2959,10 +2948,11 @@ pub unsafe fn schedule(requeue_current: bool)
         }
     }
 
-    // Load the per-thread IOPB into the TSS (x86_64 only).
-    // If the thread has no port bindings, fill the TSS IOPB with 0xFF (deny all).
-    #[cfg(all(not(test), target_arch = "x86_64"))]
+    // Load the per-thread IOPB into the TSS (x86-64 only; `load_iopb` is a
+    // no-op on RISC-V, where `iopb` is always null). If the thread has no port
+    // bindings, fill the TSS IOPB with 0xFF (deny all).
     // SAFETY: next is a valid TCB; iopb pointer is null or a valid heap-allocated [u8; IOPB_SIZE].
+    #[cfg(not(test))]
     unsafe {
         let iopb_ptr = (*next).iopb;
         if iopb_ptr.is_null()

--- a/core/kernel/src/syscall/hw.rs
+++ b/core/kernel/src/syscall/hw.rs
@@ -162,25 +162,13 @@ pub fn sys_irq_register(tf: &mut TrapFrame) -> Result<u64, SyscallError>
         crate::arch::current::cpu::restore_interrupts(saved);
     }
 
-    // Program arch-specific interrupt routing.
-    // x86_64: write IOAPIC redirection entry (entry starts masked; driver ACKs
-    //         to unmask after registering).
-    // RISC-V: enable the PLIC source (starts masked at controller; ACK unmasks).
-    #[cfg(target_arch = "x86_64")]
-    // SAFETY: irq_id validated from capability; route() requires valid IRQ number.
+    // Route the device IRQ at the interrupt controller. The line is left
+    // masked (x86_64 IOAPIC redirection entry / RISC-V PLIC source); the driver
+    // unmasks via SYS_IRQ_ACK after registering.
+    // SAFETY: irq_id validated from capability; route_device_irq requires a
+    // valid IRQ number.
     unsafe {
-        crate::arch::current::ioapic::route(
-            irq_id,
-            crate::arch::current::ioapic::DEVICE_VECTOR_BASE + irq_id as u8,
-        );
-        // Entry is left masked by route(); driver unmasks via SYS_IRQ_ACK.
-    }
-
-    #[cfg(target_arch = "riscv64")]
-    {
-        // Enable at PLIC, then immediately mask until the driver ACKs.
-        crate::arch::current::interrupts::plic_enable(irq_id);
-        crate::arch::current::interrupts::mask(irq_id);
+        crate::arch::current::interrupts::route_device_irq(irq_id);
     }
 
     Ok(0)
@@ -353,22 +341,15 @@ pub fn sys_mmio_map(_tf: &mut TrapFrame) -> Result<u64, SyscallError>
 /// On RISC-V: always returns `NotSupported` (no I/O port concept).
 ///
 /// Returns 0 on success.
-// needless_return: the cfg-gated early return is required to terminate the
-// riscv64 path; the x86_64 path follows in the same function body.
 #[cfg(not(test))]
-#[allow(clippy::needless_return)]
 pub fn sys_ioport_bind(tf: &mut TrapFrame) -> Result<u64, SyscallError>
 {
-    // RISC-V has no I/O port space.
-    #[cfg(target_arch = "riscv64")]
+    // RISC-V has no I/O port space; the IOPB machinery below is x86-64-only.
+    if !crate::arch::current::HAS_IO_PORTS
     {
-        let _ = tf;
-        // unnecessary_wraps suppressed: sys_ioport_bind must match the dispatch
-        // table signature Result<u64, SyscallError> on all targets.
         return Err(SyscallError::NotSupported);
     }
 
-    #[cfg(target_arch = "x86_64")]
     {
         use crate::arch::current::gdt;
         use crate::cap::object::{IoPortObject, ThreadObject};
@@ -756,21 +737,18 @@ pub fn sys_irq_split(_tf: &mut TrapFrame) -> Result<u64, SyscallError>
 /// On RISC-V: always returns `NotSupported` (no I/O port concept).
 ///
 /// Returns `slot1 | (slot2 << 32)` on success.
-// needless_return: the cfg-gated early return is required to terminate the
-// riscv64 path; the x86_64 path follows in the same function body.
 // too_many_lines: mirrors sys_irq_split exactly; the shape is unavoidable.
-#[allow(clippy::needless_return, clippy::too_many_lines)]
+#[allow(clippy::too_many_lines)]
 #[cfg(not(test))]
 pub fn sys_ioport_split(tf: &mut TrapFrame) -> Result<u64, SyscallError>
 {
-    // RISC-V has no I/O port space.
-    #[cfg(target_arch = "riscv64")]
+    // RISC-V has no I/O port space; the IoPort cap-split logic below is
+    // x86-64-only (no IoPort capability is ever minted on RISC-V).
+    if !crate::arch::current::HAS_IO_PORTS
     {
-        let _ = tf;
         return Err(SyscallError::NotSupported);
     }
 
-    #[cfg(target_arch = "x86_64")]
     {
         use crate::cap::object::{IoPortObject, KernelObjectHeader, ObjectType, dealloc_object};
         use crate::cap::retype::alloc_in_seed;

--- a/core/kernel/src/syscall/sbi.rs
+++ b/core/kernel/src/syscall/sbi.rs
@@ -34,27 +34,27 @@ use crate::arch::current::trap_frame::TrapFrame;
 use syscall::SyscallError;
 
 /// SBI System Reset (SRST) extension ID — ASCII "SRST".
-#[cfg(all(not(test), target_arch = "riscv64"))]
+#[cfg(not(test))]
 const SBI_EXT_SRST: u64 = 0x5352_5354;
 
 /// SBI System Suspend (SUSP) extension ID — ASCII "SUSP".
-#[cfg(all(not(test), target_arch = "riscv64"))]
+#[cfg(not(test))]
 const SBI_EXT_SUSP: u64 = 0x5355_5350;
 
 /// SBI CPPC (processor performance control) extension ID — ASCII "CPPC".
-#[cfg(all(not(test), target_arch = "riscv64"))]
+#[cfg(not(test))]
 const SBI_EXT_CPPC: u64 = 0x4350_5043;
 
 /// SBI Base extension ID (version / extension probe; read-only).
-#[cfg(all(not(test), target_arch = "riscv64"))]
+#[cfg(not(test))]
 const SBI_EXT_BASE: u64 = 0x10;
 
 /// SBI Debug Console (DBCN) extension ID — ASCII "DBCN".
-#[cfg(all(not(test), target_arch = "riscv64"))]
+#[cfg(not(test))]
 const SBI_EXT_DBCN: u64 = 0x4442_434E;
 
 /// SBI Performance Monitoring Unit (PMU) extension ID — ASCII "PMU".
-#[cfg(all(not(test), target_arch = "riscv64"))]
+#[cfg(not(test))]
 const SBI_EXT_PMU: u64 = 0x0050_4D55;
 
 /// Map an SBI extension ID to the `SbiControl` right required to forward it.
@@ -65,7 +65,7 @@ const SBI_EXT_PMU: u64 = 0x0050_4D55;
 /// receives a cap bearing that right is userspace cap-distribution policy.
 /// Adding a sanctioned extension is one entry here plus one `Rights` bit in
 /// `cap::slot::Rights`.
-#[cfg(all(not(test), target_arch = "riscv64"))]
+#[cfg(not(test))]
 fn sbi_required_right(extension: u64) -> Option<crate::cap::slot::Rights>
 {
     use crate::cap::slot::Rights;
@@ -82,11 +82,17 @@ fn sbi_required_right(extension: u64) -> Option<crate::cap::slot::Rights>
 }
 
 /// `SYS_SBI_CALL` handler — RISC-V implementation.
-#[cfg(all(not(test), target_arch = "riscv64"))]
+#[cfg(not(test))]
 pub fn sys_sbi_call(tf: &mut TrapFrame) -> Result<u64, SyscallError>
 {
     use crate::cap::slot::CapTag;
     use crate::syscall::current_tcb;
+
+    // SBI is a RISC-V firmware interface; x86-64 has no equivalent.
+    if !crate::arch::current::HAS_SBI
+    {
+        return Err(SyscallError::NotSupported);
+    }
 
     #[allow(clippy::cast_possible_truncation)] // CSpace slot indices are u32.
     let sbi_cap_idx = tf.arg(0) as u32;
@@ -113,23 +119,9 @@ pub fn sys_sbi_call(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     // SAFETY: cspace from current TCB; lookup_cap validates tag and rights.
     let _slot = unsafe { super::lookup_cap(cspace, sbi_cap_idx, CapTag::SbiControl, required) }?;
 
-    // Forward the SBI call.
-    let ret = crate::arch::current::sbi::sbi_call(extension, function, a0, a1, a2);
-
-    if ret.error != 0
-    {
-        // SBI errors are small negative integers (-1 through -9).
-        return Err(SyscallError::NotSupported);
-    }
-
-    Ok(ret.value)
-}
-
-/// `SYS_SBI_CALL` stub — x86-64 (SBI does not exist on x86-64).
-#[cfg(all(not(test), target_arch = "x86_64"))]
-pub fn sys_sbi_call(_tf: &mut TrapFrame) -> Result<u64, SyscallError>
-{
-    Err(SyscallError::NotSupported)
+    // Forward the SBI call to firmware; SBI errors map to NotSupported.
+    crate::arch::current::sbi_forward(extension, function, a0, a1, a2)
+        .map_err(|()| SyscallError::NotSupported)
 }
 
 /// Test stub.

--- a/core/kernel/src/syscall/thread.rs
+++ b/core/kernel/src/syscall/thread.rs
@@ -45,18 +45,9 @@ pub fn sys_thread_configure(tf: &mut TrapFrame) -> Result<u64, SyscallError>
 
     let thread_idx = tf.arg(0) as u32;
     let entry = tf.arg(1);
-    // Round the user stack pointer to match the entry point's `extern "C"`
-    // ABI expectations. On x86-64 SysV the convention is `rsp = 8 mod 16`
-    // at function entry (the 8 accounts for the return address a normal
-    // caller would have pushed); without this, the first 128-bit-aligned
-    // SSE/AVX memory operand in user code (e.g. a compiler-emitted
-    // `vmovaps (%rsp)` from a struct init) #GPs. On RISC-V LP64D the
-    // return address lives in `ra`, not on the stack, so function entry
-    // expects `sp = 0 mod 16`.
-    #[cfg(target_arch = "x86_64")]
-    let stack_ptr = (tf.arg(2) & !0xFu64).wrapping_sub(8);
-    #[cfg(target_arch = "riscv64")]
-    let stack_ptr = tf.arg(2) & !0xFu64;
+    // Round the user stack pointer to the entry point's `extern "C"` ABI
+    // alignment (arch-specific; see `context::align_initial_stack`).
+    let stack_ptr = crate::arch::current::context::align_initial_stack(tf.arg(2));
     let arg = tf.arg(3);
     let tls_base = tf.arg(4);
 
@@ -1423,55 +1414,16 @@ pub fn sys_thread_write_regs(tf: &mut TrapFrame) -> Result<u64, SyscallError>
 /// Mutates `regs` in place to force safe segment/flag values.
 ///
 /// # Adding new checks
-/// Add per-field validation below the existing blocks. Use `InvalidArgument`
-/// for bad user data (not a kernel invariant violation).
+/// Add per-field validation in the per-arch `TrapFrame::sanitize_for_user_resume`
+/// implementations (`arch/<target>/trap_frame.rs`). Use `InvalidArgument` for
+/// bad user data (not a kernel invariant violation).
 #[cfg(not(test))]
 fn validate_write_regs(
     regs: &mut crate::arch::current::trap_frame::TrapFrame,
 ) -> Result<(), SyscallError>
 {
-    #[cfg(target_arch = "x86_64")]
-    {
-        // Canonical user address: bits [63:47] must all be zero.
-        const USER_ADDR_MASK: u64 = 0xFFFF_8000_0000_0000;
-
-        if regs.rip & USER_ADDR_MASK != 0
-        {
-            return Err(SyscallError::InvalidArgument);
-        }
-        if regs.rsp & USER_ADDR_MASK != 0
-        {
-            return Err(SyscallError::InvalidArgument);
-        }
-
-        // Force segment selectors to user-mode values (ring 3, RPL=3).
-        regs.cs = u64::from(crate::arch::current::gdt::USER_CS);
-        regs.ss = u64::from(crate::arch::current::gdt::USER_DS);
-
-        // rflags: must have IF (bit 9) set. Clear IOPL (bits 12-13), VM (bit
-        // 17), VIF (bit 19), VIP (bit 20) — none of which should be set in
-        // user mode. Bit 1 (reserved) must be 1 per the x86 spec.
-        regs.rflags = (regs.rflags | 0x202) & !0x0013_F000;
-    }
-
-    #[cfg(target_arch = "riscv64")]
-    {
-        // sepc must be a valid user address. On RV64, virtual addresses in
-        // the supervisor range start at 0xFFFF_FFC0_0000_0000 (sv39). Any
-        // address ≥ 0x8000_0000_0000_0000 is non-user.
-        const USER_ADDR_LIMIT: u64 = 0x8000_0000_0000_0000;
-        if regs.sepc >= USER_ADDR_LIMIT
-        {
-            return Err(SyscallError::InvalidArgument);
-        }
-
-        // scause and stval are kernel-internal; zero them out to prevent
-        // spurious fault handling on resume.
-        regs.scause = 0;
-        regs.stval = 0;
-    }
-
-    Ok(())
+    regs.sanitize_for_user_resume()
+        .map_err(|()| SyscallError::InvalidArgument)
 }
 
 // Test stubs.


### PR DESCRIPTION
## Summary

Removes every `#[cfg(target_arch)]` guard from architecture-neutral kernel code (~30
attributes across `cap/`, `sched/`, `syscall/`, `percpu.rs`, `main.rs`), bringing the
codebase into line with `docs/coding-standards.md` §C and the invariant already asserted in
`core/kernel/README.md` ("No code outside `arch/` contains `#[cfg(target_arch)]` guards").

Surfaced by #199; this is the **code** side it filed. §C is **met, not relaxed** — no
amendment, no exceptions.

## Approach

Per-site, each guard resolves into one of §C's three sanctioned forms:

| Form | Sites |
|---|---|
| **Arch const / predicate** | `ROOT_IRQ_COUNT`, `HAS_SBI` (new) and `HAS_IO_PORTS` (existing) gate the Phase-7 `IoPort` / `SbiControl` / UART cap mints; trap-frame field reads use `TrapFrame::{instruction_pointer,syscall_nr}` |
| **New surface fn** (both arches real) | `interrupts::route_device_irq` (unsafe), `cpu::current_stack_pointer`, `context::align_initial_stack` |
| **New surface fn + documented stub** | `init_ap_percpu_storage` (riscv no-op), `platform::console_mmio` (x86 `None`), `sbi_forward` (x86 `NotSupported`), `gdt::{load_iopb,permit_port_range_u32}` (riscv no-ops), `TrapFrame::sanitize_for_user_resume` |

The single-arch I/O-port and SBI syscalls stay in the neutral `syscall/` layer, gated on
`HAS_IO_PORTS` / `HAS_SBI`; only the irreducible hardware op is pushed behind the surface.
The SEED-scratch helpers (`alloc_seed_scratch`/`free_seed_scratch`) are made
architecture-unconditional. `main.rs`'s backtrace stack-pointer read moves behind
`cpu::current_stack_pointer`, which also fixes the separate §C rule against inline assembly
inlined alongside logic.

Behaviour-preserving: per-arch cap distribution and syscall results are unchanged.

## Scope beyond the issue's representative list

The exhaustive sweep covered sites the issue did not name (all mechanically reachable, all
required by acceptance criterion 3): the whole of `syscall/sbi.rs`, `percpu.rs::fpu_owner_for`,
the two `cap/retype.rs` SEED-scratch helpers, and the context-switch IOPB reload in
`sched/mod.rs`.

## Acceptance (#200)

- [x] Enumerate every `#[cfg(target_arch)]` outside `arch/mod.rs` with its rationale — see
  the per-site dispositions above; the implementation worked from a fresh
  `rg target_arch core/kernel/src -g '!arch/**'` sweep.
- [x] For each: route through the arch surface, replace with a documented stub, or record a
  §C exception — **zero exceptions**; every site routes or stubs.
- [x] No `#[cfg(target_arch)]` remains in architecture-neutral code; `coding-standards.md`
  §C unchanged (rule met, not relaxed). `arch-interface.md` documents the new surface.

Final check returns empty:
```
rg '#\[cfg.*target_arch|#\[cfg_attr.*target_arch' core/kernel/src -g '*.rs' \
  | rg -v '^core/kernel/src/arch/mod\.rs:'
```

## Test plan

- `cargo xtask build` — clippy-clean (`-D warnings`) on **x86_64** and **riscv64**.
- `cargo xtask compose-bundle --harness ktest` + `cargo xtask run` — **`[ktest] ALL TESTS
  PASSED`** on both arches (exercises Phase-7 minting, IRQ routing, context-switch IOPB
  reload, fault/`sanitize_for_user_resume`, `integration::sbi_gating`, FPU-owner, and SMP
  `init_ap_percpu_storage` under `-smp 4`).
- `cargo xtask test` — host workspace tests pass.
- `cargo xtask run` (Init harness, x86_64) — full userspace boots to services (memmgr,
  procmgr, devmgr w/ HW caps, vfsd, serial driver, virtio-blk, GPT) with no faults.

Closes #200. Refs #189, #199.