### PR TITLE
kernel/memmgr: reclaim demand-region intermediate page tables on unmap (#273)

### DIFF
--- a/abi/syscall/src/lib.rs
+++ b/abi/syscall/src/lib.rs
@@ -454,6 +454,22 @@ pub const MAP_READONLY: u64 = 0;
 /// trivially (neither WRITE nor EXECUTE set).
 pub const MAP_READ: u64 = 0x1;
 
+// ── Unmap flags ──────────────────────────────────────────────────────────────
+
+/// `SYS_MEM_UNMAP` flags (arg3): reclaim intermediate page tables.
+///
+/// After clearing the leaf PTEs across the requested span, reclaim each
+/// intermediate page table that the cleared span leaves empty back to the
+/// address space's page-table growth pool, crediting `pt_growth_budget_bytes`
+/// (observable via `cap_info(CAP_INFO_ASPACE_PT_BUDGET)`). A single coarse
+/// TLB + paging-structure-cache shootdown covers the whole teardown. memmgr
+/// sets this at `UNREGISTER_REGION` to release a demand region's page tables
+/// mid-life rather than holding them until address-space death.
+///
+/// Without this bit `SYS_MEM_UNMAP` clears only leaf PTEs and issues a per-page
+/// shootdown; intermediate tables persist until the address space is destroyed.
+pub const MEM_UNMAP_RECLAIM_PTS: u64 = 0x1;
+
 // ── Capability rights masks ─────────────────────────────────────────────────
 //
 // `u64` masks for `cap_derive` / `cap_copy` / `cap_insert` rights parameters.

--- a/core/kernel/src/arch/riscv64/paging.rs
+++ b/core/kernel/src/arch/riscv64/paging.rs
@@ -744,6 +744,134 @@ pub unsafe fn unmap_user_page(root_virt: u64, virt: u64)
     unsafe { flush_page(virt) };
 }
 
+/// `true` if no entry in `table` is present (all 512 slots clear).
+#[cfg(not(test))]
+fn table_is_empty(table: &[PageTableEntry; 512]) -> bool
+{
+    table.iter().all(|e| !e.is_present())
+}
+
+/// Unmap every 4 KiB leaf in `[virt_base, virt_base + page_count*4 KiB)` and
+/// reclaim each intermediate table the cleared span leaves empty back to
+/// `aso`'s page-table growth pool. Returns the number of L0/L1/L2 frames freed.
+///
+/// Walks VPN[3] → VPN[2] → VPN[1] → VPN[0] over the span, clearing in-range
+/// leaf PTEs. A table is freed only when it is fully empty afterwards **and**
+/// `aso` owns the frame
+/// ([`owns_phys`](crate::cap::object::AddressSpaceObject::owns_phys)) —
+/// emptiness, not span-containment, is the gate, so a boundary table shared
+/// with a live neighbour (or the guard-page table whose first slot sits just
+/// outside the span) is reclaimed exactly when its last live entry clears.
+/// Leaf entries at a non-leaf level (mega/gigapages: R/W/X set) are not
+/// produced by the user mapping path; they are skipped (never descended, never
+/// freed), so a table holding one is never seen as empty. The root frame is
+/// never freed.
+///
+/// Issues no TLB flush: the caller performs one coarse `sfence.vma` shootdown
+/// for the whole span and holds `pt_lock` across it, so a freed frame cannot be
+/// popped and reused before every hart is coherent.
+///
+/// # Safety
+/// `root_virt` must be the direct-map VA of a valid 4 KiB Sv48 root frame, `aso`
+/// must wrap that page table, and the caller must hold the address space's
+/// `pt_lock`. `[virt_base, virt_base + page_count*4 KiB)` must lie in the user
+/// half.
+#[cfg(not(test))]
+pub unsafe fn unmap_user_region_pooled(
+    root_virt: u64,
+    virt_base: u64,
+    page_count: usize,
+    aso: &crate::cap::object::AddressSpaceObject,
+) -> usize
+{
+    use crate::mm::PAGE_SIZE;
+    use crate::mm::paging::phys_to_virt;
+
+    // A leaf at any level sets at least one of R/W/X; a table pointer has none.
+    const LEAF_BITS: u64 = READ | WRITE | EXECUTE;
+    let p = PAGE_SIZE as u64;
+    let virt_end = virt_base + page_count as u64 * p;
+    let mut freed = 0usize;
+
+    // SAFETY: root_virt is the direct-map VA of a valid Sv48 root (caller's contract).
+    let root = unsafe { table_at(root_virt) };
+    let mut va = virt_base;
+    while va < virt_end
+    {
+        let i3 = vpn3_index(va);
+        let e3_end = virt_end.min(((va >> 39) + 1) << 39);
+        let r3 = root[i3];
+        // Skip 512 GiB gigapage leaves (not produced by the user path).
+        if r3.is_present() && r3.0 & LEAF_BITS == 0
+        {
+            let l2_pa = r3.phys_addr();
+            // SAFETY: present non-leaf VPN[3] entry points at a live L2 frame.
+            let l2 = unsafe { table_at(phys_to_virt(l2_pa)) };
+            let mut va2 = va;
+            while va2 < e3_end
+            {
+                let i2 = vpn2_index(va2);
+                let e2_end = e3_end.min(((va2 >> 30) + 1) << 30);
+                let r2 = l2[i2];
+                // Skip 1 GiB gigapage leaves.
+                if r2.is_present() && r2.0 & LEAF_BITS == 0
+                {
+                    let l1_pa = r2.phys_addr();
+                    // SAFETY: present non-leaf VPN[2] entry points at a live L1 frame.
+                    let l1 = unsafe { table_at(phys_to_virt(l1_pa)) };
+                    let mut va1 = va2;
+                    while va1 < e2_end
+                    {
+                        let i1 = vpn1_index(va1);
+                        let e1_end = e2_end.min(((va1 >> 21) + 1) << 21);
+                        let r1 = l1[i1];
+                        // Skip 2 MiB megapage leaves.
+                        if r1.is_present() && r1.0 & LEAF_BITS == 0
+                        {
+                            let l0_pa = r1.phys_addr();
+                            // SAFETY: present non-leaf VPN[1] entry points at a live L0 frame.
+                            let l0 = unsafe { table_at(phys_to_virt(l0_pa)) };
+                            let mut va0 = va1;
+                            while va0 < e1_end
+                            {
+                                l0[vpn0_index(va0)] = PageTableEntry(0);
+                                va0 += p;
+                            }
+                            if table_is_empty(l0) && aso.owns_phys(l0_pa)
+                            {
+                                l1[i1] = PageTableEntry(0);
+                                // SAFETY: L0 is empty and unlinked above; frame
+                                // came from this aso's pool (owns_phys).
+                                unsafe { aso.free_pt_page(l0_pa) };
+                                freed += 1;
+                            }
+                        }
+                        va1 = e1_end;
+                    }
+                    if table_is_empty(l1) && aso.owns_phys(l1_pa)
+                    {
+                        l2[i2] = PageTableEntry(0);
+                        // SAFETY: L1 is empty and unlinked above; aso-owned.
+                        unsafe { aso.free_pt_page(l1_pa) };
+                        freed += 1;
+                    }
+                }
+                va2 = e2_end;
+            }
+            if table_is_empty(l2) && aso.owns_phys(l2_pa)
+            {
+                root[i3] = PageTableEntry(0);
+                // SAFETY: L2 is empty and unlinked above; aso-owned.
+                unsafe { aso.free_pt_page(l2_pa) };
+                freed += 1;
+            }
+        }
+        va = e3_end;
+    }
+
+    freed
+}
+
 /// RISC-V counterpart to [`crate::mm::paging::unmap_identity_page`].
 ///
 /// Walks the kernel Sv48 root from `phys_to_virt(kernel_pml4_pa())` down

--- a/core/kernel/src/arch/x86_64/paging.rs
+++ b/core/kernel/src/arch/x86_64/paging.rs
@@ -862,6 +862,132 @@ pub unsafe fn unmap_user_page(root_virt: u64, virt: u64)
     unsafe { flush_page(virt) };
 }
 
+/// `true` if no entry in `table` is present (all 512 slots clear).
+#[cfg(not(test))]
+fn table_is_empty(table: &[PageTableEntry; 512]) -> bool
+{
+    table.iter().all(|e| !e.is_present())
+}
+
+/// Unmap every 4 KiB leaf in `[virt_base, virt_base + page_count*4 KiB)` and
+/// reclaim each intermediate table the cleared span leaves empty back to
+/// `aso`'s page-table growth pool. Returns the number of PT/PD/PDPT frames
+/// freed.
+///
+/// Walks PML4 → PDPT → PD → PT over the span, clearing in-range leaf PTEs. A
+/// table is freed only when it is fully empty afterwards **and** `aso` owns the
+/// frame ([`owns_phys`](crate::cap::object::AddressSpaceObject::owns_phys)) —
+/// emptiness, not span-containment, is the gate, so a boundary table shared
+/// with a live neighbour (or the guard-page table whose first slot sits just
+/// outside the span) is reclaimed exactly when its last live entry clears.
+/// Large-page leaves (1 GiB / 2 MiB) are not produced by the user mapping path;
+/// they are skipped (never descended, never freed), so a table holding one is
+/// never seen as empty. The root PML4 frame is never freed.
+///
+/// Issues no TLB flush: the caller performs one coarse TLB +
+/// paging-structure-cache shootdown for the whole span and holds `pt_lock`
+/// across it, so a freed frame cannot be popped and reused before every CPU is
+/// coherent.
+///
+/// # Safety
+/// `root_virt` must be the direct-map VA of a valid 4 KiB PML4 frame, `aso`
+/// must wrap that page table, and the caller must hold the address space's
+/// `pt_lock`. `[virt_base, virt_base + page_count*4 KiB)` must lie in the user
+/// half.
+#[cfg(not(test))]
+pub unsafe fn unmap_user_region_pooled(
+    root_virt: u64,
+    virt_base: u64,
+    page_count: usize,
+    aso: &crate::cap::object::AddressSpaceObject,
+) -> usize
+{
+    use crate::mm::PAGE_SIZE;
+    use crate::mm::paging::phys_to_virt;
+
+    let p = PAGE_SIZE as u64;
+    let virt_end = virt_base + page_count as u64 * p;
+    let mut freed = 0usize;
+
+    // SAFETY: root_virt is the direct-map VA of a valid user PML4 (caller's contract).
+    let pml4 = unsafe { table_at(root_virt) };
+    let mut va = virt_base;
+    while va < virt_end
+    {
+        let l4 = pml4_index(va);
+        let l4_end = virt_end.min(((va >> 39) + 1) << 39);
+        let e4 = pml4[l4];
+        // PML4 entries never encode a leaf on this target.
+        if e4.is_present()
+        {
+            let pdpt_pa = e4.phys_addr();
+            // SAFETY: present PML4E points at a live PDPT frame.
+            let pdpt = unsafe { table_at(phys_to_virt(pdpt_pa)) };
+            let mut va3 = va;
+            while va3 < l4_end
+            {
+                let l3 = pdpt_index(va3);
+                let l3_end = l4_end.min(((va3 >> 30) + 1) << 30);
+                let e3 = pdpt[l3];
+                // Skip 1 GiB large-page leaves (not produced by the user path).
+                if e3.is_present() && e3.0 & LARGE_PAGE == 0
+                {
+                    let pd_pa = e3.phys_addr();
+                    // SAFETY: present PDPTE (non-large) points at a live PD frame.
+                    let pd = unsafe { table_at(phys_to_virt(pd_pa)) };
+                    let mut va2 = va3;
+                    while va2 < l3_end
+                    {
+                        let l2 = pd_index(va2);
+                        let l2_end = l3_end.min(((va2 >> 21) + 1) << 21);
+                        let e2 = pd[l2];
+                        // Skip 2 MiB large-page leaves.
+                        if e2.is_present() && e2.0 & LARGE_PAGE == 0
+                        {
+                            let pt_pa = e2.phys_addr();
+                            // SAFETY: present PDE (non-large) points at a live PT frame.
+                            let pt = unsafe { table_at(phys_to_virt(pt_pa)) };
+                            let mut va1 = va2;
+                            while va1 < l2_end
+                            {
+                                pt[pt_index(va1)] = PageTableEntry(0);
+                                va1 += p;
+                            }
+                            if table_is_empty(pt) && aso.owns_phys(pt_pa)
+                            {
+                                pd[l2] = PageTableEntry(0);
+                                // SAFETY: PT is empty and unlinked above; frame
+                                // came from this aso's pool (owns_phys).
+                                unsafe { aso.free_pt_page(pt_pa) };
+                                freed += 1;
+                            }
+                        }
+                        va2 = l2_end;
+                    }
+                    if table_is_empty(pd) && aso.owns_phys(pd_pa)
+                    {
+                        pdpt[l3] = PageTableEntry(0);
+                        // SAFETY: PD is empty and unlinked above; aso-owned.
+                        unsafe { aso.free_pt_page(pd_pa) };
+                        freed += 1;
+                    }
+                }
+                va3 = l3_end;
+            }
+            if table_is_empty(pdpt) && aso.owns_phys(pdpt_pa)
+            {
+                pml4[l4] = PageTableEntry(0);
+                // SAFETY: PDPT is empty and unlinked above; aso-owned.
+                unsafe { aso.free_pt_page(pdpt_pa) };
+                freed += 1;
+            }
+        }
+        va = l4_end;
+    }
+
+    freed
+}
+
 /// x86-64 implementation of [`crate::mm::paging::unmap_identity_page`].
 ///
 /// Walks the kernel PML4 from `phys_to_virt(kernel_pml4_pa())` down to the

--- a/core/kernel/src/cap/object.rs
+++ b/core/kernel/src/cap/object.rs
@@ -693,7 +693,6 @@ impl AddressSpaceObject
     /// `phys` must come from a prior [`alloc_pt_page`] call on this AS, and
     /// the page must no longer be in use as a page table.
     #[cfg(not(test))]
-    #[allow(dead_code)]
     pub unsafe fn free_pt_page(&self, phys: u64)
     {
         pool_lock(&self.pt_pool_lock);
@@ -703,6 +702,47 @@ impl AddressSpaceObject
         pool_unlock(&self.pt_pool_lock);
         self.pt_growth_budget_bytes
             .fetch_add(crate::mm::PAGE_SIZE as u64, Ordering::AcqRel);
+    }
+
+    /// Whether `phys` lies inside one of this AS's retype-source chunks — i.e.
+    /// the page was carved from this AS's PT pool (rather than `kernel_pt_pool`
+    /// or another allocator).
+    ///
+    /// The region-reclaim walk consults this before returning a now-empty
+    /// intermediate page table via [`free_pt_page`]: only pool-owned pages may
+    /// re-enter the pool. Every intermediate PT the walk reaches in a
+    /// retype-backed AS is pool-owned; the check defends a heap-backed AS (or
+    /// any future non-pooled user mapping) against corrupting the pool's
+    /// free-list and budget accounting.
+    #[cfg(not(test))]
+    pub fn owns_phys(&self, phys: u64) -> bool
+    {
+        let p = crate::mm::PAGE_SIZE as u64;
+        pool_lock(&self.pt_pool_lock);
+        let mut owned = false;
+        for slot in &self.pt_chunks
+        {
+            let anc = slot.ancestor.load(Ordering::Acquire);
+            if anc.is_null()
+            {
+                continue;
+            }
+            // SAFETY: ancestor is published with Release at chunk recording and
+            // kept alive by the chunk's inc_ref for the AS's lifetime;
+            // MemoryObject.base is immutable after creation.
+            // cast_ptr_alignment: header at offset 0; MemoryObject is repr(C).
+            #[allow(clippy::cast_ptr_alignment)]
+            let base = unsafe { (*anc.cast::<MemoryObject>()).base };
+            let start = base + slot.base_offset.load(Ordering::Relaxed);
+            let end = start + slot.page_count.load(Ordering::Relaxed) * p;
+            if phys >= start && phys < end
+            {
+                owned = true;
+                break;
+            }
+        }
+        pool_unlock(&self.pt_pool_lock);
+        owned
     }
 
     /// Record a freshly-retyped chunk and seed its pages onto the pool.

--- a/core/kernel/src/mm/address_space.rs
+++ b/core/kernel/src/mm/address_space.rs
@@ -767,6 +767,17 @@ impl AddressSpace
         // cache is clean. The contended `pt_lock` path enables interrupts while
         // spinning, so a remote CPU waiting on this lock still services and acks
         // our IPI: no deadlock.
+        // INV-3 Dekker A-side: bump tlb_gen and fence BEFORE snapshotting
+        // active_cpus (the same order as `shootdown_remote`). This guarantees
+        // that for any CPU caching this space, either it is in the snapshot
+        // below (gets the IPI) or it observes the bumped tlb_gen on its next
+        // reactivation (flushes the tag then). Snapshotting first would leave a
+        // CPU that activates concurrently in neither cover.
+        if crate::mm::tag_allocator::tagging_enabled()
+        {
+            self.tlb_gen.fetch_add(1, Ordering::Release);
+            core::sync::atomic::fence(Ordering::SeqCst);
+        }
         let current = crate::arch::current::cpu::current_cpu() as usize;
         // Only CPUs that run this AS cache its translations — the kernel edits
         // these page tables through the direct map, never by loading this root.
@@ -779,13 +790,6 @@ impl AddressSpace
         }
         let mut remote = self.active_cpu_mask();
         remote.clear(current);
-        if crate::mm::tag_allocator::tagging_enabled()
-        {
-            // Late-joiner cover: a CPU switched away (absent from `remote`, no
-            // IPI) flushes this tag on reactivation. Mirrors `shootdown_remote`.
-            self.tlb_gen.fetch_add(1, Ordering::Release);
-            core::sync::atomic::fence(Ordering::SeqCst);
-        }
         if !remote.is_empty()
         {
             // virt = u64::MAX routes the remote handler to flush_tlb_all()

--- a/core/kernel/src/mm/address_space.rs
+++ b/core/kernel/src/mm/address_space.rs
@@ -80,9 +80,11 @@ pub use init_protocol::{INIT_STACK_PAGES, INIT_STACK_TOP};
 
 /// A user-mode virtual address space.
 ///
-/// Owns the physical frame of the root page table. All intermediate frames
-/// allocated during mapping are tracked only implicitly through the page table
-/// structure (full tracking + freeing is deferred to a future phase).
+/// Owns the physical frame of the root page table. Intermediate frames
+/// allocated during mapping are tracked implicitly through the page table
+/// structure; they are returned to the per-AS pool on region teardown
+/// ([`unmap_region_pooled`](Self::unmap_region_pooled)) and reclaimed wholesale
+/// at address-space death.
 pub struct AddressSpace
 {
     /// Physical address of the root page table frame (PML4 / Sv48 root).
@@ -685,8 +687,9 @@ impl AddressSpace
     /// Remove the mapping for a single 4 KiB page at `virt`.
     ///
     /// If `virt` is not mapped, this is a no-op (safe to call redundantly).
-    /// Does not free intermediate page table frames. Invalidates TLB entries
-    /// on all CPUs where this address space is active.
+    /// Does not free intermediate page table frames; the reclaiming region path
+    /// is [`unmap_region_pooled`](Self::unmap_region_pooled). Invalidates TLB
+    /// entries on all CPUs where this address space is active.
     ///
     /// # Safety
     /// `virt` must be in the user half. Caller must not access `virt` after
@@ -719,6 +722,85 @@ impl AddressSpace
         self.pt_unlock();
         self.shootdown_remote(virt);
         crate::percpu::preempt_enable();
+    }
+
+    /// Unmap `page_count` pages from `[virt_base, ..)` and reclaim every
+    /// intermediate page table the cleared span leaves empty back to `aso`'s
+    /// growth pool (crediting `pt_growth_budget_bytes`). Returns the number of
+    /// page-table frames reclaimed.
+    ///
+    /// Drives `SYS_MEM_UNMAP` with `MEM_UNMAP_RECLAIM_PTS` (memmgr region
+    /// teardown). Unlike the per-page [`unmap_page`](Self::unmap_page), it tears
+    /// the whole span down under a single `pt_lock` hold and a single coarse TLB
+    /// + paging-structure-cache shootdown.
+    ///
+    /// `aso` MUST wrap *this* `AddressSpace`; `sys_mem_unmap` enforces this by
+    /// resolving both from the same capability.
+    ///
+    /// # Safety
+    /// `virt_base` must be page-aligned and the span `[virt_base, virt_base +
+    /// page_count * PAGE_SIZE)` must lie in the user half (caller validates).
+    #[cfg(not(test))]
+    pub unsafe fn unmap_region_pooled(
+        &self,
+        virt_base: u64,
+        page_count: usize,
+        aso: &crate::cap::object::AddressSpaceObject,
+    ) -> usize
+    {
+        use crate::arch::current::paging::{flush_tlb_all, unmap_user_region_pooled};
+
+        crate::percpu::preempt_disable();
+        self.pt_lock();
+
+        // Clear every leaf in the span and free each now-empty, aso-owned
+        // intermediate table back to the pool.
+        // SAFETY: root_virt is valid; aso wraps this AS; the span is user-range
+        // (caller's contract); pt_lock is held.
+        let freed = unsafe { unmap_user_region_pooled(self.root_virt, virt_base, page_count, aso) };
+
+        // ONE coarse shootdown for the whole teardown, performed UNDER pt_lock
+        // (the per-VA `unmap_page` drops the lock first for throughput; here it
+        // must stay held). A freed PT frame is poppable only via `alloc_pt_page`,
+        // which runs under THIS `pt_lock`, so no other CPU reuses a just-freed
+        // frame until we release — by then every CPU's TLB + paging-structure
+        // cache is clean. The contended `pt_lock` path enables interrupts while
+        // spinning, so a remote CPU waiting on this lock still services and acks
+        // our IPI: no deadlock.
+        let current = crate::arch::current::cpu::current_cpu() as usize;
+        // Only CPUs that run this AS cache its translations — the kernel edits
+        // these page tables through the direct map, never by loading this root.
+        // The caller is normally memmgr, which does not run the target AS, so
+        // the local flush is usually skipped.
+        if self.active_cpus.test_cpu(current, Ordering::Acquire)
+        {
+            // SAFETY: ring 0 / S-mode; full flush clears TLB + PS-caches.
+            unsafe { flush_tlb_all() };
+        }
+        let mut remote = self.active_cpu_mask();
+        remote.clear(current);
+        if crate::mm::tag_allocator::tagging_enabled()
+        {
+            // Late-joiner cover: a CPU switched away (absent from `remote`, no
+            // IPI) flushes this tag on reactivation. Mirrors `shootdown_remote`.
+            self.tlb_gen.fetch_add(1, Ordering::Release);
+            core::sync::atomic::fence(Ordering::SeqCst);
+        }
+        if !remote.is_empty()
+        {
+            // virt = u64::MAX routes the remote handler to flush_tlb_all()
+            // (ignores tag) — correct even cross-AS where this AS's tag is not
+            // stable on the current CPU.
+            // SAFETY: root_phys is a valid root; remote excludes current; preempt
+            // is held and pt_lock no-pop invariant holds; tag unused on this path.
+            unsafe {
+                crate::mm::tlb_shootdown::shootdown(self.root_phys, &remote, u64::MAX, 0);
+            }
+        }
+
+        self.pt_unlock();
+        crate::percpu::preempt_enable();
+        freed
     }
 
     /// Change the permission flags on an existing 4 KiB leaf mapping at `virt`.

--- a/core/kernel/src/syscall/mem.rs
+++ b/core/kernel/src/syscall/mem.rs
@@ -240,12 +240,17 @@ pub fn sys_mem_map(_tf: &mut TrapFrame) -> Result<u64, SyscallError>
 /// arg0 = `AddressSpace` cap index (must have MAP right).
 /// arg1 = virtual address of the first page to unmap (page-aligned, user range).
 /// arg2 = number of pages to unmap (non-zero).
+/// arg3 = flags. `MEM_UNMAP_RECLAIM_PTS` additionally reclaims each now-empty
+///        intermediate page table the cleared span leaves to the address
+///        space's growth pool (one coarse TLB + paging-structure-cache
+///        shootdown); otherwise only leaf PTEs are cleared, with a per-page
+///        shootdown.
 ///
 /// Unmapping a page that is not mapped is a no-op (not an error).
 /// Returns 0 on success.
 ///
-/// Note: intermediate page table frames are not reclaimed; full teardown
-/// happens when the address space object is destroyed.
+/// Without `MEM_UNMAP_RECLAIM_PTS`, intermediate page table frames are not
+/// reclaimed; full teardown happens when the address space object is destroyed.
 #[cfg(not(test))]
 pub fn sys_mem_unmap(tf: &mut TrapFrame) -> Result<u64, SyscallError>
 {
@@ -254,10 +259,12 @@ pub fn sys_mem_unmap(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     const USER_HALF_TOP: u64 = 0x0000_8000_0000_0000;
     use crate::mm::PAGE_SIZE;
     use crate::syscall::current_tcb;
+    use syscall::MEM_UNMAP_RECLAIM_PTS;
 
     let aspace_idx = tf.arg(0) as u32;
     let virt_base = tf.arg(1);
     let page_count = tf.arg(2) as usize;
+    let flags = tf.arg(3);
 
     // ── Validation ────────────────────────────────────────────────────────────
 
@@ -302,22 +309,34 @@ pub fn sys_mem_unmap(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     // SAFETY: caller_cspace validated; lookup_cap checks tag and rights.
     let aspace_slot =
         unsafe { super::lookup_cap(caller_cspace, aspace_idx, CapTag::AddressSpace, Rights::MAP) }?;
-    let as_ptr = {
+    let (as_ptr, aso_raw) = {
         let obj = aspace_slot.object.ok_or(SyscallError::InvalidCapability)?;
-        // SAFETY: tag confirmed AddressSpace.
         // cast_ptr_alignment: header at offset 0; allocator guarantees alignment.
         #[allow(clippy::cast_ptr_alignment)]
-        let as_obj = unsafe { &*(obj.as_ptr().cast::<AddressSpaceObject>()) };
-        as_obj.address_space
+        let aso = obj.as_ptr().cast::<AddressSpaceObject>();
+        // SAFETY: tag confirmed AddressSpace; aso is a valid AddressSpaceObject.
+        let as_inner = unsafe { (*aso).address_space };
+        (as_inner, aso)
     };
 
-    // ── Unmap loop ────────────────────────────────────────────────────────────
+    // ── Unmap ───────────────────────────────────────────────────────────────
 
-    for i in 0..page_count
+    if flags & MEM_UNMAP_RECLAIM_PTS != 0
     {
-        let virt = virt_base + (i * PAGE_SIZE) as u64;
-        // SAFETY: virt is in user range (validated above); as_ptr is valid.
-        unsafe { (*as_ptr).unmap_page(virt) };
+        // Region teardown: clear the whole span and reclaim each now-empty
+        // intermediate page table to the AS's pool, with one coarse shootdown.
+        // SAFETY: as_ptr is valid; aso_raw wraps it; the span is user-range
+        // (validated above).
+        unsafe { (*as_ptr).unmap_region_pooled(virt_base, page_count, &*aso_raw) };
+    }
+    else
+    {
+        for i in 0..page_count
+        {
+            let virt = virt_base + (i * PAGE_SIZE) as u64;
+            // SAFETY: virt is in user range (validated above); as_ptr is valid.
+            unsafe { (*as_ptr).unmap_page(virt) };
+        }
     }
 
     Ok(0)

--- a/core/ktest/src/integration/tlb_coherency.rs
+++ b/core/ktest/src/integration/tlb_coherency.rs
@@ -7,7 +7,11 @@
 //!
 //! Exercises the TLB shootdown protocol by creating threads pinned to different
 //! CPUs and performing map/unmap operations that trigger inter-processor
-//! interrupts (IPIs) for TLB invalidation.
+//! interrupts (IPIs) for TLB invalidation. A second phase repeats the cycles
+//! with `mem_unmap_reclaim` (the `MEM_UNMAP_RECLAIM_PTS` path), which frees the
+//! now-empty intermediate page table back to the AS pool and issues one coarse
+//! full-flush shootdown *while holding `pt_lock`* — a distinct path from the
+//! per-VA shootdown above.
 //!
 //! ktest threads run in user mode, so a stale-TLB access the shootdown failed
 //! to flush would surface as a page fault. The kernel retries only faults the
@@ -16,16 +20,19 @@
 //! `integration::fault_kills_thread`). This test does not construct such a
 //! window — it verifies that:
 //!
-//! 1. Repeated map/unmap cycles across CPUs complete without deadlock
-//! 2. Threads on different CPUs can safely access newly mapped memory
-//! 3. The shootdown protocol doesn't panic or corrupt kernel state
+//! 1. Repeated map/unmap cycles across CPUs complete without deadlock — for
+//!    both the per-VA and the coarse pool-reclaiming shootdown paths.
+//! 2. Threads on different CPUs read back the sentinel from newly mapped
+//!    memory, including after a same-VA remap whose intermediate page table was
+//!    reclaimed and re-allocated from the pool.
+//! 3. The shootdown protocol doesn't panic or corrupt kernel state.
 //!
 //! This validates Phase E.4's TLB shootdown IPI mechanism indirectly by
 //! confirming the protocol operates correctly under concurrent access.
 
 use syscall::{
-    cap_copy, cap_create_notification, cap_delete, mem_map, mem_unmap, notification_send,
-    notification_wait, system_info, thread_exit,
+    cap_copy, cap_create_notification, cap_delete, mem_map, mem_unmap, mem_unmap_reclaim,
+    notification_send, notification_wait, system_info, thread_exit,
 };
 use syscall_abi::SystemInfoType;
 
@@ -34,6 +41,9 @@ use crate::{ChildStack, TestContext, TestResult};
 const TEST_VA: u64 = 0x5000_0000; // 1.25 GiB — distinct from other integration tests.
 const RIGHTS_NOTIFY_WAIT: u64 = (1 << 7) | (1 << 8);
 const CYCLES: usize = 100;
+/// Value the parent writes into the mapped frame each cycle; the child reads it
+/// back to confirm the translation resolves to the right frame.
+const SENTINEL: u64 = 0xA5A5_5A5A_DEAD_BEEF;
 
 static mut CHILD_STACK: ChildStack = ChildStack::ZERO;
 
@@ -96,49 +106,74 @@ pub fn run(ctx: &TestContext) -> TestResult
         return Err("integration::tlb_coherency: child sent wrong readiness bits");
     }
 
-    // ── 4. Perform multiple map/unmap cycles to exercise TLB shootdown. ──────
+    // ── 4. Map/access/unmap cycles to exercise TLB shootdown. ────────────────
     //
     // Each cycle:
-    //   a. Map page at TEST_VA
-    //   b. Notification child on p2c that page is mapped (0x2)
-    //   c. Wait for child to confirm access on c2p (0x4)
-    //   d. Unmap page (triggers TLB shootdown IPI to CPU 1)
+    //   a. Map page at TEST_VA and write SENTINEL into it.
+    //   b. Notify child on p2c that the page is mapped (0x2).
+    //   c. Wait for child to confirm it read SENTINEL back on c2p (0x4); a
+    //      stale translation resolving to the wrong frame acks 0x10.
+    //   d. Unmap the page (triggers a TLB shootdown IPI to CPU 1).
     //
-    // If TLB shootdown is broken, the kernel would panic or deadlock.
-
-    for cycle in 0..CYCLES
+    // Phase 0 uses per-page `mem_unmap` (single-VA shootdown). Phase 1 uses
+    // `mem_unmap_reclaim` (the MEM_UNMAP_RECLAIM_PTS path): it frees the
+    // now-empty intermediate page table back to the AS pool and issues one
+    // coarse full-flush shootdown *while holding pt_lock*. The next cycle
+    // remaps the same VA, re-allocating an intermediate table (often the same
+    // frame) from the pool. A broken shootdown would panic, deadlock, fault the
+    // child, or read the wrong frame.
+    for phase in 0..2u32
     {
-        // Map the page.
-        mem_map(
-            memory_cap,
-            ctx.aspace_cap,
-            TEST_VA,
-            0,
-            1,
-            syscall::MAP_WRITABLE,
-        )
-        .map_err(|_| "integration::tlb_coherency: mem_map failed")?;
-
-        // Notification child on p2c: page is mapped, you may access it.
-        notification_send(p2c, 0x2)
-            .map_err(|_| "integration::tlb_coherency: notification_send (map) failed")?;
-
-        // Wait for child to confirm access on c2p.
-        let ack = notification_wait(c2p)
-            .map_err(|_| "integration::tlb_coherency: notification_wait (ack) failed")?;
-        if ack != 0x4
+        let reclaim = phase == 1;
+        for cycle in 0..CYCLES
         {
-            return Err("integration::tlb_coherency: child sent wrong ack bits");
-        }
+            mem_map(
+                memory_cap,
+                ctx.aspace_cap,
+                TEST_VA,
+                0,
+                1,
+                syscall::MAP_WRITABLE,
+            )
+            .map_err(|_| "integration::tlb_coherency: mem_map failed")?;
 
-        // Unmap the page. This triggers TLB shootdown IPI to CPU 1.
-        mem_unmap(ctx.aspace_cap, TEST_VA, 1)
-            .map_err(|_| "integration::tlb_coherency: mem_unmap failed")?;
+            // Stamp the freshly mapped frame so the child can validate the
+            // translation by value.
+            // SAFETY: TEST_VA is mapped writable on this CPU by the map above.
+            unsafe { (TEST_VA as *mut u64).write_volatile(SENTINEL) };
 
-        // Log progress every 5 cycles.
-        if cycle % 5 == 0
-        {
-            crate::log_u64("ktest: integration::tlb_coherency: cycle ", cycle as u64);
+            notification_send(p2c, 0x2)
+                .map_err(|_| "integration::tlb_coherency: notification_send (map) failed")?;
+
+            let ack = notification_wait(c2p)
+                .map_err(|_| "integration::tlb_coherency: notification_wait (ack) failed")?;
+            if ack == 0x10
+            {
+                return Err(
+                    "integration::tlb_coherency: child read wrong frame (stale translation)",
+                );
+            }
+            if ack != 0x4
+            {
+                return Err("integration::tlb_coherency: child sent wrong ack bits");
+            }
+
+            // Unmap. Phase 1 also reclaims the now-empty intermediate PT.
+            if reclaim
+            {
+                mem_unmap_reclaim(ctx.aspace_cap, TEST_VA, 1)
+                    .map_err(|_| "integration::tlb_coherency: mem_unmap_reclaim failed")?;
+            }
+            else
+            {
+                mem_unmap(ctx.aspace_cap, TEST_VA, 1)
+                    .map_err(|_| "integration::tlb_coherency: mem_unmap failed")?;
+            }
+
+            if cycle % 25 == 0
+            {
+                crate::log_u64("ktest: integration::tlb_coherency: cycle ", cycle as u64);
+            }
         }
     }
 
@@ -188,18 +223,19 @@ fn tlb_worker_thread(p2c_slot: u64) -> !
 
         if bits & 0x2 != 0
         {
-            // Page is mapped. Access it (read) to load TLB entry.
+            // Page is mapped and stamped with SENTINEL. Read it back to load
+            // the TLB entry and validate the translation by value.
             //
-            // SAFETY: Parent maps TEST_VA before notifying 0x2. The parent's
-            // prior-cycle unmap shot down this hart's entry, so the read sees
-            // the fresh mapping; a broken shootdown would instead fault here
-            // and terminate this thread.
-            let ptr = TEST_VA as *const u64;
-            // SAFETY: TEST_VA is mapped by parent; see comment above.
-            let _value = unsafe { ptr.read_volatile() };
+            // SAFETY: Parent maps + writes TEST_VA before notifying 0x2. The
+            // parent's prior-cycle unmap (or reclaiming unmap) shot down this
+            // hart's entry, so the read sees the fresh mapping; a broken
+            // shootdown would instead fault here (terminating this thread) or,
+            // if it resolved to a stale frame, read a non-SENTINEL value.
+            let value = unsafe { (TEST_VA as *const u64).read_volatile() };
 
-            // Acknowledge to parent on c2p: we've accessed the page.
-            notification_send(c2p, 0x4).ok();
+            // Ack match (0x4) or wrong-frame (0x10).
+            let ack = if value == SENTINEL { 0x4 } else { 0x10 };
+            notification_send(c2p, ack).ok();
         }
     }
 

--- a/core/ktest/src/unit/mod.rs
+++ b/core/ktest/src/unit/mod.rs
@@ -162,6 +162,14 @@ pub fn run_all(ctx: &TestContext)
         retype::deep_pt_walk_consumes_pool(ctx)
     );
     run_test!(
+        "retype::region_unmap_reclaims_pt_budget",
+        retype::region_unmap_reclaims_pt_budget(ctx)
+    );
+    run_test!(
+        "retype::concurrent_regions_release_pt_budget_on_unmap",
+        retype::concurrent_regions_release_pt_budget_on_unmap(ctx)
+    );
+    run_test!(
         "retype::cspace_grow_consumes_pool",
         retype::cspace_grow_consumes_pool(ctx)
     );

--- a/core/ktest/src/unit/retype.rs
+++ b/core/ktest/src/unit/retype.rs
@@ -31,7 +31,7 @@
 
 use syscall::{
     cap_copy, cap_create_aspace, cap_create_cspace, cap_create_endpoint, cap_delete, cap_info,
-    mem_map, mem_unmap,
+    mem_map, mem_unmap, mem_unmap_reclaim,
 };
 use syscall_abi::{
     CAP_INFO_ASPACE_PT_BUDGET, CAP_INFO_CSPACE_BUDGET, CAP_INFO_CSPACE_USED, MAP_WRITABLE,
@@ -177,6 +177,132 @@ pub fn deep_pt_walk_consumes_pool(ctx: &TestContext) -> TestResult
     }
 
     cap_delete(aspace).ok();
+    Ok(())
+}
+
+/// `mem_unmap_reclaim` (the `MEM_UNMAP_RECLAIM_PTS` path) returns the
+/// intermediate page tables a freed span empties back to the per-AS pool,
+/// crediting `pt_growth_budget_bytes`. A fresh single-page mapping at a clean
+/// VA allocates three intermediate tables (PDPT+PD+PT on x86-64, L2+L1+L0 on
+/// Sv48); tearing the region down reclaims all three (the budget round-trips to
+/// its pre-map value), and the same VA then remaps from the returned pool pages.
+pub fn region_unmap_reclaims_pt_budget(ctx: &TestContext) -> TestResult
+{
+    let memory = ctx.memory_base;
+
+    // Slab: page 0 = wrapper, page 1 = root PT, pages 2..8 = 6 pool pages —
+    // ample for the 3 intermediate PTs a single fresh mapping needs.
+    let aspace = cap_create_aspace(memory, 0, 8)
+        .map_err(|_| "retype::region_reclaim: cap_create_aspace failed")?;
+
+    let budget0 = cap_info(aspace, CAP_INFO_ASPACE_PT_BUDGET)
+        .map_err(|_| "retype::region_reclaim: cap_info(budget0) failed")?;
+
+    // Map one page at a fresh 2 MiB-aligned VA: allocates the full intermediate
+    // chain (3 pages) from the pool.
+    if mem_map(memory, aspace, TEST_VA_BASE, 0, 1, MAP_WRITABLE).is_err()
+    {
+        cap_delete(aspace).ok();
+        return Err("retype::region_reclaim: initial mem_map failed");
+    }
+    let budget1 = cap_info(aspace, CAP_INFO_ASPACE_PT_BUDGET)
+        .map_err(|_| "retype::region_reclaim: cap_info(budget1) failed")?;
+    if budget1 >= budget0
+    {
+        cap_delete(aspace).ok();
+        return Err("retype::region_reclaim: mapping did not consume PT budget");
+    }
+
+    // Reclaiming unmap: clears the leaf, empties PT→PD→PDPT, returns all three
+    // to the pool and credits the budget.
+    if mem_unmap_reclaim(aspace, TEST_VA_BASE, 1).is_err()
+    {
+        cap_delete(aspace).ok();
+        return Err("retype::region_reclaim: mem_unmap_reclaim failed");
+    }
+    let budget2 = cap_info(aspace, CAP_INFO_ASPACE_PT_BUDGET)
+        .map_err(|_| "retype::region_reclaim: cap_info(budget2) failed")?;
+    if budget2 <= budget1
+    {
+        cap_delete(aspace).ok();
+        return Err("retype::region_reclaim: unmap did not credit PT budget");
+    }
+    if budget2 != budget0
+    {
+        cap_delete(aspace).ok();
+        return Err("retype::region_reclaim: reclaimed budget != pre-map budget");
+    }
+
+    // The returned pages are reusable: remap the same VA (re-allocates the
+    // chain from the pool), then tear it down again.
+    if mem_map(memory, aspace, TEST_VA_BASE, 0, 1, MAP_WRITABLE).is_err()
+    {
+        cap_delete(aspace).ok();
+        return Err("retype::region_reclaim: remap after reclaim failed");
+    }
+    mem_unmap_reclaim(aspace, TEST_VA_BASE, 1).ok();
+
+    cap_delete(aspace).ok();
+    Ok(())
+}
+
+/// A burst of concurrent distinct-VA regions holds peak PT-pool RAM while all
+/// are mapped; reclaiming-unmap of each returns its intermediate tables, so the
+/// budget recovers to its pre-burst value instead of staying depressed until
+/// address-space death. This is the #273 peak-concurrency retention case: the
+/// 1 GiB stride gives every region its own PD+PT under a shared PDPT, and the
+/// final unmap empties and frees the PDPT too — a full round-trip to baseline.
+pub fn concurrent_regions_release_pt_budget_on_unmap(ctx: &TestContext) -> TestResult
+{
+    const N: u64 = 6;
+    const STRIDE: u64 = 0x4000_0000; // 1 GiB — distinct PDPT slot per region.
+
+    let memory = ctx.memory_base;
+
+    // Generous pool: 1 PDPT + N*(PD+PT) intermediate pages plus slack.
+    let aspace = cap_create_aspace(memory, 0, 64)
+        .map_err(|_| "retype::concurrent_regions: cap_create_aspace failed")?;
+
+    let baseline = cap_info(aspace, CAP_INFO_ASPACE_PT_BUDGET)
+        .map_err(|_| "retype::concurrent_regions: cap_info(baseline) failed")?;
+
+    // Map the whole burst (peak concurrency): budget drops as PTs allocate.
+    for i in 0..N
+    {
+        let va = TEST_VA_BASE + i * STRIDE;
+        if mem_map(memory, aspace, va, 0, 1, MAP_WRITABLE).is_err()
+        {
+            cap_delete(aspace).ok();
+            return Err("retype::concurrent_regions: mem_map failed");
+        }
+    }
+    let peak = cap_info(aspace, CAP_INFO_ASPACE_PT_BUDGET)
+        .map_err(|_| "retype::concurrent_regions: cap_info(peak) failed")?;
+    if peak >= baseline
+    {
+        cap_delete(aspace).ok();
+        return Err("retype::concurrent_regions: burst did not consume PT budget");
+    }
+
+    // Reclaiming-unmap each region; the budget must climb back to baseline.
+    for i in 0..N
+    {
+        let va = TEST_VA_BASE + i * STRIDE;
+        if mem_unmap_reclaim(aspace, va, 1).is_err()
+        {
+            cap_delete(aspace).ok();
+            return Err("retype::concurrent_regions: mem_unmap_reclaim failed");
+        }
+    }
+    let after = cap_info(aspace, CAP_INFO_ASPACE_PT_BUDGET)
+        .map_err(|_| "retype::concurrent_regions: cap_info(after) failed")?;
+
+    cap_delete(aspace).ok();
+
+    if after != baseline
+    {
+        return Err("retype::concurrent_regions: PT budget not fully released on unmap");
+    }
     Ok(())
 }
 

--- a/docs/capability-model.md
+++ b/docs/capability-model.md
@@ -447,6 +447,14 @@ the budget returns `NoMemory`; the budget refills via *augment mode* on
 the same create syscall (passing the existing AS/CS slot as the augment
 target merges a new slab of pages into its growth budget).
 
+An `AddressSpace`'s intermediate page tables are also returned to its
+growth budget mid-life when a region is torn down: `SYS_MEM_UNMAP` with
+`MEM_UNMAP_RECLAIM_PTS` (issued by memmgr at `UNREGISTER_REGION`) clears
+the span's leaf entries and frees each now-empty intermediate page table
+back to the pool, crediting the budget. Without the flag, intermediate
+page tables persist until the `AddressSpace` is destroyed. The credited
+budget is observable via `SYS_CAP_INFO`.
+
 This means every kernel-half page-table and slot-page allocation is
 gated by a Memory cap the owning process holds. There is no untracked
 kernel growth path.

--- a/services/memmgr/docs/ipc-interface.md
+++ b/services/memmgr/docs/ipc-interface.md
@@ -357,12 +357,16 @@ mid-life — e.g. ruststd freeing a joined thread's guarded stack.
 | data[0] | `va_base` (must equal the registered base) |
 | data[1] | `len_bytes` (must equal the registered length) |
 
-memmgr finds the exact-match region, unmaps each backing frame from the
-caller's delegated `AddressSpace`, returns the frame to the free pool, and
-frees the region. Frames the caller mapped itself (e.g. `REQUEST_MEMORY_CAPS`
-grants) are never unmapped — only frames memmgr backed on fault inside the
-region. The frames return to the pool as on `PROCESS_DIED`, so the
-all-RAM-accounted identity is unaffected.
+memmgr finds the exact-match region and tears the whole span down in one
+`mem_unmap_reclaim` call against the caller's delegated `AddressSpace`: the
+kernel clears the span's leaf PTEs and returns the now-empty intermediate page
+tables to that address space's PT growth budget (observable via
+`CAP_INFO_ASPACE_PT_BUDGET`) under a single coarse TLB shootdown. memmgr then
+returns each backing frame to the free pool and frees the region. The region
+occupies its own VA surface, so the span unmap touches only frames memmgr
+backed on fault; frames the caller mapped itself (e.g. `REQUEST_MEMORY_CAPS`
+grants) live on a disjoint surface and are untouched. The frames return to the
+pool as on `PROCESS_DIED`, so the all-RAM-accounted identity is unaffected.
 
 **Reply (success):** `label` 0.
 

--- a/services/memmgr/src/main.rs
+++ b/services/memmgr/src/main.rs
@@ -502,11 +502,13 @@ impl ProcessRecord
         None
     }
 
-    /// Unmap and reclaim every memmgr-mapped frame whose page base lies in
-    /// `[base, end)`: unmap from `aspace_cap`, return the cap to the pool, free
-    /// the node. Used by `UNREGISTER_REGION` on a live process. Frames the
-    /// caller mapped ([`FRAME_VA_UNMAPPED`]) are left untouched.
-    fn reclaim_frames_in(&mut self, base: u64, end: u64, aspace_cap: u32, pool: &mut FreePool)
+    /// Return to the pool every memmgr-mapped frame whose page base lies in
+    /// `[base, end)`, freeing its tracking node. Used by `UNREGISTER_REGION`:
+    /// the caller has already cleared the span's leaf PTEs and reclaimed the
+    /// intermediate page tables via `mem_unmap_reclaim`, so this only re-pools
+    /// the backing frames. Frames the caller mapped ([`FRAME_VA_UNMAPPED`]) are
+    /// left untouched.
+    fn return_frames_in(&mut self, base: u64, end: u64, pool: &mut FreePool)
     {
         let mut prev = NODE_NULL;
         let mut cur = self.frame_head;
@@ -525,7 +527,6 @@ impl ProcessRecord
                 && va >= base
                 && va < end
             {
-                let _ = syscall::mem_unmap(aspace_cap, va, u64::from(page_count));
                 let _ = pool.push_or_coalesce(FreeRun {
                     cap_slot,
                     page_count,
@@ -1491,7 +1492,12 @@ fn handle_unregister_region(req: &IpcMessage, ipc_buf: *mut u64)
     };
     let end = region.va_base.saturating_add(region.len);
     let aspace_cap = record.aspace_cap;
-    record.reclaim_frames_in(region.va_base, end, aspace_cap, pool);
+    // Tear down the whole region span in the child AS in one call: clear every
+    // leaf PTE and reclaim the now-empty intermediate page tables to the child's
+    // PT growth pool (one coarse shootdown). Done before re-pooling the backing
+    // frames so no frame is re-handed to a future fault before its PTE clears.
+    let _ = syscall::mem_unmap_reclaim(aspace_cap, region.va_base, region.len / PAGE_SIZE);
+    record.return_frames_in(region.va_base, end, pool);
     // Restore contiguity across the reclaimed runs. The per-frame
     // `push_or_coalesce` only fires `coalesce` under slot pressure, so a churn
     // working set that never fills the array would otherwise leave the pool more

--- a/shared/syscall/src/lib.rs
+++ b/shared/syscall/src/lib.rs
@@ -39,19 +39,20 @@ extern crate rustc_std_workspace_core as core;
 use core::prelude::rust_2024::*;
 
 use syscall_abi::{
-    MSG_CAP_SLOTS_MAX, MSG_DATA_WORDS_MAX, SYS_ASPACE_BIND_NOTIFICATION, SYS_ASPACE_QUERY,
-    SYS_CAP_COPY, SYS_CAP_CREATE_ASPACE, SYS_CAP_CREATE_CSPACE, SYS_CAP_CREATE_ENDPOINT,
-    SYS_CAP_CREATE_EVENT_Q, SYS_CAP_CREATE_NOTIFICATION, SYS_CAP_CREATE_THREAD,
-    SYS_CAP_CREATE_WAIT_SET, SYS_CAP_DELETE, SYS_CAP_DERIVE, SYS_CAP_DERIVE_BADGE, SYS_CAP_INFO,
-    SYS_CAP_MOVE, SYS_CAP_REVOKE, SYS_EVENT_POST, SYS_EVENT_RECV, SYS_IOPORT_BIND,
-    SYS_IOPORT_SPLIT, SYS_IPC_BUFFER_SET, SYS_IPC_CALL, SYS_IPC_RECV, SYS_IPC_REPLY, SYS_IRQ_ACK,
-    SYS_IRQ_REGISTER, SYS_IRQ_SPLIT, SYS_MEM_MAP, SYS_MEM_PROTECT, SYS_MEM_UNMAP, SYS_MEMORY_MERGE,
-    SYS_MEMORY_SPLIT, SYS_MMIO_MAP, SYS_MMIO_SPLIT, SYS_NOTIFICATION_SEND, SYS_NOTIFICATION_WAIT,
-    SYS_SBI_CALL, SYS_SCHED_SPLIT, SYS_SYSTEM_INFO, SYS_THREAD_BIND_NOTIFICATION,
-    SYS_THREAD_CONFIGURE, SYS_THREAD_EXIT, SYS_THREAD_READ_REGS, SYS_THREAD_SET_AFFINITY,
-    SYS_THREAD_SET_FAULT_HANDLER, SYS_THREAD_SET_PRIORITY, SYS_THREAD_SLEEP, SYS_THREAD_START,
-    SYS_THREAD_STOP, SYS_THREAD_WRITE_REGS, SYS_THREAD_YIELD, SYS_WAIT_SET_ADD,
-    SYS_WAIT_SET_REMOVE, SYS_WAIT_SET_WAIT,
+    MEM_UNMAP_RECLAIM_PTS, MSG_CAP_SLOTS_MAX, MSG_DATA_WORDS_MAX, SYS_ASPACE_BIND_NOTIFICATION,
+    SYS_ASPACE_QUERY, SYS_CAP_COPY, SYS_CAP_CREATE_ASPACE, SYS_CAP_CREATE_CSPACE,
+    SYS_CAP_CREATE_ENDPOINT, SYS_CAP_CREATE_EVENT_Q, SYS_CAP_CREATE_NOTIFICATION,
+    SYS_CAP_CREATE_THREAD, SYS_CAP_CREATE_WAIT_SET, SYS_CAP_DELETE, SYS_CAP_DERIVE,
+    SYS_CAP_DERIVE_BADGE, SYS_CAP_INFO, SYS_CAP_MOVE, SYS_CAP_REVOKE, SYS_EVENT_POST,
+    SYS_EVENT_RECV, SYS_IOPORT_BIND, SYS_IOPORT_SPLIT, SYS_IPC_BUFFER_SET, SYS_IPC_CALL,
+    SYS_IPC_RECV, SYS_IPC_REPLY, SYS_IRQ_ACK, SYS_IRQ_REGISTER, SYS_IRQ_SPLIT, SYS_MEM_MAP,
+    SYS_MEM_PROTECT, SYS_MEM_UNMAP, SYS_MEMORY_MERGE, SYS_MEMORY_SPLIT, SYS_MMIO_MAP,
+    SYS_MMIO_SPLIT, SYS_NOTIFICATION_SEND, SYS_NOTIFICATION_WAIT, SYS_SBI_CALL, SYS_SCHED_SPLIT,
+    SYS_SYSTEM_INFO, SYS_THREAD_BIND_NOTIFICATION, SYS_THREAD_CONFIGURE, SYS_THREAD_EXIT,
+    SYS_THREAD_READ_REGS, SYS_THREAD_SET_AFFINITY, SYS_THREAD_SET_FAULT_HANDLER,
+    SYS_THREAD_SET_PRIORITY, SYS_THREAD_SLEEP, SYS_THREAD_START, SYS_THREAD_STOP,
+    SYS_THREAD_WRITE_REGS, SYS_THREAD_YIELD, SYS_WAIT_SET_ADD, SYS_WAIT_SET_REMOVE,
+    SYS_WAIT_SET_WAIT,
 };
 
 pub use syscall_abi::{
@@ -957,6 +958,10 @@ pub fn mem_map(
 
 /// Remove `page_count` mappings starting at `virt` from `aspace_cap`.
 ///
+/// Clears leaf PTEs only; intermediate page tables persist until the address
+/// space is destroyed. To also reclaim now-empty intermediate tables to the
+/// page-table growth pool, use [`mem_unmap_reclaim`].
+///
 /// Unmapping a page that is not mapped is a no-op (not an error).
 /// `virt` must be page-aligned and in the user address range.
 ///
@@ -966,9 +971,38 @@ pub fn mem_map(
 #[inline]
 pub fn mem_unmap(aspace_cap: u32, virt: u64, page_count: u64) -> Result<(), i64>
 {
-    // SAFETY: syscall3 issues raw syscall instruction; all arguments are scalar u64 values
-    // (cap index, virtual address, page count); kernel validates cap and unmaps pages.
-    let ret = unsafe { syscall3(SYS_MEM_UNMAP, u64::from(aspace_cap), virt, page_count) };
+    // SAFETY: syscall4 issues raw syscall instruction; all arguments are scalar u64 values
+    // (cap index, virtual address, page count, flags=0); kernel validates cap and unmaps pages.
+    // arg3 is passed explicitly so it is never an uninitialised register (the flag path keys on it).
+    let ret = unsafe { syscall4(SYS_MEM_UNMAP, u64::from(aspace_cap), virt, page_count, 0) };
+    if ret < 0 { Err(ret) } else { Ok(()) }
+}
+
+/// Like [`mem_unmap`], but additionally reclaims every intermediate page table
+/// the cleared span leaves empty back to `aspace_cap`'s page-table growth pool
+/// (crediting `pt_growth_budget_bytes`), with a single coarse TLB +
+/// paging-structure-cache shootdown for the whole teardown.
+///
+/// Intended for region teardown (memmgr `UNREGISTER_REGION`): pass the whole
+/// region span in one call so a wholly-covered intermediate table is reclaimed.
+///
+/// # Errors
+/// Returns a negative `i64` error code if the cap is invalid or `virt` is
+/// not page-aligned.
+#[inline]
+pub fn mem_unmap_reclaim(aspace_cap: u32, virt: u64, page_count: u64) -> Result<(), i64>
+{
+    // SAFETY: syscall4 issues raw syscall instruction; all arguments are scalar u64 values
+    // (cap index, virtual address, page count, reclaim flag); kernel validates cap and unmaps pages.
+    let ret = unsafe {
+        syscall4(
+            SYS_MEM_UNMAP,
+            u64::from(aspace_cap),
+            virt,
+            page_count,
+            MEM_UNMAP_RECLAIM_PTS,
+        )
+    };
     if ret < 0 { Err(ret) } else { Ok(()) }
 }
 


### PR DESCRIPTION
## Summary

Closes #273.

A process's per-`AddressSpace` page-table growth pool was debited as demand pages faulted in but never credited until address-space death: the intermediate page tables backing a region were not reclaimed on unmap. A process holding many distinct-VA demand regions concurrently (e.g. many live demand-paged thread stacks) grew its PT pool by the peak working set and held that RAM until it died.

This adds an **opt-in** pool-reclaiming mode to `SYS_MEM_UNMAP` (`MEM_UNMAP_RECLAIM_PTS`), driven once per region from memmgr's `UNREGISTER_REGION`. The reclaim walk clears every leaf in the freed span and returns each now-empty, aso-owned intermediate page table to the per-AS pool (crediting `pt_growth_budget_bytes`), with **one coarse TLB + paging-structure-cache shootdown** per teardown, performed **under `pt_lock`** so a freed PT frame cannot be popped and reused before every CPU is coherent.

## Acceptance

(verbatim from #273; each satisfied by this PR)

- [x] Unmapping a demand region returns its now-empty intermediate PTs to the per-AS pool and credits `pt_growth_budget_bytes` (verify via `CAP_INFO_ASPACE_PT_BUDGET`) — `ktest retype::region_unmap_reclaims_pt_budget` (budget round-trips exactly on reclaim; same-VA remap reuses the returned pages).
- [x] A map/unmap/remap-same-VA-across-CPUs stress test shows no stale-PT corruption on x86_64 and riscv64 — `ktest integration::tlb_coherency` gains a second phase using `mem_unmap_reclaim` (coarse under-`pt_lock` shootdown) with a cross-CPU sentinel integrity check; 100 cycles/phase, both arches.
- [x] Peak PT-pool RAM after a burst of concurrent demand regions is released when the regions are unmapped, not held until process death — `ktest retype::concurrent_regions_release_pt_budget_on_unmap` (6 concurrent regions; budget recovers to baseline after reclaiming-unmap).

## Test plan

- [x] `cargo xtask build` (x86_64)
- [x] `cargo xtask run` (x86_64, ktest harness) — **184 passed / 0 failed**, `ALL TESTS PASSED`
- [x] `cargo xtask build --arch riscv64`
- [x] `cargo xtask run --arch riscv64` (ktest harness) — **184 passed / 0 failed**, `ALL TESTS PASSED`
- [x] additional component-specific checks: usertest tier (`run-parallel`, init bundle) on riscv64 → `[usertest] ALL TESTS PASSED` (end-to-end demand-stack teardown via threadstack/threadchurn through the changed memmgr `UNREGISTER_REGION`); `cargo xtask test` (host-side) pass. CI green across the full matrix (x86_64 + riscv64 × debug + release × ktest/svctest/usertest).

## Changes

- **abi**: `MEM_UNMAP_RECLAIM_PTS`; `mem_unmap` → `syscall4(.., 0)` (so `arg3` is never an uninitialised register; audited as the sole `SYS_MEM_UNMAP` issuer); new `mem_unmap_reclaim`.
- **kernel**: `AddressSpace::unmap_region_pooled`; arch `unmap_user_region_pooled` (x86_64 + riscv64, identical structure); `AddressSpaceObject::owns_phys`; `free_pt_page` un-dead; `sys_mem_unmap` flag branch.
- **memmgr**: `UNREGISTER_REGION` issues one region-granular `mem_unmap_reclaim`, then re-pools backing frames (`return_frames_in`).
- **docs**: `capability-model` growth-budgets + memmgr `ipc-interface` `UNREGISTER_REGION` document mid-life reclaim.

## Notes

Deviations from #273's literal approach, each a deliberate design choice (not a scope reduction):

- **Emptiness gate, not "wholly inside the freed span"**: a demand stack's usable base is never 2 MiB-aligned (one-page guard offset), so span-containment would reclaim nothing. Emptiness is equally safe and reclaims boundary tables once their last sharer is torn down.
- **Opt-in flag, not a new syscall**: keeps the ~30 surgical single-page `mem_unmap` callers on the unchanged per-VA path. (Master's #302 took syscall number 54 for `SYS_PROCESS_EXIT` while this was in flight — a new syscall would have collided.)
- **Coarse full-flush shootdown** (`virt = u64::MAX`): no shootdown-protocol change; robust to the cross-AS tag case (memmgr unmaps the child's AS). A true ranged shootdown is a possible future optimization.

Pre-merge review fix (commit `fa8a886`): `unmap_region_pooled` now bumps `tlb_gen` + fences **before** snapshotting `active_cpus` (INV-3 Dekker order, matching `shootdown_remote`); the first cut inverted it.
