### PR TITLE
kernel/services: distinguish CSpace pool exhaustion from quota; seed pools to cover max_slots

### DIFF
--- a/abi/syscall/src/lib.rs
+++ b/abi/syscall/src/lib.rs
@@ -437,12 +437,17 @@ pub enum SyscallError
     Deadlock = -12,
     /// Event queue is full; post would be lost.
     QueueFull = -13,
+    // -14 retired (`DmaUnsafe`, removed with `SYS_DMA_GRANT`); never reuse.
     /// The target object is not in the required state for this operation
     /// (e.g. thread not `Stopped` for `read_regs`/`write_regs`).
     InvalidState = -15,
     /// A blocking operation was cancelled because the thread was stopped.
     /// The stopped thread sees this as the return value of its blocked syscall.
     Interrupted = -16,
+    /// A per-object quota was reached (e.g. a `CSpace`'s `max_slots`).
+    /// Unlike `OutOfMemory`, donating memory (augment mode) cannot satisfy
+    /// the request.
+    QuotaExceeded = -17,
 }
 
 // ── Scheduling constants ──────────────────────────────────────────────────────

--- a/core/kernel/src/cap/cspace.rs
+++ b/core/kernel/src/cap/cspace.rs
@@ -60,14 +60,35 @@ const _: () = assert!(L1_SIZE * L2_SIZE <= (1usize << syscall::CAP_INDEX_BITS));
 #[derive(Debug, PartialEq, Eq)]
 pub enum CapError
 {
-    /// No free slots remain and the `CSpace` is at `max_slots`.
+    /// No free slots remain and the `CSpace` is at `max_slots` (or the
+    /// directory is full). A hard quota: donating memory cannot satisfy it.
     OutOfSlots,
-    /// Heap allocation failed while growing the `CSpace`.
-    OutOfMemory,
+    /// The slot-page pool was exhausted while growing. Refillable: donate
+    /// pages via augment-mode `cap_create_cspace`. (Host-test heap path:
+    /// heap allocation failed.)
+    PoolExhausted,
     /// The provided slot index is out of range or unmapped.
     InvalidIndex,
     /// Mapping request violates the W^X constraint (both writable and executable).
     WxViolation,
+}
+
+/// The one canonical `CapError` → `SyscallError` mapping. Every syscall-path
+/// consumer routes through this so the pool-exhausted (refillable,
+/// `OutOfMemory`) vs quota-reached (hard, `QuotaExceeded`) distinction
+/// reaches userspace uniformly (#366).
+impl From<CapError> for syscall::SyscallError
+{
+    fn from(e: CapError) -> Self
+    {
+        match e
+        {
+            CapError::OutOfSlots => Self::QuotaExceeded,
+            CapError::PoolExhausted => Self::OutOfMemory,
+            CapError::InvalidIndex => Self::InvalidArgument,
+            CapError::WxViolation => Self::WxViolation,
+        }
+    }
 }
 
 // ── CSpacePage ────────────────────────────────────────────────────────────────
@@ -193,7 +214,8 @@ impl CSpace
 
     /// Allocate a free slot index, growing the `CSpace` if needed.
     ///
-    /// Returns an error if `max_slots` is reached or heap allocation fails.
+    /// Returns [`CapError::OutOfSlots`] if `max_slots` is reached, or
+    /// [`CapError::PoolExhausted`] if the slot-page pool has no page left.
     /// The returned slot is cleared to null; callers must populate it.
     ///
     /// The returned index is always non-zero (slot 0 is reserved).
@@ -270,7 +292,17 @@ impl CSpace
             );
             // SAFETY: kobj_ptr is the wrapper that owns this CSpace; its
             // pool was seeded at retype time.
-            let phys = unsafe { (*kobj_ptr).alloc_slot_page() }.ok_or(CapError::OutOfMemory)?;
+            let Some(phys) = (unsafe { (*kobj_ptr).alloc_slot_page() })
+            else
+            {
+                crate::kprintln!(
+                    "cspace {}: slot-page pool exhausted (allocated={}, max={})",
+                    self.id,
+                    self.allocated_slots,
+                    self.max_slots
+                );
+                return Err(CapError::PoolExhausted);
+            };
             let virt = crate::mm::paging::phys_to_virt(phys);
             // SAFETY: pool returns page-aligned, freshly-zeroed pages mapped
             // in the kernel direct map.
@@ -287,7 +319,7 @@ impl CSpace
         }
         else
         {
-            return Err(CapError::OutOfMemory);
+            return Err(CapError::PoolExhausted);
         };
 
         // SAFETY: page_nn points at an exclusively-owned, zeroed CSpacePage.
@@ -549,7 +581,7 @@ impl CSpace
     /// # Errors
     ///
     /// - [`CapError::InvalidIndex`] — index is 0, out of range, or occupied.
-    /// - [`CapError::OutOfMemory`] — backing page allocation failed during grow.
+    /// - [`CapError::PoolExhausted`] — slot-page pool empty during grow.
     pub fn insert_cap_at(
         &mut self,
         index: u32,
@@ -793,6 +825,19 @@ mod tests
         }
         let err = cs.allocate_slot().unwrap_err();
         assert_eq!(err, CapError::OutOfSlots);
+    }
+
+    #[test]
+    fn pool_exhaustion_is_distinct()
+    {
+        // A retype-backed CSpace (non-null kobj) with no pool page left
+        // fails grow with PoolExhausted, not the OutOfSlots quota error.
+        // The test-mode grow path returns before dereferencing the kobj
+        // pointer, so a dangling marker stands in for a real wrapper.
+        let mut cs = CSpace::new(0, 16384);
+        cs.set_kobj(NonNull::dangling().as_ptr());
+        let err = cs.allocate_slot().unwrap_err();
+        assert_eq!(err, CapError::PoolExhausted);
     }
 
     #[test]

--- a/core/kernel/src/cap/mod.rs
+++ b/core/kernel/src/cap/mod.rs
@@ -472,8 +472,17 @@ const ROOT_CSPACE_MAX_SLOTS: usize = 14336;
 /// peak boot slot count means `pre_allocate`'s grow loop hits an
 /// exhausted pool, the syscall errors out, and the userspace caller
 /// either retries indefinitely (e.g. `request_round` in a child) or
-/// surfaces an unexpected `OutOfMemory`. After memmgr is alive, further
-/// growth is bounded only by `ROOT_CSPACE_MAX_SLOTS`.
+/// surfaces an unexpected `OutOfMemory`.
+///
+/// This is the one creation site deliberately seeded below its
+/// `max_slots` quota (see docs/capability-model.md, growth budgets):
+/// backing all `ROOT_CSPACE_MAX_SLOTS` would cost 257 SEED pages
+/// (~1 MiB) for a `CSpace` whose occupancy peaks at boot and is bounded
+/// in steady state. Growth past the seeded pool returns the refillable
+/// `OutOfMemory`; init owns the shortfall and can refill via
+/// augment-mode `cap_create_cspace` against its own `CSpace` cap
+/// (`ProcessInfo.cspace_cap`). The `ROOT_CSPACE_MAX_SLOTS` quota only
+/// binds after such a refill.
 #[cfg(not(test))]
 const ROOT_CSPACE_INIT_SLOT_CAPACITY: u64 = 1536;
 
@@ -2380,7 +2389,7 @@ pub unsafe fn move_cap_between_cspaces(
     // Insert into destination (auto-allocate free slot).
     // SAFETY: dst_cspace is a valid CSpace pointer; guaranteed by caller contract.
     let new_idx_nz = unsafe { (*dst_cspace).insert_cap(src_tag, src_rights, src_object) }
-        .map_err(|_| SyscallError::OutOfMemory)?;
+        .map_err(SyscallError::from)?;
     let new_idx = new_idx_nz.get();
 
     let src_idx_nz = core::num::NonZeroU32::new(src_idx).ok_or(SyscallError::InvalidCapability)?;

--- a/core/kernel/src/cap/split.rs
+++ b/core/kernel/src/cap/split.rs
@@ -63,14 +63,14 @@ pub(crate) unsafe fn install_split_children(
         (*caller_cspace).lock.unlock_raw(saved);
         r
     }
-    .map_err(|_| {
+    .map_err(|e| {
         // SAFETY: child1_ptr and child2_ptr were freshly allocated with
         // refcount 1; neither has been inserted into any CSpace.
         unsafe {
             dealloc_object(child1_ptr);
             dealloc_object(child2_ptr);
         }
-        SyscallError::OutOfMemory
+        SyscallError::from(e)
     })?;
     let slot1 = slot1_nz.get();
 
@@ -81,7 +81,7 @@ pub(crate) unsafe fn install_split_children(
         (*caller_cspace).lock.unlock_raw(saved);
         r
     }
-    .map_err(|_| {
+    .map_err(|e| {
         // Undo slot1: child1_ptr was inserted (reachable only via slot1, which
         // we free here); child2_ptr was passed to the failing insert_cap and
         // never stored.
@@ -96,7 +96,7 @@ pub(crate) unsafe fn install_split_children(
             dealloc_object(child1_ptr);
             dealloc_object(child2_ptr);
         }
-        SyscallError::OutOfMemory
+        SyscallError::from(e)
     })?;
     // ── Wire derivation tree ──────────────────────────────────────────────────
 

--- a/core/kernel/src/syscall/cap.rs
+++ b/core/kernel/src/syscall/cap.rs
@@ -175,24 +175,24 @@ pub fn sys_cap_create_endpoint(tf: &mut TrapFrame) -> Result<u64, SyscallError>
         r
     };
 
-    if let Ok(idx) = idx_res
+    match idx_res
     {
-        Ok(u64::from(idx))
-    }
-    else
-    {
-        // CSpace is full; roll back the allocation. Drop in place, return
-        // the bytes, drop the lease.
-        // SAFETY: we just constructed both objects in place above; nothing
-        // else has observed them yet.
-        unsafe {
-            core::ptr::drop_in_place(ep_obj_ptr);
-            core::ptr::drop_in_place(ep_state_ptr);
+        Ok(idx) => Ok(u64::from(idx)),
+        Err(e) =>
+        {
+            // CSpace slot allocation failed; roll back. Drop in place,
+            // return the bytes, drop the lease.
+            // SAFETY: we just constructed both objects in place above;
+            // nothing else has observed them yet.
+            unsafe {
+                core::ptr::drop_in_place(ep_obj_ptr);
+                core::ptr::drop_in_place(ep_state_ptr);
+            }
+            retype_free(memory, offset, entry.raw_bytes);
+            // SAFETY: matches the inc_ref above.
+            unsafe { ancestor.as_ref().dec_ref() };
+            Err(e.into())
         }
-        retype_free(memory, offset, entry.raw_bytes);
-        // SAFETY: matches the inc_ref above.
-        unsafe { ancestor.as_ref().dec_ref() };
-        Err(SyscallError::OutOfMemory)
     }
 }
 
@@ -288,22 +288,23 @@ pub fn sys_cap_create_notification(tf: &mut TrapFrame) -> Result<u64, SyscallErr
         r
     };
 
-    if let Ok(idx) = idx_res
+    match idx_res
     {
-        Ok(u64::from(idx))
-    }
-    else
-    {
-        // CSpace full: roll back the in-place construction.
-        // SAFETY: nothing else has observed these constructed objects.
-        unsafe {
-            core::ptr::drop_in_place(sig_obj_ptr);
-            core::ptr::drop_in_place(sig_state_ptr);
+        Ok(idx) => Ok(u64::from(idx)),
+        Err(e) =>
+        {
+            // CSpace slot allocation failed: roll back the in-place
+            // construction.
+            // SAFETY: nothing else has observed these constructed objects.
+            unsafe {
+                core::ptr::drop_in_place(sig_obj_ptr);
+                core::ptr::drop_in_place(sig_state_ptr);
+            }
+            retype_free(memory, offset, entry.raw_bytes);
+            // SAFETY: matches the inc_ref above.
+            unsafe { ancestor.as_ref().dec_ref() };
+            Err(e.into())
         }
-        retype_free(memory, offset, entry.raw_bytes);
-        // SAFETY: matches the inc_ref above.
-        unsafe { ancestor.as_ref().dec_ref() };
-        Err(SyscallError::OutOfMemory)
     }
 }
 
@@ -518,7 +519,7 @@ pub fn sys_cap_create_aspace(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     let nonnull = unsafe { NonNull::new_unchecked(aso_ptr.cast::<KernelObjectHeader>()) };
 
     // SAFETY: cspace validated non-null above; lock_raw/unlock_raw paired.
-    let idx = unsafe {
+    let idx_res = unsafe {
         let saved = (*cspace).lock.lock_raw();
         let r = (*cspace).insert_cap_handle(
             CapTag::AddressSpace,
@@ -527,8 +528,26 @@ pub fn sys_cap_create_aspace(tf: &mut TrapFrame) -> Result<u64, SyscallError>
         );
         (*cspace).lock.unlock_raw(saved);
         r
-    }
-    .map_err(|_| SyscallError::OutOfMemory)?;
+    };
+    let idx = match idx_res
+    {
+        Ok(idx) => idx,
+        Err(e) =>
+        {
+            // The cap never reached visibility; mirror the add_chunk
+            // rollback above (the chunk record lives inside the wrapper
+            // page being freed, so no external bookkeeping survives).
+            // SAFETY: aso/aspace not observed externally yet.
+            unsafe {
+                core::ptr::drop_in_place(aso_ptr);
+                core::ptr::drop_in_place(aspace_ptr);
+            }
+            retype_free(memory, offset, entry.raw_bytes);
+            // SAFETY: matches inc_ref above.
+            unsafe { memory_obj_nn.as_ref().dec_ref() };
+            return Err(e.into());
+        }
+    };
 
     Ok(u64::from(idx))
 }
@@ -544,7 +563,10 @@ pub fn sys_cap_create_aspace(tf: &mut TrapFrame) -> Result<u64, SyscallError>
 ///        empty pool that requires immediate augment-mode refill before any
 ///        cap can be inserted). Augment-mode accepts `init_pages >= 1`.
 /// arg3 = `max_slots` (create-mode only): hard cap on usable slots
-///        (clamped to `[1, 14336]`). Ignored in augment mode.
+///        (clamped to `[1, 14336]`). `0` defaults to the capacity the
+///        seeded pool actually backs: `(init_pages - 1) * 56 - 1` usable
+///        slots (minimum 1) — never an unbacked quota. Ignored in augment
+///        mode.
 ///
 /// Create-mode slab layout:
 /// - page 0 — wrapper page: [`CSpaceKernelObject`] at offset 0, immediately
@@ -653,7 +675,12 @@ pub fn sys_cap_create_cspace(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     // slot-page pool; CSpace::grow pops one when the directory needs a leaf.
     let max_slots = if requested_max_slots == 0
     {
-        MAX_SLOTS
+        // Default to what the seeded pool actually backs: `init_pages - 1`
+        // pool pages × L2_SIZE slots, minus reserved slot 0. Defaulting to
+        // MAX_SLOTS would advertise a quota the pool cannot honour (#366).
+        ((init_pages as usize - 1) * crate::cap::cspace::L2_SIZE)
+            .saturating_sub(1)
+            .clamp(1, MAX_SLOTS)
     }
     else
     {
@@ -768,28 +795,31 @@ pub fn sys_cap_create_cspace(tf: &mut TrapFrame) -> Result<u64, SyscallError>
         (*cspace).lock.unlock_raw(saved);
         r
     };
-    let Ok(idx) = insert_res
-    else
+    let idx = match insert_res
     {
-        // Roll back the registry slot, the memory inc_ref, the in-place
-        // wrapper/CSpace constructions, and the retype carve. Without
-        // this rollback, a failed `insert_cap` would leak a live CSpace
-        // registry entry, leave `memory_obj_nn`'s refcount permanently
-        // incremented, and surrender the carved offset back to the
-        // retype allocator only when the source memory itself was
-        // dec_ref'd to zero.
-        crate::cap::unregister_cspace(id);
-        // SAFETY: wrapper/cs not observed externally (no slot in any
-        // CSpace points at `nonnull`, and we just removed the registry
-        // entry).
-        unsafe {
-            core::ptr::drop_in_place(cs_kobj_ptr);
-            core::ptr::drop_in_place(cs_ptr);
+        Ok(idx) => idx,
+        Err(e) =>
+        {
+            // Roll back the registry slot, the memory inc_ref, the in-place
+            // wrapper/CSpace constructions, and the retype carve. Without
+            // this rollback, a failed `insert_cap` would leak a live CSpace
+            // registry entry, leave `memory_obj_nn`'s refcount permanently
+            // incremented, and surrender the carved offset back to the
+            // retype allocator only when the source memory itself was
+            // dec_ref'd to zero.
+            crate::cap::unregister_cspace(id);
+            // SAFETY: wrapper/cs not observed externally (no slot in any
+            // CSpace points at `nonnull`, and we just removed the registry
+            // entry).
+            unsafe {
+                core::ptr::drop_in_place(cs_kobj_ptr);
+                core::ptr::drop_in_place(cs_ptr);
+            }
+            retype_free(memory, offset, entry.raw_bytes);
+            // SAFETY: matches the `memory_obj_nn.as_ref().inc_ref()` above.
+            unsafe { memory_obj_nn.as_ref().dec_ref() };
+            return Err(e.into());
         }
-        retype_free(memory, offset, entry.raw_bytes);
-        // SAFETY: matches the `memory_obj_nn.as_ref().inc_ref()` above.
-        unsafe { memory_obj_nn.as_ref().dec_ref() };
-        return Err(SyscallError::OutOfMemory);
     };
 
     Ok(u64::from(idx))
@@ -1022,36 +1052,40 @@ pub fn sys_cap_create_thread(tf: &mut TrapFrame) -> Result<u64, SyscallError>
         r
     };
 
-    if let Ok(idx) = idx_res
+    match idx_res
     {
-        // Thread the new TCB onto the diagnostic live-thread registry now that
-        // its cap is visible and the construction has committed. Registering
-        // only on the success path keeps it symmetric with the unregister in
-        // `dealloc_object(Thread)`: the rollback arm below frees the TCB via
-        // `retype_free` without ever registering it. The thread is still
-        // `Created` (not startable until SYS_THREAD_START), so it cannot become
-        // a Blocked watchdog victim before this point.
-        // SAFETY: tcb_ptr is the just-constructed, not-yet-registered TCB.
-        unsafe { crate::sched::thread_registry::register(tcb_ptr) };
-        let _ = kstack_virt;
-        Ok(u64::from(idx))
-    }
-    else
-    {
-        // The cap never reached visibility, so no scheduler queue can hold
-        // this TCB and no IPC object has a back-pointer to it. Drop both
-        // in-place objects, return the slot bytes (all 5 pages) to the
-        // ancestor cap, and undo the lease bump.
-        // SAFETY: tcb and wrapper were just constructed in place above and
-        // have not been observed by any other thread.
-        unsafe {
-            core::ptr::drop_in_place(tcb_ptr);
-            core::ptr::drop_in_place(thread_obj_ptr);
+        Ok(idx) =>
+        {
+            // Thread the new TCB onto the diagnostic live-thread registry now
+            // that its cap is visible and the construction has committed.
+            // Registering only on the success path keeps it symmetric with the
+            // unregister in `dealloc_object(Thread)`: the rollback arm below
+            // frees the TCB via `retype_free` without ever registering it. The
+            // thread is still `Created` (not startable until
+            // SYS_THREAD_START), so it cannot become a Blocked watchdog victim
+            // before this point.
+            // SAFETY: tcb_ptr is the just-constructed, not-yet-registered TCB.
+            unsafe { crate::sched::thread_registry::register(tcb_ptr) };
+            let _ = kstack_virt;
+            Ok(u64::from(idx))
         }
-        retype_free(memory, offset, entry.raw_bytes);
-        // SAFETY: matches the inc_ref above.
-        unsafe { ancestor.as_ref().dec_ref() };
-        Err(SyscallError::OutOfMemory)
+        Err(e) =>
+        {
+            // The cap never reached visibility, so no scheduler queue can hold
+            // this TCB and no IPC object has a back-pointer to it. Drop both
+            // in-place objects, return the slot bytes (all 5 pages) to the
+            // ancestor cap, and undo the lease bump.
+            // SAFETY: tcb and wrapper were just constructed in place above and
+            // have not been observed by any other thread.
+            unsafe {
+                core::ptr::drop_in_place(tcb_ptr);
+                core::ptr::drop_in_place(thread_obj_ptr);
+            }
+            retype_free(memory, offset, entry.raw_bytes);
+            // SAFETY: matches the inc_ref above.
+            unsafe { ancestor.as_ref().dec_ref() };
+            Err(e.into())
+        }
     }
 }
 
@@ -1180,12 +1214,7 @@ pub fn sys_cap_copy(tf: &mut TrapFrame) -> Result<u64, SyscallError>
         unsafe {
             (*src_object.as_ptr()).dec_ref();
         }
-        match e
-        {
-            crate::cap::cspace::CapError::WxViolation => SyscallError::WxViolation,
-            crate::cap::cspace::CapError::InvalidIndex => SyscallError::InvalidArgument,
-            _ => SyscallError::OutOfMemory,
-        }
+        SyscallError::from(e)
     })?;
     // new_idx is non-zero: auto-allocation returns a non-zero slot and the
     // explicit path used a non-zero dest_slot_idx.
@@ -1283,11 +1312,7 @@ pub fn sys_cap_derive(tf: &mut TrapFrame) -> Result<u64, SyscallError>
         unsafe {
             (*src_object.as_ptr()).dec_ref();
         }
-        match e
-        {
-            crate::cap::cspace::CapError::WxViolation => SyscallError::WxViolation,
-            _ => SyscallError::OutOfMemory,
-        }
+        SyscallError::from(e)
     })?;
     // Wire derivation link.
     let src_idx_nz = core::num::NonZeroU32::new(src_idx).ok_or(SyscallError::InvalidCapability)?;
@@ -1395,11 +1420,7 @@ pub fn sys_cap_derive_badge(tf: &mut TrapFrame) -> Result<u64, SyscallError>
         unsafe {
             (*src_object.as_ptr()).dec_ref();
         }
-        match e
-        {
-            crate::cap::cspace::CapError::WxViolation => SyscallError::WxViolation,
-            _ => SyscallError::OutOfMemory,
-        }
+        SyscallError::from(e)
     })?;
     // Wire derivation link.
     let src_idx_nz = core::num::NonZeroU32::new(src_idx).ok_or(SyscallError::InvalidCapability)?;
@@ -1861,7 +1882,7 @@ pub fn sys_cap_move(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     // SAFETY: dest_cs_ptr validated above; DERIVATION_LOCK and both CSpace locks held.
     let insert_result =
         unsafe { (*dest_cs_ptr).insert_cap_at(dest_idx, src_tag, src_rights, src_object) };
-    if insert_result.is_err()
+    if let Err(e) = insert_result
     {
         // Unlock before returning error.
         // SAFETY: saved1 and saved2 came from lock_raw calls above.
@@ -1886,7 +1907,7 @@ pub fn sys_cap_move(tf: &mut TrapFrame) -> Result<u64, SyscallError>
             }
         }
         crate::cap::DERIVATION_LOCK.write_unlock();
-        return Err(SyscallError::InvalidArgument);
+        return Err(e.into());
     }
 
     let src_slot_id = SlotId::current(src_cspace_id, src_idx_nz);
@@ -2114,26 +2135,26 @@ pub fn sys_cap_create_event_queue(tf: &mut TrapFrame) -> Result<u64, SyscallErro
         r
     };
 
-    if let Ok(idx) = idx_res
+    match idx_res
     {
-        Ok(u64::from(idx))
-    }
-    else
-    {
-        // The cap never reached visibility, so no waiter or `wait_set`
-        // back-pointer can exist. Drop the in-place state and wrapper,
-        // return the slot bytes (which include the inline ring) to the
-        // ancestor cap, and undo the lease bump.
-        // SAFETY: state and wrapper were just constructed in place above
-        // and have not been observed by any other thread.
-        unsafe {
-            core::ptr::drop_in_place(eq_state_ptr);
-            core::ptr::drop_in_place(eq_obj_ptr);
+        Ok(idx) => Ok(u64::from(idx)),
+        Err(e) =>
+        {
+            // The cap never reached visibility, so no waiter or `wait_set`
+            // back-pointer can exist. Drop the in-place state and wrapper,
+            // return the slot bytes (which include the inline ring) to the
+            // ancestor cap, and undo the lease bump.
+            // SAFETY: state and wrapper were just constructed in place above
+            // and have not been observed by any other thread.
+            unsafe {
+                core::ptr::drop_in_place(eq_state_ptr);
+                core::ptr::drop_in_place(eq_obj_ptr);
+            }
+            retype_free(memory, offset, entry.raw_bytes);
+            // SAFETY: matches the inc_ref above.
+            unsafe { ancestor.as_ref().dec_ref() };
+            Err(e.into())
         }
-        retype_free(memory, offset, entry.raw_bytes);
-        // SAFETY: matches the inc_ref above.
-        unsafe { ancestor.as_ref().dec_ref() };
-        Err(SyscallError::OutOfMemory)
     }
 }
 
@@ -2215,22 +2236,22 @@ pub fn sys_cap_create_wait_set(tf: &mut TrapFrame) -> Result<u64, SyscallError>
         r
     };
 
-    if let Ok(idx) = idx_res
+    match idx_res
     {
-        Ok(u64::from(idx))
-    }
-    else
-    {
-        // Roll back: nothing else has observed these constructed objects.
-        // SAFETY: pointers are unique-ownership for this caller.
-        unsafe {
-            core::ptr::drop_in_place(ws_obj_ptr);
-            core::ptr::drop_in_place(ws_state_ptr);
+        Ok(idx) => Ok(u64::from(idx)),
+        Err(e) =>
+        {
+            // Roll back: nothing else has observed these constructed objects.
+            // SAFETY: pointers are unique-ownership for this caller.
+            unsafe {
+                core::ptr::drop_in_place(ws_obj_ptr);
+                core::ptr::drop_in_place(ws_state_ptr);
+            }
+            retype_free(memory, offset, entry.raw_bytes);
+            // SAFETY: matches the inc_ref above.
+            unsafe { ancestor.as_ref().dec_ref() };
+            Err(e.into())
         }
-        retype_free(memory, offset, entry.raw_bytes);
-        // SAFETY: matches the inc_ref above.
-        unsafe { ancestor.as_ref().dec_ref() };
-        Err(SyscallError::OutOfMemory)
     }
 }
 

--- a/core/kernel/src/syscall/ipc.rs
+++ b/core/kernel/src/syscall/ipc.rs
@@ -225,7 +225,7 @@ unsafe fn transfer_caps(
         (*dst_cspace).lock.unlock_raw(saved);
         r
     }
-    .map_err(|_| SyscallError::OutOfMemory)?;
+    .map_err(SyscallError::from)?;
 
     // Acquire derivation lock for the batch move.
     crate::cap::DERIVATION_LOCK.write_lock();
@@ -669,7 +669,7 @@ pub fn sys_ipc_recv(tf: &mut TrapFrame) -> Result<u64, SyscallError>
         (*cspace_ptr).lock.unlock_raw(saved);
         r
     }
-    .map_err(|_| SyscallError::OutOfMemory)?;
+    .map_err(SyscallError::from)?;
 
     // Open the park episode before the recv-queue link can publish.
     // SAFETY: tcb is the running caller, not yet claimable.
@@ -950,13 +950,14 @@ pub fn sys_ipc_reply(tf: &mut TrapFrame) -> Result<u64, SyscallError>
                 (*caller_cspace).lock.unlock_raw(saved);
                 r
             };
-            if pre_res.is_err()
+            if let Err(e) = pre_res
             {
                 // Caller's CSpace cannot accept reply caps. Wake the caller with
                 // a synthetic failure reply so it un-parks and surfaces the error
-                // rather than dead-locking; bubble OOM to the server.
+                // rather than dead-locking; bubble the pool/quota distinction
+                // to the server.
                 // SAFETY: tcb validated above.
-                return Err(unsafe { fail_reply_and_wake_caller(tcb, SyscallError::OutOfMemory) });
+                return Err(unsafe { fail_reply_and_wake_caller(tcb, e.into()) });
             }
         }
     }

--- a/core/kernel/src/syscall/mem.rs
+++ b/core/kernel/src/syscall/mem.rs
@@ -661,14 +661,18 @@ pub fn sys_memory_split(tf: &mut TrapFrame) -> Result<u64, SyscallError>
         (*caller_cspace).lock.unlock_raw(saved);
         r
     };
-    let Ok(tail_slot_nz) = insert_res
-    else
+    let tail_slot_nz = match insert_res
     {
-        // SAFETY: tail_ptr just allocated; refcount is 1 with no other holders.
-        unsafe { crate::cap::object::dealloc_object(tail_ptr) };
-        parent_ref.write_unlock();
-        DERIVATION_LOCK.write_unlock();
-        return Err(SyscallError::OutOfMemory);
+        Ok(idx) => idx,
+        Err(e) =>
+        {
+            // SAFETY: tail_ptr just allocated; refcount is 1 with no other
+            // holders.
+            unsafe { crate::cap::object::dealloc_object(tail_ptr) };
+            parent_ref.write_unlock();
+            DERIVATION_LOCK.write_unlock();
+            return Err(e.into());
+        }
     };
     let tail_id = SlotId::current(cspace_id, tail_slot_nz);
 

--- a/core/ktest/src/unit/cap.rs
+++ b/core/ktest/src/unit/cap.rs
@@ -344,7 +344,7 @@ pub fn insert_out_of_bounds_err(ctx: &TestContext) -> TestResult
 {
     let sig = cap_create_notification(ctx.memory_base)
         .map_err(|_| "create_notification for insert_oob test failed")?;
-    // CSpace capacity is clamped to [256, 14336]; create the smallest possible.
+    // max_slots is clamped to [1, 14336]; create a small CSpace.
     let dest_cs = cap_create_cspace(ctx.memory_base, 0, 4, 16)
         .map_err(|_| "create_cspace for insert_oob test failed")?;
 

--- a/core/ktest/src/unit/cap_info.rs
+++ b/core/ktest/src/unit/cap_info.rs
@@ -270,6 +270,23 @@ pub fn tag_mismatch_invalid_arg(ctx: &TestContext) -> TestResult
     Ok(())
 }
 
+/// `max_slots = 0` on create-mode `cap_create_cspace` defaults the quota
+/// to what the seeded pool backs — `(init_pages - 1) * 56 - 1` usable
+/// slots — never an unbacked 14336 ceiling (#366).
+pub fn cspace_default_max_slots_is_pool_backed(ctx: &TestContext) -> TestResult
+{
+    let cs = cap_create_cspace(ctx.memory_base, 0, 4, 0)
+        .map_err(|_| "cap_create_cspace(init_pages=4, max_slots=0) failed")?;
+    let capacity = cap_info(cs, CAP_INFO_CSPACE_CAPACITY);
+    cap_delete(cs).map_err(|_| "cap_delete(cspace) failed")?;
+    let capacity = capacity.map_err(|_| "cap_info(CSPACE_CAPACITY) failed")?;
+    if capacity != 3 * 56 - 1
+    {
+        return Err("default max_slots != pool-backed capacity (3 pool pages)");
+    }
+    Ok(())
+}
+
 /// Unknown selector returns `InvalidArgument`.
 pub fn unknown_field_invalid_arg(ctx: &TestContext) -> TestResult
 {

--- a/core/ktest/src/unit/ipc.rs
+++ b/core/ktest/src/unit/ipc.rs
@@ -752,10 +752,12 @@ pub fn reply_oom_wakes_caller_with_transfer_failed(ctx: &TestContext) -> TestRes
         .map_err(|_| "cap_create_notification(xfer) for reply_oom test failed")?;
 
     // Small child CSpace: the child consumes its remaining headroom by
-    // creating notifications until full so that pre_allocate(1) on the reply path
-    // returns OutOfMemory. The 8-slot shape is part of the test contract,
-    // so this site bypasses `spawn::new_child` (which mints 16 slots) per
-    // the convention documented in `spawn.rs`.
+    // creating notifications until full so that pre_allocate(1) on the
+    // reply path fails. The 8-slot max_slots quota binds (the seeded pool
+    // backs far more), so the failure surfaces as QuotaExceeded. The
+    // 8-slot shape is part of the test contract, so this site bypasses
+    // `spawn::new_child` (which mints 16 slots) per the convention
+    // documented in `spawn.rs`.
     let child_cs = cap_create_cspace(ctx.memory_base, 0, 4, 8)
         .map_err(|_| "cap_create_cspace for reply_oom test failed")?;
     let child_ep = cap_copy(ep, child_cs, RIGHTS_SEND_GRANT)
@@ -802,16 +804,16 @@ pub fn reply_oom_wakes_caller_with_transfer_failed(ctx: &TestContext) -> TestRes
         return Err("reply_oom: ipc_recv returned wrong label");
     }
 
-    // Cap-bearing reply: child's CSpace is full, so the kernel's
-    // pre_allocate on the caller side fails. The kernel returns
-    // OutOfMemory to the server *and* wakes the caller with the synthetic
-    // IPC_REPLY_TRANSFER_FAILED label.
+    // Cap-bearing reply: child's CSpace is at its max_slots quota, so the
+    // kernel's pre_allocate on the caller side fails. The kernel returns
+    // QuotaExceeded to the server *and* wakes the caller with the
+    // synthetic IPC_REPLY_TRANSFER_FAILED label.
     let cap_reply = IpcMessage::builder(0xBEEF).cap(xfer).build();
     // SAFETY: ctx.ipc_buf is the registered per-thread IPC buffer.
     let attempt = unsafe { ipc::ipc_reply(&cap_reply, ctx.ipc_buf) };
     match attempt
     {
-        Err(code) if code == syscall_abi::SyscallError::OutOfMemory as i64 =>
+        Err(code) if code == syscall_abi::SyscallError::QuotaExceeded as i64 =>
         {}
         Err(_) => return Err("reply_oom: cap-bearing reply returned wrong error code"),
         Ok(()) => return Err("reply_oom: cap-bearing reply succeeded unexpectedly"),
@@ -899,15 +901,16 @@ fn reply_oom_caller_entry(arg: u64) -> !
 // ── sys_ipc_recv cap-transfer OOM regression ─────────────────────────────────
 
 /// `sys_ipc_recv` on a thread whose `CSpace` cannot absorb
-/// `MSG_CAP_SLOTS_MAX` more caps must return `OutOfMemory` cleanly without
-/// blocking on the recv queue, so the recv-side cap-transfer OOM cannot
-/// wedge any IPC participant.
+/// `MSG_CAP_SLOTS_MAX` more caps must fail cleanly without blocking on
+/// the recv queue, so the recv-side cap-transfer failure cannot wedge any
+/// IPC participant. The victim's 8-slot `max_slots` quota is the binding
+/// limit here, so the error is `QuotaExceeded`.
 ///
 /// Verifies the symmetric pre-allocation hoisted to the top of
 /// `sys_ipc_recv`. The victim thread fills its own `CSpace`, then issues
-/// `ipc_recv`. With the fix the syscall returns `OutOfMemory` immediately;
-/// without the fix the victim would either block on the recv queue or hit
-/// the bug only when caps actually arrive.
+/// `ipc_recv`. With the fix the syscall fails immediately; without the
+/// fix the victim would either block on the recv queue or hit the bug
+/// only when caps actually arrive.
 pub fn recv_oom_returns_cleanly(ctx: &TestContext) -> TestResult
 {
     let ep = cap_create_endpoint(ctx.memory_base)
@@ -945,7 +948,7 @@ pub fn recv_oom_returns_cleanly(ctx: &TestContext) -> TestResult
         notification_wait(done).map_err(|_| "notification_wait(done) for recv_oom failed")?;
     if bits != 0xDEAD
     {
-        return Err("recv_oom: victim did not see OutOfMemory from ipc_recv");
+        return Err("recv_oom: victim did not see QuotaExceeded from ipc_recv");
     }
 
     cap_delete(victim_th).ok();
@@ -956,7 +959,7 @@ pub fn recv_oom_returns_cleanly(ctx: &TestContext) -> TestResult
 }
 
 /// Victim for `recv_oom_returns_cleanly`: fills its `CSpace` then issues
-/// `ipc_recv`. Reports `0xDEAD` if the syscall returns `OutOfMemory`
+/// `ipc_recv`. Reports `0xDEAD` if the syscall returns `QuotaExceeded`
 /// (post-fix behavior), `0xBAD` otherwise.
 fn recv_oom_victim_entry(arg: u64) -> !
 {
@@ -988,7 +991,7 @@ fn recv_oom_victim_entry(arg: u64) -> !
     let result = unsafe { ipc::ipc_recv(ep_slot, buf_addr as *mut u64) };
     let bits = match result
     {
-        Err(code) if code == syscall_abi::SyscallError::OutOfMemory as i64 => 0xDEAD,
+        Err(code) if code == syscall_abi::SyscallError::QuotaExceeded as i64 => 0xDEAD,
         _ => 0xBAD,
     };
     notification_send(done_slot, bits).ok();

--- a/core/ktest/src/unit/mod.rs
+++ b/core/ktest/src/unit/mod.rs
@@ -143,6 +143,10 @@ pub fn run_all(ctx: &TestContext)
         "cap_info::unknown_field_invalid_arg",
         cap_info::unknown_field_invalid_arg(ctx)
     );
+    run_test!(
+        "cap_info::cspace_default_max_slots_is_pool_backed",
+        cap_info::cspace_default_max_slots_is_pool_backed(ctx)
+    );
 
     // ── Retype primitive (augment, budget exhaustion, deep PT walk) ──────────
     run_test!(
@@ -172,6 +176,10 @@ pub fn run_all(ctx: &TestContext)
     run_test!(
         "retype::cspace_grow_consumes_pool",
         retype::cspace_grow_consumes_pool(ctx)
+    );
+    run_test!(
+        "retype::cspace_pool_exhaust_augment_then_quota",
+        retype::cspace_pool_exhaust_augment_then_quota(ctx)
     );
 
     // ── Memory management syscalls ────────────────────────────────────────────

--- a/core/ktest/src/unit/retype.rs
+++ b/core/ktest/src/unit/retype.rs
@@ -41,6 +41,7 @@ use crate::{TestContext, TestResult};
 
 const TEST_VA_BASE: u64 = 0x0000_0000_4000_0000;
 const SYS_OUT_OF_MEMORY: i64 = -8;
+const SYS_QUOTA_EXCEEDED: i64 = -17;
 
 /// Augment-mode on `cap_create_aspace` increases the target AS's PT
 /// growth budget without creating a new AS.
@@ -313,8 +314,8 @@ pub fn cspace_grow_consumes_pool(ctx: &TestContext) -> TestResult
 {
     let memory = ctx.memory_base;
 
-    // 3 slot pages = ~192 slots (depending on slot size). max_slots set
-    // generously so insertion isn't capped by max_slots.
+    // init_pages = 3 → wrapper page + 2 pool pages = 111 usable slots.
+    // max_slots set generously so insertion isn't capped by max_slots.
     let cspace = cap_create_cspace(memory, 0, 3, 4096)
         .map_err(|_| "retype::cspace_grow: cap_create_cspace failed")?;
     let used_before = cap_info(cspace, CAP_INFO_CSPACE_USED)
@@ -349,6 +350,81 @@ pub fn cspace_grow_consumes_pool(ctx: &TestContext) -> TestResult
     if budget_after >= budget_before
     {
         return Err("retype::cspace_grow: budget did not decrease as pool was consumed");
+    }
+    Ok(())
+}
+
+/// Pool exhaustion and the `max_slots` quota are distinct failures (#366):
+/// an under-seeded pool fails the insert with the refillable `OutOfMemory`
+/// (augment-mode then allows further inserts), while reaching `max_slots`
+/// fails with the hard `QuotaExceeded`.
+pub fn cspace_pool_exhaust_augment_then_quota(ctx: &TestContext) -> TestResult
+{
+    let memory = ctx.memory_base;
+
+    // init_pages = 2 → 1 pool page → 55 usable slots; max_slots = 120
+    // deliberately exceeds the seeded capacity to expose both bounds.
+    let cspace = cap_create_cspace(memory, 0, 2, 120)
+        .map_err(|_| "retype::pool_vs_quota: cap_create_cspace failed")?;
+    let Ok(probe) = cap_create_endpoint(memory)
+    else
+    {
+        cap_delete(cspace).ok();
+        return Err("retype::pool_vs_quota: cap_create_endpoint failed");
+    };
+
+    // Copy until the first failure: the seeded pool backs 55 slots, so 55
+    // copies succeed and the 56th hits pool exhaustion.
+    let mut ok_before = 0u32;
+    let mut err_at_pool = 0i64;
+    for _ in 0..=55
+    {
+        match cap_copy(probe, cspace, 1)
+        {
+            Ok(_) => ok_before += 1,
+            Err(e) =>
+            {
+                err_at_pool = e;
+                break;
+            }
+        }
+    }
+
+    // Refill the pool (2 more slot pages = 112 slots, ample for the
+    // remaining quota), then copy up to `max_slots`.
+    let augment_ok = cap_create_cspace(memory, cspace, 2, 0).is_ok();
+    let mut ok_after = 0u32;
+    let mut err_at_quota = 0i64;
+    for _ in 0..=65
+    {
+        match cap_copy(probe, cspace, 1)
+        {
+            Ok(_) => ok_after += 1,
+            Err(e) =>
+            {
+                err_at_quota = e;
+                break;
+            }
+        }
+    }
+
+    // Deleting the CSpace cap reclaims the copies wholesale.
+    cap_delete(probe).ok();
+    cap_delete(cspace).ok();
+
+    if ok_before != 55 || err_at_pool != SYS_OUT_OF_MEMORY
+    {
+        return Err(
+            "retype::pool_vs_quota: pool exhaustion did not surface OutOfMemory after 55 slots",
+        );
+    }
+    if !augment_ok
+    {
+        return Err("retype::pool_vs_quota: augment-mode refill failed");
+    }
+    if ok_after != 65 || err_at_quota != SYS_QUOTA_EXCEEDED
+    {
+        return Err("retype::pool_vs_quota: quota did not surface QuotaExceeded at max_slots");
     }
     Ok(())
 }

--- a/docs/capability-model.md
+++ b/docs/capability-model.md
@@ -498,9 +498,28 @@ during normal operation as a process maps memory or accumulates caps.
 Each `AddressSpace` and `CSpace` capability carries its own growth
 budget — a pool of pages donated at creation time from a Retype-bearing
 Memory cap — from which `mem_map` and `cap_insert` allocate. Exhausting
-the budget returns `NoMemory`; the budget refills via *augment mode* on
-the same create syscall (passing the existing AS/CS slot as the augment
-target merges a new slab of pages into its growth budget).
+the budget returns `OutOfMemory` (-8); the budget refills via *augment
+mode* on the same create syscall (passing the existing AS/CS slot as the
+augment target merges a new slab of pages into its growth budget).
+
+A `CSpace` has two independent growth bounds, distinguishable by error
+code at the failure site:
+
+- **Pool exhaustion** — the seeded slot-page pool is empty. Returns
+  `OutOfMemory` (-8); refillable via augment mode. The kernel also logs
+  the CSpace id, allocated count, and quota.
+- **Quota reached** — `max_slots` (or the directory limit) is hit.
+  Returns `QuotaExceeded` (-17); a hard policy ceiling that no memory
+  donation can lift.
+
+Seeding policy: every CSpace creation site MUST either seed the pool to
+cover its full `max_slots` quota (`pool_pages × 56 − 1 ≥ max_slots`,
+the default for all userspace creation sites), or document the shortfall
+at the site and name the owner responsible for augment-mode refill. The
+kernel-created root CSpace is the one documented under-seeded site (init
+owns the refill; see `ROOT_CSPACE_INIT_SLOT_CAPACITY` in the kernel).
+Passing `max_slots = 0` to create-mode `cap_create_cspace` defaults the
+quota to exactly what the seeded pool backs, never an unbacked ceiling.
 
 An `AddressSpace`'s intermediate page tables are also returned to its
 growth budget mid-life when a region is torn down: `SYS_MEM_UNMAP` with

--- a/services/init/src/main.rs
+++ b/services/init/src/main.rs
@@ -53,16 +53,18 @@ pub(crate) const ASPACE_RETYPE_PAGES: u64 = 33;
 
 /// Pages init carves for memmgr/procmgr's `CSpace`. Each slot page holds
 /// `L2_SIZE` capability slots (currently 56 slots × 72 B = 4032 B/page);
-/// the +1 covers per-MemoryObject allocator metadata. Mirrors procmgr's
+/// the +1 covers per-MemoryObject allocator metadata, and the kernel
+/// reserves the slab's page 0 as the wrapper page. Mirrors procmgr's
 /// constant.
 ///
-/// Sized for the long-lived service's full lifetime: procmgr accumulates
-/// per-child caps (aspace, cspace, thread, memory-cap slabs, derived rights
-/// caps) while children are alive. 33 pages → 32 slot pages → ~1792
-/// slots = ~28 children (aspace/cspace/thread/4 memory caps each) plus
-/// working caps. Larger workloads refill via augment-mode
-/// `cap_create_cspace`.
-pub(crate) const CSPACE_RETYPE_PAGES: u64 = 33;
+/// Seed-to-cover policy (#366): both tier-1 services are immortal and
+/// accumulate caps for the system's whole lifetime (memmgr: per-allocation
+/// Memory caps; procmgr: per-child aspace/cspace/thread/slab caps), so
+/// the seeded pool MUST back the full `max_slots = 8192` quota — an
+/// under-seeded pool wedges the service on pool exhaustion long before
+/// quota, with no one positioned to augment it. 149 pages → 148 to the
+/// kernel → 147 pool pages → 147 × 56 − 1 = 8231 usable slots ≥ 8192.
+pub(crate) const CSPACE_RETYPE_PAGES: u64 = 149;
 
 /// Base for init's scratch mappings (`ProcessInfo` memory caps, ELF pages).
 pub(crate) const TEMP_MAP_BASE: u64 = 0x0000_0001_0000_0000;

--- a/services/procmgr/src/main.rs
+++ b/services/procmgr/src/main.rs
@@ -219,10 +219,14 @@ pub(crate) const ASPACE_RETYPE_PAGES: u64 = 33;
 /// Pages requested from memmgr for the child's `CSpace` retype slab.
 /// Each slot page holds `L2_SIZE` capability slots (currently 56 slots
 /// × 72 B = 4032 B/page); the +1 covers the per-memory-cap allocator
-/// metadata footprint. Larger `CSpace`s refill via augment-mode
-/// `cap_create_cspace`. Five pages → 4 slot pages → ~224 slots covers a
-/// small driver's lifetime.
-pub(crate) const CSPACE_RETYPE_PAGES: u64 = 5;
+/// metadata footprint, and the kernel reserves the slab's page 0 as the
+/// wrapper page.
+///
+/// Seed-to-cover policy (#366): the seeded pool MUST back the child's
+/// full `max_slots = 256` quota so a cap insert can never fail on pool
+/// exhaustion below quota. 7 pages → 6 to the kernel → 5 pool pages →
+/// 5 × 56 − 1 = 279 usable slots ≥ 256.
+pub(crate) const CSPACE_RETYPE_PAGES: u64 = 7;
 
 /// Register a new child with memmgr. On success returns
 /// `(memmgr_send_cap_slot, memmgr_badge)`. On any failure (memmgr

--- a/shared/syscall/src/lib.rs
+++ b/shared/syscall/src/lib.rs
@@ -883,19 +883,22 @@ pub fn cap_create_aspace(memory_cap: u32, augment_target: u32, init_pages: u64)
 /// slot-page growth budget.
 ///
 /// `memory_cap` must carry `Rights::RETYPE` and have at least
-/// `init_pages * PAGE_SIZE` of `available_bytes`. All `init_pages`
-/// become the initial slot-page pool (the first `CSpace::grow` consumes
-/// one). `init_pages` must be `>= 1`.
+/// `init_pages * PAGE_SIZE` of `available_bytes`. In create mode the
+/// slab's page 0 is the kernel wrapper page; pages `1..init_pages` seed
+/// the slot-page pool (each backs 56 slots). `init_pages` must be `>= 1`.
 ///
 /// `augment_target`:
-/// - `0` → create new with `max_slots` (clamped to `[1, 14336]`); returns
-///   the new cap slot index.
+/// - `0` → create new with `max_slots` (clamped to `[1, 14336]`; `0`
+///   defaults to the capacity the seeded pool backs,
+///   `(init_pages - 1) * 56 - 1`); returns the new cap slot index.
 /// - non-zero → augment that `CSpace`'s growth pool; returns `0`. The
 ///   `max_slots` argument is ignored in augment mode.
 ///
 /// # Errors
-/// Returns a negative `i64` error code on insufficient memory budget,
-/// invalid cap, or a full `CSpace`.
+/// Returns a negative `i64` error code on insufficient memory budget or
+/// invalid cap. A later cap insert into the `CSpace` fails with
+/// `OutOfMemory` (-8) when the seeded pool is exhausted (refill via
+/// augment mode) and `QuotaExceeded` (-17) when `max_slots` is reached.
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 #[inline]
 pub fn cap_create_cspace(
@@ -2122,7 +2125,7 @@ pub fn thread_sleep(ms: u64) -> Result<(), i64>
 /// the bare exit reason (low 32 bits): the pre-multi-bind behaviour.
 ///
 /// Multiple observers can be registered on the same thread — up to the
-/// kernel's per-TCB cap. Returns `SyscallError::OutOfMemory` (-3) if the
+/// kernel's per-TCB cap. Returns `SyscallError::OutOfMemory` (-8) if the
 /// target thread's observer array is full.
 ///
 /// `correlator` is opaque to the kernel. Its meaning is scoped to one


### PR DESCRIPTION
Closes #366.

## Problem

A CSpace's slot-page pool is seeded at creation independently of `max_slots`, and both pool exhaustion and quota-reached collapsed to `OutOfMemory (-8)` at the syscall boundary. memmgr (`max_slots = 8192`, 31-page pool = 1735 usable slots) wedged at exactly 1735 slots with no way to tell which limit had bound (#366 GDB evidence).

## Changes

**Distinct error surface**
- abi: new `SyscallError::QuotaExceeded = -17`; `-14` marked permanently retired (`DmaUnsafe`).
- kernel: `CapError::OutOfMemory` renamed to `PoolExhausted`; one canonical `From<CapError> for SyscallError` (`OutOfSlots → QuotaExceeded`, `PoolExhausted → OutOfMemory`); all 18 syscall-path consumers routed through it (`syscall/cap.rs`, `syscall/mem.rs`, `syscall/ipc.rs`, `cap/split.rs`, `cap/mod.rs`).
- kernel: `grow()` logs `cspace <id>: slot-page pool exhausted (allocated=N, max=M)` at the failure site.
- kernel: `cap_create_cspace` with `max_slots = 0` now defaults to the seeded-pool-backed capacity (`(init_pages−1)·56 − 1`) instead of an unbacked 14336 ceiling.

**Seed-to-cover policy** (per-issue decision)
- init: tier-1 (memmgr/procmgr) CSpace slabs 33 → 149 pages; 147 pool pages back the full 8192-slot quota (cost: +464 KiB per immortal service of the 512 MiB guest).
- procmgr: child CSpace slabs 5 → 7 pages, backing the 256-slot quota.
- Root CSpace stays deliberately under-seeded — documented as the one exception, with init as the augment owner.
- `docs/capability-model.md`: policy + both failure modes documented; stale `NoMemory` name fixed. Off-by-one slot math fixed in both retype-pages constants' comments and two ktest comments.

**Incidental fix on the audited surface**
- `sys_cap_create_aspace` leaked the retyped slab, in-place objects, and ancestor refcount when the final cap insert failed; it now rolls back like every sibling create syscall.

## Behavioral deltas

- Quota-reached failures on cap insert/copy/derive/move/IPC-transfer paths now return `-17` instead of `-8`. No in-tree consumer matched `-8` on these paths (swept; ruststd's augment-retry is `mem_map`-only).
- `sys_cap_move` to an explicit destination previously flattened grow-time failures to `InvalidArgument`; they now surface as `OutOfMemory`/`QuotaExceeded`.
- ktest `ipc::reply_oom`/`recv_oom` expectations updated: their 8-slot CSpaces exhaust at quota, so the error is `QuotaExceeded`.

## Test plan

- [x] `cargo xtask test` (host; includes new `pool_exhaustion_is_distinct`)
- [x] New ktest `retype::cspace_pool_exhaust_augment_then_quota`: exhaust pool → `OutOfMemory`, augment, fill to quota → `QuotaExceeded`
- [x] New ktest `cap_info::cspace_default_max_slots_is_pool_backed`
- [x] x86_64: build; ktest 194/194; svctest ALL TESTS PASSED; default boot to `terminal: READY`
- [x] riscv64: same, after `cargo xtask clean`