### PR TITLE
fix(xtask): prune sysroot files deleted from rootfs/ (authoritative mirror)

### DIFF
--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -229,7 +229,11 @@ The `esp/` and root-partition trees are populated from two sources:
   binaries and per-program testers).
 - Static files in [`rootfs/`](../rootfs/) are mirrored directly into
   the sysroot — every file's path under `rootfs/` is its path under
-  `sysroot/` (see [`rootfs/README.md`](../rootfs/README.md)).
+  `sysroot/`. The mirror is authoritative over the subtrees it owns
+  (`config/`, `data/`): files deleted from `rootfs/` are pruned from the
+  sysroot on the next build, while the installed binaries above and the
+  synthesised `data/svctest/` fixtures are left untouched (see
+  [`rootfs/README.md`](../rootfs/README.md)).
 
 The disk image is assembled by xtask after the sysroot is populated. Cargo's
 own `target/` directory contains intermediate compilation artifacts and is

--- a/rootfs/README.md
+++ b/rootfs/README.md
@@ -2,7 +2,11 @@
 
 Static source files mirrored into the sysroot during `cargo xtask build`. Every
 file's path under `rootfs/` becomes its path under `sysroot/`; no rename or
-remap table is involved.
+remap table is involved. The mirror is authoritative over the subtrees it owns
+(`config/`, `data/`): a file deleted from `rootfs/` is removed from the sysroot
+(and the disk image) on the next `cargo xtask build` or `mkdisk`. Build-installed
+binaries and the synthesised `data/svctest/` fixtures live in the sysroot but
+outside `rootfs/`, and are never pruned.
 
 This directory holds the non-binary parts of the runtime image: boot
 configuration, system configuration, and pre-populated data files for
@@ -36,8 +40,9 @@ hand-authored counterpart under `rootfs/`. There is no `boot.conf`
 vfsd, plus automatic `/esp` mount).
 
 To add a new static file, place it under the path it should occupy in the
-sysroot. The build will pick it up automatically — `README.md` files are the
-only excluded names.
+sysroot; the build picks it up automatically. Removing a file here removes it
+from the sysroot on the next build. `README.md` files are the only excluded
+names.
 
 For the sysroot layout this tree contributes to, see
 [`docs/build-system.md`](../docs/build-system.md). The implementation that

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -88,12 +88,20 @@ Default firmware search paths per host:
 
 Re-mirror `rootfs/` into `sysroot/`, re-synthesise test fixtures, and
 regenerate `disk.img` without invoking cargo. Use after editing
-`rootfs/` or the sysroot directly (e.g. staging a test recipe by
-copying it from `sysroot/config/svcmgr/tests/` into
-`sysroot/config/svcmgr/services/`) to refresh the boot image without
-paying for a full `cargo xtask build` (which would also run cargo
-fmt + clippy + check + binary install). Requires a populated,
-arch-tagged sysroot from a prior `cargo xtask build`.
+`rootfs/` to refresh the boot image without paying for a full
+`cargo xtask build` (which would also run cargo fmt + clippy + check +
+binary install). Requires a populated, arch-tagged sysroot from a prior
+`cargo xtask build`.
+
+The mirror is authoritative over the rootfs-managed subtrees (`config/`,
+`data/`): files deleted from `rootfs/` are pruned from the sysroot, while
+build-owned trees (`esp/`, `services/`, `programs/`, `tests/`) and the
+synthesised `data/svctest/` fixtures are left untouched. To pack a
+hand-staged sysroot that diverges from `rootfs/` — e.g. a test recipe
+copied from `sysroot/config/svcmgr/tests/` into
+`sysroot/config/svcmgr/services/` — use `--repack-only`, which skips the
+re-mirror and packs the sysroot exactly as it stands (a plain repack would
+prune the hand-added recipe).
 
 `mkdisk` does **not** author `sysroot/EFI/seraph/bootstrap.bundle` — it
 fails if the bundle is missing. The bundle is composed by
@@ -113,18 +121,20 @@ uses the partition.) This applies to `build`, `mkdisk`, and
 `compose-bundle` alike.
 
 ```
-cargo xtask mkdisk [--arch x86_64|riscv64]
+cargo xtask mkdisk [--arch x86_64|riscv64] [--repack-only]
 ```
 
 | Option | Default | Description |
 |---|---|---|
 | `--arch` | `x86_64` | Target architecture — must match the existing sysroot's arch tag |
+| `--repack-only` | `false` | Skip the `rootfs/` re-mirror and pack the sysroot as it stands — preserves a hand-staged service set the authoritative mirror would otherwise reconcile |
 
-Example — stage `svctest` and run it:
+Example — stage `svctest` and run it (`--repack-only` keeps the hand-added
+recipe; a plain repack would prune it):
 
 ```sh
 cp sysroot/config/svcmgr/tests/svctest.svc sysroot/config/svcmgr/services/
-cargo xtask mkdisk --arch x86_64
+cargo xtask mkdisk --repack-only --arch x86_64
 cargo xtask run --arch x86_64
 ```
 

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -48,10 +48,10 @@ pub enum CliCommand
     RunParallel(RunParallelArgs),
 
     /// Mirror `rootfs/` into the sysroot, re-synthesise test fixtures,
-    /// and regenerate `disk.img` without invoking cargo. Used to refresh
-    /// the boot image after `rootfs/` or sysroot files were edited
-    /// outside the cargo flow (e.g. staging a test recipe). Requires an
-    /// arch-tagged sysroot from a prior `cargo xtask build`.
+    /// and regenerate `disk.img` without invoking cargo. The mirror is
+    /// authoritative over `config/`+`data/` (deletions in `rootfs/` are
+    /// pruned); use `--repack-only` to pack a hand-staged sysroot verbatim.
+    /// Requires an arch-tagged sysroot from a prior `cargo xtask build`.
     Mkdisk(MkdiskArgs),
 
     /// Compose `sysroot/esp/EFI/seraph/bootstrap.bundle` from
@@ -190,8 +190,9 @@ pub struct MkdiskArgs
 
     /// Repack `disk.img` from the sysroot exactly as it is, skipping the
     /// `rootfs/` re-mirror. Use after editing the staged sysroot directly
-    /// (e.g. adding a test recipe and removing a default one) when the
-    /// additive re-mirror would otherwise restore the removed file.
+    /// (e.g. adding a test recipe or removing a default one): a normal
+    /// re-mirror is authoritative and would restore `rootfs/`-present recipes
+    /// and prune `rootfs/`-absent ones, undoing the manual staging.
     #[arg(long)]
     pub repack_only: bool,
 }

--- a/xtask/src/commands/mkdisk.rs
+++ b/xtask/src/commands/mkdisk.rs
@@ -5,16 +5,18 @@
 //!
 //! Mkdisk command: re-mirror `rootfs/` into `sysroot/`, re-synthesise
 //! test fixtures, and regenerate `disk.img` without invoking cargo.
-//! Used to refresh the boot image after `rootfs/` or sysroot files
-//! were edited outside the cargo flow (notably: staging a test recipe
-//! by copying it from `sysroot/config/svcmgr/tests/` into
-//! `sysroot/config/svcmgr/services/`).
+//! Used to refresh the boot image after `rootfs/` or sysroot files were
+//! edited outside the cargo flow. Hand-staging a test recipe (copying it
+//! from `sysroot/config/svcmgr/tests/` into `sysroot/config/svcmgr/services/`)
+//! requires `--repack-only`, since a normal re-mirror is authoritative and
+//! would prune the hand-added file.
 //!
 //! `--repack-only` skips the `rootfs/` re-mirror and packs the sysroot as it
-//! stands. The mirror is additive (it copies rootfs files over the sysroot but
-//! never deletes), so a default recipe removed from the staged sysroot would be
-//! restored by a normal repack; `--repack-only` lets a test boot compose an
-//! exact service set by removing such a recipe and packing without the restore.
+//! stands. A normal re-mirror is authoritative over the rootfs-managed subtrees
+//! (`config/`, `data/`): it restores recipes that exist in `rootfs/` and removes
+//! sysroot ones that do not. `--repack-only` lets a test boot compose a service
+//! set that diverges from `rootfs/` — e.g. a default recipe removed, or a test
+//! recipe hand-staged — by packing the staged sysroot without that pass.
 
 use anyhow::Result;
 

--- a/xtask/src/sysroot.rs
+++ b/xtask/src/sysroot.rs
@@ -313,4 +313,49 @@ mod tests
         prune_stale(&roots, &HashSet::new()).unwrap();
         fs::remove_dir_all(&sysroot).unwrap();
     }
+
+    /// End-to-end: `install_rootfs` mirrors `rootfs/`, synthesises the fixtures,
+    /// and prunes a stale sysroot recipe while leaving a build-owned binary
+    /// untouched. Covers `ROOTFS_MANAGED_ROOTS` and the keep-set construction —
+    /// the pieces that make the prune safe — which the `prune_stale` unit tests,
+    /// rebuilding roots and keep by hand, do not.
+    #[test]
+    fn install_rootfs_mirrors_synthesises_and_prunes()
+    {
+        let base = scratch("install");
+        let root = base.join("root");
+        let sysroot = base.join("sysroot");
+
+        // Source rootfs/: one default recipe and one data file.
+        let rootfs_services = root.join("rootfs/config/svcmgr/services");
+        fs::create_dir_all(&rootfs_services).unwrap();
+        fs::write(rootfs_services.join("procmgr.svc"), b"binary = /services/procmgr\n").unwrap();
+        fs::create_dir_all(root.join("rootfs/data")).unwrap();
+        fs::write(root.join("rootfs/data/test.txt"), b"marker").unwrap();
+
+        // Pre-existing sysroot: a stale recipe under a managed root (no rootfs
+        // source) and a build-owned binary outside the managed roots.
+        let sys_services = sysroot.join("config/svcmgr/services");
+        fs::create_dir_all(&sys_services).unwrap();
+        fs::write(sys_services.join("stale.svc"), b"binary = /services/stale\n").unwrap();
+        let bin_dir = sysroot.join("services");
+        fs::create_dir_all(&bin_dir).unwrap();
+        fs::write(bin_dir.join("procmgr"), b"\x7fELF").unwrap();
+
+        let ctx = BuildContext {
+            root: root.clone(),
+            sysroot: sysroot.clone(),
+            target_dir: base.join("target"),
+        };
+        install_rootfs(&ctx).unwrap();
+
+        assert!(sys_services.join("procmgr.svc").exists(), "rootfs recipe mirrored");
+        assert!(sysroot.join("data/test.txt").exists(), "rootfs data file mirrored");
+        assert!(sysroot.join("data/svctest/large.bin").exists(), "large fixture kept");
+        assert!(sysroot.join("data/svctest/bench.bin").exists(), "bench fixture kept");
+        assert!(!sys_services.join("stale.svc").exists(), "stale recipe pruned");
+        assert!(bin_dir.join("procmgr").exists(), "build-owned binary untouched");
+
+        fs::remove_dir_all(&base).unwrap();
+    }
 }

--- a/xtask/src/sysroot.rs
+++ b/xtask/src/sysroot.rs
@@ -10,8 +10,9 @@
 //! recorded in `sysroot/.arch`. Switching architectures requires `cargo xtask
 //! clean` first to avoid mixing binaries.
 
+use std::collections::HashSet;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
 
@@ -53,12 +54,26 @@ pub fn record_arch(ctx: &BuildContext, arch: Arch) -> Result<()>
     Ok(())
 }
 
-/// Mirror `rootfs/` into the sysroot, skipping README.md.
+/// Top-level sysroot subtrees the rootfs mirror owns exclusively: rootfs static
+/// files plus the synthesised `data/svctest/` fixtures. The prune pass is
+/// authoritative over these and only these. Build-owned trees (`esp/`,
+/// `services/`, `programs/`, `tests/`) and metadata (`.arch`, `NvVars`) are
+/// deliberately absent, so a scoping mistake cannot delete a binary.
+const ROOTFS_MANAGED_ROOTS: &[&str] = &["config", "data"];
+
+/// Mirror `rootfs/` into the sysroot (skipping README.md), then make the mirror
+/// authoritative over [`ROOTFS_MANAGED_ROOTS`].
 ///
 /// Each file's destination directory is created as needed. Files are processed
 /// in sorted order for deterministic output. To add a new sysroot file, place
 /// it under `rootfs/` at the path it should appear in the sysroot — no build
 /// changes required.
+///
+/// After copying, files under the managed roots with no `rootfs/` source (nor a
+/// synthesised-fixture origin) are removed, so deleting a file from `rootfs/` is
+/// reflected in the sysroot and the disk image on the next build. Build-owned
+/// subtrees are never touched. `mkdisk --repack-only` bypasses this whole step
+/// to pack a hand-staged sysroot verbatim.
 pub fn install_rootfs(ctx: &BuildContext) -> Result<()>
 {
     let src_root = ctx.root.join("rootfs");
@@ -69,6 +84,8 @@ pub fn install_rootfs(ctx: &BuildContext) -> Result<()>
 
     let mut files = collect_files(&src_root)?;
     files.sort();
+
+    let mut keep: HashSet<PathBuf> = HashSet::new();
 
     for src in files
     {
@@ -89,10 +106,17 @@ pub fn install_rootfs(ctx: &BuildContext) -> Result<()>
         fs::copy(&src, &dst)
             .with_context(|| format!("copying {} -> {}", src.display(), dst.display()))?;
         step(&format!("Rootfs: {}", dst.display()));
+        keep.insert(dst);
     }
 
-    synthesise_svctest_large_bin(ctx)?;
-    synthesise_svctest_bench_bin(ctx)?;
+    keep.insert(synthesise_svctest_large_bin(ctx)?);
+    keep.insert(synthesise_svctest_bench_bin(ctx)?);
+
+    let roots: Vec<PathBuf> = ROOTFS_MANAGED_ROOTS
+        .iter()
+        .map(|r| ctx.sysroot.join(r))
+        .collect();
+    prune_stale(&roots, &keep)?;
 
     Ok(())
 }
@@ -106,13 +130,14 @@ const SVCTEST_LARGE_BIN_PAGE_SIZE: usize = 4096;
 /// page index. The phase asserts the first 8 bytes equal `PAGE_00_` to
 /// confirm content integrity across the FS_READ_FRAME / mem_map /
 /// release sequence. Treated as a build artifact (synthesised here, not
-/// shipped in `rootfs/`).
-fn synthesise_svctest_large_bin(ctx: &BuildContext) -> Result<()>
+/// shipped in `rootfs/`). Returns the destination path so `install_rootfs`
+/// keeps it through the prune pass.
+fn synthesise_svctest_large_bin(ctx: &BuildContext) -> Result<PathBuf>
 {
     let dst = ctx.sysroot.join("data/svctest/large.bin");
     if dst.exists()
     {
-        return Ok(());
+        return Ok(dst);
     }
     if let Some(parent) = dst.parent()
     {
@@ -134,7 +159,7 @@ fn synthesise_svctest_large_bin(ctx: &BuildContext) -> Result<()>
     buf.truncate(total);
     fs::write(&dst, &buf).with_context(|| format!("writing {}", dst.display()))?;
     step(&format!("Rootfs: {} (synthesised, 16 KiB)", dst.display()));
-    Ok(())
+    Ok(dst)
 }
 
 const SVCTEST_BENCH_BIN_SIZE: usize = 65536;
@@ -144,12 +169,13 @@ const SVCTEST_BENCH_BIN_SIZE: usize = 65536;
 /// benchmark). Filled with a byte-position-derived pattern so any
 /// read-path corruption shows up as a content mismatch at the byte
 /// level. Treated as a build artifact, same pattern as `large.bin`.
-fn synthesise_svctest_bench_bin(ctx: &BuildContext) -> Result<()>
+/// Returns the destination path (kept through the prune pass).
+fn synthesise_svctest_bench_bin(ctx: &BuildContext) -> Result<PathBuf>
 {
     let dst = ctx.sysroot.join("data/svctest/bench.bin");
     if dst.exists()
     {
-        return Ok(());
+        return Ok(dst);
     }
     if let Some(parent) = dst.parent()
     {
@@ -164,6 +190,30 @@ fn synthesise_svctest_bench_bin(ctx: &BuildContext) -> Result<()>
     }
     fs::write(&dst, &buf).with_context(|| format!("writing {}", dst.display()))?;
     step(&format!("Rootfs: {} (synthesised, 64 KiB)", dst.display()));
+    Ok(dst)
+}
+
+/// Make the rootfs mirror authoritative over `roots`: remove every regular file
+/// under each root that is not in `keep`. Directories are left in place — an
+/// empty `/config/svcmgr/services` is valid (svcmgr reads it at boot) and the
+/// disk packer recreates directories as needed. A non-existent root is skipped.
+fn prune_stale(roots: &[PathBuf], keep: &HashSet<PathBuf>) -> Result<()>
+{
+    for root in roots
+    {
+        if !root.exists()
+        {
+            continue;
+        }
+        for f in collect_files(root)?
+        {
+            if !keep.contains(&f)
+            {
+                fs::remove_file(&f).with_context(|| format!("pruning {}", f.display()))?;
+                step(&format!("Rootfs: pruned {}", f.display()));
+            }
+        }
+    }
     Ok(())
 }
 
@@ -186,4 +236,81 @@ fn collect_files(dir: &Path) -> Result<Vec<std::path::PathBuf>>
         }
     }
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests
+{
+    use super::*;
+
+    /// Create a unique scratch directory under the system temp dir.
+    fn scratch(tag: &str) -> PathBuf
+    {
+        let p = std::env::temp_dir().join(format!(
+            "seraph-{tag}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    /// `prune_stale` deletes files with no source, keeps those in `keep`
+    /// (including a synthesised fixture under `data/`), and never touches a
+    /// build-owned tree that sits outside the managed roots.
+    #[test]
+    fn prune_stale_removes_unkept_spares_kept_and_unmanaged()
+    {
+        let sysroot = scratch("prune");
+
+        let services = sysroot.join("config/svcmgr/services");
+        let tests_dir = sysroot.join("config/svcmgr/tests");
+        let data_fix = sysroot.join("data/svctest");
+        let build_tree = sysroot.join("services");
+        for d in [&services, &tests_dir, &data_fix, &build_tree]
+        {
+            fs::create_dir_all(d).unwrap();
+        }
+
+        let kept = services.join("a.svc");
+        let stale = services.join("b.svc");
+        let stale_test = tests_dir.join("c.svc");
+        let synth = data_fix.join("large.bin");
+        let binary = build_tree.join("init");
+        for f in [&kept, &stale, &stale_test, &synth, &binary]
+        {
+            fs::write(f, b"x").unwrap();
+        }
+
+        let mut keep = HashSet::new();
+        keep.insert(kept.clone());
+        keep.insert(synth.clone());
+
+        let roots = vec![sysroot.join("config"), sysroot.join("data")];
+        prune_stale(&roots, &keep).unwrap();
+
+        assert!(kept.exists(), "recipe in keep survives");
+        assert!(synth.exists(), "synth fixture in keep survives");
+        assert!(binary.exists(), "binary outside managed roots untouched");
+        assert!(!stale.exists(), "stale recipe pruned");
+        assert!(
+            !stale_test.exists(),
+            "stale recipe in sibling subtree pruned"
+        );
+
+        fs::remove_dir_all(&sysroot).unwrap();
+    }
+
+    /// A managed root that does not exist on disk is skipped without error.
+    #[test]
+    fn prune_stale_skips_missing_root()
+    {
+        let sysroot = scratch("prune-missing");
+        let roots = vec![sysroot.join("config")];
+        prune_stale(&roots, &HashSet::new()).unwrap();
+        fs::remove_dir_all(&sysroot).unwrap();
+    }
 }


### PR DESCRIPTION
## Summary

`install_rootfs` (`xtask/src/sysroot.rs`) mirrored `rootfs/` into the sysroot
additively — it never removed sysroot entries whose `rootfs/` source was
deleted. On an incremental build (no `cargo xtask clean`) a `*.svc` deleted from
`rootfs/config/svcmgr/services/` lingered and svcmgr auto-started it at boot
(this wedged the boot in #310 while the diff looked correct). This makes the
rootfs mirror authoritative over the subtrees it owns (`config/`, `data/`):
files with no `rootfs/` source (nor a synthesised-fixture origin) are pruned,
while build-owned trees and the `data/svctest/` fixtures are never touched.
`mkdisk --repack-only` still bypasses the mirror to pack a hand-staged service
set verbatim.

Closes #311

## Acceptance

Issue #311 has no explicit Acceptance section; derived from its Summary /
Suggested fix:

- [x] Files deleted from `rootfs/` are pruned from the sysroot (and `disk.img`) on incremental `cargo xtask build` / `mkdisk` — no stale `*.svc` lingers under `config/svcmgr/services/`.
- [x] Pruning is scoped to the rootfs-managed subtrees (`config/`, `data/`); build-owned trees (`esp/`, `services/`, `programs/`, `tests/`) and the synthesised `data/svctest/{large,bench}.bin` fixtures are never removed.
- [x] `mkdisk --repack-only` (and `compose-bundle`) continue to bypass the mirror, preserving a hand-staged service set.

## Test plan

- [x] `cargo xtask build` (x86_64)
- [x] `cargo xtask run` (x86_64), terminal pass marker observed — svctest boot via `run-parallel`: `[svctest] ALL TESTS PASSED` (pass=1)
- [x] `cargo xtask build --arch riscv64`
- [x] `cargo xtask run --arch riscv64`, terminal pass marker observed — svctest boot via `run-parallel`: `[svctest] ALL TESTS PASSED` (pass=1)
- [x] additional component-specific checks:
  - `cargo xtask test` — new unit tests `prune_stale_removes_unkept_spares_kept_and_unmanaged` and `prune_stale_skips_missing_root` pass.
  - Prune regression (file-level): injected a stale `config/svcmgr/services/stale.svc` + `data/stale.txt`; plain `cargo xtask mkdisk` pruned both (`Rootfs: pruned …`) while keeping all default recipes, test recipes, `data/test.txt`, the synth fixtures, and the binary trees.
  - Escape hatch: `cargo xtask mkdisk --repack-only` kept a hand-staged `stale.svc`.

## Notes

- Behavior change: hand-staging a recipe into the sysroot and running a **plain**
  `mkdisk`/`build` now prunes it. The documented staging workflow moves to
  `mkdisk --repack-only` (xtask/README.md, mkdisk.rs / cli.rs doc-comments,
  rootfs/README.md, docs/build-system.md updated to the authoritative contract).
- CI is unaffected: the `validate` job stages svctest/usertest via
  `--repack-only` (bypasses the prune), and the usertest cell's plain `mkdisk`
  runs after `rm usertest.svc`, so the authoritative re-mirror yields the same
  result as before (terminal restored, usertest absent).
- Scope decision: managed roots are an explicit allowlist (`["config","data"]`),
  not derived from `rootfs/` contents, so the destructive pass can never reach a
  binary tree. No empty-directory removal (svcmgr `read_dir` tolerates an empty
  scan dir but not a missing one; the packer recreates dirs).