### PR TITLE
fix(kernel): generation-tagged capability handles close the cross-CSpace stale-slot alias class (#349)

### DIFF
--- a/abi/init-protocol/src/lib.rs
+++ b/abi/init-protocol/src/lib.rs
@@ -76,7 +76,13 @@
 ///     (previously both 0). `Rights::ELEVATE` is removed: holding a
 ///     `SchedControl` cap plus its range is the authority. Field layout
 ///     unchanged; semantic change to the `SchedControl` descriptor only.
-pub const INIT_PROTOCOL_VERSION: u32 = 12;
+/// v13: Capability handles are generation-tagged (#349). Each [`CapDescriptor`]
+///     slot is now a `(generation << CAP_INDEX_BITS) | index` handle, not a bare
+///     slot index. Field layout is unchanged and every handover cap is a
+///     never-recycled generation-0 slot, so the delivered values are
+///     byte-identical; the semantic change is that the handle's high bits are
+///     now meaningful and the kernel validates them on every use.
+pub const INIT_PROTOCOL_VERSION: u32 = 13;
 
 /// Length of [`InitModuleName::name`], matching
 /// [`boot_protocol::BOOT_MODULE_NAME_LEN`] so the kernel copies the bundle

--- a/abi/process-abi/src/lib.rs
+++ b/abi/process-abi/src/lib.rs
@@ -50,7 +50,13 @@ use core::prelude::rust_2024::*;
 ///      / [`ProcessInfo::pager_badge`] are nonzero for default-spawned processes
 ///      and zero only for pinned ones (`procmgr_labels::CREATE_PINNED`, e.g. DMA
 ///      drivers) and the pre-pager bootstrap (init/memmgr/procmgr).
-pub const PROCESS_ABI_VERSION: u32 = 19;
+/// v20: Capability handles are generation-tagged (#349). Each `ProcessInfo` cap
+///      field is now a `(generation << CAP_INDEX_BITS) | index` handle, not a
+///      bare slot index. Layout is unchanged and every handover cap is a
+///      never-recycled generation-0 slot, so the delivered values are
+///      byte-identical; the semantic change is that the handle's high bits are
+///      now meaningful and the kernel validates them on every use.
+pub const PROCESS_ABI_VERSION: u32 = 20;
 
 // ── Address space constants ──────────────────────────────────────────────────
 

--- a/abi/syscall/src/lib.rs
+++ b/abi/syscall/src/lib.rs
@@ -54,6 +54,58 @@ use core::prelude::rust_2024::*;
 /// RV64GC under Sv48) use 4 KiB base pages.
 pub const PAGE_SIZE: u64 = 0x1000;
 
+// ── Capability handle encoding ────────────────────────────────────────────────
+
+/// Number of low bits in a capability handle that hold the `CSpace` slot index.
+///
+/// The remaining high bits hold a per-slot generation counter (see
+/// [`cap_handle_gen`]). 24 index bits cover the maximum `CSpace` capacity with
+/// generous headroom; the kernel static-asserts that its slot capacity fits.
+pub const CAP_INDEX_BITS: u32 = 24;
+
+/// Mask selecting the slot-index bits of a capability handle.
+pub const CAP_INDEX_MASK: u32 = (1u32 << CAP_INDEX_BITS) - 1;
+
+// Generation (8 bits) plus index (`CAP_INDEX_BITS`) must fit in the u32 handle.
+// The handle is returned to userspace in a u64 register and reinterpreted as
+// i64 by the dispatcher; a u32 zero-extends with bit 63 clear, so a single-cap
+// return is never misread as a negative error code.
+const _: () = assert!(CAP_INDEX_BITS + 8 <= 32);
+
+/// Build a capability handle from a slot `index` and per-slot `generation`.
+///
+/// The handle userspace receives and passes back is
+/// `(generation << CAP_INDEX_BITS) | index`. A `generation` of `0` makes the
+/// handle numerically equal to the bare index, so a long-lived cap minted once
+/// and never recycled keeps its historical handle value under this encoding
+/// (the backward-compatibility hinge).
+#[inline]
+#[must_use]
+// `u32::from` is not const-stable; the `u8 -> u32` widening cast is exact.
+#[allow(clippy::cast_lossless)]
+pub const fn cap_handle_encode(index: u32, generation: u8) -> u32
+{
+    ((generation as u32) << CAP_INDEX_BITS) | (index & CAP_INDEX_MASK)
+}
+
+/// Extract the slot index from a capability handle.
+#[inline]
+#[must_use]
+pub const fn cap_handle_index(handle: u32) -> u32
+{
+    handle & CAP_INDEX_MASK
+}
+
+/// Extract the per-slot generation from a capability handle.
+#[inline]
+#[must_use]
+// `>> CAP_INDEX_BITS` leaves at most 8 significant bits, so the `as u8` is exact.
+#[allow(clippy::cast_possible_truncation)]
+pub const fn cap_handle_gen(handle: u32) -> u8
+{
+    (handle >> CAP_INDEX_BITS) as u8
+}
+
 // ── Syscall numbers ───────────────────────────────────────────────────────────
 
 /// IPC: synchronous call (send + block waiting for reply).
@@ -722,14 +774,17 @@ pub const FAULT_CLASS_ALL: u64 = !0u64;
 /// patch = version & 0xFFFF
 /// ```
 ///
-/// The version is `0.0.2` during initial kernel development. Major will remain
+/// The version is `0.0.3` during initial kernel development. Major will remain
 /// `0` until the kernel reaches a meaningful level of completeness; during this
 /// phase all ABI changes are considered fully fluid regardless of minor/patch.
+/// `0.0.3` introduced the generation-tagged capability handle format (#349):
+/// a handle is `(generation << CAP_INDEX_BITS) | index`; a stale handle to a
+/// recycled slot fails with `InvalidCapability`.
 // Encode as (major << 32) | (minor << 16) | patch. The zero shifts are retained
 // to preserve the positional structure; they will carry non-zero values when
 // the ABI stabilises.
 #[allow(clippy::identity_op, clippy::eq_op)]
-pub const KERNEL_VERSION: u64 = (0u64 << 32) | (0u64 << 16) | 2u64; // 0.0.2
+pub const KERNEL_VERSION: u64 = (0u64 << 32) | (0u64 << 16) | 3u64; // 0.0.3
 
 /// Discriminant for `SYS_SYSTEM_INFO` queries.
 ///

--- a/core/kernel/docs/capability-internals.md
+++ b/core/kernel/docs/capability-internals.md
@@ -143,6 +143,32 @@ boundaries without holding per-CSpace locks longer than necessary, and lets
 recycled — a stale `SlotId` stamped with the pre-recycle epoch cannot
 mis-target the new tenant. See #137 for the recycling allocator design.
 
+### Per-Slot Generation
+
+Each slot carries an 8-bit **generation** counter (in the spare `pad[1]` byte,
+keeping the slot at 72 bytes). `CSpace::free_slot` increments it every time the
+slot is recycled. The generation is encoded into the capability handle userspace
+receives — `handle = (generation << CAP_INDEX_BITS) | index` (see
+[capability-model.md](../../../docs/capability-model.md) § Capability Handle
+Format) — and `lookup_cap`, together with the raw-resolution handlers in
+`cap.rs` / `mem.rs` / `ipc.rs`, rejects a handle whose generation no longer
+matches the slot's, returning `InvalidCapability`. This is the #349 fix: a stale
+handle that reaches a recycled slot — including a slot a cross-`CSpace` revoke
+freed out from under its holder — fails closed instead of aliasing the new
+occupant. A never-recycled slot has generation 0, so its handle equals the bare
+index — the backward-compatibility hinge that lets long-lived boot caps keep
+their historical handle values.
+
+The generation is distinct from `SlotId.epoch` (the per-`CSpace`-registry
+counter) and from the `pad[0]` free-list marker. It must survive the
+free→reallocate transition: `free_slot` bumps it *before* threading the slot onto
+the free list, `set_next_free` preserves `pad[1]`, and `allocate_slot` clears the
+slot with `clear_keep_generation` (which keeps `pad[1]`). The 8-bit counter wraps
+after 256 recycles of one index — a bounded ABA window: on wrap a replayed handle
+is no better protected than under the pre-generation scheme, and no worse. The
+generation byte `pad[1]` plus the spare `pad[2]` leave a one-step widening to a
+16-bit generation if churn ever makes 256 marginal.
+
 ### Capability Tags
 
 ```rust
@@ -359,18 +385,51 @@ own access:
 1. Hold capability C (the original).
 2. Derive C1 from C — you retain C1 as an intermediary.
 3. Derive C2 from C1 — C2 is the delegated capability.
-4. Transfer C2 to the child process via SYS_CAP_COPY or IPC capability slots.
+4. Copy C2 into the child's CSpace with SYS_CAP_COPY.
 5. To revoke: call SYS_CAP_REVOKE on your slot holding C1.
-   This destroys C1 and C2 (all descendants of C1).
+   This destroys C1 and C2 (all descendants of C1), including C2 in the child.
    You still hold C with its full rights intact.
 ```
 
-This pattern works because revocation is subtree-local. Revoking C1 removes C1 and
-all descendants but leaves C and any siblings of C1 untouched.
+This pattern works because revocation is subtree-local: revoking C1 removes C1 and
+all descendants but leaves C and any siblings of C1 untouched. Delegation uses
+`SYS_CAP_COPY` so you keep your own access to C2 while the child holds a revocable
+copy. **IPC transfer** and `SYS_CAP_MOVE` instead hand the slot away — the sender's
+slot is freed — but the moved cap keeps its position in the derivation tree (see
+[Derivation Across Processes](#derivation-across-processes)), so it stays a
+descendant of C1 and a `SYS_CAP_REVOKE` on C1 still reaches it across the `CSpace`
+boundary. Revoking C1 frees the child's C2 slot in the child's own `CSpace`;
+per-slot generation handles ensure the child's now-stale C2 handle then fails with
+`InvalidCapability` instead of aliasing a recycled slot (#349).
 
 ### Derivation Across Processes
 
-`SlotId` encodes `(ProcessId, slot_index)`. Resolving a remote slot requires:
+The hazard a cross-`CSpace` derivation edge creates (#349): `revoke_subtree` walks
+derivation edges and `free_slot`s each descendant in its own `CSpace`. If an edge
+crosses a `CSpace` boundary, revoking a source's subtree frees a slot in a foreign
+`CSpace` that the recipient still legitimately holds — and because cap handles
+recycle slot indices, that freed index would then alias an unrelated live object.
+
+Per-slot generation handles make cross-`CSpace` capability sharing safe. Both forms
+of cross-`CSpace` sharing keep a derivation edge across the boundary:
+
+- **IPC capability transfer / `SYS_CAP_MOVE`** hand the cap to the recipient and
+  free the sender's slot, but the moved cap keeps its position in the derivation
+  tree — it stays a descendant of whatever it was derived from, so an ancestor's
+  `cap_revoke` reaches it across the boundary. (Same-`CSpace` moves likewise keep
+  the source's position.)
+- **`SYS_CAP_COPY`** keeps the new cap a derivation **child** of the source (the
+  "Derive Twice" pattern above), so the source can revoke the delegated copy.
+
+In both cases a `cap_revoke` can `free_slot` the recipient's slot in its own
+`CSpace`. The handle the recipient holds carries the slot's **generation**
+(`handle = (generation << CAP_INDEX_BITS) | index`); `free_slot` bumps the
+generation, so the recipient's now-stale handle fails with `InvalidCapability`
+rather than aliasing whatever later occupies the recycled index. See the per-slot
+generation discussion under [Capability Slot](#capability-slot-capslotrs).
+
+`SlotId` encodes `(cspace_id, epoch, slot_index)`. The derivation tree is resolved
+by:
 
 ```
 resolve(slot_id):
@@ -378,8 +437,8 @@ resolve(slot_id):
     return cspace.slot(slot_id.index)         // O(1) two-level lookup
 ```
 
-Neither operation requires holding a lock on the target process's CSpace — the
-derivation tree write lock is sufficient to prevent concurrent modification.
+Resolution does not require holding a lock on the target `CSpace` — the derivation
+tree write lock is sufficient to prevent concurrent modification.
 
 ---
 
@@ -423,18 +482,26 @@ transfer_cap(sender, sender_slot_idx, receiver, receiver_slot_idx):
     src_slot = sender.cspace.slot(sender_slot_idx)
     dst_slot = receiver.cspace.slot(receiver_slot_idx)
     // dst_slot must be null (verified before IPC delivery begins)
-    *dst_slot = *src_slot  // copy the entire slot structure
-    // Update derivation tree: dst_slot takes src_slot's position
-    relink_derivation_pointers(src_slot_id, dst_slot_id)
-    // Clear the sender's slot
-    src_slot.tag = CapTag::Null
+    dst_slot.{tag, rights, badge, object} = src_slot.{...}  // copy the cap
+    // The moved cap takes the source's position in the derivation tree: its
+    // parent, children, and siblings are repointed onto dst_slot, including
+    // across the CSpace boundary. That cross-boundary edge is what lets an
+    // ancestor's cap_revoke reach the moved cap; per-slot generation (#349)
+    // makes the receiver's handle fail closed if such a revoke frees this slot.
+    repoint_derivation_links(src_slot_id -> dst_slot_id)
+    src_slot.tag = CapTag::Null                    // clear the sender's slot
     src_slot.object = None
     // Note: ref_count does not change (same number of slots reference the object)
     release derivation tree write lock
 ```
 
-The derivation write lock is held for the duration of the transfer. This ensures
-no revocation can run concurrently with a transfer, preventing torn state.
+IPC capability transfer is always cross-`CSpace` (sender and receiver are distinct
+processes). The transferred cap keeps its position in the derivation tree, so it
+remains reachable by a `cap_revoke` on one of its ancestors; per-slot generation
+handles make the receiver's handle fail closed if such a revoke frees the
+receiver's slot (#349). The derivation write lock is held for the duration of the
+transfer, so no revocation can run concurrently with a transfer, preventing torn
+state.
 
 Reply capabilities are not part of the derivation tree — they are single-use,
 cannot be derived, and are not tracked for revocation. A reply capability is not

--- a/core/kernel/docs/syscalls.md
+++ b/core/kernel/docs/syscalls.md
@@ -396,6 +396,23 @@ suffices because `notification_send` rejects zero-bit sends.
 
 ---
 
+## Capability Handles
+
+A capability handle — the value passed in and returned through the cap-index
+argument and return registers — packs a per-slot generation with the slot index:
+`handle = (generation << 24) | index`. The low 24 bits are the `CSpace` slot
+index; the high 8 bits are the slot's generation, which the kernel bumps each
+time the slot is freed and recycled. Every cap-bearing syscall checks the
+handle's generation against the slot's current generation and returns
+`InvalidCapability` on mismatch — a handle held across a free/reallocate of its
+slot fails closed rather than aliasing the unrelated capability now at that index
+(#349). A never-recycled slot has generation 0, so its handle equals the bare
+index; long-lived boot/spawn caps keep their historical values, and a `0` handle
+still means "no capability". Range-split syscalls return their two child handles
+in the primary and secondary return registers (never packed into one word). See
+[capability-model.md](../../../docs/capability-model.md) § Capability Handle
+Format.
+
 ## Capability Syscalls
 
 ### `SYS_CAP_CREATE_ENDPOINT` (7)

--- a/core/kernel/src/cap/cspace.rs
+++ b/core/kernel/src/cap/cspace.rs
@@ -48,6 +48,12 @@ pub const L2_SIZE: usize = 56;
 /// Directory entries per `CSpace` (max 256 × 56 = 14336 slots).
 pub const L1_SIZE: usize = 256;
 
+// Every slot index must fit in the cap handle's index field; the rest of the
+// handle carries the per-slot generation. If the maximum CSpace capacity ever
+// exceeds the index field, the encoding would truncate indices — trip at
+// compile time instead.
+const _: () = assert!(L1_SIZE * L2_SIZE <= (1usize << syscall::CAP_INDEX_BITS));
+
 // ── Error type ────────────────────────────────────────────────────────────────
 
 /// Errors returned by `CSpace` operations.
@@ -215,9 +221,11 @@ impl CSpace
         };
 
         self.free_head = next;
-        // Clear the slot (removes free-list encoding).
+        // Clear the slot (removes free-list encoding) but keep the per-slot
+        // generation that `free_slot` left, so the minted cap handle's
+        // generation matches the slot the recipient will resolve (#349).
         let slot = self.slot_mut(idx.get()).ok_or(CapError::InvalidIndex)?;
-        slot.clear();
+        slot.clear_keep_generation();
         self.free_count -= 1;
         Ok(idx)
     }
@@ -381,6 +389,11 @@ impl CSpace
             );
             return;
         }
+        // Bump the per-slot generation before returning the slot to the free
+        // list (the legitimate-free path only — the double-free guard above
+        // returns without bumping). Every outstanding handle to the prior
+        // occupant now carries a stale generation and fails lookup_cap (#349).
+        slot.bump_generation();
         slot.set_next_free(old_head);
         self.free_head = Some(nz_index);
         self.free_count += 1;
@@ -411,6 +424,38 @@ impl CSpace
         slot.deriv_prev_sibling = None;
 
         Ok(index)
+    }
+
+    /// Encode the cap handle (per-slot generation + slot index) for `index`.
+    ///
+    /// Call right after inserting a cap at `index`, under the `CSpace` lock, to
+    /// build the handle returned to userspace. Reads the slot's current
+    /// generation and packs it with the index per [`syscall::cap_handle_encode`];
+    /// a never-recycled slot has generation 0, so the handle equals the bare
+    /// index. Returns the bare index if the slot is somehow absent.
+    pub fn cap_handle(&self, index: NonZeroU32) -> u32
+    {
+        let generation = self
+            .slot(index.get())
+            .map_or(0, super::slot::CapabilitySlot::generation);
+        syscall::cap_handle_encode(index.get(), generation)
+    }
+
+    /// Allocate a slot, populate it, and return the encoded cap handle.
+    ///
+    /// Convenience over [`insert_cap`](Self::insert_cap) +
+    /// [`cap_handle`](Self::cap_handle) for the common mint path: the
+    /// generation read happens under the same `&mut self` the caller already
+    /// holds the `CSpace` lock for, so no separate locked read is needed.
+    pub fn insert_cap_handle(
+        &mut self,
+        tag: CapTag,
+        rights: Rights,
+        object: NonNull<KernelObjectHeader>,
+    ) -> Result<u32, CapError>
+    {
+        let index = self.insert_cap(tag, rights, object)?;
+        Ok(self.cap_handle(index))
     }
 
     /// Grow the `CSpace` until at least `min_free` slots are available without
@@ -446,10 +491,12 @@ impl CSpace
             self.free_head = next;
             self.free_count -= 1;
             // Drop the free-list marker so the unlinked slot is canonical
-            // off-list (same state as an `allocate_slot` pop).
+            // off-list (same state as an `allocate_slot` pop). Keep the
+            // generation so a cap later placed here via insert_cap_at carries
+            // the recycled slot's generation (#349).
             if let Some(slot) = self.slot_mut(target)
             {
-                slot.clear();
+                slot.clear_keep_generation();
             }
             return true;
         }
@@ -481,10 +528,11 @@ impl CSpace
                 };
                 cur_slot.set_next_free(after);
                 self.free_count -= 1;
-                // Drop the free-list marker on the spliced-out slot.
+                // Drop the free-list marker on the spliced-out slot; keep the
+                // generation (see the head case above).
                 if let Some(slot) = self.slot_mut(target)
                 {
-                    slot.clear();
+                    slot.clear_keep_generation();
                 }
                 return true;
             }

--- a/core/kernel/src/cap/mod.rs
+++ b/core/kernel/src/cap/mod.rs
@@ -2311,10 +2311,18 @@ fn nonnull_from_box<T>(b: Box<T>) -> NonNull<KernelObjectHeader>
 
 /// Move a capability between `CSpaces`, rewriting derivation tree pointers in place.
 ///
-/// The moved slot takes the **same position** in the derivation tree as the source:
-/// parent, children, and siblings all have their pointers updated to the new
-/// `(dst_cspace_id, new_idx)` location. No ref-count change occurs — this is a
-/// move, not a copy.
+/// The destination slot takes the source's exact position in the derivation
+/// tree: parent, children, and siblings are repointed to the new
+/// `(dst_cspace_id, new_idx)` location. A cross-CSpace move preserves the
+/// derivation edge across the boundary, so a `revoke_subtree` rooted in the
+/// source `CSpace` can reach and free the moved slot in the destination.
+///
+/// That cross-CSpace free is safe against stale-handle aliasing (#349) because
+/// cap handles carry a per-slot generation: freeing a slot bumps its
+/// generation, so a recipient that still holds the old handle fails with
+/// `InvalidCapability` instead of aliasing whatever later reuses the index.
+///
+/// No ref-count change occurs — this is a move, not a copy.
 ///
 /// # Contract
 /// - **Caller must hold [`DERIVATION_LOCK`]`.write_lock()`** for the duration.
@@ -2325,8 +2333,12 @@ fn nonnull_from_box<T>(b: Box<T>) -> NonNull<KernelObjectHeader>
 /// - Source slot must be non-null.
 /// - `dst_cspace` must have at least one free slot (call `pre_allocate` first).
 ///
-/// Returns the new slot index in `dst_cspace`, or an error if the source slot
-/// is null/invalid or the destination `CSpace` is full.
+/// Returns the encoded cap handle (generation + index) for the new slot in
+/// `dst_cspace`, or an error if the source slot is null/invalid or the
+/// destination `CSpace` is full. `src_idx` must be a decoded (bare) index. The
+/// `sys_cap_move` caller decodes and generation-validates the source handle
+/// first; the IPC transfer path supplies a generation-stripped index and does
+/// not (the send-path residual, #349).
 ///
 /// # Safety
 /// `src_cspace` and `dst_cspace` must be valid, live `CSpace` pointers.
@@ -2375,7 +2387,9 @@ pub unsafe fn move_cap_between_cspaces(
     let src_slot_id = SlotId::current(src_cspace_id, src_idx_nz);
     let dst_slot_id = SlotId::current(dst_cspace_id, new_idx_nz);
 
-    // Read derivation links from the source slot.
+    // The destination takes the source's exact position in the derivation tree:
+    // parent, children, and siblings are repointed to the new slot, including
+    // across a CSpace boundary. Read derivation links from the source slot.
     let (src_parent, src_first_child, src_prev, src_next) = {
         // SAFETY: src_cspace is a valid CSpace pointer; guaranteed by caller contract.
         let cs = unsafe { &*src_cspace };
@@ -2468,7 +2482,9 @@ pub unsafe fn move_cap_between_cspaces(
         (*src_cspace).free_slot(src_idx);
     }
 
-    Ok(new_idx)
+    // Return the encoded destination handle (generation + index, #349).
+    // SAFETY: dst_cspace valid and locked by the caller; slot just inserted.
+    Ok(unsafe { (*dst_cspace).cap_handle(new_idx_nz) })
 }
 
 /// Insert a capability, calling [`crate::fatal`] on error.

--- a/core/kernel/src/cap/slot.rs
+++ b/core/kernel/src/cap/slot.rs
@@ -349,7 +349,8 @@ pub struct CapabilitySlot
     /// Explicit padding: aligns `rights` to offset 4 and `badge` to offset 8.
     /// `pad[0]` doubles as the intrusive free-list membership marker
     /// ([`FREE_LIST_MARKER`] when the Null slot is linked on a `CSpace` free
-    /// list); `pad[1..]` are always zero.
+    /// list); `pad[1]` holds the per-slot generation counter (see
+    /// [`CapabilitySlot::generation`]); `pad[2]` is always zero.
     pad: [u8; 3],
     /// Rights bitmask (type-specific).
     pub rights: Rights,
@@ -377,6 +378,11 @@ pub struct CapabilitySlot
 unsafe impl Send for CapabilitySlot {}
 // SAFETY: CapabilitySlot is accessed only under CSpace lock; no Sync violation.
 unsafe impl Sync for CapabilitySlot {}
+
+// The 72-byte layout is a cross-boundary contract and is what makes 56 slots
+// fit a 4 KiB CSpacePage. The per-slot generation lives in the spare `pad[1]`
+// and must not grow the slot.
+const _: () = assert!(core::mem::size_of::<CapabilitySlot>() == 72);
 
 /// Value stamped into `CapabilitySlot::pad[0]` while a Null slot is linked on a
 /// `CSpace` intrusive free list. A free-list **tail** slot has `deriv_parent ==
@@ -415,6 +421,44 @@ impl CapabilitySlot
         *self = Self::null();
     }
 
+    /// Reset the slot to null but preserve the per-slot generation in `pad[1]`.
+    ///
+    /// Used on the allocation path: `CSpace::allocate_slot` pops a free slot and
+    /// must hand out the generation the previous `free_slot` left behind, so the
+    /// minted cap handle's generation matches the slot the recipient resolves.
+    /// Contrast [`clear`](Self::clear), which fully zeroes the slot (including the
+    /// generation) and is correct only when the slot is not being recycled into a
+    /// live cap.
+    pub fn clear_keep_generation(&mut self)
+    {
+        let generation = self.pad[1];
+        *self = Self::null();
+        self.pad[1] = generation;
+    }
+
+    /// Read this slot's per-slot generation counter (stored in `pad[1]`).
+    ///
+    /// `CSpace::free_slot` bumps the generation each time the slot is recycled.
+    /// It is encoded into the cap handle ([`syscall::cap_handle_encode`]), so a
+    /// stale handle to a recycled slot fails `lookup_cap` with `InvalidCapability`
+    /// instead of aliasing the new occupant (#349). Distinct from
+    /// [`SlotId::epoch`], which is the `CSpace`-registry generation.
+    pub fn generation(&self) -> u8
+    {
+        self.pad[1]
+    }
+
+    /// Increment the per-slot generation, wrapping at 256.
+    ///
+    /// Called by `CSpace::free_slot` when a slot is recycled, so every handle to
+    /// the prior occupant becomes stale. Wraparound is a bounded ABA window
+    /// (256 reuses of the same index); acceptable for a fail-closed backstop
+    /// (#349). See [`generation`](Self::generation).
+    pub fn bump_generation(&mut self)
+    {
+        self.pad[1] = self.pad[1].wrapping_add(1);
+    }
+
     // ── Intrusive free-list helpers ───────────────────────────────────────────
 
     /// Encode the next-free-list successor index in `deriv_parent`.
@@ -433,13 +477,19 @@ impl CapabilitySlot
     ///
     /// Stamps the [`FREE_LIST_MARKER`] into `pad[0]` so [`is_on_free_list`]
     /// can recognise this slot as a free-list member regardless of whether it
-    /// is the list tail.
+    /// is the list tail. Leaves `pad[1]` (the per-slot generation) untouched —
+    /// `CSpace::free_slot` bumps it immediately before this call and the next
+    /// allocation must observe the incremented value.
     ///
     /// [`is_on_free_list`]: Self::is_on_free_list
     pub fn set_next_free(&mut self, next: Option<NonZeroU32>)
     {
         self.tag = CapTag::Null;
-        self.pad = [FREE_LIST_MARKER, 0, 0];
+        self.pad[0] = FREE_LIST_MARKER;
+        self.pad[2] = 0;
+        // pad[1] holds the per-slot generation, bumped by `CSpace::free_slot`
+        // just before this call. Preserve it across the free so the next
+        // `allocate_slot` hands out the incremented generation.
         self.rights = Rights::NONE;
         self.badge = 0;
         self.object = None;
@@ -593,6 +643,81 @@ mod tests
         // clear() (the allocate-on-pop path) drops the marker.
         s.clear();
         assert!(!s.is_on_free_list());
+    }
+
+    // The per-slot generation (#349) must survive both the free-list encoding
+    // and the allocate-on-pop clear, or a recycled index would hand out a stale
+    // generation and the backstop would never fire. Mirrors the CSpace
+    // free_slot (bump then set_next_free) / allocate_slot (clear_keep_generation)
+    // sequence; a missing edit on any of the three sites fails here.
+    #[test]
+    fn generation_survives_free_then_alloc_cycle()
+    {
+        let mut s = CapabilitySlot::null();
+        assert_eq!(s.generation(), 0);
+        s.bump_generation();
+        s.set_next_free(None);
+        assert!(s.is_on_free_list());
+        assert_eq!(
+            s.generation(),
+            1,
+            "set_next_free must preserve the generation"
+        );
+        s.clear_keep_generation();
+        assert!(!s.is_on_free_list());
+        assert_eq!(
+            s.generation(),
+            1,
+            "the allocate path must keep the bumped generation"
+        );
+    }
+
+    // clear() fully zeroes (including the generation); clear_keep_generation does
+    // not. The distinction is what makes the recycle backstop work.
+    #[test]
+    fn clear_variants_differ_on_generation()
+    {
+        let mut s = CapabilitySlot::null();
+        s.bump_generation();
+        s.bump_generation();
+        s.clear_keep_generation();
+        assert_eq!(s.generation(), 2);
+        s.clear();
+        assert_eq!(s.generation(), 0, "clear() must zero the generation");
+    }
+
+    // 8-bit generation wraps after 256 recycles — bounded ABA, documented (#349).
+    #[test]
+    fn bump_generation_wraps_at_256()
+    {
+        let mut s = CapabilitySlot::null();
+        for _ in 0..256
+        {
+            s.bump_generation();
+        }
+        assert_eq!(s.generation(), 0);
+    }
+
+    // Cap-handle encoding round-trips index and generation, and a gen-0 handle is
+    // numerically identical to the bare index (the backward-compat hinge, #349).
+    #[test]
+    fn cap_handle_round_trip_and_gen_zero_identity()
+    {
+        use syscall::{cap_handle_encode, cap_handle_gen, cap_handle_index};
+        for &index in &[1u32, 2, 42, 14_335, syscall::CAP_INDEX_MASK]
+        {
+            for &generation in &[0u8, 1, 127, 128, 255]
+            {
+                let h = cap_handle_encode(index, generation);
+                assert_eq!(cap_handle_index(h), index);
+                assert_eq!(cap_handle_gen(h), generation);
+            }
+        }
+        assert_eq!(
+            cap_handle_encode(7, 0),
+            7,
+            "gen-0 handle equals the bare index"
+        );
     }
 
     #[test]

--- a/core/kernel/src/cap/split.rs
+++ b/core/kernel/src/cap/split.rs
@@ -27,7 +27,10 @@ use syscall::SyscallError;
 ///      both new caps to that parent;
 ///   3. frees the original slot and drops its object reference.
 ///
-/// Returns the packed `slot1 | (slot2 << 32)`.
+/// Returns the two encoded child handles `(handle1, handle2)` (generation +
+/// index each). The caller delivers `handle1` in the primary return register
+/// and `handle2` in the secondary — never packed into one word, so a high
+/// generation cannot set the sign bit of an `i64` return (#349).
 ///
 /// # Safety
 /// `caller_cspace` must be a valid non-null `CSpace` pointer for the calling
@@ -49,7 +52,7 @@ pub(crate) unsafe fn install_split_children(
     orig_obj_ptr: NonNull<KernelObjectHeader>,
     child1_ptr: NonNull<KernelObjectHeader>,
     child2_ptr: NonNull<KernelObjectHeader>,
-) -> Result<u64, SyscallError>
+) -> Result<(u32, u32), SyscallError>
 {
     // Insert both children into the caller's CSpace under cspace.lock so the
     // freelist mutation cannot tear against a concurrent SYS_CAP_CREATE_*.
@@ -95,8 +98,6 @@ pub(crate) unsafe fn install_split_children(
         }
         SyscallError::OutOfMemory
     })?;
-    let slot2 = slot2_nz.get();
-
     // ── Wire derivation tree ──────────────────────────────────────────────────
 
     let orig_idx_nz = NonZeroU32::new(orig_idx).ok_or(SyscallError::InvalidCapability)?;
@@ -142,5 +143,17 @@ pub(crate) unsafe fn install_split_children(
         unsafe { dealloc_object(orig_obj_ptr) };
     }
 
-    Ok(u64::from(slot1) | (u64::from(slot2) << 32))
+    // Encode both child handles (generation + index, #349). Returned separately
+    // so the caller can deliver them in two registers.
+    // SAFETY: caller_cspace validated; both slots occupied so the reads are stable.
+    let handles = unsafe {
+        let saved = (*caller_cspace).lock.lock_raw();
+        let h = (
+            (*caller_cspace).cap_handle(slot1_nz),
+            (*caller_cspace).cap_handle(slot2_nz),
+        );
+        (*caller_cspace).lock.unlock_raw(saved);
+        h
+    };
+    Ok(handles)
 }

--- a/core/kernel/src/syscall/cap.rs
+++ b/core/kernel/src/syscall/cap.rs
@@ -26,6 +26,49 @@ use syscall::SyscallError;
 #[cfg(not(test))]
 use super::current_tcb;
 
+/// Resolve a user-supplied source-cap handle for `cap_copy` / `cap_derive` /
+/// `cap_derive_badge` / `cap_move`: verify the slot is non-null and that the
+/// handle's generation matches the slot's, rejecting a stale handle to a
+/// recycled slot (#349). The index is decoded from the handle. Returns the
+/// `(tag, rights, object, badge)` a copy/derive/move needs.
+///
+/// # Safety
+/// `cspace` must be a valid `CSpace` pointer.
+#[cfg(not(test))]
+unsafe fn resolve_src_cap(
+    cspace: *mut crate::cap::cspace::CSpace,
+    handle: u32,
+) -> Result<
+    (
+        crate::cap::slot::CapTag,
+        crate::cap::slot::Rights,
+        core::ptr::NonNull<crate::cap::object::KernelObjectHeader>,
+        u64,
+    ),
+    SyscallError,
+>
+{
+    // SAFETY: cspace is a valid CSpace pointer (caller contract).
+    let cs = unsafe { &*cspace };
+    let slot = cs
+        .slot(syscall::cap_handle_index(handle))
+        .ok_or(SyscallError::InvalidCapability)?;
+    if slot.tag == crate::cap::slot::CapTag::Null
+    {
+        return Err(SyscallError::InvalidCapability);
+    }
+    if slot.generation() != syscall::cap_handle_gen(handle)
+    {
+        return Err(SyscallError::InvalidCapability);
+    }
+    Ok((
+        slot.tag,
+        slot.rights,
+        slot.object.ok_or(SyscallError::InvalidCapability)?,
+        slot.badge,
+    ))
+}
+
 /// `SYS_CAP_CREATE_ENDPOINT` (7): retype a Memory cap into a new Endpoint.
 ///
 /// arg0 = Memory-cap slot index in the caller's `CSpace`. The Memory cap
@@ -123,7 +166,7 @@ pub fn sys_cap_create_endpoint(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     // SAFETY: cspace validated non-null above; lock_raw/unlock_raw paired.
     let idx_res = unsafe {
         let saved = (*cspace).lock.lock_raw();
-        let r = (*cspace).insert_cap(
+        let r = (*cspace).insert_cap_handle(
             CapTag::Endpoint,
             Rights::SEND | Rights::RECEIVE | Rights::GRANT,
             nonnull,
@@ -134,7 +177,7 @@ pub fn sys_cap_create_endpoint(tf: &mut TrapFrame) -> Result<u64, SyscallError>
 
     if let Ok(idx) = idx_res
     {
-        Ok(u64::from(idx.get()))
+        Ok(u64::from(idx))
     }
     else
     {
@@ -236,14 +279,18 @@ pub fn sys_cap_create_notification(tf: &mut TrapFrame) -> Result<u64, SyscallErr
     // SAFETY: cspace validated non-null; lock_raw/unlock_raw paired.
     let idx_res = unsafe {
         let saved = (*cspace).lock.lock_raw();
-        let r = (*cspace).insert_cap(CapTag::Notification, Rights::NOTIFY | Rights::WAIT, nonnull);
+        let r = (*cspace).insert_cap_handle(
+            CapTag::Notification,
+            Rights::NOTIFY | Rights::WAIT,
+            nonnull,
+        );
         (*cspace).lock.unlock_raw(saved);
         r
     };
 
     if let Ok(idx) = idx_res
     {
-        Ok(u64::from(idx.get()))
+        Ok(u64::from(idx))
     }
     else
     {
@@ -473,7 +520,7 @@ pub fn sys_cap_create_aspace(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     // SAFETY: cspace validated non-null above; lock_raw/unlock_raw paired.
     let idx = unsafe {
         let saved = (*cspace).lock.lock_raw();
-        let r = (*cspace).insert_cap(
+        let r = (*cspace).insert_cap_handle(
             CapTag::AddressSpace,
             Rights::MAP | Rights::READ | Rights::CONTROL,
             nonnull,
@@ -483,7 +530,7 @@ pub fn sys_cap_create_aspace(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     }
     .map_err(|_| SyscallError::OutOfMemory)?;
 
-    Ok(u64::from(idx.get()))
+    Ok(u64::from(idx))
 }
 
 /// `SYS_CAP_CREATE_CSPACE` (12): retype a Memory cap into a new `CSpace`,
@@ -713,7 +760,7 @@ pub fn sys_cap_create_cspace(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     // SAFETY: cspace validated non-null above; lock_raw/unlock_raw paired.
     let insert_res = unsafe {
         let saved = (*cspace).lock.lock_raw();
-        let r = (*cspace).insert_cap(
+        let r = (*cspace).insert_cap_handle(
             CapTag::CSpace,
             Rights::INSERT | Rights::DELETE | Rights::DERIVE,
             nonnull,
@@ -745,7 +792,7 @@ pub fn sys_cap_create_cspace(tf: &mut TrapFrame) -> Result<u64, SyscallError>
         return Err(SyscallError::OutOfMemory);
     };
 
-    Ok(u64::from(idx.get()))
+    Ok(u64::from(idx))
 }
 
 /// `SYS_CAP_CREATE_THREAD` (10): create a new Thread object.
@@ -957,8 +1004,11 @@ pub fn sys_cap_create_thread(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     // SAFETY: caller_cspace validated non-null above; lock_raw/unlock_raw paired.
     let idx_res = unsafe {
         let saved = (*caller_cspace).lock.lock_raw();
-        let r =
-            (*caller_cspace).insert_cap(CapTag::Thread, Rights::CONTROL | Rights::OBSERVE, nonnull);
+        let r = (*caller_cspace).insert_cap_handle(
+            CapTag::Thread,
+            Rights::CONTROL | Rights::OBSERVE,
+            nonnull,
+        );
         (*caller_cspace).lock.unlock_raw(saved);
         r
     };
@@ -966,7 +1016,7 @@ pub fn sys_cap_create_thread(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     if let Ok(idx) = idx_res
     {
         let _ = kstack_virt;
-        Ok(u64::from(idx.get()))
+        Ok(u64::from(idx))
     }
     else
     {
@@ -1010,9 +1060,12 @@ pub fn sys_cap_copy(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     use crate::cap::object::CSpaceKernelObject;
     use crate::cap::slot::Rights;
 
-    let src_idx = tf.arg(0) as u32;
+    let src_handle = tf.arg(0) as u32;
+    let src_idx = syscall::cap_handle_index(src_handle);
     let dest_cs_idx = tf.arg(1) as u32;
-    let dest_slot_idx = tf.arg(2) as u32;
+    // Destination is a placement index (slot may be empty), not a live handle:
+    // decode the index, but do not generation-check it.
+    let dest_slot_idx = syscall::cap_handle_index(tf.arg(2) as u32);
     let rights_mask = Rights(tf.arg(3) as u32);
 
     // SAFETY: syscall entry ensures current_tcb() returns active thread's TCB.
@@ -1031,21 +1084,10 @@ pub fn sys_cap_copy(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     let caller_cspace_id = unsafe { (*caller_cspace).id() };
 
     // Resolve source slot (any non-null tag, any rights — just non-null).
-    let (src_tag, src_rights, src_object, src_badge) = {
-        // SAFETY: caller_cspace validated non-null above.
-        let cs = unsafe { &*caller_cspace };
-        let slot = cs.slot(src_idx).ok_or(SyscallError::InvalidCapability)?;
-        if slot.tag == crate::cap::slot::CapTag::Null
-        {
-            return Err(SyscallError::InvalidCapability);
-        }
-        (
-            slot.tag,
-            slot.rights,
-            slot.object.ok_or(SyscallError::InvalidCapability)?,
-            slot.badge,
-        )
-    };
+    // SAFETY: caller_cspace validated non-null above. Decodes + generation-
+    // checks the source handle, rejecting a stale handle to a recycled slot.
+    let (src_tag, src_rights, src_object, src_badge) =
+        unsafe { resolve_src_cap(caller_cspace, src_handle)? };
 
     // Convert src_idx to NonZeroU32 before any state mutation. The non-null
     // tag check above excludes slot 0 (which is permanently Null), so this
@@ -1141,7 +1183,16 @@ pub fn sys_cap_copy(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     }
     crate::cap::DERIVATION_LOCK.write_unlock();
 
-    Ok(u64::from(new_idx))
+    // Encode the destination slot's generation into the returned handle (#349).
+    // Re-lock the destination CSpace to read the generation soundly.
+    // SAFETY: dest_cs_ptr validated above.
+    let new_handle = unsafe {
+        let saved = (*dest_cs_ptr).lock.lock_raw();
+        let h = (*dest_cs_ptr).cap_handle(new_idx_nz);
+        (*dest_cs_ptr).lock.unlock_raw(saved);
+        h
+    };
+    Ok(u64::from(new_handle))
 }
 
 /// `SYS_CAP_DERIVE` (14): attenuate a capability within the caller's own `CSpace.`
@@ -1159,7 +1210,8 @@ pub fn sys_cap_derive(tf: &mut TrapFrame) -> Result<u64, SyscallError>
 {
     use crate::cap::slot::Rights;
 
-    let src_idx = tf.arg(0) as u32;
+    let src_handle = tf.arg(0) as u32;
+    let src_idx = syscall::cap_handle_index(src_handle);
     let rights_mask = Rights(tf.arg(1) as u32);
 
     // SAFETY: syscall entry ensures current_tcb() returns active thread's TCB.
@@ -1178,21 +1230,10 @@ pub fn sys_cap_derive(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     let cspace_id = unsafe { (*caller_cspace).id() };
 
     // Resolve source slot.
-    let (src_tag, src_rights, src_object, src_badge) = {
-        // SAFETY: caller_cspace validated non-null above.
-        let cs = unsafe { &*caller_cspace };
-        let slot = cs.slot(src_idx).ok_or(SyscallError::InvalidCapability)?;
-        if slot.tag == crate::cap::slot::CapTag::Null
-        {
-            return Err(SyscallError::InvalidCapability);
-        }
-        (
-            slot.tag,
-            slot.rights,
-            slot.object.ok_or(SyscallError::InvalidCapability)?,
-            slot.badge,
-        )
-    };
+    // SAFETY: caller_cspace validated non-null above. Decodes + generation-
+    // checks the source handle, rejecting a stale handle to a recycled slot.
+    let (src_tag, src_rights, src_object, src_badge) =
+        unsafe { resolve_src_cap(caller_cspace, src_handle)? };
 
     let effective_rights = rights_mask & src_rights;
 
@@ -1230,8 +1271,6 @@ pub fn sys_cap_derive(tf: &mut TrapFrame) -> Result<u64, SyscallError>
             _ => SyscallError::OutOfMemory,
         }
     })?;
-    let new_idx = new_idx_nz.get();
-
     // Wire derivation link.
     let src_idx_nz = core::num::NonZeroU32::new(src_idx).ok_or(SyscallError::InvalidCapability)?;
     let parent = crate::cap::slot::SlotId::current(cspace_id, src_idx_nz);
@@ -1243,7 +1282,17 @@ pub fn sys_cap_derive(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     }
     crate::cap::DERIVATION_LOCK.write_unlock();
 
-    Ok(u64::from(new_idx))
+    // Encode the new slot's generation into the returned handle (#349). Re-lock
+    // to read the generation soundly; the slot is occupied (no handle returned
+    // yet) so the value is stable.
+    // SAFETY: caller_cspace validated non-null above.
+    let new_handle = unsafe {
+        let saved = (*caller_cspace).lock.lock_raw();
+        let h = (*caller_cspace).cap_handle(new_idx_nz);
+        (*caller_cspace).lock.unlock_raw(saved);
+        h
+    };
+    Ok(u64::from(new_handle))
 }
 
 /// `SYS_CAP_DERIVE_BADGE` (48): derive a capability with a badge attached.
@@ -1263,7 +1312,8 @@ pub fn sys_cap_derive_badge(tf: &mut TrapFrame) -> Result<u64, SyscallError>
 {
     use crate::cap::slot::Rights;
 
-    let src_idx = tf.arg(0) as u32;
+    let src_handle = tf.arg(0) as u32;
+    let src_idx = syscall::cap_handle_index(src_handle);
     let rights_mask = Rights(tf.arg(1) as u32);
     let badge_value = tf.arg(2);
 
@@ -1288,21 +1338,10 @@ pub fn sys_cap_derive_badge(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     let cspace_id = unsafe { (*caller_cspace).id() };
 
     // Resolve source slot.
-    let (src_tag, src_rights, src_object, src_badge) = {
-        // SAFETY: caller_cspace validated non-null above.
-        let cs = unsafe { &*caller_cspace };
-        let slot = cs.slot(src_idx).ok_or(SyscallError::InvalidCapability)?;
-        if slot.tag == crate::cap::slot::CapTag::Null
-        {
-            return Err(SyscallError::InvalidCapability);
-        }
-        (
-            slot.tag,
-            slot.rights,
-            slot.object.ok_or(SyscallError::InvalidCapability)?,
-            slot.badge,
-        )
-    };
+    // SAFETY: caller_cspace validated non-null above. Decodes + generation-
+    // checks the source handle, rejecting a stale handle to a recycled slot.
+    let (src_tag, src_rights, src_object, src_badge) =
+        unsafe { resolve_src_cap(caller_cspace, src_handle)? };
 
     // Cannot re-badge a capability that already has a badge.
     if src_badge != 0
@@ -1344,8 +1383,6 @@ pub fn sys_cap_derive_badge(tf: &mut TrapFrame) -> Result<u64, SyscallError>
             _ => SyscallError::OutOfMemory,
         }
     })?;
-    let new_idx = new_idx_nz.get();
-
     // Wire derivation link.
     let src_idx_nz = core::num::NonZeroU32::new(src_idx).ok_or(SyscallError::InvalidCapability)?;
     let parent = crate::cap::slot::SlotId::current(cspace_id, src_idx_nz);
@@ -1357,7 +1394,17 @@ pub fn sys_cap_derive_badge(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     }
     crate::cap::DERIVATION_LOCK.write_unlock();
 
-    Ok(u64::from(new_idx))
+    // Encode the new slot's generation into the returned handle (#349). Re-lock
+    // to read the generation soundly; the slot is occupied (no handle returned
+    // yet) so the value is stable.
+    // SAFETY: caller_cspace validated non-null above.
+    let new_handle = unsafe {
+        let saved = (*caller_cspace).lock.lock_raw();
+        let h = (*caller_cspace).cap_handle(new_idx_nz);
+        (*caller_cspace).lock.unlock_raw(saved);
+        h
+    };
+    Ok(u64::from(new_handle))
 }
 
 /// One-shot guard for [`log_self_cap_delete_refused`].
@@ -1406,7 +1453,8 @@ fn log_self_cap_delete_refused(tcb: *mut crate::sched::thread::ThreadControlBloc
 #[cfg(not(test))]
 pub fn sys_cap_delete(tf: &mut TrapFrame) -> Result<u64, SyscallError>
 {
-    let slot_idx = tf.arg(0) as u32;
+    let slot_handle = tf.arg(0) as u32;
+    let slot_idx = syscall::cap_handle_index(slot_handle);
 
     // SAFETY: syscall entry ensures current_tcb() returns active thread's TCB.
     let tcb = unsafe { current_tcb() };
@@ -1438,6 +1486,14 @@ pub fn sys_cap_delete(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     {
         Some(slot) if slot.tag != crate::cap::slot::CapTag::Null =>
         {
+            // Reject a stale handle to a recycled slot (#349). Must not fall to
+            // the idempotent Null arm below — that would silently succeed
+            // against the unrelated live cap now occupying the index.
+            if slot.generation() != syscall::cap_handle_gen(slot_handle)
+            {
+                crate::cap::DERIVATION_LOCK.write_unlock();
+                return Err(SyscallError::InvalidCapability);
+            }
             let Some(obj) = slot.object
             else
             {
@@ -1527,7 +1583,8 @@ pub fn sys_cap_delete(tf: &mut TrapFrame) -> Result<u64, SyscallError>
 #[cfg(not(test))]
 pub fn sys_cap_revoke(tf: &mut TrapFrame) -> Result<u64, SyscallError>
 {
-    let slot_idx = tf.arg(0) as u32;
+    let slot_handle = tf.arg(0) as u32;
+    let slot_idx = syscall::cap_handle_index(slot_handle);
 
     // SAFETY: syscall entry ensures current_tcb() returns active thread's TCB.
     let tcb = unsafe { current_tcb() };
@@ -1544,12 +1601,17 @@ pub fn sys_cap_revoke(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     // SAFETY: caller_cspace validated non-null above.
     let cspace_id = unsafe { (*caller_cspace).id() };
 
-    // Validate slot is non-null.
+    // Validate slot is non-null and the handle's generation is current.
     {
         // SAFETY: caller_cspace validated non-null above.
         let cs = unsafe { &*caller_cspace };
         let slot = cs.slot(slot_idx).ok_or(SyscallError::InvalidCapability)?;
         if slot.tag == crate::cap::slot::CapTag::Null
+        {
+            return Err(SyscallError::InvalidCapability);
+        }
+        // Reject a stale handle to a recycled slot (#349).
+        if slot.generation() != syscall::cap_handle_gen(slot_handle)
         {
             return Err(SyscallError::InvalidCapability);
         }
@@ -1616,9 +1678,12 @@ pub fn sys_cap_move(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     use crate::cap::object::CSpaceKernelObject;
     use crate::cap::slot::{Rights, SlotId};
 
-    let src_idx = tf.arg(0) as u32;
+    let src_handle = tf.arg(0) as u32;
+    let src_idx = syscall::cap_handle_index(src_handle);
     let dest_cs_idx = tf.arg(1) as u32;
-    let dest_idx = tf.arg(2) as u32; // 0 = auto-allocate
+    // Destination is a placement index (slot may be empty), not a live handle:
+    // decode the index, but do not generation-check it. 0 = auto-allocate.
+    let dest_idx = syscall::cap_handle_index(tf.arg(2) as u32);
 
     // SAFETY: syscall entry ensures current_tcb() returns active thread's TCB.
     let tcb = unsafe { current_tcb() };
@@ -1651,6 +1716,20 @@ pub fn sys_cap_move(tf: &mut TrapFrame) -> Result<u64, SyscallError>
         let cs_obj = unsafe { &*(obj.as_ptr().cast::<CSpaceKernelObject>()) };
         cs_obj.cspace
     };
+
+    // Generation-check the source handle before the move. `move_cap_between_cspaces`
+    // takes a pre-decoded, pre-validated bare index (the IPC transfer path feeds
+    // it a generation-stripped index), so the source check lives in the caller (#349).
+    {
+        // SAFETY: caller_cspace validated non-null above.
+        let cs = unsafe { &*caller_cspace };
+        let slot = cs.slot(src_idx).ok_or(SyscallError::InvalidCapability)?;
+        if slot.tag == crate::cap::slot::CapTag::Null
+            || slot.generation() != syscall::cap_handle_gen(src_handle)
+        {
+            return Err(SyscallError::InvalidCapability);
+        }
+    }
 
     if dest_idx == 0
     {
@@ -1719,21 +1798,10 @@ pub fn sys_cap_move(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     let dest_cspace_id = unsafe { (*dest_cs_ptr).id() };
 
     // Read source slot contents.
-    let (src_tag, src_rights, src_object, src_badge) = {
-        // SAFETY: caller_cspace validated non-null above.
-        let cs = unsafe { &*caller_cspace };
-        let slot = cs.slot(src_idx).ok_or(SyscallError::InvalidCapability)?;
-        if slot.tag == crate::cap::slot::CapTag::Null
-        {
-            return Err(SyscallError::InvalidCapability);
-        }
-        (
-            slot.tag,
-            slot.rights,
-            slot.object.ok_or(SyscallError::InvalidCapability)?,
-            slot.badge,
-        )
-    };
+    // SAFETY: caller_cspace validated non-null above. Decodes + generation-
+    // checks the source handle, rejecting a stale handle to a recycled slot.
+    let (src_tag, src_rights, src_object, src_badge) =
+        unsafe { resolve_src_cap(caller_cspace, src_handle)? };
 
     // Pre-convert indices before locking so failure cannot leak locks.
     // src_idx cleared the non-null tag check (slot 0 is permanently Null);
@@ -1920,7 +1988,15 @@ pub fn sys_cap_move(tf: &mut TrapFrame) -> Result<u64, SyscallError>
 
     crate::cap::DERIVATION_LOCK.write_unlock();
 
-    Ok(u64::from(dest_idx))
+    // Encode the destination slot's generation into the returned handle (#349).
+    // SAFETY: dest_cs_ptr validated above; slot occupied so the read is stable.
+    let dest_handle = unsafe {
+        let saved = (*dest_cs_ptr).lock.lock_raw();
+        let h = (*dest_cs_ptr).cap_handle(dest_idx_nz);
+        (*dest_cs_ptr).lock.unlock_raw(saved);
+        h
+    };
+    Ok(u64::from(dest_handle))
 }
 
 /// `SYS_CAP_CREATE_EVENT_Q` (9): create a new `EventQueue` object.
@@ -2014,14 +2090,15 @@ pub fn sys_cap_create_event_queue(tf: &mut TrapFrame) -> Result<u64, SyscallErro
     // SAFETY: cspace validated non-null above; lock_raw/unlock_raw paired.
     let idx_res = unsafe {
         let saved = (*cspace).lock.lock_raw();
-        let r = (*cspace).insert_cap(CapTag::EventQueue, Rights::POST | Rights::RECV, nonnull);
+        let r =
+            (*cspace).insert_cap_handle(CapTag::EventQueue, Rights::POST | Rights::RECV, nonnull);
         (*cspace).lock.unlock_raw(saved);
         r
     };
 
     if let Ok(idx) = idx_res
     {
-        Ok(u64::from(idx.get()))
+        Ok(u64::from(idx))
     }
     else
     {
@@ -2114,14 +2191,15 @@ pub fn sys_cap_create_wait_set(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     // SAFETY: cspace validated non-null above; lock_raw/unlock_raw paired.
     let idx_res = unsafe {
         let saved = (*cspace).lock.lock_raw();
-        let r = (*cspace).insert_cap(CapTag::WaitSet, Rights::MODIFY | Rights::WAIT, nonnull);
+        let r =
+            (*cspace).insert_cap_handle(CapTag::WaitSet, Rights::MODIFY | Rights::WAIT, nonnull);
         (*cspace).lock.unlock_raw(saved);
         r
     };
 
     if let Ok(idx) = idx_res
     {
-        Ok(u64::from(idx.get()))
+        Ok(u64::from(idx))
     }
     else
     {
@@ -2183,7 +2261,8 @@ pub fn sys_cap_info(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     use crate::cap::slot::{CapTag, Rights};
     use crate::sched::thread::ThreadState;
 
-    let slot_idx = tf.arg(0) as u32;
+    let slot_handle = tf.arg(0) as u32;
+    let slot_idx = syscall::cap_handle_index(slot_handle);
     let field = tf.arg(1);
 
     // Resolve the caller's CSpace via its TCB.
@@ -2207,6 +2286,11 @@ pub fn sys_cap_info(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     let cs = unsafe { &*caller_cspace };
     let slot = cs.slot(slot_idx).ok_or(SyscallError::InvalidCapability)?;
     if slot.tag == CapTag::Null
+    {
+        return Err(SyscallError::InvalidCapability);
+    }
+    // Reject a stale handle to a recycled slot (#349).
+    if slot.generation() != syscall::cap_handle_gen(slot_handle)
     {
         return Err(SyscallError::InvalidCapability);
     }

--- a/core/kernel/src/syscall/hw.rs
+++ b/core/kernel/src/syscall/hw.rs
@@ -577,7 +577,7 @@ pub fn sys_mmio_split(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     // SAFETY: caller_cspace validated non-null; cspace_id is its id; both
     // children are freshly-allocated SEED-backed MmioObjects (refcount 1);
     // orig_obj_ptr is the live original from lookup_cap.
-    unsafe {
+    let (handle1, handle2) = unsafe {
         install_split_children(
             caller_cspace,
             cspace_id,
@@ -588,7 +588,12 @@ pub fn sys_mmio_split(tf: &mut TrapFrame) -> Result<u64, SyscallError>
             child1_ptr,
             child2_ptr,
         )
-    }
+    }?;
+    // Deliver both child handles: first in the primary return register, second
+    // in the secondary (rdx / a1). Never packed into one word, so a high
+    // generation cannot set the sign bit of the i64 return (#349).
+    tf.set_ipc_return(u64::from(handle1), u64::from(handle2));
+    Ok(u64::from(handle1))
 }
 
 #[cfg(test)]
@@ -700,7 +705,7 @@ pub fn sys_irq_split(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     // SAFETY: caller_cspace validated non-null; cspace_id is its id; both
     // children are freshly-allocated SEED-backed InterruptObjects (refcount 1);
     // orig_obj_ptr is the live original from lookup_cap.
-    unsafe {
+    let (handle1, handle2) = unsafe {
         install_split_children(
             caller_cspace,
             cspace_id,
@@ -711,7 +716,11 @@ pub fn sys_irq_split(tf: &mut TrapFrame) -> Result<u64, SyscallError>
             child1_ptr,
             child2_ptr,
         )
-    }
+    }?;
+    // Deliver both child handles: first in the primary return register, second
+    // in the secondary (rdx / a1). Never packed into one word (#349).
+    tf.set_ipc_return(u64::from(handle1), u64::from(handle2));
+    Ok(u64::from(handle1))
 }
 
 #[cfg(test)]
@@ -859,7 +868,7 @@ pub fn sys_ioport_split(tf: &mut TrapFrame) -> Result<u64, SyscallError>
         // SAFETY: caller_cspace validated non-null; cspace_id is its id; both
         // children are freshly-allocated SEED-backed IoPortObjects (refcount 1);
         // orig_obj_ptr is the live original from lookup_cap.
-        unsafe {
+        let (handle1, handle2) = unsafe {
             install_split_children(
                 caller_cspace,
                 cspace_id,
@@ -870,7 +879,11 @@ pub fn sys_ioport_split(tf: &mut TrapFrame) -> Result<u64, SyscallError>
                 child1_ptr,
                 child2_ptr,
             )
-        }
+        }?;
+        // Deliver both child handles: first in the primary return register,
+        // second in the secondary (rdx / a1). Never packed into one word (#349).
+        tf.set_ipc_return(u64::from(handle1), u64::from(handle2));
+        Ok(u64::from(handle1))
     }
 }
 

--- a/core/kernel/src/syscall/ipc.rs
+++ b/core/kernel/src/syscall/ipc.rs
@@ -145,7 +145,14 @@ unsafe fn write_cap_results(buf: u64, cap_count: usize, indices: &[u32; MSG_CAP_
 
 /// Unpack `count` slot indices from a packed u64 (4 × u16).
 ///
-/// Matches the encoding in `shared/syscall::pack_cap_slots`.
+/// Matches the encoding in `shared/syscall::pack_cap_slots`. Each value is a slot
+/// **index** only — the sender's handle generation was stripped by the 16-bit
+/// packing and is not transmitted. The kernel re-derives the destination handle's
+/// generation from the freshly inserted slot (so the recipient's handle is
+/// generation-correct), but it cannot generation-validate the sender's named
+/// index: a sender naming a stale, recycled handle transmits the slot's current
+/// occupant rather than failing closed. This is the one cap resolution path the
+/// per-slot generation backstop does not cover (#349).
 #[cfg(not(test))]
 fn unpack_cap_slots(packed: u64, count: usize) -> [u32; MSG_CAP_SLOTS_MAX]
 {
@@ -191,7 +198,10 @@ unsafe fn transfer_caps(
         return Ok(0);
     }
 
-    // Pre-validate: all source slots must be non-null.
+    // Pre-validate: all source slots must be non-null. The index is bare (the
+    // send pack stripped the generation), so this cannot reject a sender's stale,
+    // recycled handle — the send-path residual documented on `unpack_cap_slots`
+    // (#349).
     {
         // SAFETY: src_cspace validated by caller.
         let cs = unsafe { &*src_cspace };
@@ -1357,7 +1367,8 @@ pub fn sys_wait_set_add(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     let ws_idx = tf.arg(0) as u32;
     // cast_possible_truncation: kernel runs on 64-bit only; value is bounded by kernel policy.
     #[allow(clippy::cast_possible_truncation)]
-    let src_idx = tf.arg(1) as u32;
+    let src_handle = tf.arg(1) as u32;
+    let src_idx = syscall::cap_handle_index(src_handle);
     let badge = tf.arg(2);
 
     // SAFETY: syscall entry ensures current_tcb() returns active thread's TCB.
@@ -1398,6 +1409,11 @@ pub fn sys_wait_set_add(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     let (source_ptr, source_tag, source_header) = unsafe {
         let cs = &*cspace_ptr;
         let src_slot = cs.slot(src_idx).ok_or(SyscallError::InvalidCapability)?;
+        // Reject a stale handle to a recycled slot (#349).
+        if src_slot.generation() != syscall::cap_handle_gen(src_handle)
+        {
+            return Err(SyscallError::InvalidCapability);
+        }
         match src_slot.tag
         {
             CapTag::Endpoint =>
@@ -1582,7 +1598,8 @@ pub fn sys_wait_set_remove(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     let ws_idx = tf.arg(0) as u32;
     // cast_possible_truncation: kernel runs on 64-bit only; value is bounded by kernel policy.
     #[allow(clippy::cast_possible_truncation)]
-    let src_idx = tf.arg(1) as u32;
+    let src_handle = tf.arg(1) as u32;
+    let src_idx = syscall::cap_handle_index(src_handle);
 
     // SAFETY: syscall entry ensures current_tcb() returns active thread's TCB.
     let tcb = unsafe { current_tcb() };
@@ -1617,6 +1634,11 @@ pub fn sys_wait_set_remove(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     let (source_ptr, source_tag, source_header) = unsafe {
         let cs = &*cspace_ptr;
         let src_slot = cs.slot(src_idx).ok_or(SyscallError::InvalidCapability)?;
+        // Reject a stale handle to a recycled slot (#349).
+        if src_slot.generation() != syscall::cap_handle_gen(src_handle)
+        {
+            return Err(SyscallError::InvalidCapability);
+        }
         match src_slot.tag
         {
             CapTag::Endpoint =>

--- a/core/kernel/src/syscall/mem.rs
+++ b/core/kernel/src/syscall/mem.rs
@@ -525,7 +525,8 @@ pub fn sys_memory_split(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     use crate::mm::PAGE_SIZE;
     use crate::syscall::current_tcb;
 
-    let memory_idx = tf.arg(0) as u32;
+    let memory_handle = tf.arg(0) as u32;
+    let memory_idx = syscall::cap_handle_index(memory_handle);
     let split_offset = tf.arg(1);
     // arg2 is reserved; ignore.
 
@@ -557,7 +558,7 @@ pub fn sys_memory_split(tf: &mut TrapFrame) -> Result<u64, SyscallError>
 
     // SAFETY: caller_cspace validated; lookup_cap checks tag and rights.
     let parent_slot =
-        unsafe { super::lookup_cap(caller_cspace, memory_idx, CapTag::Memory, Rights::MAP) }?;
+        unsafe { super::lookup_cap(caller_cspace, memory_handle, CapTag::Memory, Rights::MAP) }?;
     let parent_obj_nn = parent_slot.object.ok_or(SyscallError::InvalidCapability)?;
     // cast_ptr_alignment: MemoryObject (8-byte) behind KernelObjectHeader header.
     // SAFETY: tag confirmed Memory; pointer is valid MemoryObject.
@@ -669,7 +670,6 @@ pub fn sys_memory_split(tf: &mut TrapFrame) -> Result<u64, SyscallError>
         DERIVATION_LOCK.write_unlock();
         return Err(SyscallError::OutOfMemory);
     };
-    let tail_slot = tail_slot_nz.get();
     let tail_id = SlotId::current(cspace_id, tail_slot_nz);
 
     // ── Wire derivation: tail becomes a sibling of parent under parent's parent ──
@@ -715,7 +715,15 @@ pub fn sys_memory_split(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     parent_ref.write_unlock();
     DERIVATION_LOCK.write_unlock();
 
-    Ok(u64::from(tail_slot))
+    // Encode the tail slot's generation into the returned handle (#349).
+    // SAFETY: caller_cspace valid; slot occupied so the read is stable.
+    let tail_handle = unsafe {
+        let saved = (*caller_cspace).lock.lock_raw();
+        let h = (*caller_cspace).cap_handle(tail_slot_nz);
+        (*caller_cspace).lock.unlock_raw(saved);
+        h
+    };
+    Ok(u64::from(tail_handle))
 }
 
 // Test stub.
@@ -758,8 +766,10 @@ pub fn sys_memory_merge(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     use crate::cap::slot::{CapTag, Rights, SlotId};
     use crate::syscall::current_tcb;
 
-    let parent_idx = tf.arg(0) as u32;
-    let tail_idx = tf.arg(1) as u32;
+    let parent_handle = tf.arg(0) as u32;
+    let tail_handle = tf.arg(1) as u32;
+    let parent_idx = syscall::cap_handle_index(parent_handle);
+    let tail_idx = syscall::cap_handle_index(tail_handle);
     // arg2 reserved.
 
     if parent_idx == tail_idx
@@ -784,11 +794,11 @@ pub fn sys_memory_merge(tf: &mut TrapFrame) -> Result<u64, SyscallError>
 
     // SAFETY: caller_cspace validated; lookup_cap checks tag and rights.
     let parent_slot =
-        unsafe { super::lookup_cap(caller_cspace, parent_idx, CapTag::Memory, Rights::MAP) }?;
+        unsafe { super::lookup_cap(caller_cspace, parent_handle, CapTag::Memory, Rights::MAP) }?;
     let parent_obj_nn = parent_slot.object.ok_or(SyscallError::InvalidCapability)?;
     // SAFETY: caller_cspace validated; lookup_cap checks tag and rights.
     let tail_slot =
-        unsafe { super::lookup_cap(caller_cspace, tail_idx, CapTag::Memory, Rights::MAP) }?;
+        unsafe { super::lookup_cap(caller_cspace, tail_handle, CapTag::Memory, Rights::MAP) }?;
     let tail_obj_nn = tail_slot.object.ok_or(SyscallError::InvalidCapability)?;
 
     if parent_obj_nn == tail_obj_nn

--- a/core/kernel/src/syscall/mod.rs
+++ b/core/kernel/src/syscall/mod.rs
@@ -617,16 +617,24 @@ pub(crate) unsafe fn current_tcb() -> *mut crate::sched::thread::ThreadControlBl
     unsafe { crate::sched::scheduler_for(cpu).current }
 }
 
-/// Look up a capability slot in a `CSpace` by index.
+/// Look up a capability slot in a `CSpace` by user handle.
+///
+/// `handle` is the encoded value userspace passes: slot index in the low
+/// [`syscall::CAP_INDEX_BITS`] bits, per-slot generation in the high bits. This
+/// is the single chokepoint for resolving a user-supplied handle; raw-index
+/// resolvers in `cap.rs` (`cap_copy`/`derive`/`delete`/`revoke`/`move`/`info`)
+/// must decode and generation-check themselves.
 ///
 /// Returns a reference to the slot, or an appropriate [`SyscallError`]:
 /// - Null cspace pointer or missing slot → [`SyscallError::InvalidCapability`].
 /// - Tag mismatch → [`SyscallError::InvalidCapability`].
+/// - Generation mismatch (stale handle to a recycled slot) →
+///   [`SyscallError::InvalidCapability`] (#349).
 /// - Insufficient rights → [`SyscallError::InsufficientRights`].
 #[cfg(not(test))]
 pub(crate) unsafe fn lookup_cap(
     cspace: *mut crate::cap::cspace::CSpace,
-    index: u32,
+    handle: u32,
     expected_tag: crate::cap::slot::CapTag,
     required_rights: crate::cap::slot::Rights,
 ) -> Result<&'static crate::cap::slot::CapabilitySlot, SyscallError>
@@ -637,8 +645,16 @@ pub(crate) unsafe fn lookup_cap(
     }
     // SAFETY: cspace is a valid CSpace pointer from the current thread's TCB.
     let cs = unsafe { &*cspace };
+    let index = syscall::cap_handle_index(handle);
     let slot = cs.slot(index).ok_or(SyscallError::InvalidCapability)?;
     if slot.tag != expected_tag
+    {
+        return Err(SyscallError::InvalidCapability);
+    }
+    // Reject a stale handle whose generation no longer matches the slot — the
+    // slot was freed and recycled since the handle was minted (#349). Checked
+    // after the tag so a handle to a now-null slot reports InvalidCapability.
+    if slot.generation() != syscall::cap_handle_gen(handle)
     {
         return Err(SyscallError::InvalidCapability);
     }

--- a/core/kernel/src/syscall/thread.rs
+++ b/core/kernel/src/syscall/thread.rs
@@ -1051,7 +1051,7 @@ pub fn sys_sched_split(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     // SAFETY: caller_cspace validated non-null; cspace_id is its id; both
     // children are freshly-allocated SEED-backed SchedControlObjects (refcount 1);
     // orig_obj_ptr is the live original from lookup_cap.
-    unsafe {
+    let (handle1, handle2) = unsafe {
         install_split_children(
             caller_cspace,
             cspace_id,
@@ -1062,7 +1062,11 @@ pub fn sys_sched_split(tf: &mut TrapFrame) -> Result<u64, SyscallError>
             child1_ptr,
             child2_ptr,
         )
-    }
+    }?;
+    // Deliver both child handles: first in the primary return register, second
+    // in the secondary (rdx / a1). Never packed into one word (#349).
+    tf.set_ipc_return(u64::from(handle1), u64::from(handle2));
+    Ok(u64::from(handle1))
 }
 
 /// `SYS_THREAD_SET_AFFINITY` (38): set a thread's CPU affinity.

--- a/core/ktest/src/integration/cap_generation_stale_handle.rs
+++ b/core/ktest/src/integration/cap_generation_stale_handle.rs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// ktest/src/integration/cap_generation_stale_handle.rs
+
+//! Integration: a same-`CSpace` stale cap handle fails closed (#349).
+//!
+//! Per-slot generation is the mechanism that closes the stale-slot alias class.
+//! This is the same-`CSpace` counterpart to `cross_cspace_revoke_no_alias`: a
+//! handle reused within one `CSpace` after its slot is freed and recycled.
+//! Create a notification, delete it (freeing and generation-bumping the slot),
+//! create another notification that reclaims the same slot index (LIFO free
+//! list), then replay the original handle. The original must fail with
+//! `InvalidCapability` (its generation no longer matches the slot) rather than
+//! aliasing the new occupant, while the new handle works.
+
+use syscall::{cap_create_notification, cap_delete, notification_send, notification_wait};
+use syscall_abi::{SyscallError, cap_handle_gen, cap_handle_index};
+
+use crate::{TestContext, TestResult};
+
+pub fn run(ctx: &TestContext) -> TestResult
+{
+    crate::log("cap_generation_stale_handle: starting");
+
+    // First notification — capture its handle, then delete it (free + bump gen).
+    let stale = cap_create_notification(ctx.memory_base)
+        .map_err(|_| "cap_generation_stale_handle: cap_create_notification (first) failed")?;
+    cap_delete(stale).map_err(|_| "cap_generation_stale_handle: cap_delete (first) failed")?;
+
+    // Second notification — LIFO reclaims the freed slot at the same index, with
+    // the bumped generation.
+    let fresh = cap_create_notification(ctx.memory_base)
+        .map_err(|_| "cap_generation_stale_handle: cap_create_notification (second) failed")?;
+
+    // The two handles must address the same slot index but differ in generation;
+    // otherwise the slot was not recycled and the test would not exercise the
+    // alias window.
+    if cap_handle_index(stale) != cap_handle_index(fresh)
+    {
+        // Slot not reused (e.g. cspace grew); not a failure of the fix, but the
+        // scenario was not exercised. Clean up and report so the gap is visible.
+        cap_delete(fresh).ok();
+        return Err("cap_generation_stale_handle: freed slot was not recycled (index differs)");
+    }
+    if cap_handle_gen(stale) == cap_handle_gen(fresh)
+    {
+        cap_delete(fresh).ok();
+        return Err("cap_generation_stale_handle: generation did not advance on recycle");
+    }
+
+    // The stale handle must be rejected (generation mismatch), not aliased onto
+    // the new occupant.
+    match notification_send(stale, 0x1)
+    {
+        Err(e) if e == SyscallError::InvalidCapability as i64 =>
+        {}
+        Ok(()) =>
+        {
+            cap_delete(fresh).ok();
+            return Err(
+                "cap_generation_stale_handle: stale handle still usable (aliased the new cap)",
+            );
+        }
+        Err(_) =>
+        {
+            cap_delete(fresh).ok();
+            return Err("cap_generation_stale_handle: stale handle failed with the wrong error");
+        }
+    }
+
+    // The fresh handle must still work end-to-end.
+    notification_send(fresh, 0x2)
+        .map_err(|_| "cap_generation_stale_handle: fresh handle send failed")?;
+    let bits = notification_wait(fresh)
+        .map_err(|_| "cap_generation_stale_handle: fresh handle wait failed")?;
+    if bits != 0x2
+    {
+        cap_delete(fresh).ok();
+        return Err("cap_generation_stale_handle: fresh handle delivered wrong bits");
+    }
+
+    cap_delete(fresh).ok();
+    crate::log("cap_generation_stale_handle: PASS");
+    Ok(())
+}

--- a/core/ktest/src/integration/cross_cspace_revoke_no_alias.rs
+++ b/core/ktest/src/integration/cross_cspace_revoke_no_alias.rs
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// ktest/src/integration/cross_cspace_revoke_no_alias.rs
+
+//! Integration: a cross-`CSpace` `cap_revoke` must not let a recipient's stale
+//! handle alias a recycled slot (#349).
+//!
+//! Regression for the cross-`CSpace` stale-slot alias class. A capability
+//! derived in one `CSpace` and IPC-moved into another keeps its derivation edge
+//! across the boundary, so revoking the source's subtree walks into the foreign
+//! `CSpace` and `free_slot`s the slot the recipient still legitimately holds.
+//! With bare slot-index handles the freed index was recycled (LIFO) onto an
+//! unrelated live object and the recipient's handle silently aliased it (#341
+//! was one instance, delivered via an IPC **reply**, which is why this test uses
+//! the reply direction). Per-slot generation closes the class: freeing the slot
+//! bumps its generation, so the recipient's now-stale handle fails
+//! `InvalidCapability` instead of aliasing whatever later occupies the index.
+//!
+//! Scenario:
+//!   1. Parent creates `target` (the derive source), `ep`, `go`/`report` (the
+//!      release + verdict handshake), and `decoy` (the unrelated object used to
+//!      recycle the freed slot).
+//!   2. Child (fresh `CSpace`) `ipc_call`s `ep`; parent `cap_derive`s `c1` from
+//!      `target` and returns it in the **reply** — the kernel moves `c1` into
+//!      the child's `CSpace` at slot K, preserving the cross-`CSpace` edge.
+//!   3. Parent `cap_revoke(target)`: the subtree walk reaches the child and frees
+//!      slot K (bumping its generation).
+//!   4. Parent recycles slot K by `cap_copy`ing `decoy` into the child's `CSpace`
+//!      (LIFO reclaims K) and hands the child the new handle through `go`.
+//!   5. Child confirms the recycle landed at K with an advanced generation, then
+//!      uses its stale `c1`: it must fail `InvalidCapability` (not alias `decoy`),
+//!      while the fresh handle to K still works. The child reports the verdict on
+//!      `report`.
+//!
+//! This asserts the generation-only model: the test depends on the cross-`CSpace`
+//! edge being preserved (so the revoke frees the recipient's slot) and on the
+//! stale handle then failing closed.
+
+use ipc::IpcMessage;
+use syscall::{
+    cap_copy, cap_create_endpoint, cap_create_notification, cap_delete, cap_derive, cap_revoke,
+    ipc_buffer_set, notification_send, notification_wait, notification_wait_timeout, thread_exit,
+};
+use syscall_abi::{SyscallError, cap_handle_gen, cap_handle_index};
+
+use crate::{ChildStack, TestContext, TestResult};
+
+// NOTIFY (bit 7) — send only; WAIT (bit 8) — wait only; SEND|GRANT (bits 4,6).
+const RIGHTS_NOTIFY: u64 = 1 << 7;
+const RIGHTS_WAIT: u64 = 1 << 8;
+const RIGHTS_SEND_GRANT: u64 = (1 << 4) | (1 << 6);
+
+// Verdict codes the child reports on `report`. Distinct single bits so the
+// parent can name the exact failure. `0` is reserved for the wait-timeout path.
+const REPORT_OK: u64 = 0x01;
+const REPORT_NOT_REUSED: u64 = 0x02;
+const REPORT_GEN_NOT_ADVANCED: u64 = 0x04;
+const REPORT_STALE_ALIASED: u64 = 0x08;
+const REPORT_STALE_WRONG_ERROR: u64 = 0x10;
+const REPORT_FRESH_BROKEN: u64 = 0x20;
+
+// Bits the child writes through the stale / fresh handles. Non-zero and distinct;
+// the parent never reads them (the verdict travels on `report`).
+const ALIAS_BITS: u64 = 0xA1;
+const FRESH_BITS: u64 = 0xF5;
+
+// Generous bound: the child only needs a few syscalls after the `go` signal.
+const REPORT_TIMEOUT_MS: u64 = 1000;
+
+static mut CHILD_STACK: ChildStack = ChildStack::ZERO;
+
+pub fn run(ctx: &TestContext) -> TestResult
+{
+    crate::log("cross_cspace_revoke_no_alias: starting");
+
+    // `target` is the derive source whose subtree the parent revokes. `decoy` is
+    // an unrelated notification used to recycle the child's freed slot. `go`
+    // releases the child (and carries the recycled handle); `report` returns the
+    // child's verdict.
+    let target = cap_create_notification(ctx.memory_base)
+        .map_err(|_| "cross_cspace_revoke_no_alias: cap_create_notification (target) failed")?;
+    let decoy = cap_create_notification(ctx.memory_base)
+        .map_err(|_| "cross_cspace_revoke_no_alias: cap_create_notification (decoy) failed")?;
+    let go = cap_create_notification(ctx.memory_base)
+        .map_err(|_| "cross_cspace_revoke_no_alias: cap_create_notification (go) failed")?;
+    let report = cap_create_notification(ctx.memory_base)
+        .map_err(|_| "cross_cspace_revoke_no_alias: cap_create_notification (report) failed")?;
+    let ep = cap_create_endpoint(ctx.memory_base)
+        .map_err(|_| "cross_cspace_revoke_no_alias: cap_create_endpoint failed")?;
+
+    // Child CSpace: a SEND|GRANT copy of `ep` (to call), a WAIT copy of `go` (to
+    // park on), and a NOTIFY copy of `report` (to answer). `c1` arrives via the
+    // reply.
+    let child = crate::spawn::new_child(ctx)
+        .map_err(|_| "cross_cspace_revoke_no_alias: spawn::new_child failed")?;
+    let child_ep = cap_copy(ep, child.cs, RIGHTS_SEND_GRANT)
+        .map_err(|_| "cross_cspace_revoke_no_alias: cap_copy (child_ep) failed")?;
+    let child_go = cap_copy(go, child.cs, RIGHTS_WAIT)
+        .map_err(|_| "cross_cspace_revoke_no_alias: cap_copy (child_go) failed")?;
+    let child_report = cap_copy(report, child.cs, RIGHTS_NOTIFY)
+        .map_err(|_| "cross_cspace_revoke_no_alias: cap_copy (child_report) failed")?;
+
+    let arg = u64::from(child_ep) | (u64::from(child_go) << 16) | (u64::from(child_report) << 32);
+    let stack_top = ChildStack::top(core::ptr::addr_of!(CHILD_STACK));
+    crate::spawn::configure_and_start(&child, child_entry, stack_top, arg)
+        .map_err(|_| "cross_cspace_revoke_no_alias: configure_and_start failed")?;
+
+    // Receive the child's call, derive `c1` from `target`, and hand it back in
+    // the reply — the kernel moves it into the child's CSpace (cross-CSpace),
+    // keeping the derivation edge to `target`.
+    // SAFETY: ctx.ipc_buf is the registered per-thread IPC buffer.
+    let _ = unsafe { ipc::ipc_recv(ep, ctx.ipc_buf) }
+        .map_err(|_| "cross_cspace_revoke_no_alias: ipc_recv failed")?;
+    let c1 = cap_derive(target, RIGHTS_NOTIFY)
+        .map_err(|_| "cross_cspace_revoke_no_alias: cap_derive (c1) failed")?;
+    let reply = IpcMessage::builder(0).cap(c1).build();
+    // SAFETY: ctx.ipc_buf is the registered per-thread IPC buffer.
+    unsafe { ipc::ipc_reply(&reply, ctx.ipc_buf) }
+        .map_err(|_| "cross_cspace_revoke_no_alias: ipc_reply failed")?;
+
+    // Revoke `target`'s subtree. The cross-CSpace edge is intact, so this walks
+    // into the child and frees the slot holding `c1` (bumping its generation).
+    cap_revoke(target).map_err(|_| "cross_cspace_revoke_no_alias: cap_revoke (target) failed")?;
+
+    // Recycle the just-freed child slot: `cap_copy` into `child.cs` pops the LIFO
+    // free list, reclaiming `c1`'s old index for an unrelated live notification.
+    // The returned handle carries the bumped generation; hand it to the child so
+    // it can confirm the recycle aliased `c1`'s slot.
+    let recycled = cap_copy(decoy, child.cs, RIGHTS_NOTIFY)
+        .map_err(|_| "cross_cspace_revoke_no_alias: cap_copy (recycle) failed")?;
+    notification_send(go, u64::from(recycled))
+        .map_err(|_| "cross_cspace_revoke_no_alias: notification_send (go) failed")?;
+
+    let verdict = notification_wait_timeout(report, REPORT_TIMEOUT_MS)
+        .map_err(|_| "cross_cspace_revoke_no_alias: notification_wait_timeout (report) failed")?;
+    let outcome = match verdict
+    {
+        REPORT_OK => Ok(()),
+        REPORT_NOT_REUSED => Err(
+            "cross_cspace_revoke_no_alias: freed slot was not recycled at the moved cap's index",
+        ),
+        REPORT_GEN_NOT_ADVANCED =>
+        {
+            Err("cross_cspace_revoke_no_alias: generation did not advance on the cross-CSpace free")
+        }
+        REPORT_STALE_ALIASED =>
+        {
+            Err("cross_cspace_revoke_no_alias: stale handle aliased the recycled slot after revoke")
+        }
+        REPORT_STALE_WRONG_ERROR =>
+        {
+            Err("cross_cspace_revoke_no_alias: stale handle failed with the wrong error")
+        }
+        REPORT_FRESH_BROKEN =>
+        {
+            Err("cross_cspace_revoke_no_alias: generation rejected the valid recycled handle")
+        }
+        0 => Err("cross_cspace_revoke_no_alias: child did not report (timeout)"),
+        _ => Err("cross_cspace_revoke_no_alias: unexpected report value"),
+    };
+
+    cap_delete(child.th).ok();
+    cap_delete(child.cs).ok();
+    cap_delete(ep).ok();
+    cap_delete(go).ok();
+    cap_delete(report).ok();
+    cap_delete(decoy).ok();
+    cap_delete(target).ok();
+
+    outcome?;
+    crate::log("cross_cspace_revoke_no_alias: PASS");
+    Ok(())
+}
+
+// ── Child thread ──────────────────────────────────────────────────────────────
+
+/// `arg` packs: bits[15:0] = `ep_slot`, bits[31:16] = `go_slot`,
+/// bits[47:32] = `report_slot` (all child `CSpace` indices).
+fn child_entry(arg: u64) -> !
+{
+    let ep_slot = (arg & 0xFFFF) as u32;
+    let go_slot = ((arg >> 16) & 0xFFFF) as u32;
+    let report_slot = ((arg >> 32) & 0xFFFF) as u32;
+
+    let buf_addr = core::ptr::addr_of_mut!(crate::IPC_BUF) as u64;
+    if ipc_buffer_set(buf_addr).is_err()
+    {
+        thread_exit()
+    }
+
+    // Call the parent; the reply carries the derived `c1` in cap_slots[0].
+    // SAFETY: buf_addr was registered as this thread's IPC buffer above.
+    let Ok(reply) = (unsafe { ipc::ipc_call(ep_slot, &IpcMessage::new(0), buf_addr as *mut u64) })
+    else
+    {
+        thread_exit()
+    };
+    let caps = reply.caps();
+    if caps.is_empty()
+    {
+        thread_exit()
+    }
+    let c1 = caps[0];
+
+    // Park until the parent has revoked `target` and recycled the freed slot. The
+    // release carries the recycled slot's fresh handle.
+    let Ok(recycled_bits) = notification_wait(go_slot)
+    else
+    {
+        thread_exit()
+    };
+    // The parent zero-extended a u32 handle into the notification word; the low
+    // 32 bits are exact.
+    let recycled = (recycled_bits & 0xFFFF_FFFF) as u32;
+
+    let _ = notification_send(report_slot, child_verdict(c1, recycled));
+    thread_exit()
+}
+
+/// Compute the child's verdict: the recycle must have landed on `c1`'s slot with
+/// an advanced generation, the stale `c1` handle must fail closed, and the fresh
+/// `recycled` handle to that slot must still work.
+fn child_verdict(c1: u32, recycled: u32) -> u64
+{
+    if cap_handle_index(recycled) != cap_handle_index(c1)
+    {
+        return REPORT_NOT_REUSED;
+    }
+    if cap_handle_gen(recycled) == cap_handle_gen(c1)
+    {
+        return REPORT_GEN_NOT_ADVANCED;
+    }
+
+    // The stale handle addresses `c1`'s old (index, generation); the slot now
+    // holds `decoy` with the bumped generation. It must be rejected, not aliased.
+    match notification_send(c1, ALIAS_BITS)
+    {
+        Err(e) if e == SyscallError::InvalidCapability as i64 =>
+        {}
+        Ok(()) => return REPORT_STALE_ALIASED,
+        Err(_) => return REPORT_STALE_WRONG_ERROR,
+    }
+
+    // The fresh handle to the recycled slot must still resolve and send.
+    if notification_send(recycled, FRESH_BITS).is_err()
+    {
+        return REPORT_FRESH_BROKEN;
+    }
+
+    REPORT_OK
+}

--- a/core/ktest/src/integration/mod.rs
+++ b/core/ktest/src/integration/mod.rs
@@ -30,6 +30,8 @@
 //! - `priority_preemption.rs`    — higher-priority runnable thread preempts a busy lower-priority one
 //! - `shared_memory_two_aspaces.rs` — one Memory cap mapped into two `AddressSpace` caps; phys round-trip
 //! - `cap_move_into_fresh_cspace_then_ipc.rs` — `cap_move` an endpoint into a child cspace; child IPC-calls through it
+//! - `cross_cspace_revoke_no_alias.rs` — after a cross-CSpace `cap_revoke` frees a recipient's reply-delivered cap, the recipient's stale handle fails closed, not aliases the recycled slot (#349)
+//! - `cap_generation_stale_handle.rs` — a same-CSpace stale cap handle fails closed after the slot is recycled (#349)
 //! - `fpu_survives_ipc_call.rs` — FP register file survives a raw `SYS_IPC_CALL` round-trip across CPU migration
 //! - `fault_kills_thread.rs`     — a genuine userspace page fault terminates the thread with the right exit reason
 //! - `fault_pager_roundtrip.rs`  — a bound userspace pager maps a frame on fault and resumes the thread
@@ -44,8 +46,10 @@
 
 pub mod aspace_fault_notification_late_bind;
 pub mod cap_delegation_chain;
+pub mod cap_generation_stale_handle;
 pub mod cap_move_into_fresh_cspace_then_ipc;
 pub mod cap_transfer;
+pub mod cross_cspace_revoke_no_alias;
 pub mod death_notification_late_bind;
 pub mod fault_exception_no_handler_kills;
 pub mod fault_exception_redirect;
@@ -114,6 +118,14 @@ pub fn run_all(ctx: &TestContext)
     run_integration_test!(
         "integration::cap_move_into_fresh_cspace_then_ipc",
         cap_move_into_fresh_cspace_then_ipc::run(ctx)
+    );
+    run_integration_test!(
+        "integration::cross_cspace_revoke_no_alias",
+        cross_cspace_revoke_no_alias::run(ctx)
+    );
+    run_integration_test!(
+        "integration::cap_generation_stale_handle",
+        cap_generation_stale_handle::run(ctx)
     );
     run_integration_test!(
         "integration::fpu_survives_ipc_call",

--- a/core/ktest/src/unit/sysinfo.rs
+++ b/core/ktest/src/unit/sysinfo.rs
@@ -17,7 +17,7 @@ use crate::{TestContext, TestResult};
 
 /// `system_info(KernelVersion)` returns the expected version constant.
 ///
-/// The kernel version is `0.0.2` (packed as `2`). See `KERNEL_VERSION` in
+/// The kernel version is `0.0.3` (packed as `3`). See `KERNEL_VERSION` in
 /// `abi/syscall/src/lib.rs` for the encoding details.
 pub fn kernel_version(_ctx: &TestContext) -> TestResult
 {

--- a/docs/capability-model.md
+++ b/docs/capability-model.md
@@ -32,6 +32,43 @@ capability".
 
 ---
 
+## Capability Handle Format
+
+A capability handle — the value userspace passes to and receives from the kernel —
+packs a per-slot **generation** with the slot index:
+
+```
+handle = (generation << CAP_INDEX_BITS) | index      // CAP_INDEX_BITS = 24
+```
+
+The low 24 bits are the slot index; the high 8 bits are the slot's generation
+counter, which the kernel increments each time the slot is freed and recycled. On
+every operation the kernel checks the handle's generation against the slot's
+current generation and returns `InvalidCapability` on mismatch. This closes the
+stale-slot alias class (#349): a handle held across a free/reallocate of its slot
+fails closed instead of silently operating on whatever unrelated capability now
+occupies the index.
+
+A never-recycled slot has generation 0, so its handle is numerically identical to
+the bare slot index. Long-lived capabilities minted once at boot or process spawn
+(the `ProcessInfo`/`InitInfo`/`CapDescriptor` handover caps) therefore keep their
+historical handle values, and the `handle == 0` "no capability" sentinel still
+holds (a live cap always has index ≥ 1 in the low bits).
+
+The handle is `u32`-wide and travels in the low half of a 64-bit syscall register.
+Capabilities transferred over IPC, and the second child of a range split, are
+delivered with their generation intact (the split delivers its two children in the
+two return registers rather than packing them into one). The handle's generation
+is **not** carried on the IPC *send* path (the packed send slots are index-only):
+a cap named for transfer is identified by index alone, so a sender naming a stale,
+recycled handle transmits the slot's current occupant rather than failing closed —
+the one resolution path the generation check does not cover (#349), no worse than
+the pre-generation behaviour and tightenable by widening the send pack. The cap the
+recipient *receives* is generation-correct: the kernel re-derives it from the
+freshly inserted destination slot.
+
+---
+
 ## Capability Types
 
 Each capability type represents a distinct kind of kernel object. The rights attached
@@ -351,10 +388,20 @@ dispatch crate are in
 
 ## Transfer
 
-A capability may be transferred via IPC (see [ipc-design.md](ipc-design.md)). Transfer
-moves the capability from the sender's CSpace to the receiver's CSpace — the sender's
-slot becomes null. This is not derivation; no new entry appears in the derivation tree.
-The receiver inherits the sender's position in the existing tree.
+A capability may be transferred via IPC (see [ipc-design.md](ipc-design.md)) or moved
+with `SYS_CAP_MOVE`. Transfer moves the capability from the source CSpace to the
+destination CSpace — the source slot becomes null. This is not derivation; no new
+entry appears in the derivation tree — the existing node is restamped onto the
+destination slot.
+
+Because the cap keeps its derivation position, a move transfers ownership of the
+slot but not revocation authority over the lineage: the mover, having nulled its own
+slot, no longer holds the cap, yet a `cap_revoke` on one of the cap's ancestors
+still reaches it — even across a CSpace boundary. Such a revoke frees the recipient's
+slot in the recipient's own CSpace; per-slot generation handles make the recipient's
+now-stale handle fail closed rather than alias a recycled slot (#349). (A move within
+the same CSpace likewise keeps the source's position.) To delegate a capability while
+keeping your own copy, use `SYS_CAP_COPY` instead (see [Revocation](#revocation)).
 
 
 ---
@@ -369,6 +416,14 @@ Any process may revoke a capability it has derived. Revocation:
 After revocation, any process that held a derived capability can no longer use it.
 The underlying kernel object is not destroyed — only the authority to access it is
 withdrawn. If the revoker still holds the parent capability, it retains access.
+
+A descendant delivered to another CSpace — by **IPC transfer**, `SYS_CAP_MOVE`, or
+`SYS_CAP_COPY` — keeps its position in the derivation tree (see
+[Transfer](#transfer)), so the revoke reaches it across the boundary and frees the
+recipient's slot in the recipient's own CSpace. Per-slot generation handles ensure
+the recipient's now-stale handle then fails with `InvalidCapability` rather than
+aliasing a recycled slot index — the cross-CSpace stale-slot alias that was the #349
+hazard.
 
 
 ---

--- a/runtime/ruststd/src/sys/process/seraph.rs
+++ b/runtime/ruststd/src/sys/process/seraph.rs
@@ -458,18 +458,19 @@ impl Command {
 
         // The death observer now lives on the child's Thread object (its TCB),
         // not on the cap, so the parent's `thread_cap` is dead weight after the
-        // bind. Delete it NOW (#341 root fix): retaining it until Process::drop
-        // leaves a cross-CSpace derivation CHILD of procmgr's `child_thread` in
-        // this process's CSpace (the cap was `cap_derive`'d by procmgr then
-        // IPC-MOVED here, which preserves the derivation edge). At child reap,
-        // procmgr's `cap_revoke(child_thread)` walks that edge and `free_slot`s
-        // THIS still-live slot; a later thread spawn reuses the freed index, and
-        // Process::drop's `cap_delete(self.thread_cap)` then tears down an
-        // unrelated live thread -> self-teardown / all-idle hang. Severing the
-        // edge here, before reap, removes the hazard while procmgr still reaps
-        // the child Thread normally (its `cap_revoke` is load-bearing for the
-        // thread-before-aspace teardown order). The kernel-side refuse-self-
-        // delete guard remains as defense-in-depth.
+        // bind. Delete it now: this frees the slot promptly and unlinks this
+        // process's copy from procmgr's `child_thread` derivation subtree (procmgr
+        // `cap_derive`'d the cap then IPC-MOVED it here, preserving the derivation
+        // edge), so procmgr's reap-time `cap_revoke(child_thread)` need not reach
+        // across the CSpace boundary into this process. Retaining it would be safe
+        // regardless: were the reap-revoke to free this slot and a later spawn
+        // reuse the index, `Process::drop`'s `cap_delete(self.thread_cap)` would
+        // replay a stale handle, which per-slot generation handles (#349) reject
+        // with `InvalidCapability` instead of tearing down the unrelated new
+        // occupant (the #341 self-teardown / all-idle hang). The early delete is
+        // thus hygiene and defense-in-depth; procmgr's `cap_revoke` stays
+        // load-bearing for the thread-before-aspace teardown order, and the
+        // kernel-side refuse-self-delete guard remains as further defense.
         let _ = syscall::cap_delete(thread_cap);
         let thread_cap = 0u32;
 

--- a/shared/syscall/src/lib.rs
+++ b/shared/syscall/src/lib.rs
@@ -533,6 +533,19 @@ unsafe fn syscall6(nr: u64, a0: u64, a1: u64, a2: u64, a3: u64, a4: u64, a5: u64
 /// Each index occupies 16 bits (sufficient for max `CSpace` size of 14336 slots).
 /// Indices beyond `MSG_CAP_SLOTS_MAX` are silently ignored.
 ///
+/// The 16-bit field carries only the slot **index**; a capability handle's
+/// generation (its high bits, see `cap_handle_encode`) is stripped here and is
+/// not transmitted on the IPC send path. The kernel re-derives the destination
+/// handle's generation from the freshly inserted slot, so the recipient's
+/// delivered handle is generation-correct. It cannot, however, generation-
+/// validate the sender's named index (the generation is gone by the time the
+/// kernel resolves it): a sender naming a stale, recycled handle transmits the
+/// slot's current occupant rather than failing closed. This is the one cap
+/// resolution path the per-slot generation backstop does not cover (#349) — no
+/// worse than the pre-generation behaviour, and tightenable by widening the pack
+/// to carry the generation. A caller may pass either a bare index or a full
+/// handle; both pack to the same 16-bit index.
+///
 /// Pass the result as arg4 of `SYS_IPC_CALL` or arg3 of `SYS_IPC_REPLY`.
 #[must_use]
 pub fn pack_cap_slots(slots: &[u32]) -> u64
@@ -540,6 +553,8 @@ pub fn pack_cap_slots(slots: &[u32]) -> u64
     let mut packed: u64 = 0;
     for (i, &idx) in slots.iter().take(MSG_CAP_SLOTS_MAX).enumerate()
     {
+        // Mask to the index field; any generation high bits are intentionally
+        // dropped (the index fits in 16 bits; generation is re-derived kernel-side).
         packed |= (u64::from(idx) & 0xFFFF) << (i * 16);
     }
     packed
@@ -1140,17 +1155,18 @@ pub fn memory_merge(parent_cap: u32, tail_cap: u32) -> Result<(), i64>
 #[inline]
 pub fn mmio_split(mmio_cap: u32, split_offset: u64) -> Result<(u32, u32), i64>
 {
-    // SAFETY: syscall3 issues raw syscall instruction; mmio_cap is cap index as u64, split_offset
-    // is byte offset; kernel validates cap and offset, returns packed slot indices.
-    let ret = unsafe { syscall3(SYS_MMIO_SPLIT, u64::from(mmio_cap), split_offset, 0) };
+    // SAFETY: syscall5_ret2 issues raw syscall instruction; mmio_cap is cap index as
+    // u64, split_offset is byte offset; kernel validates cap and offset and returns
+    // the first child handle in the primary register, the second in the secondary.
+    let (ret, handle2) =
+        unsafe { syscall5_ret2(SYS_MMIO_SPLIT, u64::from(mmio_cap), split_offset, 0, 0, 0) };
     if ret < 0
     {
         Err(ret)
     }
     else
     {
-        let v = ret as u64;
-        Ok(((v & 0xFFFF_FFFF) as u32, (v >> 32) as u32))
+        Ok((ret as u32, handle2 as u32))
     }
 }
 
@@ -1170,16 +1186,25 @@ pub fn mmio_split(mmio_cap: u32, split_offset: u64) -> Result<(u32, u32), i64>
 #[inline]
 pub fn irq_split(irq_cap: u32, split_at: u32) -> Result<(u32, u32), i64>
 {
-    // SAFETY: syscall3 issues raw syscall instruction; kernel validates cap and split point.
-    let ret = unsafe { syscall3(SYS_IRQ_SPLIT, u64::from(irq_cap), u64::from(split_at), 0) };
+    // SAFETY: syscall5_ret2 issues raw syscall instruction; kernel validates cap and
+    // split point, returning the two child handles in the primary/secondary registers.
+    let (ret, handle2) = unsafe {
+        syscall5_ret2(
+            SYS_IRQ_SPLIT,
+            u64::from(irq_cap),
+            u64::from(split_at),
+            0,
+            0,
+            0,
+        )
+    };
     if ret < 0
     {
         Err(ret)
     }
     else
     {
-        let v = ret as u64;
-        Ok(((v & 0xFFFF_FFFF) as u32, (v >> 32) as u32))
+        Ok((ret as u32, handle2 as u32))
     }
 }
 
@@ -1205,12 +1230,15 @@ pub fn irq_split(irq_cap: u32, split_at: u32) -> Result<(u32, u32), i64>
 #[inline]
 pub fn ioport_split(ioport_cap: u32, split_at: u16) -> Result<(u32, u32), i64>
 {
-    // SAFETY: syscall3 issues raw syscall instruction; kernel validates cap and split point.
-    let ret = unsafe {
-        syscall3(
+    // SAFETY: syscall5_ret2 issues raw syscall instruction; kernel validates cap and
+    // split point, returning the two child handles in the primary/secondary registers.
+    let (ret, handle2) = unsafe {
+        syscall5_ret2(
             SYS_IOPORT_SPLIT,
             u64::from(ioport_cap),
             u64::from(split_at),
+            0,
+            0,
             0,
         )
     };
@@ -1220,8 +1248,7 @@ pub fn ioport_split(ioport_cap: u32, split_at: u16) -> Result<(u32, u32), i64>
     }
     else
     {
-        let v = ret as u64;
-        Ok(((v & 0xFFFF_FFFF) as u32, (v >> 32) as u32))
+        Ok((ret as u32, handle2 as u32))
     }
 }
 
@@ -1242,12 +1269,15 @@ pub fn ioport_split(ioport_cap: u32, split_at: u16) -> Result<(u32, u32), i64>
 #[inline]
 pub fn sched_split(sched_cap: u32, split_at: u8) -> Result<(u32, u32), i64>
 {
-    // SAFETY: syscall3 issues raw syscall instruction; kernel validates cap and split point.
-    let ret = unsafe {
-        syscall3(
+    // SAFETY: syscall5_ret2 issues raw syscall instruction; kernel validates cap and
+    // split point, returning the two child handles in the primary/secondary registers.
+    let (ret, handle2) = unsafe {
+        syscall5_ret2(
             SYS_SCHED_SPLIT,
             u64::from(sched_cap),
             u64::from(split_at),
+            0,
+            0,
             0,
         )
     };
@@ -1257,8 +1287,7 @@ pub fn sched_split(sched_cap: u32, split_at: u8) -> Result<(u32, u32), i64>
     }
     else
     {
-        let v = ret as u64;
-        Ok(((v & 0xFFFF_FFFF) as u32, (v >> 32) as u32))
+        Ok((ret as u32, handle2 as u32))
     }
 }
 


### PR DESCRIPTION
Closes #349.

A `cap_revoke` on a derivation root could free a slot in a **foreign** CSpace that
still legitimately held an IPC-moved derived cap. Because handles were bare slot
indices with no per-slot generation, the freed index was recycled (LIFO) and aliased
an unrelated live object; a later `cap_delete` of the stale index tore down whatever
now occupied it (#341 was one instance).

This adopts the issue's **per-slot generation handle** option. The cross-CSpace
derivation edge is left intact — master's edge-preserving `move_cap_between_cspaces`
and procmgr-driven aspace teardown are unchanged — and per-slot generation is what
makes the cross-CSpace free safe: a stale handle to a recycled slot fails
`InvalidCapability` instead of aliasing the new occupant.

## Mechanism
8-bit generation in `CapabilitySlot.pad[1]` (slot stays 72 bytes, asserted at compile
time), bumped on `free_slot`, encoded as `handle = (generation << 24) | index`
(`CAP_INDEX_BITS = 24`). `lookup_cap` and every raw-resolution handler that bypasses
it (`cap_delete`/`revoke`/`copy`/`move`/`derive`/`derive_badge`/`info`,
`memory_split`/`merge`, `wait_set` add/remove) decode the index and validate the
generation. Mint sites encode the slot's generation; explicit-destination copy/move
re-encode the destination slot's real generation. Range splits return their two
children in the primary + secondary registers (no i64 sign collision). gen-0 is
numerically identical to the bare index, so all boot/spawn caps and the `handle == 0`
sentinel are unchanged (no flag day). `KERNEL_VERSION` 0.0.2 → 0.0.3;
`INIT_PROTOCOL_VERSION` / `PROCESS_ABI_VERSION` bumped so a mismatched old userspace
fails fast.

## Documented residual (not closed)
The IPC **send** path names a cap by 16-bit index, stripping the generation, so a
sender that names a stale, recycled handle transmits the slot's current occupant
rather than failing closed — the one resolution path the backstop does not cover, no
worse than the pre-generation behaviour and tightenable by widening the send pack
(tracked in #355). The cap a recipient *receives* is generation-correct.

## Invariant documented
The issue sanctioned either severing cross-CSpace derivation edges **or** adopting
per-slot generation handles; this PR takes the generation option. See
`docs/capability-model.md` § Capability Handle Format and
`core/kernel/docs/capability-internals.md` § Per-Slot Generation.

## Test plan (both arches)
- `cargo xtask build` (x86_64, riscv64) — clean under `-D warnings`, including the
  compile-time 72-byte slot-layout and sign-invariant `const` asserts.
- `cargo xtask test` — host workspace, pass.
- ktest (x86_64 + riscv64): `[ktest] ALL TESTS PASSED`, including new
  `cross_cspace_revoke_no_alias` (a cross-CSpace revoke frees the recipient's
  reply-delivered cap; after the freed index is recycled onto an unrelated live
  notification, the recipient's stale handle fails closed, while the fresh handle to
  that slot works) and `cap_generation_stale_handle` (same-CSpace free→realloc replay
  fails closed).
- svctest + crasher stress (x86_64 5/5, riscv64 3/3; terminal dropped):
  `[svctest] ALL TESTS PASSED`, 0 hangs — process spawn/teardown (memmgr reclaim + cap
  ABI) and devmgr mmio/irq splits work end-to-end with the edge-preserving move +
  generation backstop.

Refs #341, PR #346.
