### PR TITLE
release: add preflight gate and document the release procedure

### DIFF
--- a/.github/workflows/burnin.yml
+++ b/.github/workflows/burnin.yml
@@ -3,6 +3,9 @@ name: burn-in
 on:
   push:
     tags: ['v*.*.*']
+  # Intentionally unguarded for branch refs (unlike release.yml): a manual
+  # dispatch stress-tests whatever ref it targets and mints no version-named
+  # artifacts. Release certification reads the tag-push run only.
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,13 +45,15 @@ jobs:
             echo "Copy docs/releases/TEMPLATE.md and commit it before tagging ${TAG}." >&2
             exit 1
           fi
-          if ! grep -qF "# Seraph ${TAG}" "${NOTES}"; then
+          # -qxF: fixed-string whole-line matches, so a body bullet merely
+          # quoting a heading cannot satisfy the structure check.
+          if ! grep -qxF "# Seraph ${TAG}" "${NOTES}"; then
             echo "::error::${NOTES}: title must be '# Seraph ${TAG}' per TEMPLATE.md" >&2
             exit 1
           fi
           for h in "## Highlights" "## Components Shipped" "## ABI and Protocol Versions" \
                    "## Breaking Changes" "## Known Issues" "## Verification" "## Validation"; do
-            if ! grep -qF "$h" "${NOTES}"; then
+            if ! grep -qxF "$h" "${NOTES}"; then
               echo "::error::${NOTES} missing TEMPLATE.md section: $h" >&2
               exit 1
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,56 @@ permissions:
   contents: write
 
 jobs:
+  preflight:
+    # Fail-fast gate: catches a stale workspace version or missing/malformed
+    # release notes in seconds, before the expensive build matrix runs.
+    # Guard workflow_dispatch from running against a branch ref — release
+    # artifacts must be anchored to a tagged commit so the asset filenames
+    # match the version they encode.
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Verify workspace version matches tag
+        run: |
+          TAG="${{ github.ref_name }}"
+          # The root Cargo.toml is the workspace manifest; its only top-level
+          # `version =` line is [workspace.package] version.
+          WS_VERSION="$(sed -n 's/^version = "\(.*\)"$/\1/p' Cargo.toml | head -n1)"
+          if [ "v${WS_VERSION}" != "${TAG}" ]; then
+            echo "::error::Tag ${TAG} does not match [workspace.package] version ${WS_VERSION}." >&2
+            echo "Bump the workspace version in Cargo.toml before tagging." >&2
+            exit 1
+          fi
+
+      - name: Verify release notes exist and follow TEMPLATE.md
+        run: |
+          TAG="${{ github.ref_name }}"
+          NOTES="docs/releases/${TAG}.md"
+          if [ ! -f "${NOTES}" ]; then
+            echo "::error::Release notes missing: ${NOTES}" >&2
+            echo "Copy docs/releases/TEMPLATE.md and commit it before tagging ${TAG}." >&2
+            exit 1
+          fi
+          if ! grep -qF "# Seraph ${TAG}" "${NOTES}"; then
+            echo "::error::${NOTES}: title must be '# Seraph ${TAG}' per TEMPLATE.md" >&2
+            exit 1
+          fi
+          for h in "## Highlights" "## Components Shipped" "## ABI and Protocol Versions" \
+                   "## Breaking Changes" "## Known Issues" "## Verification" "## Validation"; do
+            if ! grep -qF "$h" "${NOTES}"; then
+              echo "::error::${NOTES} missing TEMPLATE.md section: $h" >&2
+              exit 1
+            fi
+          done
+
   build-image:
     # Guard workflow_dispatch from running against a branch ref — release
     # artifacts must be anchored to a tagged commit so the asset filenames
     # match the version they encode.
     if: startsWith(github.ref, 'refs/tags/v')
+    needs: preflight
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -332,7 +332,7 @@ CI workflows live in `.github/workflows/`. Local equivalents are the
 |---|---|---|
 | `build-test.yml` | push to `master`, PR to `master`, manual dispatch | Light validation: one `host-tests` job runs `cargo xtask test`; the matrix `validate` job builds each `arch × profile` cell, then per-tester either stages a recipe + `mkdisk` (svctest, usertest) or re-composes the bundle via `compose-bundle --harness ktest`, and runs one iteration. |
 | `burnin.yml` | tag push (`v*.*.*`), manual dispatch | Heavy validation: the `arch × profile × tester` matrix builds each cell, stages that one harness (svctest/usertest drop the autostarted `terminal` and `mkdisk --repack-only`; ktest via `compose-bundle --harness ktest`), then burns it in with `run-parallel --parallel 2 --runs 20 --timeout 180`. |
-| `release.yml` | tag push (`v*.*.*`), manual dispatch | Builds release-profile disk images per architecture, compresses with zstd, generates `SHA256SUMS`, creates a draft GitHub Release whose body is `docs/releases/<tag>.md`. |
+| `release.yml` | tag push (`v*.*.*`), manual dispatch | A `preflight` job verifies the workspace version matches the tag and `docs/releases/<tag>.md` exists and follows the template; then builds release-profile disk images per architecture, compresses with zstd, generates `SHA256SUMS`, creates a draft GitHub Release whose body is `docs/releases/<tag>.md`. |
 
 `build-test.yml` cancels stacked runs on the same ref
 (`cancel-in-progress: true`). `burnin.yml` and `release.yml` do not

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -175,9 +175,23 @@ equivalents are the `cargo xtask` commands documented there.
 
 ## Release Production
 
-See [docs/releases/README.md](releases/README.md) for per-tag release notes discipline. Each `Y` bump tag MUST have a corresponding `docs/releases/<tag>.md` file present at the tagged commit; `release.yml` aborts the publish step if the file is missing.
+See [docs/releases/README.md](releases/README.md) for per-tag release notes discipline.
 
-The maintainer publishes the draft Release manually after verifying the `burnin.yml` run for the same tag completed successfully.
+Producing a release for tag `v<X>.<Y>.<Z>`:
+
+1. Bump `[workspace.package] version` in the root `Cargo.toml` to `<X>.<Y>.<Z>`.
+2. Copy `docs/releases/TEMPLATE.md` to `docs/releases/v<X>.<Y>.<Z>.md` and fill
+   every section.
+3. Land both changes on `master` through the normal PR workflow. The tag MUST
+   point at a commit that contains them.
+4. Tag that commit and push the tag:
+   `git tag v<X>.<Y>.<Z> && git push origin v<X>.<Y>.<Z>`.
+5. The tag push triggers `release.yml` and `burnin.yml`. The `preflight` job in
+   `release.yml` aborts the run before any image is built if the workspace
+   version does not match the tag or the notes file is missing or does not
+   follow `TEMPLATE.md`'s structure.
+6. The maintainer publishes the draft Release manually after verifying the
+   `burnin.yml` run for the same tag completed successfully.
 
 ---
 

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -24,9 +24,10 @@ published via the project's release workflow.
 `docs/releases/<tag>.md` at the tagged commit is the canonical text of that
 tag's release notes.
 
-- The notes file MUST exist at the tagged commit. The release workflow reads
-  it via `gh release create --notes-file` and aborts the publish step if the
-  file is missing.
+- The notes file MUST exist at the tagged commit. The release workflow's
+  `preflight` job aborts the run before any image is built if the file is
+  missing or does not follow `TEMPLATE.md`'s structure; the publish step
+  re-checks existence before `gh release create --notes-file`.
 - New release notes MUST be authored by copying `TEMPLATE.md` and filling
   every section. Non-template structure introduces inconsistency across
   releases.
@@ -37,9 +38,12 @@ tag's release notes.
 
 The release workflow at `.github/workflows/release.yml` is the sole
 mechanism for creating GitHub Releases. It triggers on tag push matching
-`v*.*.*`, builds release-profile disk images for every supported
-architecture, and creates a draft Release whose body is the contents of
-`docs/releases/<tag>.md`.
+`v*.*.*`. A `preflight` job first verifies that the workspace version in
+the root `Cargo.toml` matches the tag and that `docs/releases/<tag>.md`
+exists and follows `TEMPLATE.md`'s structure. The workflow then builds
+release-profile disk images for every supported architecture, compresses
+them with `zstd -19`, and creates a draft Release whose body is the
+contents of `docs/releases/<tag>.md`.
 
 The draft is published manually by the maintainer after verifying the
 burn-in workflow at `.github/workflows/burnin.yml` completed successfully
@@ -67,4 +71,4 @@ are immutable; the title, body, and asset list are mutable.
 
 ## Summarized By
 
-[README.md](../../README.md)
+[README.md](../../README.md), [conventions.md](../conventions.md)

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -71,4 +71,5 @@ are immutable; the title, body, and asset list are mutable.
 
 ## Summarized By
 
-[README.md](../../README.md), [conventions.md](../conventions.md)
+[README.md](../../README.md), [conventions.md](../conventions.md),
+[build-system.md](../build-system.md)


### PR DESCRIPTION
## Summary
`release.yml` gains a fail-fast `preflight` job — version↔tag match plus release-notes presence and TEMPLATE.md structure — that runs before the build matrix; previously the only check was notes-file existence inside the publish job, after both release builds, and nothing checked the workspace version at all. conventions.md §Release Production now spells out the ordered pre-tag procedure, with propagation touch-ups in docs/releases/README.md (zstd note, `Summarized By` backlinks), docs/build-system.md (CI table), and an intent comment on burnin.yml's deliberately unguarded `workflow_dispatch`.

## Acceptance
No linked Issue (release-workflow hardening pass requested interactively ahead of the v0.1.0 tag).

## Test plan
- [x] `cargo xtask build` (x86_64) — via CI run 27343490631, all x86_64 validate cells green
- [x] `cargo xtask run` (x86_64), terminal pass marker observed — via CI run 27343490631 (ktest/svctest/usertest pass markers per cell)
- [x] `cargo xtask build --arch riscv64` — via CI run 27343490631, all riscv64 validate cells green
- [x] `cargo xtask run --arch riscv64`, terminal pass marker observed — via CI run 27343490631 (ktest/svctest/usertest pass markers per cell)
- [x] Workflow YAML parse-checked (`yaml.safe_load`; jobs: `preflight`, `build-image`, `publish`)
- [x] Preflight `sed` version extraction verified against the root `Cargo.toml` (`0.1.0`, line 79 is the only top-level `version =` line)

## Notes
- The preflight job cannot be exercised end-to-end until the first `v*.*.*` tag is pushed; it is deliberately fail-fast so a broken first tag attempt costs seconds, not a matrix build. The publish-job notes check stays as defense in depth.
- Pre-merge audit follow-ups applied in a second commit: anchored structure greps (`-qxF`) and the `build-system.md` backlink in docs/releases/README.md.