### PR TITLE
fix(kernel): #351 dealloc reply-wake self-pin to the wedged CPU + scheduler diagnostics & relocator hardening

### DIFF
--- a/core/kernel/docs/scheduling-internals.md
+++ b/core/kernel/docs/scheduling-internals.md
@@ -366,6 +366,22 @@ cache-warmth alignment with the documented soft-affinity intent in
 to be unrelated (`CSpaceId` namespace exhaustion, see commits on
 that issue).
 
+`select_target_cpu_excluding(tcb, exclude)` is the same policy with one CPU
+removed from the save-window-pin / sticky / min-load branches (hard affinity
+still wins, and the excluded CPU is returned only as a single-CPU fallback).
+`dealloc_object(Thread)`'s deferred reply-wake calls it with
+`exclude = Some(dealloc_cpu)`: the dealloc CPU is wedged in a preempt-disabled
+UAF gate, **not** in `schedule()`, so the save-window pin's deadlock-avoidance
+rationale does not apply to it — pinning a `context_saved == 0` woken client
+there strands it on a CPU that cannot re-enter the scheduler until the dealloc
+returns, which it cannot do while that client is the only runnable thread
+(#351). The target is also recomputed at the *wake* site rather than snapshotted
+inside the all-CPU-locks region: snapshotting two unbounded gate-spins before
+the link let the client's state drift, widening the double-enqueue straddle
+(#289). A peer dispatches the `cs == 0` client safely because the consumer-side
+`schedule()` waits on the `context_saved` Acquire publication barrier before the
+register switch.
+
 Consumer side (`idle_thread_entry`, `core/kernel/src/sched/mod.rs`):
 
 ```

--- a/core/kernel/docs/scheduling-internals.md
+++ b/core/kernel/docs/scheduling-internals.md
@@ -191,6 +191,23 @@ and leaves the pending link to place the TCB. The next caller of
 `migrate_ready_thread` (or the load balancer) re-runs the migration if still
 warranted.
 
+`migrate_ready_thread` and the load balancer's `pull_unpinned_ready` both
+funnel their validate-then-move through one primitive, `relocate_ready_thread`,
+which reads `(state == Ready && context_saved == 1 && cpu_affinity permits
+dst_cpu)` entirely under the caller-held `(*tcb).sched_lock` (the caller owns the
+four-lock lifecycle and the post-move IPI). The affinity gate closes a
+load-balancer affinity violation: `pull_unpinned_ready`'s `find_runnable`
+predicate reads `cpu_affinity` *advisorily* under the run-queue lock, so a
+concurrent `sys_thread_set_affinity` pinning the candidate away from `dst_cpu`
+between the predicate and the move was previously honoured nowhere — the puller
+would relocate a freshly-pinned thread to a forbidden CPU. Re-reading affinity
+under `sched_lock` (the owning serializer) makes the puller decline; the
+candidate is then placed correctly by the next `schedule()` cross-affinity arm
+or balance tick (eventual consistency, not instant re-homing — #116). The
+primitive takes the caller-located `priority` (the level `find_runnable` /
+`migrate` found the candidate at), never re-reading `(*tcb).priority`, which a
+concurrent `sys_thread_set_priority` could desync from the linked level.
+
 `PerCpuScheduler::enqueue` (not `change_priority`) is the correct primitive
 for the syscall's re-enqueue half: `change_priority`'s enqueue is
 unconditional, so calling it on a scheduler whose `remove_from_queue`

--- a/core/kernel/docs/scheduling-internals.md
+++ b/core/kernel/docs/scheduling-internals.md
@@ -43,6 +43,10 @@ The following ordering MUST be observed everywhere in the kernel. Acquiring lock
         │         └─────► SLEEP_LIST_LOCK   (leaf; held alone, or under a
         │                                    source lock — source.lock →
         │                                    SLEEP_LIST_LOCK is the only edge)
+        │
+        │                 THREAD_REGISTRY_LOCK (leaf; held strictly alone — never
+        │                                    under any other lock. Diagnostic-only
+        │                                    live-thread list; see § Thread Registry)
         ▼
    (*tcb).sched_lock                         (per-TCB Scheduling-group serializer)
         │
@@ -57,6 +61,8 @@ The following ordering MUST be observed everywhere in the kernel. Acquiring lock
 2. **At most one source IPC lock at a time.** A code path holding `sig.lock` MUST NOT acquire `ep.lock`, `eq.lock`, or `ws.lock`. The single exception is `waitset_notify`, which is invoked from within a source lock (the source notifying the wait set) and acquires `ws.lock` as the inner lock — order `source.lock → ws.lock` only.
 
 3. **`SLEEP_LIST_LOCK` is leaf-only.** It MAY be acquired from inside any source IPC lock. It MUST NOT contain calls that re-enter IPC or scheduler code while held.
+
+3a. **`THREAD_REGISTRY_LOCK` is strict-leaf-only.** The diagnostic live-thread registry (`core/kernel/src/sched/thread_registry.rs`) is linked at thread construction and unlinked at dealloc, both with `THREAD_REGISTRY_LOCK` held strictly alone — never nested under a source IPC lock, `(*tcb).sched_lock`, or a run-queue lock — so it adds no lock-order edge. The softlockup watchdog walks it via `try_for_each` (a non-blocking `try_lock`, so a contended or CPU-died lock degrades to a skipped section rather than a hang). See § Thread Registry.
 
 4. **Per-TCB-then-cross-CPU acquisition rule.** A path mutating a TCB's Scheduling field group MUST acquire `(*tcb).sched_lock` FIRST (outermost among the scheduler locks), THEN any per-CPU scheduler.lock(s); when two or more per-CPU scheduler.locks are needed simultaneously, they MUST be taken in ascending-CPU order. Live production sites: `sched::migrate_ready_thread` (used by `sys_thread_set_affinity` active migration and the periodic load balancer; `(*tcb).sched_lock` then the two CPU locks ascending), `dealloc_object(Thread)` (`(*tcb).sched_lock` then the all-CPU walk in ascending order), `sched::set_state_under_all_locks` (lifecycle state writes; same shape), and `sys_thread_set_priority` (priority writes plus locate-and-relocate of the Ready TCB's queue entry; `(*tcb).sched_lock` then the all-CPU walk in ascending order). A path MUST NEVER hold two different TCBs' `sched_lock`s at once — `schedule()`'s outgoing-then-incoming flip releases `current.sched_lock` before acquiring `next.sched_lock`.
 
@@ -579,6 +585,17 @@ priority, preferred_cpu, idle age, non-empty mask) plus the head of
 `WATCHDOG_THRESHOLD_TICKS` (~3 s at the observed ~1 ms tick). Single-shot
 via `WATCHDOG_FIRED`.
 
+The dump then walks the live-thread registry (§ Thread Registry) and prints
+every `Blocked` thread with its `wake_pending`/`wake_in_flight` flags and a
+decode of its `blocked_on_object`: whether the blocking object still names the
+thread as its waiter (`waiter_is_self` / `reply_is_self`) or holds data with a
+cleared waiter slot (`count > 0`). The per-CPU `current` dump shows only each
+CPU's running/idle thread, so a lost-wakeup victim — a `Blocked` thread parked
+on an IPC object, reachable from nothing the `current` dump sees — was invisible
+before this enumeration (#351). The decode distinguishes the two failure shapes:
+a wake that was never issued (object still owns the waiter) versus one deposited
+but never linked to a run queue (waiter cleared / `wake_in_flight` still set).
+
 **Cost:** one Relaxed counter increment per BSP timer tick, one Relaxed
 store per non-idle context switch, an O(MAX_CPUS) early-exit loop per tick.
 Zero overhead when healthy.
@@ -610,6 +627,32 @@ scheduler state without taking a lock that the stalled CPUs themselves hold.
 `sys_thread_stop`) carry single-shot overlong-duration warnings. These are
 not the watchdog; they fire only when the spin overruns and identify the
 stuck participants. Zero overhead in healthy paths.
+
+## Thread Registry
+
+`core/kernel/src/sched/thread_registry.rs` is a diagnostic-only intrusive
+doubly-linked list of every live TCB, threaded through `registry_next` /
+`registry_prev` and guarded by the strict-leaf `THREAD_REGISTRY_LOCK` (Lock
+Hierarchy rule 3a). It exists solely so the softlockup watchdog can enumerate
+`Blocked` waiters that the per-CPU `current` dump cannot reach.
+
+**Membership.** `register` splices a TCB onto the head; `unregister` removes it.
+A thread is registered on the success path of `sys_cap_create_thread` (after its
+cap is inserted — the rollback arm frees the TCB via `retype_free` without ever
+registering it, so register-on-success keeps the two symmetric) and on
+init's bootstrap thread. It is unregistered in the `dealloc_object(Thread)` arm
+strictly before the TCB is poisoned/freed: the walk holds `THREAD_REGISTRY_LOCK`
+across every dereference, so unlinking before the free guarantees the watchdog
+never observes a dangling node. Idle TCBs are deliberately not registered — they
+are never `Blocked` and are already shown by the per-CPU `current` dump.
+
+**Walk.** `try_for_each` takes the lock with a non-blocking `try_lock`: if it is
+contended (a register/unregister in flight) or a CPU died holding it, the walk is
+skipped rather than spun on — the watchdog must never block. A `MAX_WALK` bound
+caps a corrupted-into-a-cycle list so the already-fatal dump still terminates.
+
+**Not a scheduling structure.** The registry is never read on any hot path; it
+adds one leaf-lock acquire at thread create/destroy and nothing elsewhere.
 
 ---
 

--- a/core/kernel/docs/scheduling-internals.md
+++ b/core/kernel/docs/scheduling-internals.md
@@ -585,16 +585,29 @@ priority, preferred_cpu, idle age, non-empty mask) plus the head of
 `WATCHDOG_THRESHOLD_TICKS` (~3 s at the observed ~1 ms tick). Single-shot
 via `WATCHDOG_FIRED`.
 
+Each per-CPU line also carries a **spin-site breadcrumb**: a wedged CPU whose
+`current` is `Exited` but which never returned to the scheduler is stuck in a
+bounded protocol-spin, and the breadcrumb (`spin_site_enter`/`spin_site_exit`,
+set around each gate) names which one — `dealloc:not-current`,
+`dealloc:context-saved`, or `dealloc:wake-in-flight`. The `dealloc_object(Thread)`
+gates carried no overlong-duration warning of their own (unlike the `schedule()`
+context-saved spin and the `sys_thread_stop` drain), so a wedge there showed only
+an opaque `current = Exited` in `SYS_CAP_DELETE` (#351); the breadcrumb makes it
+explicit.
+
 The dump then walks the live-thread registry (§ Thread Registry) and prints
-every `Blocked` thread with its `wake_pending`/`wake_in_flight` flags and a
-decode of its `blocked_on_object`: whether the blocking object still names the
-thread as its waiter (`waiter_is_self` / `reply_is_self`) or holds data with a
-cleared waiter slot (`count > 0`). The per-CPU `current` dump shows only each
-CPU's running/idle thread, so a lost-wakeup victim — a `Blocked` thread parked
-on an IPC object, reachable from nothing the `current` dump sees — was invisible
-before this enumeration (#351). The decode distinguishes the two failure shapes:
-a wake that was never issued (object still owns the waiter) versus one deposited
-but never linked to a run queue (waiter cleared / `wake_in_flight` still set).
+every non-running registered thread. For a `Blocked` thread it shows the
+`wake_pending`/`wake_in_flight` flags and a decode of `blocked_on_object`:
+whether the blocking object still names the thread as its waiter
+(`waiter_is_self` / `reply_is_self`) or holds data with a cleared waiter slot
+(`count > 0`) — distinguishing a wake that was never issued from one deposited
+but never linked. For a `Ready`/`Stopped` thread it shows
+`context_saved`/`queued_on`/affinity/`preferred_cpu` — why a runnable thread is
+neither dispatched by its wedged owner CPU nor stolen by an idle one (e.g. the
+save-window pin holds a `context_saved == 0` thread on its owner). The per-CPU
+`current` dump shows only each CPU's running/idle thread, so both victim shapes
+— a `Blocked` waiter on an IPC object, or a `Ready` thread stranded in a wedged
+CPU's run queue — were invisible before this enumeration (#351).
 
 **Cost:** one Relaxed counter increment per BSP timer tick, one Relaxed
 store per non-idle context switch, an O(MAX_CPUS) early-exit loop per tick.

--- a/core/kernel/docs/thread-lifecycle-and-sleep.md
+++ b/core/kernel/docs/thread-lifecycle-and-sleep.md
@@ -128,9 +128,16 @@ The teardown sequence binds the following ordered steps. Each step's preconditio
 3. Write tcb.state = Exited.
 4. For each CPU in 0..cpu_count: scheduler_for(cpu).remove_from_queue(tcb, prio).
 5. Server-side BlockedOnReply check: if (*tcb).reply_tcb is non-null,
-   compare_exchange(bound, null, AcqRel, Acquire) to claim the binding,
-   then prepare the bound client for wake (set state = Ready, ipc_state = None,
-   blocked_on = null, trap_frame.return = Interrupted). The actual
+   compare_exchange(bound, null, AcqRel, Acquire) to claim the binding, then
+   DEPOSIT only the resume disposition (trap_frame.return = Interrupted for a
+   syscall caller, or fault_outcome = Kill for a fault-blocked client) and leave
+   the client BLOCKED. The client's Scheduling-group fields (state/ipc_state/
+   blocked_on) are NOT written here — they are written only by the gated
+   enqueue_and_wake (step 8) under the CLIENT's own sched_lock, never under the
+   server's locks (pre-setting state = Ready here was the #284 residual: a
+   concurrent dealloc(client) marking the client Exited under its sched_lock
+   raced the unsynchronised Ready write). The wake's target CPU is NOT computed
+   here either; it is recomputed at the wake site (step 8). The actual
    enqueue_and_wake happens AFTER step 7 because it would deadlock against
    the held scheduler.locks.
 6. No in-region `current` snapshot is required: the post-release gate (step 9)
@@ -138,7 +145,13 @@ The teardown sequence binds the following ordered steps. Each step's preconditio
    all-locks `running_on` reading (which names at most one CPU and can be stale
    the instant the locks drop).
 7. Release every scheduler.lock in descending order.
-8. If a server_reply_wake was prepared in step 5, enqueue_and_wake(bound, ...).
+8. If a server_reply_wake was prepared in step 5, recompute the target CPU now
+   via select_target_cpu_excluding(bound, Some(this_cpu)) — excluding THIS
+   dealloc CPU, which is wedged in the gates below (steps 9/12) and so cannot
+   dispatch a client linked onto it (#351) — then enqueue_and_wake(bound,
+   target). Recomputing here rather than snapshotting in step 5 also closes the
+   double-enqueue straddle: the placement reflects the client's state at link
+   time, not two unbounded gate-spins earlier (#289).
 9. `current`-anywhere gate (UNCONDITIONAL): scan every CPU, each under its own
    scheduler.lock; if some CPU has `scheduler_for(cpu).current == tcb`, spin on
    that CPU's lock until it switches away, then re-scan. Proceed only when a

--- a/core/kernel/src/cap/object.rs
+++ b/core/kernel/src/cap/object.rs
@@ -2026,6 +2026,16 @@ unsafe fn dealloc_object_one(
                 // is reclaimed wholesale by `retype_free` below as part of
                 // the same slot release, so no separate free is needed.
 
+                // Remove the TCB from the diagnostic live-thread registry
+                // before poisoning/freeing it. The registry walk
+                // (`thread_registry::try_for_each`) holds the registry lock
+                // across every dereference, so unlinking strictly before the
+                // free guarantees the watchdog never observes a dangling node.
+                // A no-op for a TCB that was never registered (e.g. a
+                // never-started thread torn down before its cap was inserted).
+                // SAFETY: tcb valid (not yet freed); leaf lock, nothing else held.
+                unsafe { crate::sched::thread_registry::unregister(tcb) };
+
                 // Poison the TCB so any use-after-free reads garbage
                 // instead of plausible values.
                 // SAFETY: tcb is valid; we are about to free it.

--- a/core/kernel/src/cap/object.rs
+++ b/core/kernel/src/cap/object.rs
@@ -1516,11 +1516,11 @@ unsafe fn dealloc_object_one(
                 // § dealloc_object(Thread) Drain Protocol: lock every CPU
                 // (preferred_cpu is racy with concurrent enqueue_and_wake),
                 // commit Exited, drain queues, snapshot any reply-bound
-                // client for wake outside the all-locks region.
-                let server_reply_wake: Option<(
-                    *mut crate::sched::thread::ThreadControlBlock,
-                    usize,
-                )>;
+                // client for wake outside the all-locks region. The wake's
+                // target CPU is NOT snapshotted here: it is recomputed at the
+                // deferred wake site below, under the client's up-to-date state
+                // and excluding this (dealloc) CPU (#351).
+                let server_reply_wake: Option<*mut crate::sched::thread::ThreadControlBlock>;
                 // needless_range_loop: explicit indexing reads clearer for the
                 // parallel scheduler_for(cpu) accesses across all CPUs.
                 #[allow(clippy::needless_range_loop)]
@@ -1628,8 +1628,7 @@ unsafe fn dealloc_object_one(
                                         .set_return(syscall::SyscallError::Interrupted as i64);
                                 }
                             }
-                            let bcpu = crate::sched::select_target_cpu(bound);
-                            Some((bound, bcpu))
+                            Some(bound)
                         }
                         else
                         {
@@ -1749,7 +1748,7 @@ unsafe fn dealloc_object_one(
                 // gate observes Exited and aborts the link instead of resurrecting
                 // a freed TCB. wake_in_flight (set above) kept the client alive
                 // until here and is cleared on every enqueue_and_wake exit path.
-                if let Some((bound, bcpu)) = server_reply_wake
+                if let Some(bound) = server_reply_wake
                 {
                     // #317 predecessor-of-free null: clear the claimed client's
                     // `blocked_on_object` (which still points at THIS dying server,
@@ -1775,6 +1774,34 @@ unsafe fn dealloc_object_one(
                         }
                         (*bound).sched_lock.unlock_raw(bs);
                     }
+                    // Recompute the wake target HERE (post-gates), under the
+                    // client's current state, EXCLUDING this dealloc CPU. This
+                    // CPU is wedged in the preempt-disabled UAF gates above, not
+                    // in schedule(), so it cannot dispatch a client linked onto
+                    // it — the save-window pin would strand a `context_saved==0`
+                    // client here (#351). A peer dispatches it safely via the
+                    // schedule() publication-barrier spin. Recomputing at wake
+                    // time (rather than snapshotting under the all-CPU locks
+                    // above) also closes the double-enqueue straddle: the target
+                    // reflects the state at link time, not two unbounded spins
+                    // earlier (#289).
+                    let this_cpu = crate::arch::current::cpu::current_cpu() as usize;
+                    // SAFETY: bound kept valid by wake_in_flight = 1 above;
+                    // select_target_cpu_excluding is lock-free.
+                    let bcpu =
+                        unsafe { crate::sched::select_target_cpu_excluding(bound, Some(this_cpu)) };
+                    // G1: the reply-wake is never self-pinned to the wedged
+                    // dealloc CPU unless hard affinity names it or it is the only
+                    // CPU.
+                    debug_assert!(
+                        bcpu != this_cpu
+                            || crate::sched::CPU_COUNT
+                                .load(core::sync::atomic::Ordering::Relaxed)
+                                == 1
+                            // SAFETY: bound valid (pinned by wake_in_flight).
+                            || unsafe { (*bound).cpu_affinity } != crate::sched::AFFINITY_ANY,
+                        "dealloc reply-wake self-pinned to dealloc cpu {this_cpu}",
+                    );
                     // SAFETY: bound kept valid by wake_in_flight = 1 above.
                     unsafe { crate::sched::enqueue_and_wake(bound, bcpu) };
                 }

--- a/core/kernel/src/cap/object.rs
+++ b/core/kernel/src/cap/object.rs
@@ -1683,6 +1683,7 @@ unsafe fn dealloc_object_one(
                     // until it switches away, then re-scan; once a full scan is
                     // clean, no CPU can re-install `tcb` (it is `Exited` and
                     // unlinked from every run queue under the all-locks region).
+                    crate::sched::spin_site_enter(crate::sched::SPIN_SITE_DEALLOC_NOT_CURRENT);
                     loop
                     {
                         let run_cpu = 'scan: {
@@ -1717,6 +1718,7 @@ unsafe fn dealloc_object_one(
                     }
 
                     // Step 2: register save published.
+                    crate::sched::spin_site_enter(crate::sched::SPIN_SITE_DEALLOC_CONTEXT_SAVED);
                     while (*tcb)
                         .context_saved
                         .load(core::sync::atomic::Ordering::Acquire)
@@ -1724,6 +1726,7 @@ unsafe fn dealloc_object_one(
                     {
                         core::hint::spin_loop();
                     }
+                    crate::sched::spin_site_exit();
 
                     // Restore the caller's interrupt state and preemption.
                     // SAFETY: saved_int from save_and_disable_interrupts above.
@@ -1989,6 +1992,7 @@ unsafe fn dealloc_object_one(
                     unsafe { crate::arch::current::cpu::save_and_disable_interrupts() };
                 // SAFETY: ring 0; IDT loaded; preempt disabled.
                 unsafe { crate::arch::current::interrupts::enable() };
+                crate::sched::spin_site_enter(crate::sched::SPIN_SITE_DEALLOC_WAKE_IN_FLIGHT);
                 // SAFETY: tcb is valid (not yet freed); wake_in_flight is always
                 // valid on an initialized TCB.
                 while unsafe {
@@ -1999,6 +2003,7 @@ unsafe fn dealloc_object_one(
                 {
                     core::hint::spin_loop();
                 }
+                crate::sched::spin_site_exit();
                 // SAFETY: wake_saved_int from save_and_disable_interrupts above.
                 unsafe { crate::arch::current::cpu::restore_interrupts(wake_saved_int) };
                 crate::percpu::preempt_enable();

--- a/core/kernel/src/main.rs
+++ b/core/kernel/src/main.rs
@@ -1085,6 +1085,8 @@ unsafe fn kernel_entry_post_rebase(
                         exit_reason: 0,
                         sleep_deadline: 0,
                         extended: sched::thread::ExtendedState::from_raw(init_extended_area),
+                        registry_next: core::ptr::null_mut(),
+                        registry_prev: core::ptr::null_mut(),
                         magic: sched::thread::TCB_MAGIC,
                     },
                 );
@@ -1099,6 +1101,11 @@ unsafe fn kernel_entry_post_rebase(
                         deferred_next: core::ptr::null_mut(),
                     },
                 );
+                // Diagnostic registry: thread the init TCB onto the live-thread
+                // list so the softlockup watchdog can enumerate it as a Blocked
+                // waiter (#351). Removed by `dealloc_object(Thread)` if init's
+                // Thread cap is ever deleted/revoked.
+                sched::thread_registry::register(tcb_ptr);
             }
             seed.header.inc_ref();
 

--- a/core/kernel/src/sched/mod.rs
+++ b/core/kernel/src/sched/mod.rs
@@ -240,6 +240,83 @@ static WATCHDOG_TICK_COUNTER: core::sync::atomic::AtomicU64 = core::sync::atomic
 
 static WATCHDOG_FIRED: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
 
+// ── Per-CPU spin-site breadcrumb ──────────────────────────────────────────────
+
+/// Spin-site code: this CPU is not in any bounded protocol-spin.
+pub const SPIN_SITE_NONE: u32 = 0;
+/// `dealloc_object(Thread)` UAF gate, step 1: spinning until the dying TCB is
+/// no longer `current` on any CPU.
+pub const SPIN_SITE_DEALLOC_NOT_CURRENT: u32 = 1;
+/// `dealloc_object(Thread)` UAF gate, step 2: spinning until the dying TCB's
+/// in-flight register save has published (`context_saved == 1`).
+pub const SPIN_SITE_DEALLOC_CONTEXT_SAVED: u32 = 2;
+/// `dealloc_object(Thread)` wake-in-flight gate: spinning until a waker's
+/// claimed-but-not-yet-committed `enqueue_and_wake` clears `wake_in_flight`.
+pub const SPIN_SITE_DEALLOC_WAKE_IN_FLIGHT: u32 = 3;
+/// `schedule()` cross-CPU dispatch: spinning on the next thread's
+/// `context_saved` Acquire barrier.
+pub const SPIN_SITE_SCHEDULE_CONTEXT_SAVED: u32 = 4;
+/// `sys_thread_stop` cross-CPU drain: spinning until the target leaves
+/// `current` on its owning CPU.
+pub const SPIN_SITE_THREAD_STOP_DRAIN: u32 = 5;
+
+/// Per-CPU breadcrumb naming the bounded protocol-spin a CPU is currently
+/// executing, for the softlockup watchdog. A wedged CPU (no non-idle dispatch
+/// for the threshold) that is stuck in a `dealloc_object(Thread)` gate shows
+/// the gate here, turning an opaque `current = Exited` dump into a named site
+/// (#351). Set on gate entry, cleared on exit; [`SPIN_SITE_NONE`] when not
+/// spinning. Diagnostic-only — never gates control flow.
+#[cfg(not(test))]
+static SPIN_SITE: [core::sync::atomic::AtomicU32; MAX_CPUS] =
+    [const { core::sync::atomic::AtomicU32::new(SPIN_SITE_NONE) }; MAX_CPUS];
+
+/// Record that the current CPU has entered bounded protocol-spin `site`. The
+/// gates that call this run preempt-disabled, so the CPU index is stable across
+/// the spin.
+#[cfg(not(test))]
+pub fn spin_site_enter(site: u32)
+{
+    let cpu = crate::arch::current::cpu::current_cpu() as usize;
+    if cpu < MAX_CPUS
+    {
+        SPIN_SITE[cpu].store(site, core::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+/// Clear the current CPU's spin-site breadcrumb on gate exit.
+#[cfg(not(test))]
+pub fn spin_site_exit()
+{
+    let cpu = crate::arch::current::cpu::current_cpu() as usize;
+    if cpu < MAX_CPUS
+    {
+        SPIN_SITE[cpu].store(SPIN_SITE_NONE, core::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+/// Human-readable name for a spin-site code, for the watchdog dump.
+#[cfg(not(test))]
+fn spin_site_name(site: u32) -> &'static str
+{
+    match site
+    {
+        SPIN_SITE_DEALLOC_NOT_CURRENT => "dealloc:not-current",
+        SPIN_SITE_DEALLOC_CONTEXT_SAVED => "dealloc:context-saved",
+        SPIN_SITE_DEALLOC_WAKE_IN_FLIGHT => "dealloc:wake-in-flight",
+        SPIN_SITE_SCHEDULE_CONTEXT_SAVED => "schedule:context-saved",
+        SPIN_SITE_THREAD_STOP_DRAIN => "thread-stop:drain",
+        _ => "none",
+    }
+}
+
+/// Test stub: spin-site breadcrumbs are diagnostic-only and compiled out under
+/// host `cfg(test)`.
+#[cfg(test)]
+pub fn spin_site_enter(_site: u32) {}
+/// Test stub; see [`spin_site_enter`].
+#[cfg(test)]
+pub fn spin_site_exit() {}
+
 /// Mark `cpu` as having dispatched a non-idle thread at the current tick.
 pub fn watchdog_mark_non_idle(cpu: usize)
 {
@@ -363,6 +440,14 @@ fn watchdog_tick_and_check()
             now.saturating_sub(last_tick),
             mask
         );
+        // Name the bounded protocol-spin this CPU is wedged in, if any. A CPU
+        // whose `current` is `Exited` but which never returned to the scheduler
+        // is stuck in one of these gates (#351) — the breadcrumb says which.
+        let spin = SPIN_SITE[cpu].load(core::sync::atomic::Ordering::Relaxed);
+        if spin != SPIN_SITE_NONE
+        {
+            crate::kprintln!("    spinning in {}", spin_site_name(spin));
+        }
         // Dump the user-mode trap frame if present: tells us where in
         // userspace the thread entered its currently-stuck syscall.
         // SAFETY: trap_frame is set by every userspace-syscall entry and
@@ -429,57 +514,99 @@ fn watchdog_tick_and_check()
             dl
         );
     }
-    // Enumerate Blocked waiters via the live-thread registry. The per-CPU
-    // `current` dump above shows only each CPU's running/idle thread; the
-    // lost-wakeup victim (#351) is a Blocked thread parked on an IPC object,
-    // reachable only through the registry. The decode below is the decisive
-    // signal: whether the blocking object still names this waiter (no wake was
-    // ever issued) versus holds data / a cleared waiter slot (a wake was
-    // deposited but the link to the run queue was lost).
-    crate::kprintln!("  BLOCKED THREADS:");
+    // Enumerate non-running registered threads via the live-thread registry.
+    // The per-CPU `current` dump above shows only each CPU's running/idle
+    // thread. The #351 victim is invisible there: it is either a `Blocked`
+    // waiter parked on an IPC object, or a `Ready` thread stranded in a run
+    // queue that a wedged CPU never dispatched (the `mask` bit is set but no
+    // dispatch happens). For `Blocked` threads the `blocked_on` decode says
+    // whether the blocking object still names the waiter (no wake issued) or
+    // holds data with a cleared slot (a wake deposited but never linked); for
+    // `Ready`/`Stopped` threads the scheduling fields say why a runnable thread
+    // is neither dispatched locally nor stolen (`context_saved`/`queued_on`/
+    // affinity / save-window pin).
+    crate::kprintln!("  NON-RUNNING REGISTERED THREADS:");
     // Defined outside the `try_for_each` call so the `kprintln!` expansions are
     // not lexically inside the `unsafe` wrapping that call (which would flag
     // their macro-internal `unsafe` as redundant). Each raw deref is its own
     // tight `unsafe`; the field reads race benignly by the stalled contract.
-    let dump_blocked = |t: *mut ThreadControlBlock| {
+    let dump_thread = |t: *mut ThreadControlBlock| {
         // SAFETY: t is a registry-walked TCB held stable by the registry lock.
-        let is_blocked = unsafe { (*t).state == thread::ThreadState::Blocked };
-        if !is_blocked
+        let state = unsafe { (*t).state };
+        match state
         {
-            return;
+            thread::ThreadState::Blocked =>
+            {
+                // SAFETY: same contract; reads only plain scalar fields.
+                let (tid, ipc, blocked_on, prio, pref, wake_pending, wake_in_flight, dl) = unsafe {
+                    (
+                        (*t).thread_id,
+                        (*t).ipc_state,
+                        (*t).blocked_on_object,
+                        (*t).priority,
+                        (*t).preferred_cpu,
+                        (*t).wake_pending,
+                        (*t).wake_in_flight
+                            .load(core::sync::atomic::Ordering::Relaxed),
+                        (*t).sleep_deadline,
+                    )
+                };
+                crate::kprintln!(
+                    "    tid{} Blocked ipc={:?} blocked_on={:p} prio={} pref={} \
+                     wake_pending={} wake_in_flight={} dl={}",
+                    tid,
+                    ipc,
+                    blocked_on,
+                    prio,
+                    pref,
+                    wake_pending,
+                    wake_in_flight,
+                    dl
+                );
+                // SAFETY: same contract; watchdog_decode_blocked_on only reads.
+                unsafe { watchdog_decode_blocked_on(t) };
+            }
+            thread::ThreadState::Ready
+            | thread::ThreadState::Stopped
+            | thread::ThreadState::Created =>
+            {
+                // SAFETY: same contract; reads only plain scalar fields.
+                let (tid, prio, pref, aff, queued_on, cs, wif, wp) = unsafe {
+                    (
+                        (*t).thread_id,
+                        (*t).priority,
+                        (*t).preferred_cpu,
+                        (*t).cpu_affinity,
+                        (*t).queued_on.load(core::sync::atomic::Ordering::Relaxed),
+                        (*t).context_saved
+                            .load(core::sync::atomic::Ordering::Relaxed),
+                        (*t).wake_in_flight
+                            .load(core::sync::atomic::Ordering::Relaxed),
+                        (*t).wake_pending,
+                    )
+                };
+                crate::kprintln!(
+                    "    tid{} {:?} prio={} pref={} affinity=0x{:x} queued_on={} \
+                     context_saved={} wake_in_flight={} wake_pending={}",
+                    tid,
+                    state,
+                    prio,
+                    pref,
+                    aff,
+                    queued_on,
+                    cs,
+                    wif,
+                    wp
+                );
+            }
+            // Running threads are each a CPU's `current`, already dumped above.
+            thread::ThreadState::Running | thread::ThreadState::Exited =>
+            {}
         }
-        // SAFETY: same contract; reads only plain scalar fields.
-        let (tid, ipc, blocked_on, prio, pref, wake_pending, wake_in_flight, dl) = unsafe {
-            (
-                (*t).thread_id,
-                (*t).ipc_state,
-                (*t).blocked_on_object,
-                (*t).priority,
-                (*t).preferred_cpu,
-                (*t).wake_pending,
-                (*t).wake_in_flight
-                    .load(core::sync::atomic::Ordering::Relaxed),
-                (*t).sleep_deadline,
-            )
-        };
-        crate::kprintln!(
-            "    tid{} ipc={:?} blocked_on={:p} prio={} pref={} \
-             wake_pending={} wake_in_flight={} dl={}",
-            tid,
-            ipc,
-            blocked_on,
-            prio,
-            pref,
-            wake_pending,
-            wake_in_flight,
-            dl
-        );
-        // SAFETY: same contract; watchdog_decode_blocked_on only reads.
-        unsafe { watchdog_decode_blocked_on(t) };
     };
     // SAFETY: best-effort read-only walk under the registry lock; the closure
     // only reads through each TCB pointer (no register/unregister).
-    let walked = unsafe { thread_registry::try_for_each(dump_blocked) };
+    let walked = unsafe { thread_registry::try_for_each(dump_thread) };
     if !walked
     {
         crate::kprintln!("    (registry lock contended; skipped)");

--- a/core/kernel/src/sched/mod.rs
+++ b/core/kernel/src/sched/mod.rs
@@ -253,19 +253,16 @@ pub const SPIN_SITE_DEALLOC_CONTEXT_SAVED: u32 = 2;
 /// `dealloc_object(Thread)` wake-in-flight gate: spinning until a waker's
 /// claimed-but-not-yet-committed `enqueue_and_wake` clears `wake_in_flight`.
 pub const SPIN_SITE_DEALLOC_WAKE_IN_FLIGHT: u32 = 3;
-/// `schedule()` cross-CPU dispatch: spinning on the next thread's
-/// `context_saved` Acquire barrier.
-pub const SPIN_SITE_SCHEDULE_CONTEXT_SAVED: u32 = 4;
-/// `sys_thread_stop` cross-CPU drain: spinning until the target leaves
-/// `current` on its owning CPU.
-pub const SPIN_SITE_THREAD_STOP_DRAIN: u32 = 5;
 
 /// Per-CPU breadcrumb naming the bounded protocol-spin a CPU is currently
 /// executing, for the softlockup watchdog. A wedged CPU (no non-idle dispatch
-/// for the threshold) that is stuck in a `dealloc_object(Thread)` gate shows
-/// the gate here, turning an opaque `current = Exited` dump into a named site
-/// (#351). Set on gate entry, cleared on exit; [`SPIN_SITE_NONE`] when not
-/// spinning. Diagnostic-only — never gates control flow.
+/// for the threshold) stuck in a `dealloc_object(Thread)` gate shows the gate
+/// here, turning an opaque `current = Exited` dump into a named site (#351).
+/// Set on gate entry, cleared on exit; [`SPIN_SITE_NONE`] when not spinning.
+/// Only the three `dealloc_object(Thread)` gates report here — they are the
+/// bounded spins that lack an overlong-duration warning of their own (the
+/// `schedule()` context-saved spin and the `sys_thread_stop` drain carry their
+/// own). Diagnostic-only — never gates control flow.
 #[cfg(not(test))]
 static SPIN_SITE: [core::sync::atomic::AtomicU32; MAX_CPUS] =
     [const { core::sync::atomic::AtomicU32::new(SPIN_SITE_NONE) }; MAX_CPUS];
@@ -303,8 +300,6 @@ fn spin_site_name(site: u32) -> &'static str
         SPIN_SITE_DEALLOC_NOT_CURRENT => "dealloc:not-current",
         SPIN_SITE_DEALLOC_CONTEXT_SAVED => "dealloc:context-saved",
         SPIN_SITE_DEALLOC_WAKE_IN_FLIGHT => "dealloc:wake-in-flight",
-        SPIN_SITE_SCHEDULE_CONTEXT_SAVED => "schedule:context-saved",
-        SPIN_SITE_THREAD_STOP_DRAIN => "thread-stop:drain",
         _ => "none",
     }
 }
@@ -2062,11 +2057,11 @@ pub unsafe fn migrate_ready_thread(
     let saved_hi = unsafe { hi_sched.lock.lock_raw() };
 
     // The candidate is the caller-named `tcb`, located on `src` by
-    // `relocate_ready_thread`'s own `remove_from_queue(src)`. Read its priority
-    // under sched_lock + both run-queue locks: `sys_thread_set_priority` writes
-    // priority under the same all-CPU-locks discipline (it holds every CPU's
-    // run-queue lock), so this read cannot race it.
-    // SAFETY: tcb valid; priority read under sched_lock + run-queue locks.
+    // `relocate_ready_thread`'s `remove_from_queue(src)`. Read its priority under
+    // the held `(*tcb).sched_lock` — the authoritative serializer that
+    // `sys_thread_set_priority` also takes (outer) around its priority write — so
+    // this read cannot race a concurrent priority change.
+    // SAFETY: tcb valid; priority read under the held sched_lock.
     let priority = unsafe { (*tcb).priority };
 
     // Validate (Ready && context_saved==1 && affinity permits dst) and move

--- a/core/kernel/src/sched/mod.rs
+++ b/core/kernel/src/sched/mod.rs
@@ -19,6 +19,8 @@
 
 pub mod run_queue;
 pub mod thread;
+#[cfg(not(test))]
+pub mod thread_registry;
 
 #[cfg(not(test))]
 use core::mem::MaybeUninit;
@@ -427,7 +429,162 @@ fn watchdog_tick_and_check()
             dl
         );
     }
+    // Enumerate Blocked waiters via the live-thread registry. The per-CPU
+    // `current` dump above shows only each CPU's running/idle thread; the
+    // lost-wakeup victim (#351) is a Blocked thread parked on an IPC object,
+    // reachable only through the registry. The decode below is the decisive
+    // signal: whether the blocking object still names this waiter (no wake was
+    // ever issued) versus holds data / a cleared waiter slot (a wake was
+    // deposited but the link to the run queue was lost).
+    crate::kprintln!("  BLOCKED THREADS:");
+    // Defined outside the `try_for_each` call so the `kprintln!` expansions are
+    // not lexically inside the `unsafe` wrapping that call (which would flag
+    // their macro-internal `unsafe` as redundant). Each raw deref is its own
+    // tight `unsafe`; the field reads race benignly by the stalled contract.
+    let dump_blocked = |t: *mut ThreadControlBlock| {
+        // SAFETY: t is a registry-walked TCB held stable by the registry lock.
+        let is_blocked = unsafe { (*t).state == thread::ThreadState::Blocked };
+        if !is_blocked
+        {
+            return;
+        }
+        // SAFETY: same contract; reads only plain scalar fields.
+        let (tid, ipc, blocked_on, prio, pref, wake_pending, wake_in_flight, dl) = unsafe {
+            (
+                (*t).thread_id,
+                (*t).ipc_state,
+                (*t).blocked_on_object,
+                (*t).priority,
+                (*t).preferred_cpu,
+                (*t).wake_pending,
+                (*t).wake_in_flight
+                    .load(core::sync::atomic::Ordering::Relaxed),
+                (*t).sleep_deadline,
+            )
+        };
+        crate::kprintln!(
+            "    tid{} ipc={:?} blocked_on={:p} prio={} pref={} \
+             wake_pending={} wake_in_flight={} dl={}",
+            tid,
+            ipc,
+            blocked_on,
+            prio,
+            pref,
+            wake_pending,
+            wake_in_flight,
+            dl
+        );
+        // SAFETY: same contract; watchdog_decode_blocked_on only reads.
+        unsafe { watchdog_decode_blocked_on(t) };
+    };
+    // SAFETY: best-effort read-only walk under the registry lock; the closure
+    // only reads through each TCB pointer (no register/unregister).
+    let walked = unsafe { thread_registry::try_for_each(dump_blocked) };
+    if !walked
+    {
+        crate::kprintln!("    (registry lock contended; skipped)");
+    }
     crate::kprintln!("=== END WATCHDOG ===");
+}
+
+/// Decode and print the IPC object a `Blocked` thread is parked on, for the
+/// softlockup watchdog dump. The telling field is whether the object still
+/// names `t` as its waiter (the wake was never issued) or has been cleared /
+/// carries data while `t` is still `Blocked` (the wake was lost between the
+/// waker's deposit and the run-queue link) — the #351 lost-wakeup signature.
+///
+/// # Safety
+/// `t` is a registry-walked TCB pointer held stable by the registry lock. All
+/// reads are benign-racy by the watchdog's already-stalled contract; the
+/// blocking object is read without its lock (the kernel is wedged).
+#[cfg(not(test))]
+// cast_ptr_alignment: blocked_on_object is stored as *mut u8 but always points
+// at a properly-aligned IPC object whose concrete type is named by ipc_state;
+// the same allow covers the parallel casts in dealloc_object's unlink arm.
+#[allow(clippy::cast_ptr_alignment)]
+unsafe fn watchdog_decode_blocked_on(t: *mut ThreadControlBlock)
+{
+    use core::sync::atomic::Ordering;
+    // SAFETY: caller contract; reads ipc_state + blocked_on scalars.
+    let (ipc, blocked_on) = unsafe { ((*t).ipc_state, (*t).blocked_on_object) };
+    if blocked_on.is_null()
+    {
+        return;
+    }
+    // Each arm reads object fields into locals under a tight `unsafe`, then
+    // prints outside it so the `kprintln!` macro's own `unsafe` is not redundant.
+    match ipc
+    {
+        IpcThreadState::BlockedOnEventQueue =>
+        {
+            let eq = blocked_on.cast::<crate::ipc::event_queue::EventQueueState>();
+            // SAFETY: ipc_state classifies blocked_on as an EventQueueState.
+            let (waiter_is_self, count, capacity) = unsafe {
+                (
+                    core::ptr::eq((*eq).waiter, t),
+                    (*eq).count.load(Ordering::Relaxed),
+                    (*eq).capacity,
+                )
+            };
+            crate::kprintln!(
+                "      eq: waiter_is_self={} count={} capacity={}",
+                waiter_is_self,
+                count,
+                capacity
+            );
+        }
+        IpcThreadState::BlockedOnNotification =>
+        {
+            let sig = blocked_on.cast::<crate::ipc::notification::NotificationState>();
+            // SAFETY: ipc_state classifies blocked_on as a NotificationState.
+            let (waiter_is_self, bits) = unsafe {
+                (
+                    core::ptr::eq((*sig).waiter, t),
+                    (*sig).bits.load(Ordering::Relaxed),
+                )
+            };
+            crate::kprintln!(
+                "      notif: waiter_is_self={} bits=0x{:x}",
+                waiter_is_self,
+                bits
+            );
+        }
+        IpcThreadState::BlockedOnReply | IpcThreadState::BlockedOnFault =>
+        {
+            let server = blocked_on.cast::<ThreadControlBlock>();
+            // SAFETY: for a reply/fault block, blocked_on is the server TCB.
+            let (server_tid, reply_is_self, rt) = unsafe {
+                let rt = (*server).reply_tcb.load(Ordering::Relaxed);
+                ((*server).thread_id, core::ptr::eq(rt, t), rt)
+            };
+            crate::kprintln!(
+                "      server tid{} reply_is_self={} reply_tcb={:p}",
+                server_tid,
+                reply_is_self,
+                rt
+            );
+        }
+        IpcThreadState::BlockedOnSend | IpcThreadState::BlockedOnRecv =>
+        {
+            let ep = blocked_on.cast::<crate::ipc::endpoint::EndpointState>();
+            // SAFETY: ipc_state classifies blocked_on as an EndpointState.
+            let (send_head, recv_head) = unsafe { ((*ep).send_head, (*ep).recv_head) };
+            crate::kprintln!(
+                "      ep: send_head={:p} recv_head={:p}",
+                send_head,
+                recv_head
+            );
+        }
+        IpcThreadState::BlockedOnWaitSet =>
+        {
+            let ws = blocked_on.cast::<crate::ipc::wait_set::WaitSetState>();
+            // SAFETY: ipc_state classifies blocked_on as a WaitSetState.
+            let waiter_is_self = unsafe { core::ptr::eq((*ws).waiter, t) };
+            crate::kprintln!("      waitset: waiter_is_self={}", waiter_is_self);
+        }
+        IpcThreadState::None =>
+        {}
+    }
 }
 
 // ── BSP boot transient ────────────────────────────────────────────────────────
@@ -1063,6 +1220,11 @@ pub fn init(cpu_count: u32) -> u32
                     exit_reason: 0,
                     sleep_deadline: 0,
                     extended: thread::ExtendedState::empty(),
+                    // Idle TCBs are never deallocated and never `Blocked`, and
+                    // are already shown by the watchdog's per-CPU `current` dump,
+                    // so they are not threaded onto the diagnostic registry.
+                    registry_next: core::ptr::null_mut(),
+                    registry_prev: core::ptr::null_mut(),
                     magic: thread::TCB_MAGIC,
                 },
             );

--- a/core/kernel/src/sched/mod.rs
+++ b/core/kernel/src/sched/mod.rs
@@ -2061,64 +2061,19 @@ pub unsafe fn migrate_ready_thread(
     // SAFETY: lo lock held; acquiring hi second satisfies ascending-CPU order.
     let saved_hi = unsafe { hi_sched.lock.lock_raw() };
 
-    // Authoritative read under sched_lock: only a Ready thread that has FULLY
-    // saved its context (`context_saved == 1`) is migratable. A Ready-but-
-    // `cs == 0` thread is mid-handoff — woken (e.g. a fast IPC reply) while still
-    // `current`/live on its source CPU and not yet switched away; relocating it
-    // cross-CPU would dispatch it on two CPUs at once (#314/#293). `cs == 1`
-    // proves it has switched out and is not `current` anywhere. A skipped
-    // mid-handoff thread keeps its (already-written) affinity and is placed
-    // correctly by its source CPU's `schedule()` cross-affinity arm.
-    // `remove_from_queue(src)` below is the authoritative "located on src" check —
-    // it fails (and we bail) if the thread is Ready on a different CPU's queue or
-    // in the benign Ready-but-unlinked publication window — so no separate
-    // preferred_cpu heuristic is needed.
-    // SAFETY: tcb valid; state/cs/priority read under sched_lock + run-queue locks.
-    let (state, cs, priority) = unsafe {
-        (
-            (*tcb).state,
-            (*tcb).context_saved.load(Ordering::Acquire),
-            (*tcb).priority,
-        )
-    };
+    // The candidate is the caller-named `tcb`, located on `src` by
+    // `relocate_ready_thread`'s own `remove_from_queue(src)`. Read its priority
+    // under sched_lock + both run-queue locks: `sys_thread_set_priority` writes
+    // priority under the same all-CPU-locks discipline (it holds every CPU's
+    // run-queue lock), so this read cannot race it.
+    // SAFETY: tcb valid; priority read under sched_lock + run-queue locks.
+    let priority = unsafe { (*tcb).priority };
 
-    if state != thread::ThreadState::Ready || cs != 1
-    {
-        // SAFETY: paired above; release inner (hi, lo) then outer (sched_lock).
-        unsafe {
-            hi_sched.lock.unlock_raw(saved_hi);
-            lo_sched.lock.unlock_raw(saved_lo);
-            (*tcb).sched_lock.unlock_raw(tcb_sched_saved);
-        }
-        return false;
-    }
-
-    // SAFETY: src and dst schedulers initialised; tcb is Ready; both run-queue
-    // locks held so neither queue's structure can change underneath us.
-    let removed = unsafe { scheduler_for(src_cpu).remove_from_queue(tcb, priority) };
-    if !removed
-    {
-        // Ready but not linked on src — either the benign Ready-but-unlinked
-        // publication window (a pending enqueue_and_wake will place it), or it is
-        // Ready on a different CPU's queue. Either way nothing to do here; that
-        // CPU's schedule()/enqueue honours the new affinity.
-        // SAFETY: paired above; release inner (hi, lo) then outer (sched_lock).
-        unsafe {
-            hi_sched.lock.unlock_raw(saved_hi);
-            lo_sched.lock.unlock_raw(saved_lo);
-            (*tcb).sched_lock.unlock_raw(tcb_sched_saved);
-        }
-        return false;
-    }
-
-    // SAFETY: dst scheduler initialised; tcb is no longer on src's queue.
-    unsafe { scheduler_for(dst_cpu).enqueue(tcb, priority) };
-    // SAFETY: tcb valid; sched_lock + both run-queue locks held.
-    unsafe { (*tcb).preferred_cpu = dst_cpu as u32 };
-
-    // Publish reschedule-pending before the unlock so the dst CPU's idle
-    // loop / schedule() sees it via the Release on unlock.
-    set_reschedule_pending_for(dst_cpu);
+    // Validate (Ready && context_saved==1 && affinity permits dst) and move
+    // src→dst, all under the held locks. Here the caller (sys_thread_set_affinity)
+    // has just set cpu_affinity = dst_cpu, so the affinity gate passes.
+    // SAFETY: sched_lock + both run-queue locks held (ascending CPU order).
+    let moved = unsafe { relocate_ready_thread(tcb, src_cpu, dst_cpu, priority) };
 
     // SAFETY: paired above; release inner (hi, lo) then outer (sched_lock).
     unsafe {
@@ -2127,10 +2082,103 @@ pub unsafe fn migrate_ready_thread(
         (*tcb).sched_lock.unlock_raw(tcb_sched_saved);
     }
 
-    // Always-IPI per the wake-protocol invariant.
-    // SAFETY: dst_cpu validated < cpu_count above.
-    unsafe { wake_idle_cpu(dst_cpu) };
+    if moved
+    {
+        // Always-IPI per the wake-protocol invariant.
+        // SAFETY: dst_cpu validated < cpu_count above.
+        unsafe { wake_idle_cpu(dst_cpu) };
+    }
 
+    moved
+}
+
+/// Relocate a Ready candidate from `src_cpu` to `dst_cpu`: the single
+/// validate-then-move core shared by [`migrate_ready_thread`] (canonical
+/// `sched_lock` → run-queue lock order) and [`pull_unpinned_ready`] (inverse,
+/// `try_lock`'d order). One place takes a Ready TCB off one queue and puts it on
+/// another, mirroring `PerCpuScheduler::enqueue` as the single insertion
+/// chokepoint.
+///
+/// Validates, under the caller-held `sched_lock` (the authoritative serializer):
+/// - `state == Ready` AND `context_saved == 1` — a `cs == 0` Ready thread is
+///   mid-handoff (woken while still `current`/live on its source CPU, not yet
+///   switched away); relocating it would dispatch it on two CPUs at once
+///   (#314/#293). `cs == 1` proves it switched out and is `current` nowhere.
+/// - hard `cpu_affinity` permits `dst_cpu`. This gate closes the load-balancer
+///   affinity violation: `pull_unpinned_ready`'s `find_runnable` predicate reads
+///   `cpu_affinity` *advisorily* under the run-queue lock, so a concurrent
+///   `sys_thread_set_affinity` can pin the thread away from `dst_cpu` between the
+///   predicate and here. Re-reading affinity under `sched_lock` honours the pin.
+///
+/// `remove_from_queue(src, priority)` is the authoritative "located on src at
+/// `priority`" check; it fails (benign no-op) if the thread moved or is in the
+/// Ready-but-unlinked publication window. A declined relocation leaves the
+/// candidate on `src`, corrected by the next `schedule()` cross-affinity arm or
+/// balance tick — eventual consistency, not instant re-homing (#116).
+///
+/// Returns `true` iff the thread was relocated.
+///
+/// # Safety
+/// Caller MUST hold `(*tcb).sched_lock` AND both `src`/`dst` run-queue locks
+/// (acquired in ascending CPU order). `priority` MUST be the level the candidate
+/// is linked at on `src_cpu` — the value the caller located it by — NOT a
+/// re-read of `(*tcb).priority` inside a context where a concurrent
+/// `sys_thread_set_priority` could have desynced them. Takes/releases NO lock and
+/// sends NO IPI: the caller owns the lock lifecycle and the `wake_idle_cpu(dst)`
+/// that follows a `true` return.
+#[cfg(not(test))]
+unsafe fn relocate_ready_thread(
+    tcb: *mut thread::ThreadControlBlock,
+    src_cpu: usize,
+    dst_cpu: usize,
+    priority: u8,
+) -> bool
+{
+    use core::sync::atomic::Ordering;
+    // SAFETY: tcb valid by caller contract; magic readable.
+    debug_assert!(unsafe { (*tcb).magic == thread::TCB_MAGIC });
+
+    // SAFETY: state/cs/affinity read under the caller-held sched_lock.
+    let (state, cs, affinity) = unsafe {
+        (
+            (*tcb).state,
+            (*tcb).context_saved.load(Ordering::Acquire),
+            (*tcb).cpu_affinity,
+        )
+    };
+
+    if state != thread::ThreadState::Ready || cs != 1
+    {
+        return false;
+    }
+    if affinity != AFFINITY_ANY && affinity as usize != dst_cpu
+    {
+        return false;
+    }
+
+    // G3: the relocation only proceeds for a Ready candidate.
+    debug_assert!(state == thread::ThreadState::Ready);
+    // SAFETY: both run-queue locks held; tcb pinned by them. `remove_from_queue`
+    // is the authoritative located-on-src check at `priority`.
+    if !unsafe { scheduler_for(src_cpu).remove_from_queue(tcb, priority) }
+    {
+        return false;
+    }
+    // SAFETY: tcb no longer on src; dst scheduler valid; both locks held.
+    unsafe { scheduler_for(dst_cpu).enqueue(tcb, priority) };
+    // SAFETY: tcb valid; sched_lock + both run-queue locks held.
+    unsafe { (*tcb).preferred_cpu = dst_cpu as u32 };
+    // G4: the relocated thread is linked on dst at exactly `priority` (a stale
+    // tag here would mean a double-relocate left an inconsistent link).
+    // SAFETY: tcb valid; queued_on read under the held run-queue locks.
+    let linked_at = unsafe { (*tcb).queued_on.load(Ordering::Relaxed) };
+    debug_assert!(
+        linked_at == i16::from(priority),
+        "relocate_ready_thread: queued_on != priority after enqueue",
+    );
+    // Publish reschedule-pending before the caller's unlock so the dst CPU's
+    // idle loop / schedule() observes it via the Release on unlock.
+    set_reschedule_pending_for(dst_cpu);
     true
 }
 
@@ -2350,26 +2398,16 @@ unsafe fn pull_unpinned_ready(src_cpu: usize, dst_cpu: usize)
         return;
     };
 
-    // SAFETY: tcb is currently linked in src_cpu's run queue at `priority`.
-    let removed = unsafe { scheduler_for(src_cpu).remove_from_queue(tcb, priority) };
-    if !removed
-    {
-        // SAFETY: paired above; release the candidate's sched_lock and hi, then
-        // lo last (lo captured the caller's interrupt flags).
-        unsafe {
-            (*tcb).sched_lock.unlock_raw(tcb_sched_saved);
-            hi_sched.lock.unlock_raw(saved_hi);
-            lo_sched.lock.unlock_raw(saved_lo);
-        }
-        return;
-    }
-
-    // SAFETY: tcb is no longer on src; dst_cpu scheduler is valid.
-    unsafe { scheduler_for(dst_cpu).enqueue(tcb, priority) };
-    // SAFETY: tcb valid; sched_lock + both run-queue locks held.
-    unsafe { (*tcb).preferred_cpu = dst_cpu as u32 };
-
-    set_reschedule_pending_for(dst_cpu);
+    // Validate (Ready && context_saved==1 && affinity permits dst) under the
+    // candidate's sched_lock and move src→dst, with the `priority` that
+    // `find_runnable` located it at (NOT a re-read of (*tcb).priority): that is
+    // the level `remove_from_queue` needs, and the src run-queue lock held since
+    // the predicate pins it against a concurrent `sys_thread_set_priority`. The
+    // affinity gate inside `relocate_ready_thread` closes the load-balancer
+    // affinity violation the advisory `find_runnable` predicate cannot — a
+    // `sys_thread_set_affinity` racing between the predicate and here.
+    // SAFETY: sched_lock + both run-queue locks held.
+    let moved = unsafe { relocate_ready_thread(tcb, src_cpu, dst_cpu, priority) };
 
     // SAFETY: paired above; release the candidate's sched_lock and hi, then lo
     // last (lo captured the caller's interrupt flags).
@@ -2379,8 +2417,11 @@ unsafe fn pull_unpinned_ready(src_cpu: usize, dst_cpu: usize)
         lo_sched.lock.unlock_raw(saved_lo);
     }
 
-    // SAFETY: dst_cpu validated < cpu_count.
-    unsafe { wake_idle_cpu(dst_cpu) };
+    if moved
+    {
+        // SAFETY: dst_cpu validated < cpu_count.
+        unsafe { wake_idle_cpu(dst_cpu) };
+    }
 }
 
 /// Test stub.

--- a/core/kernel/src/sched/mod.rs
+++ b/core/kernel/src/sched/mod.rs
@@ -2640,22 +2640,57 @@ pub unsafe fn enqueue_ready_thread(_tcb: *mut ThreadControlBlock, _target_cpu: u
 #[cfg(not(test))]
 pub unsafe fn select_target_cpu(tcb: *mut ThreadControlBlock) -> usize
 {
+    // SAFETY: caller guarantees tcb is valid.
+    unsafe { select_target_cpu_excluding(tcb, None) }
+}
+
+/// Like [`select_target_cpu`], but treat `exclude` (when `Some`) as ineligible
+/// for the save-window-pin, sticky, and min-load branches — UNLESS hard
+/// `cpu_affinity` names it (affinity is a correctness constraint that overrides
+/// the placement hint) or it is the only CPU.
+///
+/// `dealloc_object(Thread)`'s deferred reply-wake passes `exclude =
+/// Some(dealloc_cpu)`. That CPU is wedged in a preempt-disabled UAF gate, NOT in
+/// `schedule()`, so the save-window pin's deadlock-avoidance rationale does not
+/// apply to it: pinning a `context_saved == 0` woken client there would strand
+/// it on a CPU that cannot re-enter the scheduler until the dealloc returns —
+/// which it cannot do while that client is the only runnable thread (#351). When
+/// the pin / sticky / min-load choice would land on `exclude`, fall back to the
+/// least-loaded non-excluded CPU. A peer dispatches the `cs == 0` client safely:
+/// `schedule()` waits on the publication barrier (`context_saved` Acquire spin)
+/// before the register switch, so a peer never loads a not-yet-saved register
+/// file.
+///
+/// # Safety
+/// `tcb` must be a valid pointer to an initialized [`ThreadControlBlock`].
+// needless_range_loop: the scheduler slab is reached via scheduler_ptr(cpu);
+// indexed bounds checking is clearer than iter/enumerate pointer plumbing.
+#[allow(clippy::needless_range_loop)]
+#[cfg(not(test))]
+pub unsafe fn select_target_cpu_excluding(
+    tcb: *mut ThreadControlBlock,
+    exclude: Option<usize>,
+) -> usize
+{
     // SAFETY: caller guarantees tcb is valid; cpu_affinity field is always valid.
     let affinity = unsafe { (*tcb).cpu_affinity };
 
-    // Hard affinity: use specified CPU.
+    // Hard affinity wins, even when it names the excluded CPU: affinity is a
+    // correctness constraint, not a placement hint.
     if affinity != AFFINITY_ANY
     {
         return affinity as usize;
     }
 
     let cpu_count = CPU_COUNT.load(core::sync::atomic::Ordering::Relaxed) as usize;
+    let eligible = |c: usize| -> bool { c < cpu_count && Some(c) != exclude };
 
     // Save-window pinning: while `context_saved == 0` the source CPU is
-    // mid-switch into `tcb.saved_state`. Migrating the wake to a different
-    // CPU would force its `schedule()` to spin on the publication barrier;
-    // two such migrations on different CPUs can cross-deadlock. Pinning
-    // to `preferred_cpu` (the CPU performing the save) avoids both.
+    // mid-switch into `tcb.saved_state`. Pinning to `preferred_cpu` (the saving
+    // CPU) lets that CPU's own `schedule()` complete the save before re-running
+    // the thread, avoiding a cross-CPU publication-barrier spin. Honoured only
+    // when `preferred_cpu` is eligible; otherwise fall through so a `cs == 0`
+    // client is never pinned to the excluded (wedged) CPU.
     // SAFETY: tcb valid; context_saved is AtomicU32; preferred_cpu always set.
     let saved = unsafe {
         (*tcb)
@@ -2664,23 +2699,26 @@ pub unsafe fn select_target_cpu(tcb: *mut ThreadControlBlock) -> usize
     };
     if saved == 0
     {
-        // SAFETY: preferred_cpu is set by every prior enqueue_and_wake;
-        // bounded by CPU_COUNT at the source.
+        // SAFETY: preferred_cpu is set by every prior enqueue_and_wake.
         let pref = unsafe { (*tcb).preferred_cpu } as usize;
-        if pref < cpu_count
+        if eligible(pref)
         {
             return pref;
         }
     }
 
-    // Scan all CPUs for min load. Used both as the fallback selection and as
-    // the reference value for the sticky-preferred-CPU comparison below.
+    // Scan ELIGIBLE CPUs for min load. `usize::MAX` marks "no eligible CPU"
+    // (degenerate: cpu_count == 1 and that CPU excluded).
     let mut min_load = u32::MAX;
-    let mut min_cpu = 0;
+    let mut min_cpu = usize::MAX;
     // SAFETY: scheduler slab covers cpu_count slots, all initialised by sched::init.
     for cpu in 0..cpu_count
     {
-        // SAFETY: cpu < cpu_count; scheduler slab initialised for all CPUs by sched::init.
+        if !eligible(cpu)
+        {
+            continue;
+        }
+        // SAFETY: cpu < cpu_count; scheduler slab initialised for all CPUs.
         let load = unsafe { (*scheduler_ptr(cpu)).current_load() };
         if load < min_load
         {
@@ -2689,13 +2727,12 @@ pub unsafe fn select_target_cpu(tcb: *mut ThreadControlBlock) -> usize
         }
     }
 
-    // Sticky preferred CPU: stay if within the pull-balancer's imbalance
-    // threshold of the global minimum. See doc comment above.
-    // SAFETY: preferred_cpu is set by every prior enqueue_and_wake; bounded
-    // by CPU_COUNT at the source. The `< cpu_count` guard makes a stale or
-    // never-initialised value fall through to the min-load path.
+    // Sticky preferred CPU (eligible only): stay if within the pull-balancer's
+    // imbalance threshold of the global minimum (cache-warmth bias, #128).
+    // SAFETY: preferred_cpu is set by every prior enqueue_and_wake; the
+    // eligibility guard makes a stale value fall through to the min-load path.
     let pref = unsafe { (*tcb).preferred_cpu } as usize;
-    if pref < cpu_count
+    if eligible(pref)
     {
         // SAFETY: pref < cpu_count; slab initialised.
         let pref_load = unsafe { (*scheduler_ptr(pref)).current_load() };
@@ -2705,6 +2742,21 @@ pub unsafe fn select_target_cpu(tcb: *mut ThreadControlBlock) -> usize
         }
     }
 
+    // Degenerate: no eligible CPU (cpu_count == 1, or every non-excluded queue
+    // filtered). Returning the excluded CPU is correct — on a single CPU the
+    // dealloc caller returns to schedule() via the syscall epilogue and
+    // dispatches the client itself; the strand requires an idle peer.
+    if min_cpu == usize::MAX
+    {
+        return exclude.unwrap_or(0);
+    }
+
+    // G2: the exclusion holds for the load-scan result (affinity / single-CPU
+    // overrides returned earlier).
+    debug_assert!(
+        Some(min_cpu) != exclude,
+        "select_target_cpu_excluding: load scan returned excluded cpu {min_cpu}",
+    );
     min_cpu
 }
 

--- a/core/kernel/src/sched/run_queue.rs
+++ b/core/kernel/src/sched/run_queue.rs
@@ -328,10 +328,19 @@ impl PerCpuScheduler
             unsafe {
                 let tid = (*tcb).thread_id;
                 let prior = (*tcb).last_enqueue;
+                // Surface the state/cs/affinity of the doubly-linked TCB and the
+                // current link CPU: a residual #289/#351 double-link is driven
+                // by a Blocked-while-linked or self-pinned (cs==0) condition, not
+                // just the bare queued_on tag (G5).
+                let state = (*tcb).state;
+                let cs = (*tcb).context_saved.load(Ordering::Relaxed);
+                let aff = (*tcb).cpu_affinity;
+                let link_cpu = crate::arch::current::cpu::current_cpu();
                 panic!(
                     "PerCpuScheduler::enqueue: tcb {tcb:p} tid={tid} already \
-                     linked at queued_on={prior_link} (re-enqueue at prio={p}) \
-                     — global double-enqueue; prior={prior:?}",
+                     linked at queued_on={prior_link} (re-enqueue at prio={p} on \
+                     cpu={link_cpu}) — global double-enqueue; state={state:?} \
+                     cs={cs} affinity=0x{aff:x}; prior={prior:?}",
                 );
             }
             #[cfg(not(debug_assertions))]

--- a/core/kernel/src/sched/thread.rs
+++ b/core/kernel/src/sched/thread.rs
@@ -471,6 +471,19 @@ pub struct ThreadControlBlock
     /// lazy-restore discipline (see [`ExtendedState`]).
     pub extended: ExtendedState,
 
+    // === Diagnostic thread registry ===
+    /// Intrusive forward link in the global live-thread registry
+    /// (`sched::thread_registry`). `null` when this TCB is not threaded onto
+    /// the registry. Spliced in at construction and removed at dealloc, both
+    /// under `THREAD_REGISTRY_LOCK`. Diagnostic-only: the softlockup watchdog
+    /// walks the registry to enumerate `Blocked` waiters that the per-CPU
+    /// `current` dump cannot reach — a lost-wakeup victim is parked on an IPC
+    /// object and referenced by nothing the `current` dump can see (#351).
+    /// Never read on any scheduling hot path.
+    pub registry_next: *mut ThreadControlBlock,
+    /// Intrusive backward link; see [`registry_next`](Self::registry_next).
+    pub registry_prev: *mut ThreadControlBlock,
+
     // === Use-after-free detection ===
     /// Magic cookie for use-after-free detection. Must be `TCB_MAGIC` when valid.
     pub magic: u64,

--- a/core/kernel/src/sched/thread_registry.rs
+++ b/core/kernel/src/sched/thread_registry.rs
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// kernel/src/sched/thread_registry.rs
+
+//! Global live-thread registry — a diagnostic-only intrusive doubly-linked
+//! list of every live TCB.
+//!
+//! Threads are spliced in at construction ([`register`]) and removed at dealloc
+//! ([`unregister`]), both under [`THREAD_REGISTRY_LOCK`]. The softlockup
+//! watchdog walks it ([`try_for_each`]) to enumerate `Blocked` waiters that the
+//! per-CPU `current` dump cannot reach: the lost-wakeup victim in #351 is a
+//! `Blocked` thread referenced only by the IPC object it parked on, invisible
+//! to a `current`-only dump.
+//!
+//! [`THREAD_REGISTRY_LOCK`] is a leaf — taken alone, never nested under a
+//! `sched_lock` or a run-queue lock — so it introduces no new lock-order edge.
+//! See docs/scheduling-internals.md § Thread Registry.
+
+#![cfg(not(test))]
+
+use super::thread::ThreadControlBlock;
+use crate::sync::Spinlock;
+
+/// Serialises every access to the registry list. Leaf lock (see module docs).
+static THREAD_REGISTRY_LOCK: Spinlock = Spinlock::new();
+
+/// Head of the intrusive list (`null` when empty). Guarded by
+/// [`THREAD_REGISTRY_LOCK`].
+static mut THREAD_REGISTRY_HEAD: *mut ThreadControlBlock = core::ptr::null_mut();
+
+/// Upper bound on nodes visited by [`try_for_each`]. A defensive backstop: if
+/// the list is ever corrupted into a cycle, the watchdog walk terminates rather
+/// than spinning forever inside the already-fatal stall dump.
+const MAX_WALK: usize = 4096;
+
+/// Splice `tcb` onto the head of the live-thread registry.
+///
+/// Idempotent only in the sense that it assumes `tcb` is not already linked;
+/// callers register exactly once, at construction.
+///
+/// # Safety
+/// `tcb` must be a valid, freshly-constructed TCB that is not already on the
+/// registry.
+pub unsafe fn register(tcb: *mut ThreadControlBlock)
+{
+    // SAFETY: lock serialises all registry access; tcb valid per contract.
+    let saved = unsafe { THREAD_REGISTRY_LOCK.lock_raw() };
+    // SAFETY: single-writer access under lock; head read/written as a scalar.
+    unsafe {
+        let head = THREAD_REGISTRY_HEAD;
+        (*tcb).registry_prev = core::ptr::null_mut();
+        (*tcb).registry_next = head;
+        if !head.is_null()
+        {
+            (*head).registry_prev = tcb;
+        }
+        THREAD_REGISTRY_HEAD = tcb;
+    }
+    // SAFETY: paired with lock_raw above.
+    unsafe { THREAD_REGISTRY_LOCK.unlock_raw(saved) };
+}
+
+/// Remove `tcb` from the live-thread registry. A no-op for a TCB that was never
+/// registered (both links null and not the head), so it is safe to call on the
+/// dealloc path regardless of whether the thread was ever linked.
+///
+/// Must run before the TCB storage is freed: the walk holds
+/// [`THREAD_REGISTRY_LOCK`] across every dereference, so an unlink that precedes
+/// the free guarantees the watchdog never observes a dangling node.
+///
+/// # Safety
+/// `tcb` must be a valid TCB pointer that is not concurrently freed.
+pub unsafe fn unregister(tcb: *mut ThreadControlBlock)
+{
+    // SAFETY: lock serialises all registry access; tcb valid per contract.
+    let saved = unsafe { THREAD_REGISTRY_LOCK.lock_raw() };
+    // SAFETY: single-writer access under lock.
+    unsafe {
+        let prev = (*tcb).registry_prev;
+        let next = (*tcb).registry_next;
+        if prev.is_null()
+        {
+            // `tcb` is the head, or was never linked: only patch the head when
+            // it actually names `tcb`, so an unregistered TCB cannot corrupt the
+            // list.
+            if THREAD_REGISTRY_HEAD == tcb
+            {
+                THREAD_REGISTRY_HEAD = next;
+            }
+        }
+        else
+        {
+            (*prev).registry_next = next;
+        }
+        if !next.is_null()
+        {
+            (*next).registry_prev = prev;
+        }
+        (*tcb).registry_next = core::ptr::null_mut();
+        (*tcb).registry_prev = core::ptr::null_mut();
+    }
+    // SAFETY: paired with lock_raw above.
+    unsafe { THREAD_REGISTRY_LOCK.unlock_raw(saved) };
+}
+
+/// Walk the live-thread registry, invoking `f` on each registered TCB pointer.
+///
+/// Best-effort: if the registry lock is contended — a `register`/`unregister`
+/// is in flight, or a CPU died holding it — returns `false` without walking
+/// rather than spinning. The watchdog must never block. Returns `true` if the
+/// walk ran to completion (or hit [`MAX_WALK`]).
+///
+/// # Safety
+/// `f` must only read through the TCB pointer and must not register or
+/// unregister any thread (it runs under [`THREAD_REGISTRY_LOCK`]).
+pub unsafe fn try_for_each(mut f: impl FnMut(*mut ThreadControlBlock)) -> bool
+{
+    // SAFETY: try_lock_raw never blocks; None means contended, so we back off.
+    let Some(saved) = (unsafe { THREAD_REGISTRY_LOCK.try_lock_raw() })
+    else
+    {
+        return false;
+    };
+    // SAFETY: list is consistent under the lock; MAX_WALK bounds a corrupt cycle.
+    unsafe {
+        let mut node = THREAD_REGISTRY_HEAD;
+        let mut visited = 0usize;
+        while !node.is_null() && visited < MAX_WALK
+        {
+            f(node);
+            node = (*node).registry_next;
+            visited += 1;
+        }
+    }
+    // SAFETY: paired with try_lock_raw above.
+    unsafe { THREAD_REGISTRY_LOCK.unlock_raw(saved) };
+    true
+}

--- a/core/kernel/src/syscall/cap.rs
+++ b/core/kernel/src/syscall/cap.rs
@@ -934,6 +934,8 @@ pub fn sys_cap_create_thread(tf: &mut TrapFrame) -> Result<u64, SyscallError>
                 exit_reason: 0,
                 sleep_deadline: 0,
                 extended: crate::sched::thread::ExtendedState::from_raw(extended_area),
+                registry_next: core::ptr::null_mut(),
+                registry_prev: core::ptr::null_mut(),
                 magic: crate::sched::thread::TCB_MAGIC,
             },
         );
@@ -965,6 +967,15 @@ pub fn sys_cap_create_thread(tf: &mut TrapFrame) -> Result<u64, SyscallError>
 
     if let Ok(idx) = idx_res
     {
+        // Thread the new TCB onto the diagnostic live-thread registry now that
+        // its cap is visible and the construction has committed. Registering
+        // only on the success path keeps it symmetric with the unregister in
+        // `dealloc_object(Thread)`: the rollback arm below frees the TCB via
+        // `retype_free` without ever registering it. The thread is still
+        // `Created` (not startable until SYS_THREAD_START), so it cannot become
+        // a Blocked watchdog victim before this point.
+        // SAFETY: tcb_ptr is the just-constructed, not-yet-registered TCB.
+        unsafe { crate::sched::thread_registry::register(tcb_ptr) };
         let _ = kstack_virt;
         Ok(u64::from(idx.get()))
     }

--- a/core/ktest/src/stress/cap_delete_reply_wake.rs
+++ b/core/ktest/src/stress/cap_delete_reply_wake.rs
@@ -1,0 +1,310 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// ktest/src/stress/cap_delete_reply_wake.rs
+
+//! Stress: `cap_delete` of a server that a client is `BlockedOnReply` on MUST
+//! wake that client — the dealloc deferred reply-wake *liveness* invariant
+//! (issue #351, the cap-delete / dealloc → wake lost-wakeup family).
+//!
+//! ## The hazard
+//!
+//! When a client issues `ipc_call` and the server `ipc_recv`s it, the client is
+//! `BlockedOnReply` with `blocked_on_object = server TCB` and the server records
+//! `reply_tcb = client`. If the server is then torn down without replying,
+//! `cap_delete(server)` → `dealloc_object(Thread)` is the sole path that
+//! releases the orphaned client: it CAS-claims `reply_tcb`, deposits an
+//! `Interrupted` disposition, and *defers* the client's wake past the all-CPU
+//! locks region through the gated `enqueue_and_wake` (see
+//! `core/kernel/src/cap/object.rs`, the Thread arm's `server_reply_wake`). The
+//! server's own `thread_exit` does **not** wake the client — only the dealloc
+//! does.
+//!
+//! If that deferred cross-CPU wake is ever lost — coalesced against a stale
+//! live/not-live classification, or enqueued without the target CPU ever
+//! observing the reschedule — the client is stranded `BlockedOnReply` forever
+//! with nothing armed to recover it. That is the #351 signature: a thread
+//! reaches `Exited` inside `SYS_CAP_DELETE`, the wake it owed a blocked waiter
+//! is dropped, and every CPU goes idle.
+//!
+//! ## How this exercises it
+//!
+//! Each cycle pins the client and server to **different** CPUs, so the dealloc
+//! (running on the controller's CPU) and the client's wake-enqueue (targeting
+//! the client's pinned CPU) cross cores — the cross-CPU wake path that strands
+//! the waiter. The server receives the client (arming `reply_tcb = client`),
+//! announces the armed window, then dies without replying. The controller then
+//! `cap_delete`s the server, which owes the client an `Interrupted` wake.
+//!
+//! ## Liveness gate (not just anti-vacuous)
+//!
+//! Unlike `stop_reply_race` — which races `thread_stop(client)` against the
+//! free and so *cannot* require the client to wake (a stopped client stays
+//! `Stopped`) — this cell drives **only** the server dealloc. The kernel
+//! contract therefore guarantees the client wakes with `Interrupted`, so the
+//! controller **requires** `BIT_CLIENT_WOKE` every cycle. A lost wake never
+//! arrives: the controller's `notification_wait` blocks, every CPU goes idle,
+//! and the softlockup watchdog fires (its registry walk names the stranded
+//! `BlockedOnReply` client and the server it is parked on). The hang is raised
+//! by the kernel, not by a test assertion — `BIT_SERVER_ARMED` proves the race
+//! armed, and `woke_cycles == CYCLES` proves the liveness path actually ran on
+//! every cycle rather than passing vacuously.
+//!
+//! ## Pass criterion
+//!
+//! SMP-only (skips on `< 2` CPUs — the free and the wake-enqueue must run on
+//! different cores to exercise the cross-CPU strand). On a correct kernel the
+//! harness boots clean to `[ktest] ALL TESTS PASSED`.
+
+use ipc::IpcMessage;
+use syscall::{
+    cap_copy, cap_create_endpoint, cap_create_notification, cap_delete, ipc_buffer_set,
+    notification_send, notification_wait, thread_exit, thread_yield,
+};
+use syscall_abi::{RIGHTS_RECEIVE, RIGHTS_SEND_GRANT, SystemInfoType};
+
+use crate::{ChildStack, TestContext, TestResult, spawn};
+
+/// Reply-wake races to run. Higher than `stop_reply_race`'s 300: the lost wake
+/// is rarer than the #317 UAF, so give the cross-CPU strand many chances.
+const CYCLES: usize = 2000;
+
+/// Notification signal right (bit 7) — what a child needs to `notification_send`.
+const RIGHTS_SIGNAL: u64 = 1 << 7;
+
+/// `done` bit the server raises once `ipc_recv` has dequeued the client, i.e.
+/// once the client is `BlockedOnReply` and the reply-wake is armed.
+const BIT_SERVER_ARMED: u64 = 1 << 0;
+
+/// `done` bit the client raises when its `ipc_call` returns — the wake the
+/// server's dealloc owed it. **Required** every cycle; a lost wake never sends it.
+const BIT_CLIENT_WOKE: u64 = 1 << 1;
+
+/// Bound on the server's post-recv busy-spin, keeping the server TCB live for a
+/// short window after it signals armed so the `cap_delete` lands while the
+/// reply binding is on a still-running server (the harder interleaving).
+const SERVER_SPIN: u32 = 200;
+
+/// Bound on controller yields used to let the client reach `ipc_call` and park
+/// on the endpoint send queue before the server receives it.
+const SETTLE_YIELDS: usize = 8;
+
+/// A page-aligned 4 KiB IPC buffer page. The server and client run concurrently
+/// on different CPUs and each issues IPC, so they must not share one buffer page
+/// (that would be a data race in the *test*). Each gets its own static, reused
+/// across sequential cycles: both children are reaped before the next cycle.
+#[repr(C, align(4096))]
+struct IpcBufPage([u64; 512]);
+
+// SAFETY: written only by the single server child of the current cycle via its
+// own IPC syscalls (kernel-synchronous), never aliased across cycles.
+static mut SERVER_IPC_BUF: IpcBufPage = IpcBufPage([0u64; 512]);
+
+// SAFETY: written only by the single client child of the current cycle via its
+// own IPC syscalls (kernel-synchronous), never aliased across cycles.
+static mut CLIENT_IPC_BUF: IpcBufPage = IpcBufPage([0u64; 512]);
+
+pub fn run(ctx: &TestContext) -> TestResult
+{
+    let cpus = syscall::system_info(SystemInfoType::CpuCount as u64)
+        .map_err(|_| "stress::cap_delete_reply_wake: system_info(CpuCount) failed")?;
+    if cpus < 2
+    {
+        crate::log("ktest: stress::cap_delete_reply_wake SKIP (need 2+ CPUs)");
+        return Ok(());
+    }
+    let cpu_mod = u32::try_from(cpus).unwrap_or(1).max(1);
+
+    // Anti-vacuous accumulators: every cycle must arm the reply binding and then
+    // observe the client's wake.
+    let mut armed_cycles = 0usize;
+    let mut woke_cycles = 0usize;
+
+    for cycle in 0..CYCLES
+    {
+        // CYCLES is a compile-time constant well below u32::MAX; try_from keeps
+        // the narrow cast clippy-clean.
+        let cycle_u32 = u32::try_from(cycle).unwrap_or(0);
+        let server_cpu = cycle_u32 % cpu_mod;
+        // Different CPU from the server: the dealloc-free and the client's
+        // wake-enqueue must run on different cores to exercise the cross-CPU
+        // strand. With cpus >= 2, `(cycle + 1) % cpus != cycle % cpus`.
+        let client_cpu = (cycle_u32 + 1) % cpu_mod;
+
+        let ep = cap_create_endpoint(ctx.memory_base)
+            .map_err(|_| "stress::cap_delete_reply_wake: cap_create_endpoint failed")?;
+        let done = cap_create_notification(ctx.memory_base)
+            .map_err(|_| "stress::cap_delete_reply_wake: cap_create_notification failed")?;
+
+        // ── Client child: SEND|GRANT on ep, signal on done. ─────────────────
+        let client = spawn::new_child(ctx)
+            .map_err(|_| "stress::cap_delete_reply_wake: spawn::new_child client failed")?;
+        let client_ep = cap_copy(ep, client.cs, RIGHTS_SEND_GRANT)
+            .map_err(|_| "stress::cap_delete_reply_wake: cap_copy client ep failed")?;
+        let client_done = cap_copy(done, client.cs, RIGHTS_SIGNAL)
+            .map_err(|_| "stress::cap_delete_reply_wake: cap_copy client done failed")?;
+        // arg packs ep_slot[15:0] | done_slot[31:16]; the child reads its own
+        // dedicated IPC buffer address from the static directly.
+        let client_arg = u64::from(client_ep) | (u64::from(client_done) << 16);
+        // SAFETY: stack index 1 is the client's; sequential cycles never alias.
+        let client_stack = ChildStack::top(unsafe { core::ptr::addr_of!(super::STRESS_STACKS[1]) });
+        spawn::configure_and_start_pinned(
+            &client,
+            client_entry,
+            client_stack,
+            client_arg,
+            client_cpu,
+        )
+        .map_err(|_| "stress::cap_delete_reply_wake: start client failed")?;
+
+        // Let the client reach `ipc_call` and park on the endpoint send queue
+        // before the server receives it.
+        for _ in 0..SETTLE_YIELDS
+        {
+            let _ = thread_yield();
+        }
+
+        // ── Server child: RECEIVE on ep, signal on done. ────────────────────
+        let server = spawn::new_child(ctx)
+            .map_err(|_| "stress::cap_delete_reply_wake: spawn::new_child server failed")?;
+        let server_ep = cap_copy(ep, server.cs, RIGHTS_RECEIVE)
+            .map_err(|_| "stress::cap_delete_reply_wake: cap_copy server ep failed")?;
+        let server_done = cap_copy(done, server.cs, RIGHTS_SIGNAL)
+            .map_err(|_| "stress::cap_delete_reply_wake: cap_copy server done failed")?;
+        let server_arg = u64::from(server_ep) | (u64::from(server_done) << 16);
+        // SAFETY: stack index 0 is the server's; sequential cycles never alias.
+        let server_stack = ChildStack::top(unsafe { core::ptr::addr_of!(super::STRESS_STACKS[0]) });
+        spawn::configure_and_start_pinned(
+            &server,
+            server_entry,
+            server_stack,
+            server_arg,
+            server_cpu,
+        )
+        .map_err(|_| "stress::cap_delete_reply_wake: start server failed")?;
+
+        // Wait until the server has dequeued the client. The armed bit is raised
+        // only after `ipc_recv` returns, so its arrival proves the client is
+        // `BlockedOnReply` on this server — the live window in which
+        // `reply_tcb = client` and the reply-wake is owed.
+        let mut acc = 0u64;
+        while acc & BIT_SERVER_ARMED == 0
+        {
+            let bits = notification_wait(done)
+                .map_err(|_| "stress::cap_delete_reply_wake: notification_wait(armed) failed")?;
+            acc |= bits;
+        }
+        armed_cycles += 1;
+
+        // Delete the server Thread cap. This drives `dealloc_object(Thread)`,
+        // which owes the orphaned client its deferred `Interrupted` wake.
+        cap_delete(server.th)
+            .map_err(|_| "stress::cap_delete_reply_wake: cap_delete server th failed")?;
+
+        // LIVENESS GATE: the client MUST wake. A lost reply-wake never sends
+        // BIT_CLIENT_WOKE, so this `notification_wait` blocks, every CPU goes
+        // idle, and the softlockup watchdog fires — the FAIL signal, raised by
+        // the kernel (its registry walk names the stranded BlockedOnReply
+        // client), not by a test assertion.
+        while acc & BIT_CLIENT_WOKE == 0
+        {
+            let bits = notification_wait(done)
+                .map_err(|_| "stress::cap_delete_reply_wake: notification_wait(woke) failed")?;
+            acc |= bits;
+        }
+        woke_cycles += 1;
+
+        // ── Per-cycle cleanup. ──────────────────────────────────────────────
+        // The server Thread cap is already deleted; reap the rest. The client
+        // has woken and is exiting; `cap_delete(client.th)` reaps its TCB.
+        cap_delete(server.cs)
+            .map_err(|_| "stress::cap_delete_reply_wake: cap_delete server cs failed")?;
+        cap_delete(client.th)
+            .map_err(|_| "stress::cap_delete_reply_wake: cap_delete client th failed")?;
+        cap_delete(client.cs)
+            .map_err(|_| "stress::cap_delete_reply_wake: cap_delete client cs failed")?;
+        cap_delete(ep).map_err(|_| "stress::cap_delete_reply_wake: cap_delete ep failed")?;
+        cap_delete(done).map_err(|_| "stress::cap_delete_reply_wake: cap_delete done failed")?;
+    }
+
+    // Non-vacuous on both halves: every cycle armed the reply binding and then
+    // observed the owed wake, so a clean boot reflects the dealloc reply-wake
+    // liveness path actually executing CYCLES times.
+    if armed_cycles != CYCLES
+    {
+        return Err("stress::cap_delete_reply_wake: reply binding never armed on some cycle");
+    }
+    if woke_cycles != CYCLES
+    {
+        return Err("stress::cap_delete_reply_wake: client wake missing on some cycle");
+    }
+
+    Ok(())
+}
+
+// ── Child entries ───────────────────────────────────────────────────────────
+
+/// Decode the two packed fields shared by both child entries:
+/// `ep_slot[15:0]`, `done_slot[31:16]` (cap slot indices in the child's own
+/// `CSpace`). Each child reads its dedicated IPC buffer from its module static.
+// cast_possible_truncation: ep/done are kernel cap slot indices < 2^32.
+#[allow(clippy::cast_possible_truncation)]
+fn decode(arg: u64) -> (u32, u32)
+{
+    let ep_slot = (arg & 0xFFFF) as u32;
+    let done_slot = ((arg >> 16) & 0xFFFF) as u32;
+    (ep_slot, done_slot)
+}
+
+/// Server: receive one caller (making it `BlockedOnReply`), announce the reply
+/// binding is armed, busy-spin briefly to stay live, then exit **without
+/// replying** — leaving the client parked on a server about to be deleted.
+fn server_entry(arg: u64) -> !
+{
+    let (ep_slot, done_slot) = decode(arg);
+    // SAFETY: the server child of the current cycle is the sole user of
+    // SERVER_IPC_BUF; sequential cycles never alias it.
+    let buf = core::ptr::addr_of_mut!(SERVER_IPC_BUF).cast::<u64>();
+
+    if ipc_buffer_set(buf as u64).is_err()
+    {
+        thread_exit()
+    }
+
+    // SAFETY: `buf` was registered as this thread's IPC buffer above.
+    if unsafe { ipc::ipc_recv(ep_slot, buf) }.is_ok()
+    {
+        // Recv succeeded ⇒ a client is now BlockedOnReply on us. Announce the
+        // armed window before we die without replying.
+        notification_send(done_slot, BIT_SERVER_ARMED).ok();
+    }
+
+    // Stay alive a short, bounded window so the `cap_delete` lands while the
+    // reply binding is on a still-running server, then die without replying.
+    for _ in 0..SERVER_SPIN
+    {
+        core::hint::spin_loop();
+    }
+    thread_exit()
+}
+
+/// Client: call the endpoint (blocking `BlockedOnReply` on the server TCB). The
+/// call returns when the server's dealloc wakes it with `Interrupted`; it then
+/// raises the woke bit the controller gates on.
+fn client_entry(arg: u64) -> !
+{
+    let (ep_slot, done_slot) = decode(arg);
+    // SAFETY: the client child of the current cycle is the sole user of
+    // CLIENT_IPC_BUF; sequential cycles never alias it.
+    let buf = core::ptr::addr_of_mut!(CLIENT_IPC_BUF).cast::<u64>();
+
+    if ipc_buffer_set(buf as u64).is_err()
+    {
+        thread_exit()
+    }
+
+    // SAFETY: `buf` was registered as this thread's IPC buffer above.
+    let _ = unsafe { ipc::ipc_call(ep_slot, &IpcMessage::new(0), buf) };
+    notification_send(done_slot, BIT_CLIENT_WOKE).ok();
+    thread_exit()
+}

--- a/core/ktest/src/stress/mod.rs
+++ b/core/ktest/src/stress/mod.rs
@@ -19,6 +19,7 @@
 //! Each stress test uses [`run_integration_test!`](crate::run_integration_test)
 //! for logging and PASS/FAIL counting.
 
+mod cap_delete_reply_wake;
 mod cap_delete_running;
 mod cap_revoke_under_use;
 mod cap_tree_deep;
@@ -67,6 +68,10 @@ pub fn run_all(ctx: &TestContext)
     run_integration_test!("stress::idle_wake_race", idle_wake_race::run(ctx));
     run_integration_test!("stress::thread_churn", thread_churn::run(ctx));
     run_integration_test!("stress::cap_delete_running", cap_delete_running::run(ctx));
+    run_integration_test!(
+        "stress::cap_delete_reply_wake",
+        cap_delete_reply_wake::run(ctx)
+    );
     run_integration_test!(
         "stress::priority_dealloc_race",
         priority_dealloc_race::run(ctx)


### PR DESCRIPTION
## Summary

Resolves the #351 intermittent cap-delete/dealloc lost-wakeup hang (confirmed CI-reproducible on x86_64 and riscv64). Root-caused via a deep multi-agent audit of the SMP scheduler/dealloc/wake surface; the audit also surfaced a sibling load-balancer affinity violation, fixed here in the same pass.

### Root cause (#351)

`dealloc_object(Thread)`'s deferred reply-wake snapshotted the orphaned client's target CPU via `select_target_cpu` **inside** the all-CPU-locks region, then linked the client there **after** two unbounded UAF-gate spins. When the client is `context_saved == 0`, the save-window pin returns its `preferred_cpu` — which can be the very CPU now running `cap_delete`. That CPU is wedged in the preempt-disabled UAF / wake-in-flight gates (not in `schedule()`), so it cannot dispatch the client; the idle peers cannot steal a `context_saved == 0` thread; and the client is the only runnable thread → every CPU idles, watchdog fires.

- x86_64 signature: `cpu0 tid46 Exited in SYS_CAP_DELETE`, `mask=0x8001` (a Ready prio-15 thread stranded on the wedged cpu0).
- riscv64 signature: same, `mask=0x1` (nothing runnable).

The same stale snapshot — computed two gate-spins before use — also widens the #289-family double-enqueue straddle (a second concurrent waker link-arms over the already-linked TCB; the debug chokepoint panics `tid=N already linked at queued_on=15`).

### The fix

**`select_target_cpu_excluding(tcb, exclude)`** — `dealloc`'s reply-wake recomputes the target at the **wake site** (not a stale all-locks snapshot), **excluding the wedged dealloc CPU** from the save-window-pin / sticky / min-load branches (hard affinity still wins; the excluded CPU is a single-CPU fallback). A peer dispatches the `cs==0` client safely because `schedule()` waits on the `context_saved` Acquire publication barrier before the register switch — the save-window pin is a deadlock/perf optimization, not a correctness requirement, and the wedged dealloc CPU is never the client's saving CPU. Recomputing at wake time closes the double-enqueue straddle on both arches.

### Sibling fix (surfaced by the audit)

**`relocate_ready_thread`** — `migrate_ready_thread` and the load balancer's `pull_unpinned_ready` now share one validate-then-move primitive that re-checks `cpu_affinity` under `sched_lock`. Previously the puller located a candidate via `find_runnable`'s *advisory* affinity predicate (read under the run-queue lock) and relocated it without re-checking, so a concurrent `sys_thread_set_affinity` could be violated — the balancer relocated a freshly-pinned thread onto a forbidden CPU.

### Diagnostics (make every future repro self-pinpointing)

- Softlockup watchdog now names the **spin-site** a wedged CPU is stuck in (`dealloc:not-current` / `:context-saved` / `:wake-in-flight`) — these dealloc gates previously had no overlong-duration warning, which is why #351 showed as an opaque `Exited current`.
- Watchdog enumerates **all non-running registered threads** via a new diagnostic live-thread registry: `Blocked` waiters (with a `blocked_on` decode: `waiter_is_self`/`reply_is_self`/`count`) and `Ready`/`Stopped` threads (with `context_saved`/`queued_on`/affinity) — both #351 victim shapes were invisible to the per-CPU `current`-only dump.
- New `stress::cap_delete_reply_wake` ktest cell: gates each cycle on the dealloc reply-wake actually waking a `BlockedOnReply` client.

### Guards (debug tripwires)

G1: reply-wake never self-pinned to the dealloc CPU. G2: exclusion holds on the load scan. G3/G4: `relocate_ready_thread` invariants. G5: the double-enqueue chokepoint panic now reports `state`/`cs`/affinity/link-cpu so a residual names the Blocked-while-linked or self-pin condition directly.

## Validation

- `cargo xtask build` + `cargo xtask run` (ktest): **186/186 PASS on x86_64 AND riscv64**.
- CI burn-in triggered on this branch (run 27214470008) — the decisive empirical test: master reproduces #351 in ~20 iterations; this branch must boot the usertest `shell` clean on both arches with no watchdog dump and no enqueue chokepoint panic. (My local 16-core box does not open the timing window that the contended CI runners do; CI is the reproduction harness.)

## Notes

- A deterministic self-pin reproducer cell needs a current-CPU query syscall (none exists); covered instead by the existing cell + G1 + the CI burn-in.
- The #PF at `cr2=0x100000078` reported alongside #352 appears to be threadstack's *expected* guard-page overflow; #352 (mttcg-only, unconfirmed) is tracked separately and not addressed here.

Fixes #351