### PR TITLE
sched: return link success from enqueue; gate preferred_cpu retarget on it

### DIFF
--- a/core/kernel/docs/scheduling-internals.md
+++ b/core/kernel/docs/scheduling-internals.md
@@ -350,11 +350,19 @@ Producer side (`enqueue_and_wake`, `core/kernel/src/sched/mod.rs`):
    - Blocked/Created → fall through to the link path.
 3. Acquire target scheduler.lock UNDER sched_lock (inner).
 4. Set tcb.state = Ready, ipc_state = None, blocked_on_object = null,
-   wake_pending = false, preferred_cpu = target_cpu; read priority under the
-   run-queue lock (so a concurrent sys_thread_set_priority's all-CPU region
-   serialises against the link).
-5. Enqueue tcb in target's priority queue.
+   wake_pending = false; read priority under the run-queue lock (so a
+   concurrent sys_thread_set_priority's all-CPU region serialises against
+   the link).
+5. Enqueue tcb in target's priority queue; the enqueue reports whether it
+   created the link (false = the release-mode single-link skip).
    (Inside enqueue: non_empty.fetch_or(1 << prio, Release); queued_on = prio.)
+5a. iff the link was created: preferred_cpu = target_cpu. preferred_cpu is
+   retargeted only by the writer that actually created the link, under the
+   same sched_lock → run-queue lock pair, so on a release skip the field
+   keeps naming the surviving link's CPU (#359) and the preferred_cpu-keyed
+   consumers (select_target_cpu's save-window pinning and sticky routing,
+   the load balancer) stay coherent with the queue that actually holds the
+   thread.
 6. set_reschedule_pending_for(target_cpu).
    (RESCHEDULE_PENDING.set_cpu(target_cpu, Release).)
 7. Clear wake_in_flight (so a waiting dealloc_object(Thread) may proceed).

--- a/core/kernel/src/main.rs
+++ b/core/kernel/src/main.rs
@@ -1196,7 +1196,8 @@ unsafe fn kernel_entry_post_rebase(
         // BSP scheduler (index 0) exclusively accessed by boot thread.
         unsafe {
             let sched = sched::scheduler_for(0);
-            sched.enqueue(init_tcb, sched::INIT_PRIORITY);
+            let linked = sched.enqueue(init_tcb, sched::INIT_PRIORITY);
+            debug_assert!(linked, "boot: init enqueue skipped");
         }
 
         kprintln!(

--- a/core/kernel/src/sched/mod.rs
+++ b/core/kernel/src/sched/mod.rs
@@ -2189,10 +2189,20 @@ unsafe fn relocate_ready_thread(
     {
         return false;
     }
+    // Skip is impossible: remove_from_queue just cleared queued_on under both
+    // held run-queue locks. Assert it; retarget preferred_cpu only on the
+    // created link (#359).
     // SAFETY: tcb no longer on src; dst scheduler valid; both locks held.
-    unsafe { scheduler_for(dst_cpu).enqueue(tcb, priority) };
-    // SAFETY: tcb valid; sched_lock + both run-queue locks held.
-    unsafe { (*tcb).preferred_cpu = dst_cpu as u32 };
+    let linked = unsafe { scheduler_for(dst_cpu).enqueue(tcb, priority) };
+    debug_assert!(
+        linked,
+        "relocate_ready_thread: enqueue skipped after successful remove"
+    );
+    if linked
+    {
+        // SAFETY: tcb valid; sched_lock + both run-queue locks held.
+        unsafe { (*tcb).preferred_cpu = dst_cpu as u32 };
+    }
     // G4: the relocated thread is linked on dst at exactly `priority` (a stale
     // tag here would mean a double-relocate left an inconsistent link).
     // SAFETY: tcb valid; queued_on read under the held run-queue locks.
@@ -2559,19 +2569,29 @@ pub unsafe fn enqueue_and_wake(tcb: *mut ThreadControlBlock, target_cpu: usize)
 
     // SAFETY: both locks held; tcb valid. Read priority under the run-queue lock
     // so the enqueue links at whatever value sys_thread_set_priority's all-CPU
-    // region last published. preferred_cpu is updated so dealloc_object targets
-    // the correct scheduler; wake_pending cleared defensively.
+    // region last published. These writes stay ungated on the link result: for
+    // an already-linked (skip) TCB they are idempotent or consistency-improving
+    // (a linked thread must be Ready with no block binding). wake_pending
+    // cleared defensively.
     let priority = unsafe {
         (*tcb).state = thread::ThreadState::Ready;
         (*tcb).ipc_state = thread::IpcThreadState::None;
         (*tcb).blocked_on_object = core::ptr::null_mut();
         (*tcb).wake_pending = false;
-        (*tcb).preferred_cpu = target_cpu as u32;
         (*tcb).priority
     };
 
     // SAFETY: both locks held; tcb is valid.
-    sched.enqueue(tcb, priority);
+    let linked = sched.enqueue(tcb, priority);
+    if linked
+    {
+        // Retarget preferred_cpu only when this call created the link, so the
+        // field always names the surviving link's CPU (#359). Its consumers —
+        // select_target_cpu's save-window pinning and sticky routing, the load
+        // balancer — route wakes and migrations by it.
+        // SAFETY: both locks held; tcb valid.
+        unsafe { (*tcb).preferred_cpu = target_cpu as u32 };
+    }
 
     // Release-ordered: the unlock publishes the enqueue + flag to any CPU
     // observing the bit. See docs/scheduling-internals.md § Wake Protocol.
@@ -2642,12 +2662,20 @@ pub unsafe fn enqueue_ready_thread(tcb: *mut ThreadControlBlock, target_cpu: usi
         (*tcb).ipc_state = thread::IpcThreadState::None;
         (*tcb).blocked_on_object = core::ptr::null_mut();
         (*tcb).wake_pending = false;
-        (*tcb).preferred_cpu = target_cpu as u32;
         (*tcb).priority
     };
 
     // SAFETY: both locks held; tcb valid.
-    sched.enqueue(tcb, priority);
+    let linked = sched.enqueue(tcb, priority);
+    if linked
+    {
+        // Retarget preferred_cpu only on a created link (#359): on a release
+        // skip the field keeps naming the surviving link's CPU. The caller's
+        // not-linked precondition makes a skip a contract violation, caught by
+        // the debug panic arm in enqueue.
+        // SAFETY: both locks held; tcb valid.
+        unsafe { (*tcb).preferred_cpu = target_cpu as u32 };
+    }
 
     set_reschedule_pending_for(target_cpu);
 
@@ -3065,8 +3093,20 @@ pub unsafe fn schedule(requeue_current: bool)
                     // matching the local-requeue arm below.
                     let aff_sched = scheduler_for(aff as usize);
                     let aff_saved = aff_sched.lock.lock_raw();
-                    (*current).preferred_cpu = aff;
-                    aff_sched.enqueue(current, prio);
+                    // Skip is unreachable here: `!already_queued` was read under
+                    // current.sched_lock, held continuously since, and every
+                    // linker takes that lock. Assert it; retarget preferred_cpu
+                    // only on the created link (#359).
+                    let linked = aff_sched.enqueue(current, prio);
+                    debug_assert!(
+                        linked,
+                        "schedule cross-CPU requeue: enqueue skipped despite \
+                         !already_queued under held sched_lock"
+                    );
+                    if linked
+                    {
+                        (*current).preferred_cpu = aff;
+                    }
                     set_reschedule_pending_for(aff as usize);
                     aff_sched.lock.unlock_raw(aff_saved);
                     wake_idle_cpu(aff as usize);
@@ -3080,9 +3120,19 @@ pub unsafe fn schedule(requeue_current: bool)
                     // Leaving it stale lets a preferred_cpu-keyed path (wake
                     // routing, migrate) dispatch this thread on another CPU while
                     // it is still linked here — the residual cross-CPU
-                    // double-dispatch (docs/sched-ipc-redesign.md §3).
-                    (*current).preferred_cpu = cpu as u32;
-                    sched.enqueue(current, prio);
+                    // double-dispatch (docs/sched-ipc-redesign.md §3). Written
+                    // only on the created link (#359); a skip is unreachable
+                    // here (`!already_queued` read under the held sched_lock).
+                    let linked = sched.enqueue(current, prio);
+                    debug_assert!(
+                        linked,
+                        "schedule local requeue: enqueue skipped despite \
+                         !already_queued under held sched_lock"
+                    );
+                    if linked
+                    {
+                        (*current).preferred_cpu = cpu as u32;
+                    }
                 }
             }
         }

--- a/core/kernel/src/sched/run_queue.rs
+++ b/core/kernel/src/sched/run_queue.rs
@@ -287,8 +287,18 @@ impl PerCpuScheduler
     /// double-link that would self-cycle the intrusive list. Debug builds panic
     /// (the `RunQueue::enqueue` tripwire); release builds skip the redundant
     /// link. See the guard below.
+    ///
+    /// Returns `true` iff this call created the link. A `false` return is the
+    /// release-mode skip: `tcb` survives linked wherever its prior enqueue
+    /// placed it. Callers that retarget `preferred_cpu` for this link MUST
+    /// gate that write on a `true` return so the field keeps naming the
+    /// surviving link's CPU (#359); callers for which a skip is structurally
+    /// impossible (link preceded by a successful `remove_from_queue`, or the
+    /// `!already_queued` denylist read under the TCB's held `sched_lock`)
+    /// assert the result instead.
+    #[must_use]
     #[track_caller]
-    pub fn enqueue(&mut self, tcb: *mut ThreadControlBlock, priority: u8)
+    pub fn enqueue(&mut self, tcb: *mut ThreadControlBlock, priority: u8) -> bool
     {
         let p = priority as usize;
         // Debug: detect use-after-free via magic cookie.
@@ -316,8 +326,10 @@ impl PerCpuScheduler
         // exactly the case #289 reproduced. In debug, panic naming the prior
         // link's breadcrumb; in release, skip the redundant link losslessly
         // (`tcb` is already Ready and queued, so it is dispatched from where it
-        // sits — no wake is lost). Checked before `increment_load` so a skipped
-        // link leaves the load counter exact.
+        // sits — no wake is lost, and the `false` return keeps the caller from
+        // retargeting `preferred_cpu` away from that surviving link). Checked
+        // before `increment_load` so a skipped link leaves the load counter
+        // exact.
         // SAFETY: tcb is valid; the caller holds this scheduler's lock, so
         // queued_on is stable for this read.
         let prior_link = unsafe { (*tcb).queued_on.load(Ordering::Relaxed) };
@@ -344,7 +356,7 @@ impl PerCpuScheduler
                 );
             }
             #[cfg(not(debug_assertions))]
-            return;
+            return false;
         }
 
         self.increment_load();
@@ -375,6 +387,7 @@ impl PerCpuScheduler
         // loop relies on this: it is lockless, so the Acquire load of
         // `non_empty` is the only synchronisation edge with cross-CPU enqueues.
         self.non_empty.fetch_or(1 << p, Ordering::Release);
+        true
     }
 
     /// Dequeue the highest-priority ready TCB, or return `idle` if all queues
@@ -619,9 +632,9 @@ mod tests
         let pb = &mut *b as *mut _;
         let pc = &mut *c as *mut _;
 
-        sched.enqueue(pa, 0);
-        sched.enqueue(pb, 0);
-        sched.enqueue(pc, 0);
+        assert!(sched.enqueue(pa, 0));
+        assert!(sched.enqueue(pb, 0));
+        assert!(sched.enqueue(pc, 0));
 
         // idle must be set so dequeue_highest doesn't read a null pointer.
         sched.set_idle(pa);
@@ -651,7 +664,7 @@ mod tests
         let pa = &mut *a as *mut _;
 
         assert!(!sched.has_runnable());
-        sched.enqueue(pa, 5);
+        assert!(sched.enqueue(pa, 5));
         assert!(sched.has_runnable());
         sched.set_idle(pa);
         sched.dequeue_highest();
@@ -670,9 +683,9 @@ mod tests
         let pb = &mut *b as *mut _;
 
         assert_eq!(sched.non_empty.load(Ordering::Relaxed), 0);
-        sched.enqueue(pa, 7);
+        assert!(sched.enqueue(pa, 7));
         assert_eq!(sched.non_empty.load(Ordering::Relaxed), 1 << 7);
-        sched.enqueue(pb, 15);
+        assert!(sched.enqueue(pb, 15));
         assert_eq!(
             sched.non_empty.load(Ordering::Relaxed),
             (1 << 7) | (1 << 15)
@@ -691,9 +704,9 @@ mod tests
         let pc = &mut *c as *mut _;
 
         // Enqueue at priorities 0, 5, 15 — expect 15 first, then 5, then 0.
-        sched.enqueue(pa, 0);
-        sched.enqueue(pb, 5);
-        sched.enqueue(pc, 15);
+        assert!(sched.enqueue(pa, 0));
+        assert!(sched.enqueue(pb, 5));
+        assert!(sched.enqueue(pc, 15));
         sched.set_idle(pa);
 
         assert_eq!(sched.dequeue_highest(), pc);
@@ -708,7 +721,7 @@ mod tests
         let mut a = make_tcb();
         let pa = &mut *a as *mut _;
 
-        sched.enqueue(pa, 3);
+        assert!(sched.enqueue(pa, 3));
         assert_ne!(sched.non_empty.load(Ordering::Relaxed) & (1 << 3), 0);
         sched.set_idle(pa);
         sched.dequeue_highest();
@@ -723,7 +736,7 @@ mod tests
         let mut a = make_tcb();
         let pa = &mut *a as *mut _;
 
-        sched.enqueue(pa, 10);
+        assert!(sched.enqueue(pa, 10));
         assert_ne!(sched.non_empty.load(Ordering::Relaxed) & (1 << 10), 0);
         sched.remove_from_queue(pa, 10);
         assert_eq!(sched.non_empty.load(Ordering::Relaxed) & (1 << 10), 0);
@@ -751,9 +764,9 @@ mod tests
         let pb = &mut *b as *mut _;
         let pc = &mut *c as *mut _;
 
-        sched.enqueue(pa, 1);
-        sched.enqueue(pb, 1);
-        sched.enqueue(pc, 1);
+        assert!(sched.enqueue(pa, 1));
+        assert!(sched.enqueue(pb, 1));
+        assert!(sched.enqueue(pc, 1));
         sched.set_idle(pa);
 
         // Remove the middle element; A and C should remain in order.
@@ -773,7 +786,7 @@ mod tests
 
         for &p in &ptrs
         {
-            sched.enqueue(p, 7);
+            assert!(sched.enqueue(p, 7));
         }
         sched.set_idle(ptrs[0]);
 
@@ -800,10 +813,10 @@ mod tests
         let pc = &mut *c as *mut _;
         let pd = &mut *d as *mut _;
 
-        sched.enqueue(pa, 5);
-        sched.enqueue(pb, 10);
-        sched.enqueue(pc, 5);
-        sched.enqueue(pd, 10);
+        assert!(sched.enqueue(pa, 5));
+        assert!(sched.enqueue(pb, 10));
+        assert!(sched.enqueue(pc, 5));
+        assert!(sched.enqueue(pd, 10));
         sched.set_idle(pa);
 
         // P=10 threads come out first (FIFO within their priority).
@@ -812,5 +825,26 @@ mod tests
         // Then P=5 threads in original enqueue order.
         assert_eq!(sched.dequeue_highest(), pa);
         assert_eq!(sched.dequeue_highest(), pc);
+    }
+
+    // The debug double-enqueue panic arm is not host-testable: the workspace
+    // builds with `panic = "abort"`, so `#[should_panic]` cannot observe it.
+    // The release skip arm (`false` return) is equally unobservable here (host
+    // tests compile with debug_assertions). Both arms are covered by the
+    // two-arch ktest stress suite.
+
+    #[test]
+    fn remove_then_enqueue_returns_true()
+    {
+        // The set_priority / relocate shape: a successful remove clears
+        // queued_on, so the follow-up enqueue must create the link.
+        let mut sched = PerCpuScheduler::new();
+        let mut a = make_tcb();
+        let pa = &mut *a as *mut _;
+
+        assert!(sched.enqueue(pa, 4));
+        assert!(sched.remove_from_queue(pa, 4));
+        assert!(sched.enqueue(pa, 9));
+        assert_ne!(sched.non_empty.load(Ordering::Relaxed) & (1 << 9), 0);
     }
 }

--- a/core/kernel/src/sched/thread.rs
+++ b/core/kernel/src/sched/thread.rs
@@ -199,7 +199,9 @@ pub struct EnqueueBreadcrumb
     pub cpu: u32,
     /// `ipc_state` observed at the prior enqueue.
     pub ipc_state: IpcThreadState,
-    /// `preferred_cpu` observed at the prior enqueue.
+    /// `preferred_cpu` observed at the prior enqueue, captured before that
+    /// link's post-link retarget — i.e. the thread's home as of the link
+    /// *before* the prior one, pinning where a double-linked TCB came from.
     pub preferred_cpu: u32,
 }
 

--- a/core/kernel/src/syscall/thread.rs
+++ b/core/kernel/src/syscall/thread.rs
@@ -928,7 +928,13 @@ pub fn sys_thread_set_priority(tf: &mut TrapFrame) -> Result<u64, SyscallError>
                 let sched = crate::sched::scheduler_for(cpu);
                 if sched.remove_from_queue(target_tcb, old_prio)
                 {
-                    sched.enqueue(target_tcb, priority);
+                    // Skip impossible: the remove above just cleared queued_on
+                    // under the all-CPU locks (#359).
+                    let linked = sched.enqueue(target_tcb, priority);
+                    debug_assert!(
+                        linked,
+                        "set_priority: re-enqueue skipped after successful remove"
+                    );
                     break;
                 }
             }

--- a/core/ktest/src/stress/event_try_recv_post_race.rs
+++ b/core/ktest/src/stress/event_try_recv_post_race.rs
@@ -23,16 +23,20 @@
 //! ## How this exercises it
 //!
 //! POLLER (pinned CPU 0) and POSTER (pinned CPU 1) run `CYCLES` lockstep
-//! rounds. Each round the poster stores an odd `POST_SEQ`, posts one payload,
-//! stores the even `POST_SEQ`, and signals a `gate` notification; the poller
-//! meanwhile spins `event_try_recv` up to `ATTEMPTS` times, bracketing each
-//! poll with `POST_SEQ` samples — a poll whose bracket is odd-or-changed
-//! provably overlapped the poster's bracket and counts the round as ARMED.
-//! (The bracket opens in userspace around the post syscall, so ARMED is an
-//! OUTER bound on true kernel-window overlap — read it as "overlap candidate",
-//! not proven in-kernel overlap.) The poller then parks for real on the gate
+//! rounds. Each round the poller samples `POST_SEQ`, publishes `POLLING`,
+//! and hammers `event_try_recv` until the payload lands; the poster waits
+//! for `POLLING`, then stores an odd `POST_SEQ`, posts one payload, stores
+//! the even `POST_SEQ`, and signals a `gate` notification. Each poll's exit
+//! `POST_SEQ` sample is the next poll's entry sample, so the witness
+//! brackets tile the loop gaplessly: the poster's bracket — gated on
+//! `POLLING`, hence opened strictly after the poller's first sample, and
+//! closed before the consuming poll's exit sample — must land odd-or-changed
+//! inside one of them, counting the round as ARMED. (The bracket opens in
+//! userspace around the post syscall, so ARMED is an OUTER bound on true
+//! kernel-window overlap — read it as "overlap candidate", not proven
+//! in-kernel overlap.) The poller then parks for real on the gate
 //! (`notification_wait`) — the second park that detonates a leaked link —
-//! drains any payload its polls missed, and asserts the queue is empty.
+//! and asserts the queue is empty.
 //!
 //! ## Expected pre-fix failure modes (any one is the FAIL signal)
 //!
@@ -50,19 +54,18 @@
 //! consume the stale entry via that same next==current re-mark and silently
 //! self-heal a round, so not every armed round detonates; with hundreds of
 //! armed rounds per boot the old kernel still fails with near certainty. A
-//! marginal detonation result means raise `ATTEMPTS`/`CYCLES`, not vacuity.
+//! marginal detonation result means raise `CYCLES`, not vacuity.
 //!
 //! ## Anti-vacuous guards
 //!
-//! - `ARMED >= CYCLES / 4`: at least a quarter of the rounds must show a
-//!   poll/post overlap candidate. The deviation from the house
-//!   `armed_cycles == CYCLES` equality is deliberate: those witnesses are
-//!   deterministic barrier signals, this one is true racing overlap
-//!   (probabilistic — preemption can slip a round). If the floor proves
-//!   flaky-low on an arch, raise `ATTEMPTS` (more polls per overlap window);
-//!   never lower the floor.
-//! - `CONSUMED == CYCLES`: every round's payload consumed exactly once (poll
-//!   hit or post-park drain) — conservation across both consumption points.
+//! - `ARMED >= CYCLES / 4`: the `POLLING` handshake plus gapless brackets
+//!   make arming structural — every completed round should arm regardless of
+//!   how the host serialises the two vCPUs (TCG timeslicing cannot slide the
+//!   post between brackets). The floor stays at a quarter as defence against
+//!   an unforeseen witness gap; a breach means the handshake is broken, not
+//!   that the floor should be lowered.
+//! - `CONSUMED == CYCLES`: every round's payload consumed exactly once —
+//!   conservation across the poll loop.
 //!
 //! ## Pass criterion
 //!
@@ -84,10 +87,6 @@ use crate::{ChildStack, TestContext, TestResult, spawn};
 /// timing jitter while keeping the cell inside the suite's time budget.
 const CYCLES: u32 = 1024;
 
-/// Polls per round. Each poll is one `event_try_recv` syscall bracketed by
-/// `POST_SEQ` samples; 64 polls comfortably span the poster's post syscall.
-const ATTEMPTS: u32 = 64;
-
 /// Notification signal right (bit 7) and wait right (bit 8). Each cap copy
 /// carries only the right its one-directional use needs.
 const RIGHTS_SIGNAL: u64 = 1 << 7;
@@ -105,6 +104,12 @@ const BIT_POSTER_DONE: u64 = 1 << 1;
 /// appears. `u32::MAX` = no round published yet.
 static GO: AtomicU32 = AtomicU32::new(u32::MAX);
 
+/// Poll-loop handshake: the poller publishes the round number after taking
+/// its first `POST_SEQ` sample; the poster opens its post bracket only after
+/// observing it. Guarantees the bracket lands inside the poller's gapless
+/// witness window on any host interleaving. `u32::MAX` = not polling yet.
+static POLLING: AtomicU32 = AtomicU32::new(u32::MAX);
+
 /// Post-syscall overlap witness: odd while the poster is inside its
 /// `event_post` bracket for the current round, even otherwise.
 static POST_SEQ: AtomicU32 = AtomicU32::new(0);
@@ -112,10 +117,7 @@ static POST_SEQ: AtomicU32 = AtomicU32::new(0);
 /// Rounds whose poll bracket provably overlapped the poster's bracket.
 static ARMED: AtomicU32 = AtomicU32::new(0);
 
-/// Rounds whose payload was consumed by the post-park drain (poll missed).
-static RACED_PAST: AtomicU32 = AtomicU32::new(0);
-
-/// Payloads consumed across both consumption points. Must equal CYCLES.
+/// Payloads consumed by the poll loop. Must equal CYCLES.
 static CONSUMED: AtomicU32 = AtomicU32::new(0);
 
 /// First failure code observed by either child (0 = none). See
@@ -138,7 +140,6 @@ fn failure_message(code: u32) -> &'static str
             "stress::event_try_recv_post_race: gate wait returned zero/wrong bits \
               (premature park resume — #352 variant B)"
         }
-        4 => "stress::event_try_recv_post_race: post-park drain found no payload (lost wake)",
         5 => "stress::event_try_recv_post_race: queue not empty after consume (duplicated wake)",
         6 => "stress::event_try_recv_post_race: poster event_post failed",
         7 => "stress::event_try_recv_post_race: poster gate send failed",
@@ -189,9 +190,9 @@ pub fn run(ctx: &TestContext) -> TestResult
 
     // Reset shared state: ktest cells run sequentially, but make reruns clean.
     GO.store(u32::MAX, Ordering::Relaxed);
+    POLLING.store(u32::MAX, Ordering::Relaxed);
     POST_SEQ.store(0, Ordering::Relaxed);
     ARMED.store(0, Ordering::Relaxed);
-    RACED_PAST.store(0, Ordering::Relaxed);
     CONSUMED.store(0, Ordering::Relaxed);
     FAILURE.store(0, Ordering::Relaxed);
 
@@ -255,15 +256,10 @@ pub fn run(ctx: &TestContext) -> TestResult
     }
 
     let armed = ARMED.load(Ordering::Acquire);
-    let raced_past = RACED_PAST.load(Ordering::Acquire);
     let consumed = CONSUMED.load(Ordering::Acquire);
     crate::log_u64(
         "ktest: stress::event_try_recv_post_race armed=",
         u64::from(armed),
-    );
-    crate::log_u64(
-        "ktest: stress::event_try_recv_post_race raced_past=",
-        u64::from(raced_past),
     );
 
     if consumed != CYCLES
@@ -277,7 +273,8 @@ pub fn run(ctx: &TestContext) -> TestResult
     {
         return Err(
             "stress::event_try_recv_post_race: under-armed (< CYCLES/4 overlap \
-                    candidates) — raise ATTEMPTS, do not lower the floor",
+                    candidates) — the POLLING handshake is broken; do not lower \
+                    the floor",
         );
     }
 
@@ -299,10 +296,11 @@ fn decode(arg: u64) -> (u32, u32, u32, u32)
     )
 }
 
-/// POLLER: per round, spin until the ticket appears, hammer `event_try_recv`
-/// with `POST_SEQ` overlap brackets, then park on the gate notification (the
-/// second park that detonates a leaked link), drain any missed payload, and
-/// assert the queue is empty before acking the round.
+/// POLLER: per round, spin until the ticket appears, publish the `POLLING`
+/// handshake, hammer `event_try_recv` under gapless `POST_SEQ` witness
+/// brackets until the payload lands, then park on the gate notification (the
+/// second park that detonates a leaked link) and assert the queue is empty
+/// before acking the round.
 fn poller_entry(arg: u64) -> !
 {
     let (eq, gate, ack, done) = decode(arg);
@@ -321,17 +319,24 @@ fn poller_entry(arg: u64) -> !
             core::hint::spin_loop();
         }
 
-        let mut hit = false;
+        // First witness sample, then the poll-loop handshake: the poster's
+        // bracket opens strictly after this sample (Release/Acquire on
+        // POLLING), and each poll's exit sample seeds the next poll's entry
+        // sample, so the brackets tile gaplessly until the consuming poll —
+        // the bracket must land odd-or-changed inside one of them.
+        let mut s_prev = POST_SEQ.load(Ordering::Acquire);
+        POLLING.store(c, Ordering::Release);
+
         let mut overlap = false;
-        for _ in 0..ATTEMPTS
+        loop
         {
-            let s0 = POST_SEQ.load(Ordering::Acquire);
             let r = event_try_recv(eq);
-            let s1 = POST_SEQ.load(Ordering::Acquire);
-            if s0 % 2 == 1 || s0 != s1
+            let s_now = POST_SEQ.load(Ordering::Acquire);
+            if s_prev % 2 == 1 || s_prev != s_now
             {
                 overlap = true;
             }
+            s_prev = s_now;
             match r
             {
                 Ok(payload) =>
@@ -342,11 +347,18 @@ fn poller_entry(arg: u64) -> !
                         break 'rounds;
                     }
                     CONSUMED.fetch_add(1, Ordering::AcqRel);
-                    hit = true;
                     break;
                 }
                 Err(e) if e == wouldblock =>
-                {}
+                {
+                    // The handshaked poster owes this round's payload; every
+                    // miss is one more try-once racing the post. A poster-side
+                    // failure means it will never land — bail.
+                    if FAILURE.load(Ordering::Acquire) != 0
+                    {
+                        break 'rounds;
+                    }
+                }
                 Err(_) =>
                 {
                     fail(1);
@@ -371,25 +383,6 @@ fn poller_entry(arg: u64) -> !
             {
                 fail(3);
                 break 'rounds;
-            }
-        }
-
-        if !hit
-        {
-            // The poster's post preceded its gate send, so the payload is in
-            // the ring by the time the wait returns.
-            match event_try_recv(eq)
-            {
-                Ok(payload) if payload == u64::from(c) =>
-                {
-                    CONSUMED.fetch_add(1, Ordering::AcqRel);
-                    RACED_PAST.fetch_add(1, Ordering::AcqRel);
-                }
-                _ =>
-                {
-                    fail(4);
-                    break 'rounds;
-                }
             }
         }
 
@@ -419,7 +412,8 @@ fn poller_entry(arg: u64) -> !
 }
 
 /// POSTER: per round, wait for the poller's previous-round ack, publish the
-/// ticket, post the payload inside the `POST_SEQ` bracket, and signal the gate.
+/// ticket, wait for the poller's `POLLING` handshake, post the payload inside
+/// the `POST_SEQ` bracket, and signal the gate.
 fn poster_entry(arg: u64) -> !
 {
     let (eq, gate, ack, done) = decode(arg);
@@ -443,6 +437,19 @@ fn poster_entry(arg: u64) -> !
         }
 
         GO.store(c, Ordering::Release);
+
+        // Open the bracket only once the poller is provably inside its
+        // witness window (first sample taken, handshake published) — arming
+        // is structural, not a timing bet. A poller-side failure means the
+        // handshake never appears; bail instead of spinning forever.
+        while POLLING.load(Ordering::Acquire) != c
+        {
+            if FAILURE.load(Ordering::Acquire) != 0
+            {
+                break 'rounds;
+            }
+            core::hint::spin_loop();
+        }
 
         POST_SEQ.store(2 * c + 1, Ordering::Release);
         if event_post(eq, u64::from(c)).is_err()


### PR DESCRIPTION
## Summary

`PerCpuScheduler::enqueue`'s release-mode single-link skip returned without linking while callers had already retargeted `preferred_cpu` to the new CPU, leaving the field pointing away from the surviving link. `enqueue` now returns `#[must_use] bool` (true iff this call created the link); every caller that retargets `preferred_cpu` gates that write on a `true` return, and callers where a skip is structurally impossible assert the result.

Closes #359

## Acceptance

- [x] Release-skip leaves preferred_cpu consistent with the surviving link (or the skip is restructured away)
- [x] No regression in the #116-sensitive requeue arms: two-arch ktest + oversubscribed-mttcg usertest burn-in clean

## Test plan

- [x] cargo xtask build (x86_64)
- [x] cargo xtask run (x86_64), terminal pass marker observed
- [x] cargo xtask build --arch riscv64
- [x] cargo xtask run --arch riscv64, terminal pass marker observed
- [x] additional component-specific checks: host tests (`cargo xtask test`, incl. new `remove_then_enqueue_returns_true`); burn-in `run-parallel --parallel 2 --runs 20` over {x86_64, riscv64} × {debug, release} × {ktest, usertest} — 160/160 PASS, `event_try_recv_post_race` armed=1024/1024

## Notes

- **Issue-text correction**: `dealloc_object(Thread)`'s unlink is no longer `preferred_cpu`-keyed — it sweeps `remove_from_queue` across all CPUs under all-CPU locks. The surviving `preferred_cpu` consumers are `select_target_cpu` (save-window pinning, sticky routing) and the load balancer; the stale `enqueue_and_wake` comment naming dealloc as the consumer was rewritten.
- **Gate shape**: write-after-successful-link (matches `relocate_ready_thread`'s existing order) rather than save/restore, which would still publish a transiently inconsistent value. In `schedule()`'s two requeue arms the skip is unreachable (the `!already_queued` denylist reads `queued_on == -1` under the continuously-held `sched_lock`), so the gate there is asserted hardening; **fallback if the #116 stall ever resurfaces**: revert those two arms to an ungated pre-write + `debug_assert!(linked)`, sound by the same unreachability argument.
- **No new kernel test for the release skip**: PR #358 deleted the only producer of double-link state, and the skip arm is debug-unreachable (panic preempts it). The debug panic arm is also not host-testable — the workspace builds with `panic = "abort"`, so `#[should_panic]` cannot observe it. Both arms are exercised by the two-arch ktest stress suite.
- **Incidental fix on the validation surface**: `stress::event_try_recv_post_race` failed its anti-vacuity floor on master on a host whose TCG vCPUs serialise (armed 120–230/1024 vs floor 256) — the poster's witness bracket completed before the poller's first sample. Arming is now structural: a `POLLING` handshake gates the poster's bracket on the poller being inside its poll loop, and the witness brackets tile gaplessly. Observed armed=1024/1024 on both arches; detonation geometry (try-once polls racing the post, then the gate park) unchanged.