### PR TITLE
ruststd: recycle and release pooled object-slab memmgr grants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,6 +720,10 @@ version = "0.1.0"
 [[package]]
 name = "pipestress-tester"
 version = "0.1.0"
+dependencies = [
+ "syscall",
+ "syscall-abi",
+]
 
 [[package]]
 name = "prettyplease"

--- a/docs/userspace-memory-model.md
+++ b/docs/userspace-memory-model.md
@@ -191,8 +191,11 @@ memmgr serves frame requests over IPC. The contract:
   pool mid-life, named by the `phys_base` memmgr reported at grant (the caller
   need not still hold the cap — it may have retyped the region and dropped its
   copy). This keeps a per-unit-of-work retype loop (e.g. ruststd's Thread
-  slab per spawn) at a bounded pool footprint. Process death triggers automatic
-  reclamation via procmgr's `PROCESS_DIED` notification to memmgr.
+  slab per spawn) at a bounded pool footprint; ruststd's pooled object-slab
+  pages likewise recycle auto-reclaimed bytes in place and release a retired
+  page's grant once every object retyped from it has died. Process death
+  triggers automatic reclamation via procmgr's `PROCESS_DIED` notification to
+  memmgr.
 
 Authoritative wire shape lives in
 [`services/memmgr/docs/ipc-interface.md`](../services/memmgr/docs/ipc-interface.md).

--- a/programs/pipestress/tester/Cargo.toml
+++ b/programs/pipestress/tester/Cargo.toml
@@ -9,5 +9,9 @@ name = "pipestress-tester"
 path = "src/main.rs"
 test = false
 
+[dependencies]
+syscall = { path = "../../../shared/syscall" }
+syscall-abi = { path = "../../../abi/syscall" }
+
 [lints]
 workspace = true

--- a/programs/pipestress/tester/src/main.rs
+++ b/programs/pipestress/tester/src/main.rs
@@ -3,13 +3,23 @@
 
 // programs/pipestress/tester/src/main.rs
 
-//! Per-program tester for `/programs/pipestress` (#360). Repeatedly spawns
-//! the fixture with a piped stdout and asserts every iteration's output line
-//! is captured. Each iteration is one independent trial of the
+//! Per-program tester for `/programs/pipestress` (#360, #364). Repeatedly
+//! spawns the fixture with a piped stdout and asserts every iteration's
+//! output line is captured. Each iteration is one independent trial of the
 //! write-close-exit window in which a parent-side pipe drain races the
 //! death-bridge's `peer_dead` flip; a dropped line means the reader returned
 //! EOF with bytes still in the ring. The exit code is the verdict; the
 //! `[pipestress-tester]` line is advisory.
+//!
+//! The tester is also the #364 long-lived-spawner fixture: each iteration
+//! churns ~5 sub-page retype chunks through this process's pooled object
+//! slab (the pipe's data/space notifications, the bridge completion
+//! notification, the child death `EventQueue`, the bridge thread's
+//! done-notification). The pooled slab recycles the bytes the kernel
+//! auto-reclaims when those objects die, so the populated `CSpace`-slot
+//! count stays flat across the run; a pool that instead refills leaks one
+//! pool-cap slot (and strands one memmgr grant) per ~63 chunks, which the
+//! slot bound below trips.
 //!
 //! Output goes to stdout only: the usertest orchestrator drains stdout to
 //! EOF before stderr, so unbounded stderr would deadlock against it.
@@ -26,6 +36,25 @@ use std::process::{Command, Stdio};
 /// well inside the burn-in timeout.
 const ITERATIONS: usize = 250;
 
+/// Iterations run before the slot baseline is sampled, letting lazily-created
+/// one-time caps (pooled slab pages, stdio state, bridge-thread machinery)
+/// settle.
+const WARMUP: usize = 10;
+
+/// Allowed populated-CSpace-slot growth between the post-warmup baseline and
+/// the peak sample (#364). Steady-state growth is 0; the bound absorbs
+/// shelf-retained pool caps (at most 4 per pool) plus stragglers. A pooled
+/// slab that never recycles refills every ~63 chunks — ~20 leaked slots over
+/// the (250 - 10) * ~5 churned chunks — and trips this cleanly.
+const SLOT_SLACK: u64 = 8;
+
+fn used_slots() -> u64
+{
+    let cspace = std::os::seraph::startup_info().self_cspace;
+    syscall::cap_info(cspace, syscall_abi::CAP_INFO_CSPACE_USED)
+        .expect("cap_info(CSPACE_USED) on self_cspace")
+}
+
 fn fail(msg: &str, captured: &str) -> !
 {
     println!("[pipestress-tester] FAIL {msg}");
@@ -35,6 +64,8 @@ fn fail(msg: &str, captured: &str) -> !
 
 fn main()
 {
+    let mut baseline: u64 = 0;
+    let mut peak: u64 = 0;
     for i in 0..ITERATIONS
     {
         let token = i.to_string();
@@ -69,10 +100,26 @@ fn main()
             fail(&format!("iteration {i}: output line missing"), &out);
         }
 
+        if i + 1 == WARMUP
+        {
+            baseline = used_slots();
+        }
         if (i + 1) % 50 == 0
         {
+            peak = peak.max(used_slots());
             println!("[pipestress-tester] {} / {ITERATIONS} iterations", i + 1);
         }
+    }
+
+    peak = peak.max(used_slots());
+    let growth = peak.saturating_sub(baseline);
+    println!("[pipestress-tester] slots baseline {baseline} peak {peak} growth {growth}");
+    if growth > SLOT_SLACK
+    {
+        fail(
+            &format!("slot growth {growth} exceeds slack {SLOT_SLACK} (pooled-slab leak, #364)"),
+            "",
+        );
     }
 
     println!("[pipestress-tester] PASS");

--- a/programs/terminal/src/input.rs
+++ b/programs/terminal/src/input.rs
@@ -92,8 +92,9 @@ pub fn serial_loop(serial_cap: u32, tx: &Sender<Msg>)
     // Notification the driver kicks on receive-data-ready. Keep `notif` to wait
     // on; send a derived copy to the driver — IPC moves caps, so sending the
     // original would forfeit our wait handle.
-    let Some(notif) = std::os::seraph::object_slab_acquire(120)
-        .and_then(|slab| syscall::cap_create_notification(slab).ok())
+    let Some(notif) = std::os::seraph::object_slab_retype(120, |slab| {
+        syscall::cap_create_notification(slab).ok()
+    })
     else
     {
         std::os::seraph::log!("terminal: serial RX notification create failed");

--- a/programs/threadchurn/src/main.rs
+++ b/programs/threadchurn/src/main.rs
@@ -49,8 +49,13 @@ const REAP_CHURN: u64 = 50;
 const DETACH_BATCH: u64 = 48;
 /// Allowed slot growth between the baseline and the final sample. Absorbs
 /// lazily-created one-time caps (the reaper death `EventQueue`, pooled object
-/// slabs) that may not have settled at the baseline. Steady-state growth is 0.
-const SLACK: u64 = 12;
+/// slabs and their shelf entries) that may not have settled at the baseline.
+/// Steady-state growth is 0: the pooled object slab recycles auto-reclaimed
+/// done-notification bytes in place (#364), so the ~700 spawn-churned
+/// `BIN_128` chunks in this run trigger no steady-state refills. A pool that
+/// never recycles leaks one pool-cap slot per ~63-chunk refill (~11 over this
+/// run), which this bound trips.
+const SLACK: u64 = 4;
 /// Allowed memmgr free-pool drop across the churn (#274). With mid-life slab
 /// reclaim the steady-state footprint stays flat (a passing run stays far under
 /// this bound); a per-spawn slab RAM leak would drop free memory by

--- a/runtime/ruststd/src/os/seraph.rs
+++ b/runtime/ruststd/src/os/seraph.rs
@@ -715,19 +715,29 @@ pub fn namespace_lookup_dir(
     Ok(walked.dir_cap)
 }
 
-/// Return a Memory-cap slot suitable as the source for a `cap_create_*`
-/// retype, with at least `min_bytes` of `available_bytes`.
+/// Retype one kernel object out of the runtime's object-slab machinery.
 ///
 /// `min_bytes` is the raw byte cost of the kernel object the caller is
-/// about to create (e.g. 88 for `Endpoint`); the runtime rounds up to the
-/// kernel's size-class granularity and debits a per-process local ledger.
-/// The returned slot is reused across calls until exhausted, at which
-/// point a fresh slab page is fetched from memmgr.
+/// about to create (e.g. 88 for `Endpoint`, 120 for `Notification`); the
+/// runtime rounds up to the kernel's size-class granularity. `retype` is
+/// called at most once with a Memory-cap slot whose `available_bytes`
+/// covers that class and must perform exactly one `cap_create_*` syscall
+/// against the slot, returning `Some` on success.
 ///
-/// Returns `None` if memmgr is unreachable or refuses the request.
+/// # Closure contract
+///
+/// Sub-page classes run `retype` under the slab pool's spinlock: exactly
+/// one retype syscall and nothing else — no allocation, no blocking, no
+/// panicking, no re-entry into the slab APIs — and the slot must not
+/// escape the closure. Page-aligned classes draw a fresh dedicated grant
+/// whose cap slot the runtime reclaims afterwards (the retyped object
+/// keeps its own ancestor reference on the backing memory).
+///
+/// Returns `None` if memmgr is unreachable, refuses the request, or
+/// `retype` itself fails.
 #[stable(feature = "seraph_ext", since = "1.0.0")]
-pub fn object_slab_acquire(min_bytes: u64) -> Option<u32> {
-    pal_alloc::object_slab_acquire(min_bytes)
+pub fn object_slab_retype<T>(min_bytes: u64, retype: impl FnOnce(u32) -> Option<T>) -> Option<T> {
+    pal_alloc::object_slab_retype(min_bytes, retype)
 }
 
 /// memmgr's current free-pool size in bytes, or `None` if memmgr is

--- a/runtime/ruststd/src/sys/alloc/seraph.rs
+++ b/runtime/ruststd/src/sys/alloc/seraph.rs
@@ -377,20 +377,17 @@ impl Heap {
         }
         // Augment: request 1 page from memmgr, feed to cap_create_aspace
         // in augment mode (target = self_aspace). Single page covers
-        // ~511 new PT-entries' worth of mappable VA.
-        let Some(aug) = slab_acquire_fresh(PAGE_SIZE, 2) else {
-            return false;
-        };
-        let aug_memory = aug.cap;
-        if syscall::cap_create_aspace(aug_memory, self.self_aspace, 1).is_err() {
-            // Augment-mode returns 0 on success; treat any error as fatal
-            // for this grow. Drop the unused (virgin) Memory cap and return its
-            // run to memmgr's pool.
-            let _ = syscall::cap_delete(aug_memory);
-            slab_release_fresh(aug.phys);
+        // ~511 new PT-entries' worth of mappable VA. The AS's PT chunk
+        // holds its own ref on the augment's MemoryObject (`add_chunk` in
+        // `sys_cap_create_aspace`), so the slab machinery reclaims the
+        // source cap slot.
+        if object_slab_retype(PAGE_SIZE, |aug| {
+            syscall::cap_create_aspace(aug, self.self_aspace, 1).ok()
+        })
+        .is_none()
+        {
             return false;
         }
-        // The augment cap is consumed by cap_create_aspace; do not delete.
         syscall::mem_map(memory_cap, self.self_aspace, va, 0, pages, MAP_WRITABLE).is_ok()
     }
 }
@@ -656,6 +653,54 @@ fn slab_acquire_pooled(pool: &ObjectSlab, need: u64, want_pages: u64) -> Option<
     res
 }
 
+/// Retype under `pool`'s lock via `retype`, refilling from memmgr if
+/// exhausted. `need` is the rounded class size; `want_pages` is the request
+/// size used on refill. The local ledger is debited only when `retype`
+/// returns `Some`; see [`object_slab_retype`] for the closure contract.
+fn slab_retype_pooled<T>(
+    pool: &ObjectSlab,
+    need: u64,
+    want_pages: u64,
+    retype: impl FnOnce(u32) -> Option<T>,
+) -> Option<T> {
+    pool.lock.lock();
+    let res = (|| -> Option<T> {
+        // Fast path: existing slab still has room.
+        let cur = pool.cap.load(Ordering::Acquire);
+        let avail = pool.local_avail.load(Ordering::Relaxed);
+        if cur != 0 && avail >= need {
+            let out = retype(cur)?;
+            pool.local_avail.store(avail - need, Ordering::Relaxed);
+            return Some(out);
+        }
+        // Refill: request a fresh cap from memmgr. One attempt — propagate
+        // failure rather than loop on best-effort partial replies.
+        let ep = SLAB_MEMMGR_EP.load(Ordering::Acquire);
+        if ep == 0 {
+            return None;
+        }
+        let (new_cap, cap_pages, _phys) = slab_request_pages(ep, want_pages)?;
+        const ALLOCATOR_METADATA_RESERVE: u64 = 64;
+        let total = cap_pages.saturating_mul(PAGE_SIZE);
+        let usable = total.saturating_sub(ALLOCATOR_METADATA_RESERVE);
+        if usable < need {
+            // memmgr returned a cap too small for this request. Drop it
+            // (the caller will see None and decide what to do); don't
+            // install it as the slab — a smaller cap would just block the
+            // next bigger request the same way.
+            let _ = syscall::cap_delete(new_cap);
+            return None;
+        }
+        pool.cap.store(new_cap, Ordering::Release);
+        pool.local_avail.store(usable, Ordering::Relaxed);
+        let out = retype(new_cap)?;
+        pool.local_avail.store(usable - need, Ordering::Relaxed);
+        Some(out)
+    })();
+    pool.lock.unlock();
+    res
+}
+
 /// A freshly-acquired dedicated Memory cap plus the identity memmgr needs to
 /// reclaim its backing run mid-life. `phys` is the physical base memmgr
 /// reported in the grant reply; pass it to [`slab_release_fresh`] once every
@@ -740,6 +785,61 @@ pub fn object_slab_acquire(min_bytes: u64) -> Option<u32> {
     }
 }
 
+/// Retype one kernel object out of the slab machinery.
+///
+/// `min_bytes` is the raw byte cost of the upcoming retype (e.g. 88 for
+/// `Endpoint`, 120 for `Notification`); it is rounded up to the kernel's
+/// size class. `retype` is called at most once with a Memory-cap slot whose
+/// `available_bytes` covers the class and must perform exactly one
+/// `cap_create_*` syscall against that slot, returning `Some` on success.
+///
+/// # Closure contract
+///
+/// Sub-page classes run `retype` under the pool spinlock: exactly one
+/// retype syscall and nothing else — no allocation, no blocking, no
+/// panicking, no re-entry into the slab APIs — and the slot must not
+/// escape the closure.
+///
+/// Sub-page classes serve from a shared cached pool page, debiting the
+/// pool ledger only when `retype` returns `Some`. Page-aligned classes
+/// draw a fresh dedicated grant: on success the source cap slot is
+/// deleted (the retyped object holds its own ancestor reference on the
+/// grant's MemoryObject, `cap_create_aspace` augment mode included); on
+/// failure the virgin grant is deleted and its run returned to memmgr's
+/// pool.
+///
+/// Returns `None` if memmgr is unreachable, refuses the request, returns
+/// a cap too small for the class, or `retype` itself fails.
+pub fn object_slab_retype<T>(min_bytes: u64, retype: impl FnOnce(u32) -> Option<T>) -> Option<T> {
+    let need = slab_round_to_class(min_bytes);
+    // Pages we need to safely contain `need` plus the kernel's per-cap
+    // allocator metadata. One extra page covers metadata for sub-page
+    // requests; page-aligned requests need their own pages plus one.
+    let want_pages = need.div_ceil(PAGE_SIZE).max(1) + 1;
+    if need <= 128 {
+        slab_retype_pooled(&SLAB_BIN_128, need, want_pages, retype)
+    } else if need <= 512 {
+        slab_retype_pooled(&SLAB_BIN_512, need, want_pages, retype)
+    } else {
+        let grant = slab_acquire_fresh(need, want_pages)?;
+        match retype(grant.cap) {
+            Some(out) => {
+                // The retyped object holds its own ancestor ref on the
+                // grant's MemoryObject; the source slot is dead weight.
+                let _ = syscall::cap_delete(grant.cap);
+                Some(out)
+            }
+            None => {
+                // Retype failed without consuming the grant — the slab is
+                // virgin; reclaim the slot and return the run to memmgr.
+                let _ = syscall::cap_delete(grant.cap);
+                slab_release_fresh(grant.phys);
+                None
+            }
+        }
+    }
+}
+
 /// Like [`object_slab_acquire`] but always takes a fresh, dedicated cap and
 /// returns the [`SlabGrant`] identity, so the caller can return the run to
 /// memmgr's pool mid-life via [`slab_release_fresh`] once every object retyped
@@ -809,20 +909,10 @@ pub fn fund_aspace_pt_budget(self_aspace: u32, region_pages: u64) -> bool {
     }
     let shortfall_pages = (need_bytes - have).div_ceil(PAGE_SIZE).max(1);
 
-    let Some(frame) = object_slab_acquire(shortfall_pages * PAGE_SIZE) else {
-        return false;
-    };
-    if syscall::cap_create_aspace(frame, self_aspace, shortfall_pages).is_err() {
-        let _ = syscall::cap_delete(frame);
-        return false;
-    }
-    // The augment bumped the source MemoryObject's refcount into the AS's PT
-    // chunk (`add_chunk` in `sys_cap_create_aspace`), so the chunk keeps the
-    // backing alive on its own — the `frame` cap slot is now dead weight.
-    // Delete it to reclaim the slot; the bytes are reclaimed with the AS at
-    // process death.
-    let _ = syscall::cap_delete(frame);
-    true
+    object_slab_retype(shortfall_pages * PAGE_SIZE, |frame| {
+        syscall::cap_create_aspace(frame, self_aspace, shortfall_pages).ok()
+    })
+    .is_some()
 }
 
 /// Abort the calling thread via `SYS_THREAD_EXIT`. Used as the allocation-

--- a/runtime/ruststd/src/sys/alloc/seraph.rs
+++ b/runtime/ruststd/src/sys/alloc/seraph.rs
@@ -502,34 +502,88 @@ pub fn heap_is_initialized() -> bool {
 // ── Object slabs ────────────────────────────────────────────────────────────
 //
 // Per-process working Memory caps that back kernel-object retypes
-// (`SYS_CAP_CREATE_*`). Two cached slabs — one per kernel sub-page bin —
-// plus a no-cache path for page-aligned requests. Lazily acquired from
-// memmgr on first call; reused across all retypes until exhausted, then a
-// fresh slab cap is requested.
+// (`SYS_CAP_CREATE_*`). Two cached pool pages — one per kernel sub-page size
+// class — plus a no-cache fresh-grant path for page-aligned requests. Lazily
+// acquired from memmgr on first use.
 //
-// Thread-safe via per-pool spinlocks. The cached `local_avail` mirrors the
-// kernel's `available_bytes` ledger on the slab cap — debited per acquire
-// without crediting on auto-reclaim (the kernel does, against the same cap).
-// When `local_avail` underflows our request, a fresh slab is requested
-// rather than calling `SYS_CAP_INFO`; this trades a small per-process leak
-// of "stuck" bytes on the previous slab for a simpler hot path.
+// All pool state is guarded by a per-pool spinlock, and the retype syscall
+// itself runs under that lock (the [`object_slab_retype`] closure contract).
+// That discipline is what makes the cap lifecycle below sound: no caller can
+// hold an acquired-but-unretyped slot once the lock is released, so the pool
+// may resync its ledger from the kernel and delete or release caps it no
+// longer serves from, without racing a concurrent cap install into a reused
+// slot.
 //
-// Two pools (one per BIN_128 / BIN_512 size class) prevents a 512-byte
+// Ledger: `local_avail` mirrors the kernel's `available_bytes` on the
+// current pool cap, debited per successful retype without a syscall. The
+// kernel credits bytes back to the same cap when retyped objects die
+// (auto-reclaim), so the mirror is always <= the kernel ledger; the slow
+// path re-reads the kernel ledger (`SYS_CAP_INFO`) before paying for a
+// refill, so churn workloads recycle reclaimed bytes instead of consuming
+// fresh grants (#364).
+//
+// Class purity: each pool only ever retypes objects of its own size class,
+// so every freed slot in a pool page is reusable for the next request and
+// kernel `available_bytes >= class` guarantees the retype succeeds.
+//
+// Shelf: a refill displaces a current page that still carries live retypes
+// (a drained page would have served the request after resync). Displaced
+// pages park on a small per-pool shelf, keyed by the grant identity memmgr
+// needs for release. The slow path scans the shelf: a fully-drained entry
+// (`available_bytes == size`) has its cap deleted and its run returned to
+// memmgr (`RELEASE_MEMORY_CAPS`); an entry with room is promoted back to
+// current instead of refilling. When the shelf overflows, the oldest entry
+// is evicted by cap-delete alone — its run stays accounted to this process
+// until process death, the bounded residual strand.
+//
+// Two pools (one per BIN_128 / BIN_512 size class) prevent a 512-byte
 // request from blocking a 128-byte request that could otherwise have been
 // served from the same slab without refresh. Page-aligned requests bypass
 // the cache entirely — every retype consumes ≥ 1 page so caching offers
 // nothing.
 
+/// Retired pool pages a pool can park before evicting (per pool).
+const SLAB_SHELF_SIZE: usize = 4;
+
+/// One displaced pool page: the Memory-cap slot, the grant's physical base
+/// (memmgr's `RELEASE_MEMORY_CAPS` identity), and the cap's total byte size
+/// (fully drained ⇔ kernel `available_bytes == size`).
+#[derive(Clone, Copy)]
+struct ShelfEntry {
+    cap: u32,
+    phys: u64,
+    size: u64,
+}
+
+/// Page-identity state for one pool: the current page's grant identity plus
+/// the shelf of displaced pages, oldest first.
+struct SlabPages {
+    cur_phys: u64,
+    cur_size: u64,
+    shelf: [ShelfEntry; SLAB_SHELF_SIZE],
+    shelf_len: usize,
+}
+
 struct ObjectSlab {
     cap: crate::sync::atomic::AtomicU32,
     local_avail: crate::sync::atomic::AtomicU64,
+    pages: UnsafeCell<SlabPages>,
     lock: SpinLock,
 }
+
+// SAFETY: all access to `pages` is serialised by `lock`.
+unsafe impl Sync for ObjectSlab {}
 
 const fn empty_slab() -> ObjectSlab {
     ObjectSlab {
         cap: crate::sync::atomic::AtomicU32::new(0),
         local_avail: crate::sync::atomic::AtomicU64::new(0),
+        pages: UnsafeCell::new(SlabPages {
+            cur_phys: 0,
+            cur_size: 0,
+            shelf: [ShelfEntry { cap: 0, phys: 0, size: 0 }; SLAB_SHELF_SIZE],
+            shelf_len: 0,
+        }),
         lock: SpinLock::new(),
     }
 }
@@ -605,19 +659,20 @@ pub fn slab_request_pages(memmgr_ep: u32, min_pages: u64) -> Option<(u32, u64, u
     Some((caps[0], reply.word(1), reply.word(1 + returned)))
 }
 
-/// Number of pages to request when refilling the object slab.
-///
-/// The kernel's per-Memory-cap retype allocator carves a small metadata header
-/// (≈ 48 B) out of the cap's `available_bytes` on first use. A page-aligned
-/// retype therefore cannot fit in a single 4-KiB cap; we always grab two
-/// pages so a `PAGE_SIZE`-byte request (e.g. `WaitSet`) succeeds, and a
-/// follow-up sub-page request reuses the remaining ~4 KiB on the same cap.
-const SLAB_REFILL_PAGES: u64 = 2;
+/// Bytes withheld from a fresh grant's local ledger as slack against any
+/// kernel-side retype cost the mirror does not model. The kernel debits
+/// exactly the class-rounded dispatch cost, so this is conservative; the
+/// slow-path resync reads the authoritative ledger anyway. Also why a
+/// page-aligned request asks memmgr for its page count plus one.
+const ALLOCATOR_METADATA_RESERVE: u64 = 64;
 
-/// Retype under `pool`'s lock via `retype`, refilling from memmgr if
-/// exhausted. `need` is the rounded class size; `want_pages` is the request
-/// size used on refill. The local ledger is debited only when `retype`
-/// returns `Some`; see [`object_slab_retype`] for the closure contract.
+/// Retype under `pool`'s lock via `retype`. On an exhausted local ledger:
+/// resync from the kernel's `available_bytes` (recovers auto-reclaimed
+/// bytes), then scan the shelf (release drained retired pages, promote one
+/// with room), and only then refill from memmgr. `need` is the rounded class
+/// size; `want_pages` is the request size used on refill. The local ledger
+/// is debited only when `retype` returns `Some`; see [`object_slab_retype`]
+/// for the closure contract.
 fn slab_retype_pooled<T>(
     pool: &ObjectSlab,
     need: u64,
@@ -626,7 +681,7 @@ fn slab_retype_pooled<T>(
 ) -> Option<T> {
     pool.lock.lock();
     let res = (|| -> Option<T> {
-        // Fast path: existing slab still has room.
+        // Fast path: the local ledger says the current page has room.
         let cur = pool.cap.load(Ordering::Acquire);
         let avail = pool.local_avail.load(Ordering::Relaxed);
         if cur != 0 && avail >= need {
@@ -634,25 +689,111 @@ fn slab_retype_pooled<T>(
             pool.local_avail.store(avail - need, Ordering::Relaxed);
             return Some(out);
         }
+
+        // SAFETY: `pages` is only accessed under `pool.lock`, held here.
+        let pages = unsafe { &mut *pool.pages.get() };
+
+        // Resync: the kernel credits auto-reclaimed bytes back to the cap
+        // when retyped objects die; the mirror only debits. Re-read the
+        // authoritative ledger before paying for a refill. Sound because
+        // every debit against a pool cap happens under this lock and
+        // concurrent deletions only credit.
+        if cur != 0 {
+            let avail =
+                syscall::cap_info(cur, syscall_abi::CAP_INFO_MEMORY_AVAILABLE).unwrap_or(0);
+            pool.local_avail.store(avail, Ordering::Relaxed);
+            if avail >= need {
+                let out = retype(cur)?;
+                pool.local_avail.store(avail - need, Ordering::Relaxed);
+                return Some(out);
+            }
+        }
+
+        // Shelf scan: release fully-drained retired pages back to memmgr and
+        // pick the first entry with room as a promotion candidate (a drained
+        // candidate is reused rather than released — strictly cheaper than
+        // releasing it and requesting a fresh grant).
+        let mut avails = [0u64; SLAB_SHELF_SIZE];
+        for (i, slot) in avails.iter_mut().enumerate().take(pages.shelf_len) {
+            *slot = syscall::cap_info(pages.shelf[i].cap, syscall_abi::CAP_INFO_MEMORY_AVAILABLE)
+                .unwrap_or(0);
+        }
+        let mut promote: Option<(ShelfEntry, u64)> = None;
+        let mut keep = 0;
+        for i in 0..pages.shelf_len {
+            let entry = pages.shelf[i];
+            if promote.is_none() && avails[i] >= need {
+                promote = Some((entry, avails[i]));
+                continue;
+            }
+            if avails[i] == entry.size {
+                // Fully drained: no live retype remains, so the run can go
+                // back to memmgr's pool. Delete the cap first per the
+                // RELEASE_MEMORY_CAPS contract.
+                let _ = syscall::cap_delete(entry.cap);
+                slab_release_fresh(entry.phys);
+                continue;
+            }
+            pages.shelf[keep] = entry;
+            keep += 1;
+        }
+        pages.shelf_len = keep;
+
+        if let Some((entry, entry_avail)) = promote {
+            // Swap: park the displaced current page in the slot the
+            // candidate vacated (it is pinned by live retypes — a drained
+            // current page would have served at resync) and serve from the
+            // promoted page.
+            if cur != 0 {
+                pages.shelf[pages.shelf_len] =
+                    ShelfEntry { cap: cur, phys: pages.cur_phys, size: pages.cur_size };
+                pages.shelf_len += 1;
+            }
+            pool.cap.store(entry.cap, Ordering::Release);
+            pages.cur_phys = entry.phys;
+            pages.cur_size = entry.size;
+            pool.local_avail.store(entry_avail, Ordering::Relaxed);
+            let out = retype(entry.cap)?;
+            pool.local_avail.store(entry_avail - need, Ordering::Relaxed);
+            return Some(out);
+        }
+
         // Refill: request a fresh cap from memmgr. One attempt — propagate
         // failure rather than loop on best-effort partial replies.
         let ep = SLAB_MEMMGR_EP.load(Ordering::Acquire);
         if ep == 0 {
             return None;
         }
-        let (new_cap, cap_pages, _phys) = slab_request_pages(ep, want_pages)?;
-        const ALLOCATOR_METADATA_RESERVE: u64 = 64;
+        let (new_cap, cap_pages, new_phys) = slab_request_pages(ep, want_pages)?;
         let total = cap_pages.saturating_mul(PAGE_SIZE);
         let usable = total.saturating_sub(ALLOCATOR_METADATA_RESERVE);
         if usable < need {
-            // memmgr returned a cap too small for this request. Drop it
-            // (the caller will see None and decide what to do); don't
-            // install it as the slab — a smaller cap would just block the
-            // next bigger request the same way.
+            // memmgr returned a cap too small for this request. The grant is
+            // virgin — reclaim the slot and return the run rather than
+            // stranding it in memmgr's per-process accounting.
             let _ = syscall::cap_delete(new_cap);
+            slab_release_fresh(new_phys);
             return None;
         }
+        // Retire the displaced current page. It is pinned by live retypes
+        // (see above), so it cannot be released here; the shelf scan frees
+        // it once its objects die. On overflow evict the oldest entry by
+        // cap-delete alone: its run stays accounted to this process until
+        // process death — the bounded residual strand.
+        if cur != 0 {
+            if pages.shelf_len == SLAB_SHELF_SIZE {
+                let evicted = pages.shelf[0];
+                let _ = syscall::cap_delete(evicted.cap);
+                pages.shelf.copy_within(1.., 0);
+                pages.shelf_len -= 1;
+            }
+            pages.shelf[pages.shelf_len] =
+                ShelfEntry { cap: cur, phys: pages.cur_phys, size: pages.cur_size };
+            pages.shelf_len += 1;
+        }
         pool.cap.store(new_cap, Ordering::Release);
+        pages.cur_phys = new_phys;
+        pages.cur_size = total;
         pool.local_avail.store(usable, Ordering::Relaxed);
         let out = retype(new_cap)?;
         pool.local_avail.store(usable - need, Ordering::Relaxed);
@@ -683,7 +824,6 @@ fn slab_acquire_fresh(need: u64, want_pages: u64) -> Option<SlabGrant> {
         return None;
     }
     let (new_cap, cap_pages, phys) = slab_request_pages(ep, want_pages)?;
-    const ALLOCATOR_METADATA_RESERVE: u64 = 64;
     let total = cap_pages.saturating_mul(PAGE_SIZE);
     if total.saturating_sub(ALLOCATOR_METADATA_RESERVE) < need {
         // Too small for this request. Delete the inner cap and return the run
@@ -746,9 +886,8 @@ pub fn slab_release_fresh(phys: u64) {
 /// a cap too small for the class, or `retype` itself fails.
 pub fn object_slab_retype<T>(min_bytes: u64, retype: impl FnOnce(u32) -> Option<T>) -> Option<T> {
     let need = slab_round_to_class(min_bytes);
-    // Pages we need to safely contain `need` plus the kernel's per-cap
-    // allocator metadata. One extra page covers metadata for sub-page
-    // requests; page-aligned requests need their own pages plus one.
+    // One page over the class's own page count, so `need` still fits after
+    // the ledger withholds `ALLOCATOR_METADATA_RESERVE` from the grant.
     let want_pages = need.div_ceil(PAGE_SIZE).max(1) + 1;
     if need <= 128 {
         slab_retype_pooled(&SLAB_BIN_128, need, want_pages, retype)

--- a/runtime/ruststd/src/sys/alloc/seraph.rs
+++ b/runtime/ruststd/src/sys/alloc/seraph.rs
@@ -673,6 +673,11 @@ const ALLOCATOR_METADATA_RESERVE: u64 = 64;
 /// size; `want_pages` is the request size used on refill. The local ledger
 /// is debited only when `retype` returns `Some`; see [`object_slab_retype`]
 /// for the closure contract.
+///
+/// One function over the 100-line guideline by design: every step is one
+/// state machine over pool state whose invariants hold only while the pool
+/// lock is held, and splitting it would spread that lock-held contract
+/// across function boundaries.
 fn slab_retype_pooled<T>(
     pool: &ObjectSlab,
     need: u64,
@@ -712,7 +717,8 @@ fn slab_retype_pooled<T>(
         // Shelf scan: release fully-drained retired pages back to memmgr and
         // pick the first entry with room as a promotion candidate (a drained
         // candidate is reused rather than released — strictly cheaper than
-        // releasing it and requesting a fresh grant).
+        // releasing it and requesting a fresh grant). A failed probe reads
+        // as 0: the entry defers (kept, not promoted, never mis-freed).
         let mut avails = [0u64; SLAB_SHELF_SIZE];
         for (i, slot) in avails.iter_mut().enumerate().take(pages.shelf_len) {
             *slot = syscall::cap_info(pages.shelf[i].cap, syscall_abi::CAP_INFO_MEMORY_AVAILABLE)

--- a/runtime/ruststd/src/sys/alloc/seraph.rs
+++ b/runtime/ruststd/src/sys/alloc/seraph.rs
@@ -614,45 +614,6 @@ pub fn slab_request_pages(memmgr_ep: u32, min_pages: u64) -> Option<(u32, u64, u
 /// follow-up sub-page request reuses the remaining ~4 KiB on the same cap.
 const SLAB_REFILL_PAGES: u64 = 2;
 
-/// Acquire from `pool`, refilling from memmgr if exhausted. `need` is the
-/// rounded class size; `pool` is the matching cached slab; `want_pages`
-/// is the request size used on refill.
-fn slab_acquire_pooled(pool: &ObjectSlab, need: u64, want_pages: u64) -> Option<u32> {
-    pool.lock.lock();
-    let res = (|| -> Option<u32> {
-        // Fast path: existing slab still has room.
-        let cur = pool.cap.load(Ordering::Acquire);
-        let avail = pool.local_avail.load(Ordering::Relaxed);
-        if cur != 0 && avail >= need {
-            pool.local_avail.store(avail - need, Ordering::Relaxed);
-            return Some(cur);
-        }
-        // Refill: request a fresh cap from memmgr. One attempt — propagate
-        // failure rather than loop on best-effort partial replies.
-        let ep = SLAB_MEMMGR_EP.load(Ordering::Acquire);
-        if ep == 0 {
-            return None;
-        }
-        let (new_cap, cap_pages, _phys) = slab_request_pages(ep, want_pages)?;
-        const ALLOCATOR_METADATA_RESERVE: u64 = 64;
-        let total = cap_pages.saturating_mul(PAGE_SIZE);
-        let usable = total.saturating_sub(ALLOCATOR_METADATA_RESERVE);
-        if usable < need {
-            // memmgr returned a cap too small for this request. Drop it
-            // (the caller will see None and decide what to do); don't
-            // install it as the slab — a smaller cap would just block the
-            // next bigger request the same way.
-            let _ = syscall::cap_delete(new_cap);
-            return None;
-        }
-        pool.cap.store(new_cap, Ordering::Release);
-        pool.local_avail.store(usable - need, Ordering::Relaxed);
-        Some(new_cap)
-    })();
-    pool.lock.unlock();
-    res
-}
-
 /// Retype under `pool`'s lock via `retype`, refilling from memmgr if
 /// exhausted. `need` is the rounded class size; `want_pages` is the request
 /// size used on refill. The local ledger is debited only when `retype`
@@ -758,33 +719,6 @@ pub fn slab_release_fresh(phys: u64) {
     let _ = unsafe { ipc::ipc_call(ep, &msg, ipc_buf) };
 }
 
-/// Return a Memory-cap slot with at least `min_bytes` of `available_bytes`
-/// for retype.
-///
-/// Caller passes the raw byte cost of the upcoming retype (e.g. 88 for
-/// `Endpoint`); the function rounds up to the matching size class and
-/// dispatches to a per-class cached slab (sub-page) or a fresh dedicated
-/// cap (page-aligned). The returned slot index is fed directly to
-/// `cap_create_*`.
-///
-/// Returns `None` if memmgr is unreachable, refuses the request, or
-/// returns a cap too small to satisfy the request after refill (memmgr's
-/// best-effort policy may shrink the reply when the pool is fragmented).
-pub fn object_slab_acquire(min_bytes: u64) -> Option<u32> {
-    let need = slab_round_to_class(min_bytes);
-    // Pages we need to safely contain `need` plus the kernel's per-cap
-    // allocator metadata. One extra page covers metadata for sub-page
-    // requests; page-aligned requests need their own pages plus one.
-    let want_pages = need.div_ceil(PAGE_SIZE).max(1) + 1;
-    if need <= 128 {
-        slab_acquire_pooled(&SLAB_BIN_128, need, want_pages)
-    } else if need <= 512 {
-        slab_acquire_pooled(&SLAB_BIN_512, need, want_pages)
-    } else {
-        slab_acquire_fresh(need, want_pages).map(|g| g.cap)
-    }
-}
-
 /// Retype one kernel object out of the slab machinery.
 ///
 /// `min_bytes` is the raw byte cost of the upcoming retype (e.g. 88 for
@@ -840,12 +774,13 @@ pub fn object_slab_retype<T>(min_bytes: u64, retype: impl FnOnce(u32) -> Option<
     }
 }
 
-/// Like [`object_slab_acquire`] but always takes a fresh, dedicated cap and
-/// returns the [`SlabGrant`] identity, so the caller can return the run to
-/// memmgr's pool mid-life via [`slab_release_fresh`] once every object retyped
-/// from the slab is deleted. For a per-unit-of-work retype (e.g. one Thread
-/// slab per spawn) this keeps the process's memmgr-pool footprint bounded
-/// instead of leaking a run per iteration until process death.
+/// Acquire a fresh, dedicated Memory cap sized for `min_bytes` and return
+/// the [`SlabGrant`] identity, so the caller can manage the retype itself
+/// and return the run to memmgr's pool mid-life via [`slab_release_fresh`]
+/// once every object retyped from the slab is deleted. For a
+/// per-unit-of-work retype (e.g. one Thread slab per spawn) this keeps the
+/// process's memmgr-pool footprint bounded instead of leaking a run per
+/// iteration until process death.
 pub fn object_slab_acquire_fresh(min_bytes: u64) -> Option<SlabGrant> {
     let need = slab_round_to_class(min_bytes);
     let want_pages = need.div_ceil(PAGE_SIZE).max(1) + 1;

--- a/runtime/ruststd/src/sys/fs/release_handler.rs
+++ b/runtime/ruststd/src/sys/fs/release_handler.rs
@@ -85,19 +85,10 @@ pub(super) fn ensure_started() -> io::Result<&'static ReleaseState>
     })?;
     let aspace = info.self_aspace;
 
-    let slab = crate::sys::alloc::seraph::object_slab_acquire(88).ok_or_else(|| {
-        io::Error::other("seraph fs: object_slab_acquire (release ep) failed")
-    })?;
-    let release_ep = match syscall::cap_create_endpoint(slab)
-    {
-        Ok(c) => c,
-        Err(_) =>
-        {
-            return Err(io::Error::other(
-                "seraph fs: cap_create_endpoint (release) failed",
-            ));
-        }
-    };
+    let release_ep = crate::sys::alloc::seraph::object_slab_retype(88, |slab| {
+        syscall::cap_create_endpoint(slab).ok()
+    })
+    .ok_or_else(|| io::Error::other("seraph fs: cap_create_endpoint (release) failed"))?;
 
     // get_or_init runs the closure under a mutex, so only one
     // initialiser publishes to STATE. If we lose the race, our endpoint

--- a/runtime/ruststd/src/sys/pipe/seraph.rs
+++ b/runtime/ruststd/src/sys/pipe/seraph.rs
@@ -324,15 +324,13 @@ impl Pipe {
             SpscHeader::init(parent_va as *mut SpscHeader, RING_CAPACITY);
         }
 
-        let data_slab = crate::sys::alloc::seraph::object_slab_acquire(120).ok_or_else(|| {
-            // Tear down what we have so far before reporting.
-            // Allocator failure here is rare (memmgr unreachable / OOM).
-            io::Error::other("seraph pipe: object_slab_acquire (data) failed")
-        });
-        let data_notification = match data_slab.and_then(|slab| {
-            syscall::cap_create_notification(slab)
-                .map_err(|_| io::Error::other("seraph pipe: cap_create_notification (data) failed"))
-        }) {
+        // Allocator failure here is rare (memmgr unreachable / OOM); tear
+        // down what we have so far before reporting.
+        let data_notification = match crate::sys::alloc::seraph::object_slab_retype(120, |slab| {
+            syscall::cap_create_notification(slab).ok()
+        })
+        .ok_or_else(|| io::Error::other("seraph pipe: cap_create_notification (data) failed"))
+        {
             Ok(s) => s,
             Err(e) => {
                 let _ = syscall::mem_unmap(aspace, parent_va, 1);
@@ -342,13 +340,11 @@ impl Pipe {
                 return Err(e);
             }
         };
-        let space_slab = crate::sys::alloc::seraph::object_slab_acquire(120).ok_or_else(|| {
-            io::Error::other("seraph pipe: object_slab_acquire (space) failed")
-        });
-        let space_notification = match space_slab.and_then(|slab| {
-            syscall::cap_create_notification(slab)
-                .map_err(|_| io::Error::other("seraph pipe: cap_create_notification (space) failed"))
-        }) {
+        let space_notification = match crate::sys::alloc::seraph::object_slab_retype(120, |slab| {
+            syscall::cap_create_notification(slab).ok()
+        })
+        .ok_or_else(|| io::Error::other("seraph pipe: cap_create_notification (space) failed"))
+        {
             Ok(s) => s,
             Err(e) => {
                 let _ = syscall::cap_delete(data_notification);

--- a/runtime/ruststd/src/sys/process/seraph.rs
+++ b/runtime/ruststd/src/sys/process/seraph.rs
@@ -359,9 +359,10 @@ impl Command {
         // threads (not just the main thread) posts the fault class to this
         // queue and `wait()` returns.
         let destroy_msg = ipc::IpcMessage::new(procmgr_labels::DESTROY_PROCESS);
-        let death_eq = crate::sys::alloc::seraph::object_slab_acquire(88)
-            .and_then(|slab| syscall::event_queue_create(slab, 4).ok())
-            .ok_or_else(|| {
+        let death_eq = crate::sys::alloc::seraph::object_slab_retype(88, |slab| {
+            syscall::event_queue_create(slab, 4).ok()
+        })
+        .ok_or_else(|| {
                 // The child does not exist yet; just drop the file cap we
                 // would otherwise transfer to procmgr.
                 let _ = syscall::cap_delete(file_cap);
@@ -543,10 +544,13 @@ impl Command {
             || child_stderr_pipe.is_some();
         let bridge = if any_pipe {
             let bridge_setup = (|| -> io::Result<Bridge> {
-                let completion_slab = crate::sys::alloc::seraph::object_slab_acquire(120)
-                    .ok_or_else(|| io::Error::other("object_slab_acquire (completion) failed"))?;
-                let completion_notification = syscall::cap_create_notification(completion_slab)
-                    .map_err(|_| io::Error::other("cap_create_notification for completion failed"))?;
+                let completion_notification =
+                    crate::sys::alloc::seraph::object_slab_retype(120, |slab| {
+                        syscall::cap_create_notification(slab).ok()
+                    })
+                    .ok_or_else(|| {
+                        io::Error::other("cap_create_notification for completion failed")
+                    })?;
                 let exit_reason = Arc::new(AtomicU64::new(0));
                 let peer_dead = Arc::new(AtomicBool::new(false));
 

--- a/runtime/ruststd/src/sys/sync/condvar/seraph.rs
+++ b/runtime/ruststd/src/sys/sync/condvar/seraph.rs
@@ -114,10 +114,9 @@ fn ensure_notification(slot: &AtomicU32) -> u32 {
     if existing != 0 {
         return existing;
     }
-    let Some(slab) = crate::sys::alloc::seraph::object_slab_acquire(120) else {
-        return 0;
-    };
-    let Ok(fresh) = syscall::cap_create_notification(slab) else {
+    let Some(fresh) = crate::sys::alloc::seraph::object_slab_retype(120, |slab| {
+        syscall::cap_create_notification(slab).ok()
+    }) else {
         return 0;
     };
     match slot.compare_exchange(0, fresh, AcqRel, Acquire) {

--- a/runtime/ruststd/src/sys/sync/mutex/seraph.rs
+++ b/runtime/ruststd/src/sys/sync/mutex/seraph.rs
@@ -121,10 +121,9 @@ fn ensure_notification(slot: &AtomicU32) -> u32 {
     if existing != 0 {
         return existing;
     }
-    let Some(slab) = crate::sys::alloc::seraph::object_slab_acquire(120) else {
-        return 0;
-    };
-    let Ok(fresh) = syscall::cap_create_notification(slab) else {
+    let Some(fresh) = crate::sys::alloc::seraph::object_slab_retype(120, |slab| {
+        syscall::cap_create_notification(slab).ok()
+    }) else {
         return 0;
     };
     match slot.compare_exchange(0, fresh, AcqRel, Acquire) {

--- a/runtime/ruststd/src/sys/sync/once/seraph.rs
+++ b/runtime/ruststd/src/sys/sync/once/seraph.rs
@@ -221,10 +221,9 @@ fn ensure_notification(slot: &AtomicU32) -> u32 {
     if existing != 0 {
         return existing;
     }
-    let Some(slab) = crate::sys::alloc::seraph::object_slab_acquire(120) else {
-        return 0;
-    };
-    let Ok(fresh) = syscall::cap_create_notification(slab) else {
+    let Some(fresh) = crate::sys::alloc::seraph::object_slab_retype(120, |slab| {
+        syscall::cap_create_notification(slab).ok()
+    }) else {
         return 0;
     };
     match slot.compare_exchange(0, fresh, AcqRel, Acquire) {

--- a/runtime/ruststd/src/sys/sync/rwlock/seraph.rs
+++ b/runtime/ruststd/src/sys/sync/rwlock/seraph.rs
@@ -173,10 +173,9 @@ fn ensure_notification(slot: &AtomicU32) -> u32 {
     if existing != 0 {
         return existing;
     }
-    let Some(slab) = crate::sys::alloc::seraph::object_slab_acquire(120) else {
-        return 0;
-    };
-    let Ok(fresh) = syscall::cap_create_notification(slab) else {
+    let Some(fresh) = crate::sys::alloc::seraph::object_slab_retype(120, |slab| {
+        syscall::cap_create_notification(slab).ok()
+    }) else {
         return 0;
     };
     match slot.compare_exchange(0, fresh, AcqRel, Acquire) {

--- a/runtime/ruststd/src/sys/sync/thread_parking/seraph.rs
+++ b/runtime/ruststd/src/sys/sync/thread_parking/seraph.rs
@@ -115,10 +115,9 @@ fn ensure_notification(slot: &AtomicU32) -> u32 {
     if existing != 0 {
         return existing;
     }
-    let Some(slab) = crate::sys::alloc::seraph::object_slab_acquire(120) else {
-        return 0;
-    };
-    let Ok(fresh) = syscall::cap_create_notification(slab) else {
+    let Some(fresh) = crate::sys::alloc::seraph::object_slab_retype(120, |slab| {
+        syscall::cap_create_notification(slab).ok()
+    }) else {
         return 0;
     };
     match slot.compare_exchange(0, fresh, AcqRel, Acquire) {

--- a/runtime/ruststd/src/sys/thread/seraph.rs
+++ b/runtime/ruststd/src/sys/thread/seraph.rs
@@ -228,9 +228,9 @@ impl Thread {
             }
         };
 
-        let done_notification = match crate::sys::alloc::seraph::object_slab_acquire(120)
-            .and_then(|slab| syscall::cap_create_notification(slab).ok())
-        {
+        let done_notification = match crate::sys::alloc::seraph::object_slab_retype(120, |slab| {
+            syscall::cap_create_notification(slab).ok()
+        }) {
             Some(cap) => cap,
             None => {
                 // SAFETY: heap allocations owned by this function.
@@ -585,22 +585,9 @@ mod reaper {
         // EventQueue retype size = 80 + (capacity + 1) * 8 bytes; over-request a
         // little so the slab definitely covers it (fresh dedicated cap path).
         let want = (u64::from(EQ_CAPACITY) + 1) * 8 + 256;
-        let made = match crate::sys::alloc::seraph::object_slab_acquire(want) {
-            Some(slab) => match syscall::event_queue_create(slab, EQ_CAPACITY) {
-                // The EventQueue holds its own ancestor ref on the slab's
-                // MemoryObject, so the slab cap slot is now dead weight.
-                Ok(eq) => {
-                    let _ = syscall::cap_delete(slab);
-                    Some(eq)
-                }
-                // create failed without consuming the slab — reclaim its slot.
-                Err(_) => {
-                    let _ = syscall::cap_delete(slab);
-                    None
-                }
-            },
-            None => None,
-        };
+        let made = crate::sys::alloc::seraph::object_slab_retype(want, |slab| {
+            syscall::event_queue_create(slab, EQ_CAPACITY).ok()
+        });
         let Some(eq) = made else {
             return 0;
         };

--- a/services/devmgr/src/caps.rs
+++ b/services/devmgr/src/caps.rs
@@ -462,8 +462,8 @@ pub fn bootstrap_caps(info: &StartupInfo, ipc_buf: *mut u64) -> Option<DevmgrCap
     bootstrap_round1(creator, ipc_buf, &mut caps)?;
     bootstrap_rounds(creator, ipc_buf, &mut caps)?;
 
-    let slab = std::os::seraph::object_slab_acquire(88)?;
-    caps.self_bootstrap_ep = syscall::cap_create_endpoint(slab).ok()?;
+    caps.self_bootstrap_ep =
+        std::os::seraph::object_slab_retype(88, |slab| syscall::cap_create_endpoint(slab).ok())?;
 
     Some(caps)
 }

--- a/services/devmgr/src/main.rs
+++ b/services/devmgr/src/main.rs
@@ -112,9 +112,9 @@ fn main() -> !
     unreserve_pages(ecam_range);
 
     // Create block device service endpoint for the driver to receive on.
-    let blk_ep = std::os::seraph::object_slab_acquire(88)
-        .and_then(|slab| syscall::cap_create_endpoint(slab).ok())
-        .unwrap_or(0);
+    let blk_ep =
+        std::os::seraph::object_slab_retype(88, |slab| syscall::cap_create_endpoint(slab).ok())
+            .unwrap_or(0);
     if blk_ep == 0
     {
         std::os::seraph::log!("failed to create block device endpoint");
@@ -1576,9 +1576,9 @@ fn spawn_virtio_input_from_disk(
         return None;
     };
 
-    let input_ep = std::os::seraph::object_slab_acquire(88)
-        .and_then(|slab| syscall::cap_create_endpoint(slab).ok())
-        .unwrap_or(0);
+    let input_ep =
+        std::os::seraph::object_slab_retype(88, |slab| syscall::cap_create_endpoint(slab).ok())
+            .unwrap_or(0);
     if input_ep == 0
     {
         std::os::seraph::log!("virtio-input: failed to create service endpoint");
@@ -1643,9 +1643,9 @@ fn spawn_serial(caps: &mut caps::DevmgrCaps, uart_irq: u32, ipc_buf: *mut u64) -
 
     // devmgr-owned service endpoint: the driver receives on a RIGHTS_ALL
     // copy; devmgr keeps the original to mint client SEND caps on query.
-    let serial_ep = std::os::seraph::object_slab_acquire(88)
-        .and_then(|slab| syscall::cap_create_endpoint(slab).ok())
-        .unwrap_or(0);
+    let serial_ep =
+        std::os::seraph::object_slab_retype(88, |slab| syscall::cap_create_endpoint(slab).ok())
+            .unwrap_or(0);
     if serial_ep == 0
     {
         std::os::seraph::log!("serial: failed to create service endpoint");
@@ -1725,9 +1725,9 @@ fn spawn_framebuffer(
     let end_aligned = (span + 0xFFF) & !0xFFF;
     let mmio_size = end_aligned - base_aligned;
 
-    let fb_ep = std::os::seraph::object_slab_acquire(88)
-        .and_then(|slab| syscall::cap_create_endpoint(slab).ok())
-        .unwrap_or(0);
+    let fb_ep =
+        std::os::seraph::object_slab_retype(88, |slab| syscall::cap_create_endpoint(slab).ok())
+            .unwrap_or(0);
     if fb_ep == 0
     {
         std::os::seraph::log!("framebuffer: failed to create service endpoint");
@@ -1850,9 +1850,9 @@ fn spawn_rtc_from_disk(
         return None;
     };
 
-    let rtc_ep = std::os::seraph::object_slab_acquire(88)
-        .and_then(|slab| syscall::cap_create_endpoint(slab).ok())
-        .unwrap_or(0);
+    let rtc_ep =
+        std::os::seraph::object_slab_retype(88, |slab| syscall::cap_create_endpoint(slab).ok())
+            .unwrap_or(0);
     if rtc_ep == 0
     {
         std::os::seraph::log!("rtc: failed to create service endpoint");
@@ -1922,12 +1922,12 @@ fn test_spawn_orphan(
     // Throwaway service + hw endpoints handed to the child in round 1. Ownership
     // of `hw_cap` transfers to `spawn_simple_device` (moved into the child or
     // deleted on failure); `service_ep` is retained here and released below.
-    let service_ep = std::os::seraph::object_slab_acquire(88)
-        .and_then(|slab| syscall::cap_create_endpoint(slab).ok())
-        .unwrap_or(0);
-    let hw_cap = std::os::seraph::object_slab_acquire(88)
-        .and_then(|slab| syscall::cap_create_endpoint(slab).ok())
-        .unwrap_or(0);
+    let service_ep =
+        std::os::seraph::object_slab_retype(88, |slab| syscall::cap_create_endpoint(slab).ok())
+            .unwrap_or(0);
+    let hw_cap =
+        std::os::seraph::object_slab_retype(88, |slab| syscall::cap_create_endpoint(slab).ok())
+            .unwrap_or(0);
     // Non-zero query endpoint forces the two-round protocol so round 2 is reached.
     let query_ep =
         syscall::cap_derive_badge(caps.registry_ep, syscall::RIGHTS_SEND, QUERY_BADGE).unwrap_or(0);

--- a/services/drivers/virtio/blk/src/main.rs
+++ b/services/drivers/virtio/blk/src/main.rs
@@ -1034,8 +1034,9 @@ fn main() -> !
         std::os::seraph::log!("no IRQ cap, cannot operate");
         syscall::thread_exit();
     }
-    let Some(irq_notification) = std::os::seraph::object_slab_acquire(120)
-        .and_then(|slab| syscall::cap_create_notification(slab).ok())
+    let Some(irq_notification) = std::os::seraph::object_slab_retype(120, |slab| {
+        syscall::cap_create_notification(slab).ok()
+    })
     else
     {
         std::os::seraph::log!("failed to create IRQ notification");

--- a/services/drivers/virtio/input/src/main.rs
+++ b/services/drivers/virtio/input/src/main.rs
@@ -525,8 +525,9 @@ fn main() -> !
     // the read path polls the eventq regardless. When an IRQ cap is present, bind
     // the notification to it for low-latency wakeups; otherwise the bounded wait
     // degrades to timed polling.
-    let Some(irq_notification) = std::os::seraph::object_slab_acquire(120)
-        .and_then(|slab| syscall::cap_create_notification(slab).ok())
+    let Some(irq_notification) = std::os::seraph::object_slab_retype(120, |slab| {
+        syscall::cap_create_notification(slab).ok()
+    })
     else
     {
         std::os::seraph::log!("failed to create notification");

--- a/services/logd/src/main.rs
+++ b/services/logd/src/main.rs
@@ -206,25 +206,23 @@ fn create_death_eq() -> Option<u32>
     const MAX_DEATHS_PER_BURST: u32 = 64;
     // Bytes: 24 wrapper + 56 state + (capacity + 1) * 8 ring.
     let slab_bytes: u64 = 24 + 56 + (u64::from(MAX_DEATHS_PER_BURST) + 1) * 8;
-    let slab = std::os::seraph::object_slab_acquire(slab_bytes)?;
-    syscall::event_queue_create(slab, MAX_DEATHS_PER_BURST).ok()
+    std::os::seraph::object_slab_retype(slab_bytes, |slab| {
+        syscall::event_queue_create(slab, MAX_DEATHS_PER_BURST).ok()
+    })
 }
 
 /// Build a 2-member wait set: the log endpoint (`WS_BADGE_LOG`) and
 /// the death event queue (`WS_BADGE_DEATH`).
 fn create_wait_set(log_ep_recv: u32, death_eq: u32) -> Option<u32>
 {
-    let slab = std::os::seraph::object_slab_acquire(4096)?;
-    let ws = match syscall::wait_set_create(slab)
+    let Some(ws) =
+        std::os::seraph::object_slab_retype(4096, |slab| syscall::wait_set_create(slab).ok())
+    else
     {
-        Ok(c) => c,
-        Err(e) =>
-        {
-            let mut buf = SerialFmt::new();
-            let _ = write!(buf, "wait_set_create err={e} slab={slab}");
-            buf.flush_self_log();
-            return None;
-        }
+        let mut buf = SerialFmt::new();
+        let _ = write!(buf, "wait_set_create failed");
+        buf.flush_self_log();
+        return None;
     };
     if let Err(e) = syscall::wait_set_add(ws, log_ep_recv, WS_BADGE_LOG)
     {

--- a/services/procmgr/src/main.rs
+++ b/services/procmgr/src/main.rs
@@ -111,22 +111,15 @@ fn main() -> !
     // `MAX_PROCESSES * 2` to absorb a simultaneous-crash burst without
     // dropping notifications between drain calls.
     let death_eq_slab_bytes: u64 = 24 + 56 + ((process::MAX_PROCESSES as u64 * 2) + 1) * 8;
-    let Some(eq_slab) = std::os::seraph::object_slab_acquire(death_eq_slab_bytes)
+    let Some(death_eq) = std::os::seraph::object_slab_retype(death_eq_slab_bytes, |slab| {
+        syscall::event_queue_create(slab, (process::MAX_PROCESSES as u32) * 2).ok()
+    })
     else
     {
         syscall::thread_exit();
     };
-    let Ok(death_eq) = syscall::event_queue_create(eq_slab, (process::MAX_PROCESSES as u32) * 2)
-    else
-    {
-        syscall::thread_exit();
-    };
-    let Some(ws_slab) = std::os::seraph::object_slab_acquire(4096)
-    else
-    {
-        syscall::thread_exit();
-    };
-    let Ok(ws_cap) = syscall::wait_set_create(ws_slab)
+    let Some(ws_cap) =
+        std::os::seraph::object_slab_retype(4096, |slab| syscall::wait_set_create(slab).ok())
     else
     {
         syscall::thread_exit();

--- a/services/svcmgr/src/definitions/launch.rs
+++ b/services/svcmgr/src/definitions/launch.rs
@@ -224,7 +224,8 @@ fn assemble_provided_boot_caps(
     }
     else
     {
-        let Ok(ep) = syscall::cap_create_endpoint(ctx.endpoint_slab)
+        let Some(ep) =
+            std::os::seraph::object_slab_retype(88, |slab| syscall::cap_create_endpoint(slab).ok())
         else
         {
             std::os::seraph::log!("launch {}: provider endpoint create failed", def.name);

--- a/services/svcmgr/src/main.rs
+++ b/services/svcmgr/src/main.rs
@@ -131,13 +131,8 @@ fn main() -> !
         halt_loop();
     }
 
-    let Some(ws_slab) = std::os::seraph::object_slab_acquire(512)
-    else
-    {
-        std::os::seraph::log!("failed to acquire memory cap for wait set");
-        halt_loop();
-    };
-    let Ok(ws_cap) = syscall::wait_set_create(ws_slab)
+    let Some(ws_cap) =
+        std::os::seraph::object_slab_retype(512, |slab| syscall::wait_set_create(slab).ok())
     else
     {
         std::os::seraph::log!("failed to create wait set");
@@ -150,26 +145,12 @@ fn main() -> !
     // `cap::retype::event_queue_raw_bytes`: 24 wrapper + 56 state +
     // (capacity + 1) * 8 ring.
     let deaths_eq_slab_bytes: u64 = 24 + 56 + ((MAX_SERVICES as u64 * 2) + 1) * 8;
-    let Some(eq_slab) = std::os::seraph::object_slab_acquire(deaths_eq_slab_bytes)
-    else
-    {
-        std::os::seraph::log!("failed to acquire memory cap for deaths event queue");
-        halt_loop();
-    };
-    let Ok(deaths_eq) = syscall::event_queue_create(eq_slab, (MAX_SERVICES as u32) * 2)
+    let Some(deaths_eq) = std::os::seraph::object_slab_retype(deaths_eq_slab_bytes, |slab| {
+        syscall::event_queue_create(slab, (MAX_SERVICES as u32) * 2).ok()
+    })
     else
     {
         std::os::seraph::log!("failed to create deaths event queue");
-        halt_loop();
-    };
-
-    // Memory-cap slab svcmgr retypes provider service endpoints from. One page
-    // backs every `provides = ...` service (each `cap_create_endpoint`
-    // carves an endpoint object from it); the provider set is small.
-    let Some(endpoint_slab) = std::os::seraph::object_slab_acquire(syscall_abi::PAGE_SIZE)
-    else
-    {
-        std::os::seraph::log!("failed to acquire memory cap for provider endpoint slab");
         halt_loop();
     };
 
@@ -193,15 +174,7 @@ fn main() -> !
 
     std::os::seraph::log!("endowed; waiting for handover");
 
-    event_loop(
-        info,
-        &caps,
-        ws_cap,
-        deaths_eq,
-        endpoint_slab,
-        ipc_buf,
-        &mut state,
-    );
+    event_loop(info, &caps, ws_cap, deaths_eq, ipc_buf, &mut state);
 }
 
 /// Publish the well-known names svcmgr owns into its own discovery
@@ -391,7 +364,6 @@ fn event_loop(
     caps: &service::SvcmgrCaps,
     ws_cap: u32,
     deaths_eq: u32,
-    endpoint_slab: u32,
     ipc_buf: *mut u64,
     state: &mut SvcmgrState,
 ) -> !
@@ -401,7 +373,6 @@ fn event_loop(
         bootstrap_ep: caps.bootstrap_ep,
         ipc_buf,
         deaths_eq,
-        endpoint_slab,
         master_log_source: caps.master_log_source,
         procmgr_death_auth_source: caps.procmgr_death_auth_source,
         devmgr_registry: caps.devmgr_registry,

--- a/services/svcmgr/src/restart.rs
+++ b/services/svcmgr/src/restart.rs
@@ -202,10 +202,6 @@ pub struct RestartCtx
     /// the routing in `dispatch_deaths` continues to land on the
     /// correct `ServiceEntry`.
     pub deaths_eq: u32,
-    /// Memory-cap slab svcmgr retypes provider service endpoints from
-    /// (`cap_create_endpoint`). One slab backs every `provides = ...`
-    /// service's endpoint; sized for the handful of provider services.
-    pub endpoint_slab: u32,
     /// Reserved master-log endpoint source. svcmgr mints real-logd's RECV (and
     /// the first-launch `HANDOVER_PULL` SEND) from it on every (re)launch.
     pub master_log_source: u32,

--- a/services/vfsd/src/driver.rs
+++ b/services/vfsd/src/driver.rs
@@ -64,8 +64,8 @@ pub fn spawn_fatfs_driver(
     // this; vfsd holds a SEND_GRANT copy for the FS_MOUNT BPB-validation
     // probe and for `cap_derive_badge`-ing the synthetic-root and
     // caller-root caps in `do_mount`.
-    let slab = std::os::seraph::object_slab_acquire(88)?;
-    let driver_ep = syscall::cap_create_endpoint(slab).ok()?;
+    let driver_ep =
+        std::os::seraph::object_slab_retype(88, |slab| syscall::cap_create_endpoint(slab).ok())?;
     let driver_ep_for_child = syscall::cap_derive(driver_ep, syscall::RIGHTS_ALL).ok()?;
     let driver_send = syscall::cap_derive(driver_ep, syscall::RIGHTS_SEND_GRANT).ok()?;
 

--- a/services/vfsd/src/main.rs
+++ b/services/vfsd/src/main.rs
@@ -217,13 +217,8 @@ fn main() -> !
     // `GET_SYSTEM_ROOT_CAP`; the namespace endpoint is separated so
     // a single dispatcher thread can serve every walk without
     // contending with mount-table mutations.
-    let Some(namespace_slab) = std::os::seraph::object_slab_acquire(88)
-    else
-    {
-        std::os::seraph::log!("FATAL: cannot acquire namespace endpoint slab");
-        idle_loop();
-    };
-    let Ok(namespace_ep) = syscall::cap_create_endpoint(namespace_slab)
+    let Some(namespace_ep) =
+        std::os::seraph::object_slab_retype(88, |slab| syscall::cap_create_endpoint(slab).ok())
     else
     {
         std::os::seraph::log!("FATAL: cannot create namespace endpoint");

--- a/services/vfsd/src/worker_pool.rs
+++ b/services/vfsd/src/worker_pool.rs
@@ -185,8 +185,9 @@ impl WorkerPool
     /// allocation or any thread spawn fails.
     pub fn new() -> Option<Self>
     {
-        let slab = std::os::seraph::object_slab_acquire(88)?;
-        let bootstrap_ep = syscall::cap_create_endpoint(slab).ok()?;
+        let bootstrap_ep = std::os::seraph::object_slab_retype(88, |slab| {
+            syscall::cap_create_endpoint(slab).ok()
+        })?;
         let bootstrap_state = Arc::new(Mutex::new(BootstrapState::new()));
         let active_state = Arc::new(ActiveState::new());
 


### PR DESCRIPTION
Fixes #364

## Problem

The pooled object-slab bins (`SLAB_BIN_128`/`SLAB_BIN_512`) debited their local `available_bytes` mirror per retype but never recovered the bytes the kernel auto-reclaims when notifications, endpoints, and event queues die. Every ~63 chunk churns paid for a fresh 2-page memmgr grant, stranded the old page's run in memmgr's per-process accounting until process death, and leaked the old pool cap's CSpace slot.

## Approach

1. **Closure-form `object_slab_retype`** replaces acquire-returns-slot (`object_slab_acquire` removed from the public surface). The retype syscall runs under the pool spinlock, which is the soundness precondition for everything else: no acquired-but-unretyped slot can outlive the lock, so the pool may resync its ledger from the kernel and delete/release caps without racing a concurrent cap install into a reused slot. All in-tree call sites converted (mechanical); svcmgr's dedicated provider-endpoint slab is replaced by pooled per-launch retypes, removing its ~31-launch exhaustion cliff.
2. **Resync before refill**: on an exhausted mirror, re-read the kernel ledger (`SYS_CAP_INFO` `MEMORY_AVAILABLE`). Pool pages are class-pure, so ledger ≥ class guarantees the retype succeeds; steady churn recycles reclaimed bytes in place and never refills.
3. **Retired-page shelf**: a genuine refill displaces a page still pinned by live retypes; it parks on a 4-entry per-pool shelf keyed by grant phys identity. The slow path releases fully-drained entries back to memmgr (`RELEASE_MEMORY_CAPS`) and promotes an entry with room instead of refilling. Shelf overflow evicts the oldest by cap-delete alone (bounded residual strand, documented).

In-passing fixes on the same surface: a refill grant too small for the request is now released instead of stranded; the fresh path reclaims the dead-weight source slot after success and releases the virgin grant on retype failure (previously leaked at most call sites); `mem_map_with_augment_retry`'s "augment cap is consumed" comment was wrong (the kernel takes its own ref) and that path leaked a slot per augment; the false "kernel carves ≈48 B on first use" sizing comment is corrected.

## Acceptance (#364)

- [x] Long-lived spawner's memmgr grant count stays flat across sustained notification churn: the pipestress tester (250 piped spawns ≈ 1250 pooled chunks) now samples its own `CSPACE_USED` (each leaked pool-cap slot ≙ one stranded grant) and asserts growth ≤ 8 — measured growth 0 on x86_64 (pre-fix: 19). threadchurn (≈700 chunks) tightens `SLACK` 12 → 4 — measured growth 0, memmgr pool drop 0 (pre-fix: ~11 slots, absorbed by the old slack).
- [x] No regression in svctest/usertest on both arches (see test plan).

## Test plan

- [x] `cargo xtask test` (host) green
- [x] x86_64: `cargo xtask build`; default boot reaches `terminal: READY`; svctest `ALL TESTS PASSED`; usertest `ALL TESTS PASSED` (incl. tightened threadchurn + new pipestress assertion)
- [x] riscv64: `cargo xtask clean` + build; default boot reaches `terminal: READY`; usertest PASS; svctest PASS (run-parallel markers)
- [x] Tripwire sanity: tests-only commit cherry-picked onto master FAILS both testers (pipestress growth 19 > 8; threadchurn FAIL), proving the bounds bite on the pre-fix behaviour