### PR TITLE
xtask: gate host crates under workspace clippy deny-lints

### DIFF
--- a/xtask/src/accel.rs
+++ b/xtask/src/accel.rs
@@ -11,12 +11,12 @@
 //! (`SERAPH_ACCEL`), then per-`cfg(target_os)` detection, then a TCG
 //! fallback for hosts without a registered native accelerator.
 //!
-//! Scope: cross-architecture emulation (e.g. riscv64 guest on x86_64
+//! Scope: cross-architecture emulation (e.g. riscv64 guest on `x86_64`
 //! host) only ever has TCG available; this module's detection routines
 //! report the *host's* native accelerator, and a guest of a different
 //! arch is resolved to `Tcg` via `detect_for_arch`. The current Seraph
-//! launch flow uses native acceleration only for x86_64 guests on
-//! x86_64 hosts; everything else (riscv64 guest on any host, x86_64
+//! launch flow uses native acceleration only for `x86_64` guests on
+//! `x86_64` hosts; everything else (riscv64 guest on any host, `x86_64`
 //! guest on a non-x86_64 host) uses TCG.
 //!
 //! Env var:
@@ -27,7 +27,7 @@
 //!   to detection so a typo doesn't silently miss-accelerate.
 //!
 //! Cross-arch precedence: when the guest arch doesn't match the host
-//! arch (e.g. riscv64 guest on x86_64 host), native acceleration is
+//! arch (e.g. riscv64 guest on `x86_64` host), native acceleration is
 //! impossible and the result is always `Tcg`. If the user also set
 //! `SERAPH_ACCEL` to something other than `tcg`/`auto`, a stderr
 //! warning is emitted so the silent downgrade is visible.

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -310,7 +310,7 @@ pub struct RunParallelArgs
     pub fail: String,
 
     /// Grace window, in seconds, after the first `--fail` match before the
-    /// run is SIGKILLed. A kernel fault dump is multi-line and may be
+    /// run is `SIGKILLed`. A kernel fault dump is multi-line and may be
     /// followed by secondary-CPU faults; killing on the first matching byte
     /// truncates the diagnostics. The run is killed at whichever is first:
     /// this window, or the `--timeout` deadline. 0 kills on the next poll

--- a/xtask/src/commands/build.rs
+++ b/xtask/src/commands/build.rs
@@ -446,6 +446,7 @@ pub fn run(ctx: &BuildContext, args: &BuildArgs) -> Result<()>
     if !args.skip_lints
     {
         fmt_workspace(ctx)?;
+        clippy_host(ctx)?;
     }
 
     match args.component
@@ -519,60 +520,57 @@ fn build_boot(ctx: &BuildContext, args: &BuildArgs) -> Result<()>
     fs::create_dir_all(&efi_seraph_dir)
         .with_context(|| format!("creating {}", efi_seraph_dir.display()))?;
 
-    match args.arch
+    if args.arch == Arch::Riscv64
     {
-        Arch::Riscv64 =>
+        // RISC-V: cargo produces an ELF; convert to a flat PE32+ binary via
+        // llvm-objcopy. The UEFI spec requires a PE32+ image on disk.
+        let elf_out = ctx.cargo_output_dir(boot_triple, args.release).join("boot");
+        if !elf_out.exists()
         {
-            // RISC-V: cargo produces an ELF; convert to a flat PE32+ binary via
-            // llvm-objcopy. The UEFI spec requires a PE32+ image on disk.
-            let elf_out = ctx.cargo_output_dir(boot_triple, args.release).join("boot");
-            if !elf_out.exists()
-            {
-                bail!("expected ELF output not found: {}", elf_out.display());
-            }
-
-            let objcopy = find_llvm_objcopy()?;
-            let dst_boot = efi_seraph_dir.join("boot.efi");
-            run_cmd(
-                Command::new(&objcopy)
-                    .args(["-O", "binary"])
-                    .arg(&elf_out)
-                    .arg(&dst_boot),
-            )?;
-            let dst_efi = efi_boot_dir.join(efi_name);
-            copy_file(&dst_boot, &dst_efi)?;
-
-            step(&format!(
-                "Bootloader: {} (ELF → flat binary)",
-                efi_seraph_dir.join("boot.efi").display()
-            ));
-            step(&format!(
-                "Bootloader: {} (ELF → flat binary)",
-                dst_efi.display()
-            ));
+            bail!("expected ELF output not found: {}", elf_out.display());
         }
-        _ =>
+
+        let objcopy = find_llvm_objcopy()?;
+        let dst_boot = efi_seraph_dir.join("boot.efi");
+        run_cmd(
+            Command::new(&objcopy)
+                .args(["-O", "binary"])
+                .arg(&elf_out)
+                .arg(&dst_boot),
+        )?;
+        let dst_efi = efi_boot_dir.join(efi_name);
+        copy_file(&dst_boot, &dst_efi)?;
+
+        step(&format!(
+            "Bootloader: {} (ELF → flat binary)",
+            efi_seraph_dir.join("boot.efi").display()
+        ));
+        step(&format!(
+            "Bootloader: {} (ELF → flat binary)",
+            dst_efi.display()
+        ));
+    }
+    else
+    {
+        // x86_64 (and future PE-native archs): cargo produces a .efi PE directly.
+        let cargo_out = ctx
+            .cargo_output_dir(boot_triple, args.release)
+            .join("boot.efi");
+        if !cargo_out.exists()
         {
-            // x86_64 (and future PE-native archs): cargo produces a .efi PE directly.
-            let cargo_out = ctx
-                .cargo_output_dir(boot_triple, args.release)
-                .join("boot.efi");
-            if !cargo_out.exists()
-            {
-                bail!("expected EFI output not found: {}", cargo_out.display());
-            }
-
-            let dst_boot = efi_seraph_dir.join("boot.efi");
-            copy_file(&cargo_out, &dst_boot)?;
-            let dst_efi = efi_boot_dir.join(efi_name);
-            copy_file(&dst_boot, &dst_efi)?;
-
-            step(&format!(
-                "Bootloader: {}",
-                efi_seraph_dir.join("boot.efi").display()
-            ));
-            step(&format!("Bootloader: {}", dst_efi.display()));
+            bail!("expected EFI output not found: {}", cargo_out.display());
         }
+
+        let dst_boot = efi_seraph_dir.join("boot.efi");
+        copy_file(&cargo_out, &dst_boot)?;
+        let dst_efi = efi_boot_dir.join(efi_name);
+        copy_file(&dst_boot, &dst_efi)?;
+
+        step(&format!(
+            "Bootloader: {}",
+            efi_seraph_dir.join("boot.efi").display()
+        ));
+        step(&format!("Bootloader: {}", dst_efi.display()));
     }
 
     Ok(())
@@ -689,7 +687,7 @@ fn build_group(
                 cargo_out.display()
             );
         }
-        for dst in install_paths(ctx, spec)?
+        for dst in install_paths(ctx, spec)
         {
             if let Some(parent) = dst.parent()
             {
@@ -786,7 +784,7 @@ fn build_spec(ctx: &BuildContext, args: &BuildArgs, spec: &Spec) -> Result<()>
         );
     }
 
-    for dst in install_paths(ctx, spec)?
+    for dst in install_paths(ctx, spec)
     {
         if let Some(parent) = dst.parent()
         {
@@ -818,10 +816,10 @@ fn profile_params(arch: Arch, profile: BuildProfile) -> (&'static str, &'static 
     }
 }
 
-fn install_paths(ctx: &BuildContext, spec: &Spec) -> Result<Vec<PathBuf>>
+fn install_paths(ctx: &BuildContext, spec: &Spec) -> Vec<PathBuf>
 {
     let n = spec.install_name();
-    Ok(match spec.dest
+    match spec.dest
     {
         InstallDest::EfiSeraph => vec![ctx.sysroot_efi_seraph().join(n)],
         InstallDest::Services => vec![ctx.sysroot_services().join(n)],
@@ -836,7 +834,7 @@ fn install_paths(ctx: &BuildContext, spec: &Spec) -> Result<Vec<PathBuf>>
         {
             vec![ctx.sysroot.join("tests").join("programs").join(n)]
         }
-    })
+    }
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -849,6 +847,16 @@ fn fmt_workspace(ctx: &BuildContext) -> Result<()>
     run_cmd(&mut cmd)
 }
 
+/// Clippy-gate the host crates (`xtask`, `seraph-wrapper-shim`) under the
+/// workspace deny-lints. The sysroot crates are linted per-component via the
+/// seraph-toolchain path in `clippy_check_ext`; the host crates build with the
+/// plain host toolchain, which a rustc-only build never clippy-checks. Runs
+/// `cargo clippy -p xtask -p seraph-wrapper-shim -- -D warnings`.
+fn clippy_host(ctx: &BuildContext) -> Result<()>
+{
+    clippy_check(ctx, &["-p", "xtask", "-p", "seraph-wrapper-shim"])
+}
+
 /// Run `cargo clippy` with the given flags and treat all warnings as errors.
 ///
 /// Called before every `cargo build` invocation with identical flags, so lints
@@ -859,10 +867,10 @@ fn clippy_check(ctx: &BuildContext, flags: &[&str]) -> Result<()>
 }
 
 /// Clippy invocation that optionally wires the seraph toolchain mirror so
-/// StdUser lints see the overlaid `std::sys::seraph`.
+/// `StdUser` lints see the overlaid `std::sys::seraph`.
 ///
 /// For non-StdUser builds this is a straightforward `cargo clippy -- -D
-/// warnings`. For StdUser builds the path differs: `cargo clippy` hard-
+/// warnings`. For `StdUser` builds the path differs: `cargo clippy` hard-
 /// sets `RUSTC_WORKSPACE_WRAPPER=clippy-driver` itself, clobbering any
 /// value callers set. That baked-in clippy-driver reports the real rustup
 /// sysroot regardless of `RUSTC`, so cargo's build-std probe reads std
@@ -878,30 +886,27 @@ fn clippy_check_ext(
 ) -> Result<()>
 {
     let mut cmd = cargo(&ctx.root);
-    match seraph
+    if let Some(s) = seraph
     {
-        Some(s) =>
-        {
-            cmd.arg("check").args(flags);
-            // Routes RUSTC + RUSTC_WORKSPACE_WRAPPER through the shim,
-            // sets the SERAPH_SHIM_* config, and re-applies
-            // RUSTC_BOOTSTRAP=1. `std` is a recognised (non-restricted)
-            // target via the std `build.rs` overlay, so service code
-            // stays preamble-free.
-            s.apply_env(&mut cmd);
-            // Clippy-driver splits CLIPPY_ARGS on __CLIPPY_HACKERY__; this
-            // matches the encoding cargo-clippy uses internally when
-            // forwarding post-`--` args.
-            cmd.env(
-                "CLIPPY_ARGS",
-                "__CLIPPY_HACKERY__-D__CLIPPY_HACKERY__warnings__CLIPPY_HACKERY__",
-            );
-        }
-        None =>
-        {
-            cmd.arg("clippy").args(flags);
-            cmd.args(["--", "-D", "warnings"]);
-        }
+        cmd.arg("check").args(flags);
+        // Routes RUSTC + RUSTC_WORKSPACE_WRAPPER through the shim,
+        // sets the SERAPH_SHIM_* config, and re-applies
+        // RUSTC_BOOTSTRAP=1. `std` is a recognised (non-restricted)
+        // target via the std `build.rs` overlay, so service code
+        // stays preamble-free.
+        s.apply_env(&mut cmd);
+        // Clippy-driver splits CLIPPY_ARGS on __CLIPPY_HACKERY__; this
+        // matches the encoding cargo-clippy uses internally when
+        // forwarding post-`--` args.
+        cmd.env(
+            "CLIPPY_ARGS",
+            "__CLIPPY_HACKERY__-D__CLIPPY_HACKERY__warnings__CLIPPY_HACKERY__",
+        );
+    }
+    else
+    {
+        cmd.arg("clippy").args(flags);
+        cmd.args(["--", "-D", "warnings"]);
     }
     run_cmd(&mut cmd)
 }

--- a/xtask/src/commands/compose_bundle.rs
+++ b/xtask/src/commands/compose_bundle.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 // Copyright (C) 2026 George Kottler <mail@kottlerg.com>
 
-//! commands/compose_bundle.rs
+//! `commands/compose_bundle.rs`
 //!
 //! Compose the bootloader bundle from `sysroot/services/` binaries and
 //! repack the disk image. Symmetric with `mkdisk`: both call

--- a/xtask/src/commands/run.rs
+++ b/xtask/src/commands/run.rs
@@ -71,7 +71,7 @@ pub fn run(ctx: &BuildContext, args: &RunArgs) -> Result<()>
         gdb: args.gdb,
         qmp_socket: None,
     };
-    let qemu_args = build_qemu_argv(&spec);
+    let qemu_args = build_qemu_argv(&spec)?;
 
     let desc = match args.arch
     {

--- a/xtask/src/commands/run_parallel.rs
+++ b/xtask/src/commands/run_parallel.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 // Copyright (C) 2026 George Kottler <mail@kottlerg.com>
 
-//! commands/run_parallel.rs
+//! `commands/run_parallel.rs`
 //!
 //! Run-parallel command: launch N QEMU instances concurrently against an
 //! already-built sysroot, classifying each run's outcome via user-supplied
@@ -18,7 +18,7 @@ use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
@@ -59,7 +59,7 @@ impl Status
             Status::Ok => "OK".into(),
             Status::Fail => "FAIL".into(),
             Status::Hang => "HANG".into(),
-            Status::Err(rc) => format!("ERR rc={}", rc),
+            Status::Err(rc) => format!("ERR rc={rc}"),
         }
     }
 
@@ -100,6 +100,10 @@ struct FirmwareSet
     vars_template: Option<PathBuf>,
 }
 
+// too_many_lines: a linear dispatch-and-collect driver (wave loop, per-slot
+// thread spawn, join, summary). Splitting it would scatter the shared per-run
+// state across helpers without reducing complexity.
+#[allow(clippy::too_many_lines)]
 pub fn run(ctx: &BuildContext, args: &RunParallelArgs) -> Result<()>
 {
     validate_args(args)?;
@@ -120,7 +124,7 @@ pub fn run(ctx: &BuildContext, args: &RunParallelArgs) -> Result<()>
     let workdir = ctx.target_dir.join("xtask").join("run-parallel");
     std::fs::create_dir_all(&workdir)
         .with_context(|| format!("creating workdir {}", workdir.display()))?;
-    purge_prior_logs(&workdir)?;
+    purge_prior_logs(&workdir);
 
     step(&format!(
         "Starting run-parallel: arch={:?} parallel={} runs={} timeout={}s workdir={}",
@@ -132,7 +136,7 @@ pub fn run(ctx: &BuildContext, args: &RunParallelArgs) -> Result<()>
     ));
 
     let disk_src = ctx.disk_image();
-    let next_run = Arc::new(AtomicUsize::new(1));
+    let next_run = Arc::new(AtomicU32::new(1));
     let mut outcomes: Vec<RunOutcome> = Vec::with_capacity(args.runs as usize);
 
     let total_runs = args.runs;
@@ -145,9 +149,9 @@ pub fn run(ctx: &BuildContext, args: &RunParallelArgs) -> Result<()>
 
         for slot in 0..wave_size
         {
-            let run_id = next_run.fetch_add(1, Ordering::AcqRel) as u32;
+            let run_id = next_run.fetch_add(1, Ordering::AcqRel);
             let slot_dir = workdir.join(slot.to_string());
-            let log_path = workdir.join(format!("log-{}.log", run_id));
+            let log_path = workdir.join(format!("log-{run_id}.log"));
             let disk_dst = slot_dir.join("disk.img");
             let vars_dst = slot_dir.join("VARS.fd");
 
@@ -177,7 +181,7 @@ pub fn run(ctx: &BuildContext, args: &RunParallelArgs) -> Result<()>
                 {
                     let template = firmware_vars_template
                         .as_ref()
-                        .expect("riscv64 must produce a vars template");
+                        .context("riscv64 must produce a vars template")?;
                     std::fs::copy(template, &vars_dst).with_context(|| {
                         format!(
                             "copying vars template {} -> {}",
@@ -202,7 +206,7 @@ pub fn run(ctx: &BuildContext, args: &RunParallelArgs) -> Result<()>
                     gdb: false,
                     qmp_socket: None,
                 };
-                let qemu_args = build_qemu_argv(&spec);
+                let qemu_args = build_qemu_argv(&spec)?;
 
                 // O_APPEND on the log fds so the kernel writes atomically
                 // at end-of-file. Both the per-slot stdout-forwarder thread
@@ -212,7 +216,6 @@ pub fn run(ctx: &BuildContext, args: &RunParallelArgs) -> Result<()>
                 // two writers share the file.
                 let log_file = OpenOptions::new()
                     .create(true)
-                    .write(true)
                     .append(true)
                     .open(&log_path)
                     .with_context(|| format!("creating log file {}", log_path.display()))?;
@@ -334,12 +337,12 @@ fn resolve_firmware(ctx: &BuildContext, arch: Arch) -> Result<FirmwareSet>
     }
 }
 
-fn purge_prior_logs(workdir: &Path) -> Result<()>
+fn purge_prior_logs(workdir: &Path)
 {
-    let entries = match std::fs::read_dir(workdir)
+    let Ok(entries) = std::fs::read_dir(workdir)
+    else
     {
-        Ok(e) => e,
-        Err(_) => return Ok(()),
+        return;
     };
     for entry in entries.flatten()
     {
@@ -349,7 +352,9 @@ fn purge_prior_logs(workdir: &Path) -> Result<()>
         {
             continue;
         };
-        let is_log = name.ends_with(".log")
+        let is_log = Path::new(name)
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("log"))
             && (name.starts_with("log-")
                 || name.starts_with("FAIL-")
                 || name.starts_with("HANG-")
@@ -359,7 +364,6 @@ fn purge_prior_logs(workdir: &Path) -> Result<()>
             let _ = std::fs::remove_file(&path);
         }
     }
-    Ok(())
 }
 
 /// Spawn a thread that forwards `child_stdout` through `FilterWriter`
@@ -398,7 +402,7 @@ fn join_forwarder(handle: JoinHandle<Result<()>>, run_id: u32)
     }
 }
 
-/// Block until `child` exits or a watchdog deadline elapses, SIGKILLing it
+/// Block until `child` exits or a watchdog deadline elapses, `SIGKILLing` it
 /// on the deadline.
 ///
 /// Two deadlines apply, whichever comes first:
@@ -462,7 +466,7 @@ fn wait_with_timeout(
 /// missed live match only forgoes the early abort, never the verdict.
 fn fail_marker_present(log_path: &Path, last_len: &mut u64, fail_re: &Regex) -> bool
 {
-    let len = std::fs::metadata(log_path).map(|m| m.len()).unwrap_or(0);
+    let len = std::fs::metadata(log_path).map_or(0, |m| m.len());
     if len == *last_len
     {
         return false;
@@ -515,7 +519,7 @@ fn classify(
             .lines()
             .rev()
             .find(|l| !l.trim().is_empty())
-            .map(|s| s.to_string());
+            .map(ToString::to_string);
         return (Status::Hang, last);
     }
     if exit_rc == 0
@@ -527,11 +531,10 @@ fn classify(
 
 fn line_containing(text: &str, byte_offset: usize) -> String
 {
-    let start = text[..byte_offset].rfind('\n').map(|i| i + 1).unwrap_or(0);
+    let start = text[..byte_offset].rfind('\n').map_or(0, |i| i + 1);
     let end = text[byte_offset..]
         .find('\n')
-        .map(|i| byte_offset + i)
-        .unwrap_or(text.len());
+        .map_or(text.len(), |i| byte_offset + i);
     text[start..end].trim_end_matches(['\r', '\n']).to_string()
 }
 
@@ -545,7 +548,7 @@ fn finalize_log(workdir: &Path, log_path: &Path, run_id: u32, status: &Status) -
         }
         Some(prefix) =>
         {
-            let dest = workdir.join(format!("{}-{}.log", prefix, run_id));
+            let dest = workdir.join(format!("{prefix}-{run_id}.log"));
             std::fs::rename(log_path, &dest).with_context(|| {
                 format!("renaming {} -> {}", log_path.display(), dest.display())
             })?;
@@ -559,8 +562,8 @@ fn format_outcome_line(outcome: &RunOutcome) -> String
     let elapsed = format!("{:.2}s", outcome.elapsed.as_secs_f64());
     let tail = match (&outcome.status, &outcome.matched)
     {
-        (Status::Hang, Some(last)) => format!("last={:?}", last),
-        (_, Some(m)) => format!("match={:?}", m),
+        (Status::Hang, Some(last)) => format!("last={last:?}"),
+        (_, Some(m)) => format!("match={m:?}"),
         (_, None) => String::new(),
     };
     let base = format!(
@@ -576,7 +579,7 @@ fn format_outcome_line(outcome: &RunOutcome) -> String
     }
     else
     {
-        format!("{}  {}", base, tail)
+        format!("{base}  {tail}")
     }
 }
 
@@ -671,7 +674,7 @@ fn print_failing_tails(workdir: &Path, outcomes: &[RunOutcome])
         }
         else
         {
-            println!("{}", tail);
+            println!("{tail}");
         }
     }
 }
@@ -694,6 +697,9 @@ fn tail_text(body: &str, max_lines: usize, max_bytes: usize) -> String
     tail
 }
 
+// cast_precision_loss: micros→seconds for human-readable display only; run
+// elapsed times are far below f64's exact-integer range.
+#[allow(clippy::cast_precision_loss)]
 fn us_to_s(us: u128) -> f64
 {
     us as f64 / 1_000_000.0

--- a/xtask/src/commands/test_terminal.rs
+++ b/xtask/src/commands/test_terminal.rs
@@ -93,8 +93,12 @@ const PROMPT: &str = "$ ";
 const SERIAL_INPUT: &[u8] = b"helpx\x7f\r";
 
 /// Overall wall-clock budget for boot + inject + assert.
-const TIMEOUT: Duration = Duration::from_secs(180);
+const TIMEOUT: Duration = Duration::from_mins(3);
 
+// too_many_lines: a linear QMP-driven test (boot, wait for READY, inject keys
+// and serial RX, assert echoed markers). Splitting the sequential assertions
+// would obscure the flow without reducing complexity.
+#[allow(clippy::too_many_lines)]
 pub fn run(ctx: &Context, args: &TestTerminalArgs) -> Result<()>
 {
     validate_sysroot_for_launch(ctx, args.arch)?;
@@ -126,7 +130,7 @@ pub fn run(ctx: &Context, args: &TestTerminalArgs) -> Result<()>
         gdb: false,
         qmp_socket: Some(&sock_path),
     };
-    let qemu_args = build_qemu_argv(&spec);
+    let qemu_args = build_qemu_argv(&spec)?;
     let qemu_binary = require_tool(args.arch.qemu_binary())?;
 
     step("Launching QEMU for the terminal interactive test (QMP key + serial RX injection)");

--- a/xtask/src/context.rs
+++ b/xtask/src/context.rs
@@ -7,6 +7,8 @@
 
 use std::path::PathBuf;
 
+use anyhow::{Context as _, Result};
+
 /// Resolved project paths used by every command.
 pub struct Context
 {
@@ -27,20 +29,20 @@ impl Context
     ///
     /// `CARGO_MANIFEST_DIR` is set by Cargo to the xtask crate root at compile
     /// time; its parent is the workspace root.
-    pub fn from_manifest_dir() -> Self
+    pub fn from_manifest_dir() -> Result<Self>
     {
         let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let root = manifest_dir
             .parent()
-            .expect("xtask manifest dir has no parent — check workspace layout")
+            .context("xtask manifest dir has no parent — check workspace layout")?
             .to_path_buf();
         let sysroot = root.join("sysroot");
         let target_dir = root.join("target");
-        Context {
+        Ok(Context {
             root,
             sysroot,
             target_dir,
-        }
+        })
     }
 
     /// Path to `sysroot/esp/` — ESP partition staging area.

--- a/xtask/src/disk.rs
+++ b/xtask/src/disk.rs
@@ -84,7 +84,7 @@ impl Read for PartitionSlice
         {
             return Ok(0);
         }
-        let remaining = (self.offset + self.length - pos) as usize;
+        let remaining = usize::try_from(self.offset + self.length - pos).unwrap_or(usize::MAX);
         let limit = buf.len().min(remaining);
         self.file.read(&mut buf[..limit])
     }
@@ -99,7 +99,7 @@ impl Write for PartitionSlice
         {
             return Ok(0);
         }
-        let remaining = (self.offset + self.length - pos) as usize;
+        let remaining = usize::try_from(self.offset + self.length - pos).unwrap_or(usize::MAX);
         let limit = buf.len().min(remaining);
         self.file.write(&buf[..limit])
     }
@@ -122,11 +122,11 @@ impl Seek for PartitionSlice
                 let end = self.offset + self.length;
                 if p >= 0
                 {
-                    end + p as u64
+                    end + p.cast_unsigned()
                 }
                 else
                 {
-                    end.checked_sub((-p) as u64).ok_or_else(|| {
+                    end.checked_sub((-p).cast_unsigned()).ok_or_else(|| {
                         io::Error::new(
                             io::ErrorKind::InvalidInput,
                             "seek before start of partition",
@@ -139,11 +139,11 @@ impl Seek for PartitionSlice
                 let cur = self.file.stream_position()?;
                 if p >= 0
                 {
-                    cur + p as u64
+                    cur + p.cast_unsigned()
                 }
                 else
                 {
-                    cur.checked_sub((-p) as u64).ok_or_else(|| {
+                    cur.checked_sub((-p).cast_unsigned()).ok_or_else(|| {
                         io::Error::new(
                             io::ErrorKind::InvalidInput,
                             "seek before start of partition",
@@ -322,9 +322,13 @@ fn write_gpt(image_path: &Path, arch: Arch) -> Result<()>
     .context("failed to add DATA partition")?;
 
     // Set deterministic per-partition unique GUIDs for reproducible builds.
-    let esp_uuid: uuid::Uuid = ESP_UNIQUE_UUID.parse().expect("invalid ESP_UNIQUE_UUID");
-    let root_uuid: uuid::Uuid = ROOT_UNIQUE_UUID.parse().expect("invalid ROOT_UNIQUE_UUID");
-    let data_uuid: uuid::Uuid = DATA_UNIQUE_UUID.parse().expect("invalid DATA_UNIQUE_UUID");
+    let esp_uuid: uuid::Uuid = ESP_UNIQUE_UUID.parse().context("invalid ESP_UNIQUE_UUID")?;
+    let root_uuid: uuid::Uuid = ROOT_UNIQUE_UUID
+        .parse()
+        .context("invalid ROOT_UNIQUE_UUID")?;
+    let data_uuid: uuid::Uuid = DATA_UNIQUE_UUID
+        .parse()
+        .context("invalid DATA_UNIQUE_UUID")?;
 
     let mut parts = disk.take_partitions();
     if let Some(p) = parts.get_mut(&1)
@@ -409,7 +413,7 @@ fn populate_dir<T: Read + Write + Seek>(
     let mut entries: Vec<_> = fs::read_dir(host_dir)
         .with_context(|| format!("failed to read {}", host_dir.display()))?
         .collect::<std::result::Result<Vec<_>, _>>()?;
-    entries.sort_by_key(|e| e.file_name());
+    entries.sort_by_key(std::fs::DirEntry::file_name);
 
     for entry in entries
     {
@@ -440,10 +444,10 @@ fn populate_dir<T: Read + Write + Seek>(
         {
             fat_dir
                 .create_dir(&name_str)
-                .with_context(|| format!("failed to create dir in image: {}", name_str))?;
+                .with_context(|| format!("failed to create dir in image: {name_str}"))?;
             let sub = fat_dir
                 .open_dir(&name_str)
-                .with_context(|| format!("failed to open dir in image: {}", name_str))?;
+                .with_context(|| format!("failed to open dir in image: {name_str}"))?;
             populate_dir(&sub, &path, sysroot_root)?;
         }
         else if ft.is_file()
@@ -452,7 +456,7 @@ fn populate_dir<T: Read + Write + Seek>(
                 File::open(&path).with_context(|| format!("failed to open {}", path.display()))?;
             let mut dst = fat_dir
                 .create_file(&name_str)
-                .with_context(|| format!("failed to create file in image: {}", name_str))?;
+                .with_context(|| format!("failed to create file in image: {name_str}"))?;
             io::copy(&mut src, &mut dst)
                 .with_context(|| format!("failed to copy {} into image", path.display()))?;
         }

--- a/xtask/src/firmware.rs
+++ b/xtask/src/firmware.rs
@@ -25,6 +25,7 @@
 //! `qemu.rs::prepare_riscv_firmware` — this module is pure discovery.
 
 use std::ffi::OsStr;
+use std::fmt::Write;
 use std::path::PathBuf;
 
 use anyhow::{Result, anyhow};
@@ -281,9 +282,10 @@ fn not_found_error(label: &str, env_var: &str, tried: &[&str], hints: &str) -> a
             msg.push('\n');
         }
     }
-    msg.push_str(&format!(
-        "\nSet ${env_var} to a direct path, or install the firmware:\n",
-    ));
+    let _ = write!(
+        msg,
+        "\nSet ${env_var} to a direct path, or install the firmware:\n"
+    );
     msg.push_str(hints);
     anyhow!(msg)
 }
@@ -291,7 +293,7 @@ fn not_found_error(label: &str, env_var: &str, tried: &[&str], hints: &str) -> a
 /// Build the "discovered file missing" error.
 fn missing_file_error(label: &str, path: &std::path::Path) -> anyhow::Error
 {
-    anyhow!("{label} not found at resolved path: {}", path.display(),)
+    anyhow!("{label} not found at resolved path: {}", path.display())
 }
 
 /// Build the "env var set to a path that doesn't exist" error.

--- a/xtask/src/fs_compat.rs
+++ b/xtask/src/fs_compat.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 // Copyright (C) 2026 George Kottler <mail@kottlerg.com>
 
-//! fs_compat.rs
+//! `fs_compat.rs`
 //!
 //! Portable file-materialisation helpers.
 //!

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -14,6 +14,11 @@
 //! 3. Add a match arm in `main` below.
 //! 4. Re-export the module in `commands/mod.rs`.
 
+// multiple_crate_versions: duplicate transitive versions (bitflags, hashbrown,
+// windows-sys, wit-bindgen) come from third-party host deps (clap, gpt, fatfs,
+// libc, which); not resolvable without upstream releases.
+#![allow(clippy::multiple_crate_versions)]
+
 use clap::Parser;
 
 mod accel;
@@ -38,7 +43,15 @@ use context::Context;
 fn main()
 {
     let cli = Cli::parse();
-    let ctx = Context::from_manifest_dir();
+    let ctx = match Context::from_manifest_dir()
+    {
+        Ok(ctx) => ctx,
+        Err(err) =>
+        {
+            eprintln!("error: {err:#}");
+            std::process::exit(1);
+        }
+    };
 
     // Install a no-op Ctrl+C handler so SIGINT terminates the inner
     // subprocess (cargo, QEMU) without killing xtask itself. Allows

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -30,7 +30,7 @@ const PFLASH_SIZE: u64 = 32 * 1024 * 1024;
 
 /// Specification for one QEMU launch.
 ///
-/// `firmware_code_path` is the readonly pflash (OVMF on x86, RISCV_VIRT_CODE
+/// `firmware_code_path` is the readonly pflash (OVMF on x86, `RISCV_VIRT_CODE`
 /// on riscv64). `firmware_vars_path` is the writable pflash and is only used
 /// on riscv64 — x86 runs with volatile NVRAM and leaves the field `None`.
 pub struct QemuLaunchSpec<'a>
@@ -52,7 +52,7 @@ pub struct QemuLaunchSpec<'a>
 ///
 /// Pairs with `Arch::qemu_binary()` for the binary name. The returned vector
 /// is suitable for `Command::new(binary).args(&argv)`.
-pub fn build_qemu_argv(spec: &QemuLaunchSpec) -> Vec<String>
+pub fn build_qemu_argv(spec: &QemuLaunchSpec) -> Result<Vec<String>>
 {
     let mut args: Vec<String> = vec![
         "-m".into(),
@@ -98,10 +98,10 @@ pub fn build_qemu_argv(spec: &QemuLaunchSpec) -> Vec<String>
     match spec.arch
     {
         Arch::X86_64 => extend_x86(&mut args, spec, accel),
-        Arch::Riscv64 => extend_riscv(&mut args, spec),
+        Arch::Riscv64 => extend_riscv(&mut args, spec)?,
     }
 
-    args
+    Ok(args)
 }
 
 fn extend_x86(args: &mut Vec<String>, spec: &QemuLaunchSpec, accel: Accel)
@@ -176,11 +176,11 @@ fn extend_x86(args: &mut Vec<String>, spec: &QemuLaunchSpec, accel: Accel)
     }
 }
 
-fn extend_riscv(args: &mut Vec<String>, spec: &QemuLaunchSpec)
+fn extend_riscv(args: &mut Vec<String>, spec: &QemuLaunchSpec) -> Result<()>
 {
     let vars_path = spec
         .firmware_vars_path
-        .expect("riscv64 launch requires firmware_vars_path");
+        .context("riscv64 launch requires firmware_vars_path")?;
 
     args.extend(["-machine".into(), "virt".into()]);
     // Pin the CPU model to a baseline that advertises the RVA23U64 features
@@ -229,6 +229,8 @@ fn extend_riscv(args: &mut Vec<String>, spec: &QemuLaunchSpec)
             ]);
         }
     }
+
+    Ok(())
 }
 
 /// Resolve and cache riscv64 firmware.
@@ -353,10 +355,10 @@ fn preferred_display_backend(qemu_binary: &str) -> Option<String>
 /// Returns true if `cached` is missing, wrong-sized, or older than `source`.
 fn pflash_cache_stale(cached: &Path, source: &Path, target_size: u64) -> Result<bool>
 {
-    let cached_md = match std::fs::metadata(cached)
+    let Ok(cached_md) = std::fs::metadata(cached)
+    else
     {
-        Ok(m) => m,
-        Err(_) => return Ok(true),
+        return Ok(true);
     };
     if cached_md.len() != target_size
     {
@@ -384,7 +386,11 @@ fn pad_file_to(path: &Path, target_size: u64) -> Result<()>
         .with_context(|| format!("seeking {}", path.display()))?;
     if current < target_size
     {
-        let padding = vec![0u8; (target_size - current) as usize];
+        let padding = vec![
+            0u8;
+            usize::try_from(target_size - current)
+                .context("firmware padding size exceeds usize")?
+        ];
         file.write_all(&padding)
             .with_context(|| format!("padding {}", path.display()))?;
     }

--- a/xtask/src/rust_src.rs
+++ b/xtask/src/rust_src.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 // Copyright (C) 2026 George Kottler <mail@kottlerg.com>
 
-//! rust_src.rs
+//! `rust_src.rs`
 //!
 //! Assembles an in-project sysroot under `target/seraph-toolchain/` so
 //! `-Z build-std` can compile `std` with our `std::sys::seraph` overlay,
@@ -84,7 +84,7 @@ const VERSION_STAMP: &str = ".seraph-toolchain-stamp";
 // ── Public entry point ────────────────────────────────────────────────────────
 
 /// Paths and shim config callers route their cargo invocations
-/// through for StdUser builds.
+/// through for `StdUser` builds.
 ///
 /// `rustc` and `ws_clippy` point at the installed shim under
 /// `target/seraph-toolchain/bin/` (the same binary, installed under
@@ -103,7 +103,7 @@ pub struct SeraphToolchain
 
 impl SeraphToolchain
 {
-    /// Set every env var the shim and cargo need to route a StdUser
+    /// Set every env var the shim and cargo need to route a `StdUser`
     /// build through the seraph toolchain mirror: `RUSTC` and
     /// `RUSTC_WORKSPACE_WRAPPER` (mirror entry points), the three
     /// `SERAPH_SHIM_*` config vars (so the shim knows what to exec),
@@ -592,8 +592,7 @@ fn materialise_bin_dir(bin_dir: &Path) -> Result<()>
 {
     let is_symlink = bin_dir
         .symlink_metadata()
-        .map(|m| m.file_type().is_symlink())
-        .unwrap_or(false);
+        .is_ok_and(|m| m.file_type().is_symlink());
     if !is_symlink
     {
         return Ok(());
@@ -922,7 +921,7 @@ fn apply_random_overlay(rust_src: &Path) -> Result<()>
 }
 
 /// Route `std::sys::args` through a seraph module that reads argv from
-/// the read-only ProcessInfo page. See
+/// the read-only `ProcessInfo` page. See
 /// `runtime/ruststd/src/sys/args/seraph.rs` for the backing.
 fn apply_args_overlay(rust_src: &Path, overlay_root: &Path) -> Result<()>
 {

--- a/xtask/src/sysroot.rs
+++ b/xtask/src/sysroot.rs
@@ -75,8 +75,8 @@ pub fn install_rootfs(ctx: &BuildContext) -> Result<()>
         // Skip documentation files that are not part of the sysroot image.
         let rel = src
             .strip_prefix(&src_root)
-            .expect("src must be under src_root");
-        if rel.file_name().map(|n| n == "README.md").unwrap_or(false)
+            .context("src must be under src_root")?;
+        if rel.file_name().is_some_and(|n| n == "README.md")
         {
             continue;
         }
@@ -104,7 +104,7 @@ const SVCTEST_LARGE_BIN_PAGE_SIZE: usize = 4096;
 /// consumed by `svctest`'s `fs_release_on_close_phase`. Each 4 KiB page
 /// is filled with the ASCII tag `PAGE_NN_` repeated, where `NN` is the
 /// page index. The phase asserts the first 8 bytes equal `PAGE_00_` to
-/// confirm content integrity across the FS_READ_FRAME / mem_map /
+/// confirm content integrity across the `FS_READ_FRAME` / `mem_map` /
 /// release sequence. Treated as a build artifact (synthesised here, not
 /// shipped in `rootfs/`).
 fn synthesise_svctest_large_bin(ctx: &BuildContext) -> Result<()>
@@ -140,7 +140,7 @@ fn synthesise_svctest_large_bin(ctx: &BuildContext) -> Result<()>
 const SVCTEST_BENCH_BIN_SIZE: usize = 65536;
 
 /// Emit `/data/svctest/bench.bin`, a 64 KiB deterministic fixture
-/// consumed by `fsbench` (the FS_READ vs FS_READ_FRAME crossover
+/// consumed by `fsbench` (the `FS_READ` vs `FS_READ_FRAME` crossover
 /// benchmark). Filled with a byte-position-derived pattern so any
 /// read-path corruption shows up as a content mismatch at the byte
 /// level. Treated as a build artifact, same pattern as `large.bin`.

--- a/xtask/src/term/guard.rs
+++ b/xtask/src/term/guard.rs
@@ -123,7 +123,7 @@ fn capture_unix() -> Option<UnixSaved>
     let mut termios: libc::termios = unsafe { std::mem::zeroed() };
     // SAFETY: fd is a valid open file descriptor for the terminal;
     // termios points at a writable termios struct.
-    let r = unsafe { libc::tcgetattr(fd, &mut termios) };
+    let r = unsafe { libc::tcgetattr(fd, &raw mut termios) };
     if r != 0
     {
         return None;
@@ -158,7 +158,7 @@ fn restore_unix(saved: &UnixSaved)
     // SAFETY: fd is valid (held open by `saved.tty`); termios was
     // captured by tcgetattr on the same fd. Failures are ignored —
     // best-effort restore on shutdown.
-    let _ = unsafe { libc::tcsetattr(fd, libc::TCSANOW, &saved.termios) };
+    let _ = unsafe { libc::tcsetattr(fd, libc::TCSANOW, &raw const saved.termios) };
 
     if let Some(ws) = saved.winsize.as_ref()
     {

--- a/xtask/src/term/line_gate.rs
+++ b/xtask/src/term/line_gate.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 // Copyright (C) 2026 George Kottler <mail@kottlerg.com>
 
-//! term/line_gate.rs
+//! `term/line_gate.rs`
 //!
 //! Line-level marker gate for QEMU output.
 //!
@@ -62,7 +62,7 @@ impl<W: Write> LineGate<W>
     /// builds.
     pub fn new(inner: W, marker: &[u8]) -> Self
     {
-        debug_assert!(!marker.is_empty(), "LineGate marker must be non-empty",);
+        debug_assert!(!marker.is_empty(), "LineGate marker must be non-empty");
         debug_assert!(
             marker.iter().all(|&b| b.is_ascii() && b != 0x1b),
             "LineGate marker must be plain ASCII with no ESC byte",

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -29,10 +29,10 @@ pub fn run_cmd(cmd: &mut Command) -> Result<()>
 {
     let status = cmd
         .status()
-        .with_context(|| format!("failed to launch {:?}", cmd.get_program()))?;
+        .with_context(|| format!("failed to launch {}", cmd.get_program().display()))?;
     if !status.success()
     {
-        bail!("{:?} exited with {}", cmd.get_program(), status);
+        bail!("{} exited with {}", cmd.get_program().display(), status);
     }
     Ok(())
 }
@@ -44,10 +44,14 @@ pub fn run_cmd_capture(cmd: &mut Command) -> Result<String>
 {
     let output = cmd
         .output()
-        .with_context(|| format!("failed to launch {:?}", cmd.get_program()))?;
+        .with_context(|| format!("failed to launch {}", cmd.get_program().display()))?;
     if !output.status.success()
     {
-        bail!("{:?} exited with {}", cmd.get_program(), output.status);
+        bail!(
+            "{} exited with {}",
+            cmd.get_program().display(),
+            output.status
+        );
     }
     Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
@@ -59,7 +63,7 @@ pub fn run_cmd_capture(cmd: &mut Command) -> Result<String>
 /// tools that aren't part of xtask's own dependency chain (qemu,
 /// llvm-objcopy from rustup, etc.) so a missing tool produces an
 /// actionable message instead of the OS's opaque "No such file or
-/// directory" from Command::spawn.
+/// directory" from `Command::spawn`.
 pub fn require_tool(name: &str) -> Result<PathBuf>
 {
     which::which(name).map_err(|err| {

--- a/xtask/wrapper-shim/src/main.rs
+++ b/xtask/wrapper-shim/src/main.rs
@@ -20,7 +20,7 @@
 //!
 //! - **`ws-clippy`**: cargo invokes `RUSTC_WORKSPACE_WRAPPER` as
 //!   `<wrapper> <rustc_path> <args...>`. Drop the cargo-prepended
-//!   rustc_path, set `SYSROOT=<mirror>` in the env, and re-drive
+//!   `rustc_path`, set `SYSROOT=<mirror>` in the env, and re-drive
 //!   `clippy-driver` with both `<mirror>/bin/rustc` and an explicit
 //!   `--sysroot=<mirror>` arg. clippy-driver bakes its rustup env
 //!   vars at compile time, so both the env var and the flag are
@@ -55,10 +55,10 @@ const ENV_MIRROR_SYSROOT: &str = "SERAPH_SHIM_MIRROR_SYSROOT";
 fn main() -> !
 {
     let mut argv = env::args_os();
-    let argv0 = match argv.next()
+    let Some(argv0) = argv.next()
+    else
     {
-        Some(a) => a,
-        None => die("argv[0] missing (impossible per POSIX/Windows)"),
+        die("argv[0] missing (impossible per POSIX/Windows)")
     };
     let argv_rest: Vec<OsString> = argv.collect();
 
@@ -99,7 +99,7 @@ fn exec_rustc(args: Vec<OsString>) -> !
     run_or_exec(cmd, "rustc")
 }
 
-/// Drop cargo's prepended rustc_path arg and re-drive clippy-driver
+/// Drop cargo's prepended `rustc_path` arg and re-drive clippy-driver
 /// with both `SYSROOT` env and `--sysroot=` flag pointing at the
 /// seraph mirror. Never returns on success.
 fn exec_ws_clippy(mut args: Vec<OsString>) -> !


### PR DESCRIPTION
## Summary
The workspace clippy deny-lints were never enforced on the host crates (`xtask`, `seraph-wrapper-shim`), so a production `.expect()` shipped green (#318). This folds a host clippy step into `cargo xtask build`'s existing lint pass — `cargo clippy -p xtask -p seraph-wrapper-shim -- -D warnings`, alongside `cargo fmt --all` and the per-component sysroot clippy — and fixes every violation it surfaces.

Closes #319
Closes #318

## Acceptance
Linked Issues #319/#318 define no `## Acceptance` section; criteria below are derived from their Proposal/Fix:
- [x] #319: the host `xtask` crate is gated under the workspace clippy deny-lints in CI (rides every `cargo xtask build`; routed through `cargo xtask`, not a direct `cargo clippy`, per the tooling constraint)
- [x] #319: all violations the gate surfaces are fixed
- [x] #318: the `run_parallel.rs` riscv64 vars-template `.expect()` is replaced with a propagated `.context()?`

## Test plan
- [x] `cargo xtask build` (x86_64) — host clippy green, build complete
- [x] x86_64 boot, ktest pass marker observed — `cargo xtask run-parallel --arch x86_64 --parallel 1 --runs 1` → `[ktest] ALL TESTS PASSED` (run-parallel used over interactive `run` for a definitive marker)
- [x] `cargo xtask build --arch riscv64` — host clippy green, build complete
- [x] riscv64 boot, ktest pass marker observed — `cargo xtask run-parallel --arch riscv64 --parallel 1 --runs 1` → `[ktest] ALL TESTS PASSED` (exercises the extend_riscv / vars-template propagation path)
- [x] `cargo xtask test` — host unit tests green (includes the xtask crate's own tests)

## Notes
- Scope expanded by one crate beyond #319's title: `seraph-wrapper-shim` is the only other host (non-`no_std`) member and was likewise ungated, so the gate covers both. Stated and continued per the Completeness rule.
- Lint scope mirrors the sysroot gate exactly (`-p <pkg> -- -D warnings`, no `--all-targets`), so `#[cfg(test)]` modules are not linted and no `cfg_attr(test, allow(...))` carve-out is introduced — consistent with how every other crate is gated and with docs/coding-standards.md (unwrap/expect permitted in tests).
- Non-actionable or clarity-preserving lints are suppressed with justified item-level `#[allow(...)]` matching existing repo precedent (cast allows; `too_many_lines` on cohesive command entry points).
