### PR TITLE
kernel/riscv64: window SBI IPI hart masks for hart IDs >= 64

### DIFF
--- a/core/kernel/src/arch/riscv64/interrupts.rs
+++ b/core/kernel/src/arch/riscv64/interrupts.rs
@@ -1123,7 +1123,7 @@ pub fn acknowledge(irq: u32)
 /// Send a TLB shootdown IPI to a target hart via SBI IPI.
 ///
 /// Sends a supervisor software interrupt to the target hart. The
-/// The software-interrupt handler (scause=1) on the target services any
+/// software-interrupt handler (scause=1) on the target services any
 /// shootdown request naming it: executes sfence.vma, clears its pending
 /// bit, and clears SSIP.
 ///
@@ -1139,7 +1139,8 @@ pub fn acknowledge(irq: u32)
 #[allow(dead_code)]
 pub unsafe fn send_tlb_shootdown_ipi(target_hart_id: u32)
 {
-    // SAFETY: SBI call sends a supervisor software interrupt to the target hart.
+    // SAFETY: caller guarantees the target hart is online (this function's
+    // safety contract), satisfying sbi_send_ipi_to's contract.
     unsafe { sbi_send_ipi_to(target_hart_id) };
 }
 
@@ -1154,8 +1155,8 @@ pub unsafe fn send_tlb_shootdown_ipi(target_hart_id: u32)
 #[cfg(not(test))]
 pub unsafe fn send_wakeup_ipi(target_hart_id: u32)
 {
-    // SAFETY: SBI call sends a supervisor software interrupt to the target hart,
-    // waking it from wfi.
+    // SAFETY: caller guarantees the target hart is online (this function's
+    // safety contract), satisfying sbi_send_ipi_to's contract.
     unsafe { sbi_send_ipi_to(target_hart_id) };
 }
 

--- a/core/kernel/src/arch/riscv64/interrupts.rs
+++ b/core/kernel/src/arch/riscv64/interrupts.rs
@@ -1181,8 +1181,12 @@ unsafe fn sbi_send_ipi_to(target_hart_id: u32)
     let (hart_mask, hart_mask_base) = sbi_hart_mask(target_hart_id);
     // SAFETY: SBI call with EID=sPI, FID=0; caller guarantees the target hart
     // is online.
-    unsafe {
-        sbi_call_2(0x0073_5049, 0, hart_mask, hart_mask_base);
+    let err = unsafe { sbi_call_2(0x0073_5049, 0, hart_mask, hart_mask_base) };
+    if err != 0
+    {
+        // A refused IPI is a silent lost wakeup; dying loudly here beats a
+        // wedged hart. SEND_IPI errors are parameter-class, not transient.
+        crate::fatal("sbi_send_ipi_to: SBI SEND_IPI returned an error");
     }
 }
 

--- a/core/kernel/src/arch/riscv64/interrupts.rs
+++ b/core/kernel/src/arch/riscv64/interrupts.rs
@@ -1139,14 +1139,8 @@ pub fn acknowledge(irq: u32)
 #[allow(dead_code)]
 pub unsafe fn send_tlb_shootdown_ipi(target_hart_id: u32)
 {
-    // SBI IPI extension (EID=0x735049 'sPI'), function SEND_IPI (fid=0).
-    let hart_mask = 1u64 << target_hart_id;
-    let hart_mask_base = 0u64;
-
     // SAFETY: SBI call sends a supervisor software interrupt to the target hart.
-    unsafe {
-        sbi_call_2(0x0073_5049, 0, hart_mask, hart_mask_base);
-    }
+    unsafe { sbi_send_ipi_to(target_hart_id) };
 }
 
 /// Send a wakeup IPI to a target hart.
@@ -1160,13 +1154,33 @@ pub unsafe fn send_tlb_shootdown_ipi(target_hart_id: u32)
 #[cfg(not(test))]
 pub unsafe fn send_wakeup_ipi(target_hart_id: u32)
 {
-    // SBI IPI extension (EID=0x735049 'sPI'), function SEND_IPI (fid=0).
-    // Argument: hart_mask (bitmask of target harts).
-    let hart_mask = 1u64 << target_hart_id;
-    let hart_mask_base = 0u64; // hart_mask represents harts [0..63]
+    // SAFETY: SBI call sends a supervisor software interrupt to the target hart,
+    // waking it from wfi.
+    unsafe { sbi_send_ipi_to(target_hart_id) };
+}
 
-    // SAFETY: SBI call with EID=sPI, FID=0, sends an IPI to the target hart.
-    // The target will receive a supervisor software interrupt, waking it from wfi.
+/// Split a hart ID into the SBI `(hart_mask, hart_mask_base)` pair.
+///
+/// The SBI hart-mask convention addresses a 64-hart window: `hart_mask_base`
+/// is the first hart ID of the window and `hart_mask` is a bitmask relative
+/// to that base, so any hart ID up to the platform limit is reachable.
+fn sbi_hart_mask(target_hart_id: u32) -> (u64, u64)
+{
+    let base = u64::from(target_hart_id) & !63;
+    let mask = 1u64 << (u64::from(target_hart_id) & 63);
+    (mask, base)
+}
+
+/// Send a supervisor software interrupt to `target_hart_id` via the SBI IPI
+/// extension (EID=0x735049 'sPI', FID=0 `SEND_IPI`).
+///
+/// # Safety
+/// `target_hart_id` must be a valid hart ID of an online hart.
+unsafe fn sbi_send_ipi_to(target_hart_id: u32)
+{
+    let (hart_mask, hart_mask_base) = sbi_hart_mask(target_hart_id);
+    // SAFETY: SBI call with EID=sPI, FID=0; caller guarantees the target hart
+    // is online.
     unsafe {
         sbi_call_2(0x0073_5049, 0, hart_mask, hart_mask_base);
     }
@@ -1402,5 +1416,17 @@ mod tests
     fn plic_claim_complete_offset()
     {
         assert_eq!(plic_claim_complete_offset(), 0x0020_1004);
+    }
+
+    #[test]
+    fn sbi_hart_mask_windows()
+    {
+        assert_eq!(sbi_hart_mask(0), (1, 0));
+        assert_eq!(sbi_hart_mask(63), (1 << 63, 0));
+        assert_eq!(sbi_hart_mask(64), (1, 64));
+        assert_eq!(sbi_hart_mask(65), (1 << 1, 64));
+        assert_eq!(sbi_hart_mask(127), (1 << 63, 64));
+        assert_eq!(sbi_hart_mask(128), (1, 128));
+        assert_eq!(sbi_hart_mask(511), (1 << 63, 448));
     }
 }


### PR DESCRIPTION
## Summary
`send_tlb_shootdown_ipi` and `send_wakeup_ipi` built the SBI hart mask as `1u64 << target_hart_id` with `hart_mask_base` fixed at 0, which cannot address harts beyond 63 — a debug build panics with shift overflow at the first IPI to hart 64 (reproduced at `-smp 65`: all 65 harts come online via per-hart HSM bring-up, then the BSP dies on the first TLB shootdown), and a release build silently misdirects the IPI. The fix windows the ID into the SBI `(hart_mask, hart_mask_base)` pair in a shared helper, routes both senders through one `sbi_send_ipi_to`, and escalates a refused `SEND_IPI` to `fatal()` instead of discarding the SBI error code.

## Acceptance
No linked Issue (found while probing the reported ">64 CPUs fails on riscv64" behavior interactively).

## Test plan
- [x] Pre-fix repro captured: `PANIC at core/kernel/src/arch/riscv64/interrupts.rs:1143: attempt to shift left with overflow` at `--cpus 65` (debug, ktest)
- [x] `cargo xtask build --arch riscv64` + `compose-bundle --harness ktest`
- [x] `cargo xtask run-parallel --arch riscv64 --cpus 65 --parallel 1 --runs 2` — full `ALL TESTS PASSED` observed (69 s wall)
- [x] `cargo xtask run-parallel --arch riscv64 --cpus 4 --parallel 1 --runs 1` — `ALL TESTS PASSED` (regression)
- [x] `cargo xtask build` (x86_64) + ktest `run-parallel --cpus 4 --parallel 1 --runs 1` — `ALL TESTS PASSED` (15.6 s)
- [x] Host unit test `sbi_hart_mask_windows` covers window splits at 0/63/64/65/127/128/511
- [x] `grep -rn "1u64 <<"` over `arch/riscv64/`: no other single-window SBI mask sites

## Notes
High-CPU probing around this fix surfaced three pre-existing, mask-independent findings, now filed:
1. #375 — intermittent silent wedge in `thread::load_balancer_skips_pinned` at high CPU counts on BOTH arches (reproduces at 64 harts with masks that were already correct, so independent of this fix).
2. #376 — x86_64 cannot boot >256 CPUs: per-CPU slabs (AP_IST_STACKS/AP_TSS) exceed the buddy allocator's `MAX_ORDER = 10` (4 MiB) single-allocation cap regardless of guest RAM.
3. #377 — riscv64 ≥128 harts dies in UEFI (`ConvertPages: Incompatible memory types`) loading the kernel ELF.