### PR TITLE
xtask: --mem flag, --cpus bounds; docs/testing: coverage tiers

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -78,6 +78,9 @@ truth for "how work is tracked and shipped" on this project.
   2. `cargo xtask run` (a pure runner; it does not build) MUST then boot
      ktest or userspace services under QEMU and the chosen mode's
      terminal pass marker MUST appear.
+- Changes touching SMP, per-CPU, IPI, scheduler-wakeup, boot, or
+  memory-init paths MUST additionally run the local host runs defined in
+  [docs/testing.md](../docs/testing.md) "Coverage tiers".
 - Host-side compilation, unit tests, and `cargo check` alone do not
   satisfy this requirement.
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -78,9 +78,9 @@ truth for "how work is tracked and shipped" on this project.
   2. `cargo xtask run` (a pure runner; it does not build) MUST then boot
      ktest or userspace services under QEMU and the chosen mode's
      terminal pass marker MUST appear.
-- Changes touching SMP, per-CPU, IPI, scheduler-wakeup, boot, or
-  memory-init paths MUST additionally run the local host runs defined in
-  [docs/testing.md](../docs/testing.md) "Coverage tiers".
+- Changes matching the trigger paths in
+  [docs/testing.md](../docs/testing.md) "Coverage tiers" MUST additionally
+  run the local host runs defined there.
 - Host-side compilation, unit tests, and `cargo check` alone do not
   satisfy this requirement.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -255,7 +255,8 @@ not on every push.
 **Dimension inventory.** Exhaustive per CI run: architecture (x86_64,
 riscv64) × profile (debug, release) × harness (ktest, svctest, usertest).
 Fixed per CI run: vCPU count (4), guest memory (512 MiB), device set
-(virtio-blk + virtio-keyboard + serial + framebuffer), filesystem (FAT).
+(virtio-blk + virtio-keyboard + serial; CI boots headless, so no
+framebuffer), filesystem (FAT).
 A device or filesystem joining the default boot set joins the canonical
 cells automatically; variants belong to the tiers below.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -246,6 +246,68 @@ computes the verdict host-side and kills QEMU itself.
 
 ---
 
+## Coverage tiers
+
+The matrix CI exercises is exhaustive in three dimensions and fixed in the
+rest. Coverage is tiered so the fixed dimensions still get exercised — just
+not on every push.
+
+**Dimension inventory.** Exhaustive per CI run: architecture (x86_64,
+riscv64) × profile (debug, release) × harness (ktest, svctest, usertest).
+Fixed per CI run: vCPU count (4), guest memory (512 MiB), device set
+(virtio-blk + virtio-keyboard + serial + framebuffer), filesystem (FAT).
+A device or filesystem joining the default boot set joins the canonical
+cells automatically; variants belong to the tiers below.
+
+| Tier | Where | When | Coverage |
+|---|---|---|---|
+| Canonical | `build-test.yml` | every push / PR | full arch × profile × harness at the fixed defaults |
+| Burn-in | `burnin.yml` | tag push; manual dispatch on any ref | canonical cells × 20 iterations, 2-way parallel |
+| Local host runs | developer host, commands below | REQUIRED for PRs touching SMP, per-CPU, IPI, scheduler-wakeup, boot, or memory-init paths | CPU-count and memory variations CI runners cannot reach |
+
+**Why local-only.** Hosted CI runners are ~4-vCPU TCG-only machines; a
+65-vCPU guest is a ~16× thread oversubscription and a 512-vCPU guest is
+infeasible there. High `-smp` coverage is local by design, not an
+oversight. The runs below are procedurally REQUIRED for PRs touching the
+listed paths — binding the same way the pre-merge audit agents are, with
+no CI surface.
+
+```sh
+# Boundary CPU counts, riscv64 (~70 s per passing run on a 16-core host;
+# the 600 s budget is for HANG classification):
+cargo xtask build --arch riscv64
+cargo xtask compose-bundle --harness ktest --arch riscv64
+cargo xtask run-parallel --arch riscv64 --cpus 64 --parallel 1 --runs 3 --timeout 600
+cargo xtask run-parallel --arch riscv64 --cpus 65 --parallel 1 --runs 3 --timeout 600
+
+# Boundary CPU counts, x86_64 (KVM hosts boot in seconds):
+cargo xtask build
+cargo xtask compose-bundle --harness ktest
+cargo xtask run-parallel --arch x86_64 --cpus 256 --parallel 1 --runs 3 --timeout 300
+
+# Memory variation (either arch):
+cargo xtask run-parallel --arch <arch> --cpus 4 --mem 1024 --parallel 1 --runs 1 --timeout 300
+```
+
+**Known boundaries**, established empirically (QEMU 11.0.1; tracked in the
+Issue backlog — update this list as they move):
+
+- x86_64 > 256 CPUs: kernel Phase-4 `FATAL` — the per-CPU slabs
+  (`AP_IST_STACKS`, `AP_TSS`) exceed the buddy allocator's `MAX_ORDER`
+  single-allocation cap. Independent of guest memory size; QEMU itself
+  accepts `-smp 257..512` under both KVM and TCG with the stock argv.
+- riscv64 ≥ 128 harts: boot dies in UEFI (`ConvertPages: Incompatible
+  memory types`) while loading the kernel ELF; independent of guest
+  memory size. At 256 harts under TCG the firmware produces no serial
+  output within 20 minutes.
+- Both arches, high CPU counts: intermittent silent wedge in
+  `thread::load_balancer_skips_pinned` (~1/3 of runs at 64-65 harts
+  riscv64; observed once at 256 vCPUs x86_64/KVM). A HANG at that marker
+  reproduces on master and is not evidence against the change under
+  test — re-run, and attribute to the tracking Issue.
+
+---
+
 ## Cross-harness conventions
 
 - **Completion behavior.** A harness MUST request `pwrmgr` shutdown when

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -289,22 +289,25 @@ cargo xtask run-parallel --arch x86_64 --cpus 256 --parallel 1 --runs 3 --timeou
 cargo xtask run-parallel --arch <arch> --cpus 4 --mem 1024 --parallel 1 --runs 1 --timeout 300
 ```
 
-**Known boundaries**, established empirically (QEMU 11.0.1; tracked in the
-Issue backlog — update this list as they move):
+**Known boundaries**, established empirically (QEMU 11.0.1; update this
+list as the tracking Issues move):
 
-- x86_64 > 256 CPUs: kernel Phase-4 `FATAL` — the per-CPU slabs
-  (`AP_IST_STACKS`, `AP_TSS`) exceed the buddy allocator's `MAX_ORDER`
-  single-allocation cap. Independent of guest memory size; QEMU itself
-  accepts `-smp 257..512` under both KVM and TCG with the stock argv.
-- riscv64 ≥ 128 harts: boot dies in UEFI (`ConvertPages: Incompatible
-  memory types`) while loading the kernel ELF; independent of guest
-  memory size. At 256 harts under TCG the firmware produces no serial
-  output within 20 minutes.
-- Both arches, high CPU counts: intermittent silent wedge in
-  `thread::load_balancer_skips_pinned` (~1/3 of runs at 64-65 harts
-  riscv64; observed once at 256 vCPUs x86_64/KVM). A HANG at that marker
-  reproduces on master and is not evidence against the change under
-  test — re-run, and attribute to the tracking Issue.
+- x86_64 > 256 CPUs ([#376](https://github.com/kottlerg/seraph/issues/376)):
+  kernel Phase-4 `FATAL` — the per-CPU slabs (`AP_IST_STACKS`, `AP_TSS`)
+  exceed the buddy allocator's `MAX_ORDER` single-allocation cap.
+  Independent of guest memory size; QEMU itself accepts `-smp 257..512`
+  under both KVM and TCG with the stock argv.
+- riscv64 ≥ 128 harts ([#377](https://github.com/kottlerg/seraph/issues/377)):
+  boot dies in UEFI (`ConvertPages: Incompatible memory types`) while
+  loading the kernel ELF; independent of guest memory size. At 256 and
+  512 harts under TCG the firmware produces no serial output within 20
+  and 30 minutes respectively.
+- Both arches, high CPU counts ([#375](https://github.com/kottlerg/seraph/issues/375)):
+  intermittent silent wedge in `thread::load_balancer_skips_pinned`
+  (~1/3 of runs at 64-65 harts riscv64; observed once at 256 vCPUs
+  x86_64/KVM). A HANG at that marker reproduces on master and is not
+  evidence against the change under test — re-run, and attribute to
+  #375.
 
 ---
 

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -33,7 +33,7 @@ Run `cargo xtask build` first; `run` errors fast if the sysroot is empty
 or stamped for a different architecture.
 
 ```
-cargo xtask run [--arch x86_64|riscv64] [--gdb] [--headless] [--verbose] [--cpus N]
+cargo xtask run [--arch x86_64|riscv64] [--gdb] [--headless] [--verbose] [--cpus N] [--mem MIB]
 ```
 
 | Option | Description |
@@ -42,7 +42,8 @@ cargo xtask run [--arch x86_64|riscv64] [--gdb] [--headless] [--verbose] [--cpus
 | `--gdb` | Start QEMU with a GDB server on localhost:1234; QEMU pauses at startup |
 | `--headless` | Run without a display window (`-display none`) |
 | `--verbose` | Show all serial output; by default output is filtered until `[--------] boot:` appears |
-| `--cpus` | Number of vCPUs to expose to the guest (default: `4`) |
+| `--cpus` | Number of vCPUs to expose to the guest (default: `4`; bounded by `1..=512`, the boot-protocol `MAX_CPUS` the kernel sizes its per-CPU structures from) |
+| `--mem` | Guest memory size in MiB (default: `512`) |
 
 **x86-64** selects an acceleration backend per host: KVM on Linux,
 HVF on macOS, WHPX on Windows, NVMM on NetBSD, or TCG everywhere else
@@ -230,6 +231,7 @@ cargo xtask run-parallel \
     --runs M \
     [--timeout SECONDS] \
     [--cpus N] \
+    [--mem MIB] \
     [--pass REGEX] \
     [--fail REGEX] \
     [--fail-grace-secs SECONDS]
@@ -241,7 +243,8 @@ cargo xtask run-parallel \
 | `--parallel` | (required) | Concurrency: QEMU instances in flight at once |
 | `--runs` | (required) | Total runs, dispatched in waves of `--parallel` |
 | `--timeout` | `30` | Per-run timeout in seconds; expired runs are SIGKILLed and classified `HANG` (unless a pass marker matched first) |
-| `--cpus` | `4` | vCPUs per guest |
+| `--cpus` | `4` | vCPUs per guest (bounded by `1..=512`, the boot-protocol `MAX_CPUS`) |
+| `--mem` | `512` | Guest memory size in MiB |
 | `--pass` | `ALL TESTS PASSED` | Regex marking a successful run. The default matches the cross-harness terminal marker `[<harness>] ALL TESTS PASSED` standardised in [docs/testing.md](../docs/testing.md). On match the log is discarded and the run is classified `PASS` |
 | `--fail` | `SOME TESTS FAILED\|KERNEL EXCEPTION\|FATAL:\|PANIC( at \|: )` | Regex marking a failed run; the **first** match wins. Matches the cross-harness terminal marker `[<harness>] SOME TESTS FAILED` ([docs/testing.md](../docs/testing.md)) plus the kernel's own death markers (`KERNEL EXCEPTION` + `FATAL:` for a hardware trap, `PANIC at`/`PANIC:` for a Rust `panic!`) so a crash classifies `FAIL` rather than `HANG`. The benign `USERSPACE FAULT` path matches none of these. On match the log is preserved as `FAIL-<run>.log`. Failure takes precedence over success. Override with a never-matching pattern (e.g. `'$.^'`) to disable |
 | `--fail-grace-secs` | `10` | After the first `--fail` match, wait this many seconds (bounded by `--timeout`) before SIGKILL, so the trailing fault dump still lands in the log. A crashed run thus aborts ~grace seconds after the first match instead of idling to `--timeout` |
@@ -302,7 +305,7 @@ boot set, so the terminal autostarts; just build and repack:
 ```sh
 cargo xtask build
 cargo xtask mkdisk
-cargo xtask test-terminal [--arch x86_64|riscv64] [--cpus N]
+cargo xtask test-terminal [--arch x86_64|riscv64] [--cpus N] [--mem MIB]
 ```
 
 See [docs/testing.md](../docs/testing.md) for the harness model.

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -180,6 +180,10 @@ pub struct RunArgs
     /// Number of vCPUs to expose to the guest (QEMU -smp).
     #[arg(long, default_value = "4")]
     pub cpus: u32,
+
+    /// Guest memory size in MiB (QEMU -m).
+    #[arg(long, default_value = "512")]
+    pub mem: u32,
 }
 
 // ── Mkdisk ────────────────────────────────────────────────────────────────────
@@ -212,6 +216,10 @@ pub struct TestTerminalArgs
     /// Number of vCPUs to expose to the guest (QEMU -smp).
     #[arg(long, default_value = "4")]
     pub cpus: u32,
+
+    /// Guest memory size in MiB (QEMU -m).
+    #[arg(long, default_value = "512")]
+    pub mem: u32,
 }
 
 // ── ComposeBundle ────────────────────────────────────────────────────────────
@@ -291,6 +299,10 @@ pub struct RunParallelArgs
     /// Number of vCPUs to expose to each guest (QEMU -smp).
     #[arg(long, default_value = "4")]
     pub cpus: u32,
+
+    /// Guest memory size in MiB (QEMU -m).
+    #[arg(long, default_value = "512")]
+    pub mem: u32,
 
     /// Regex marking a successful run. On match the log is discarded and
     /// the run is classified PASS. The default matches the cross-harness

--- a/xtask/src/commands/run.rs
+++ b/xtask/src/commands/run.rs
@@ -67,6 +67,7 @@ pub fn run(ctx: &BuildContext, args: &RunArgs) -> Result<()>
         firmware_code_path: &firmware_code,
         firmware_vars_path: firmware_vars.as_deref(),
         cpus: args.cpus,
+        mem_mib: args.mem,
         headless: args.headless,
         gdb: args.gdb,
         qmp_socket: None,

--- a/xtask/src/commands/run_parallel.rs
+++ b/xtask/src/commands/run_parallel.rs
@@ -170,6 +170,7 @@ pub fn run(ctx: &BuildContext, args: &RunParallelArgs) -> Result<()>
             let firmware_vars_template = firmware.vars_template.clone();
             let arch = args.arch;
             let cpus = args.cpus;
+            let mem_mib = args.mem;
             let timeout = Duration::from_secs(args.timeout);
             let fail_grace = Duration::from_secs(args.fail_grace_secs);
             let pass_re = pass_re.clone();
@@ -212,6 +213,7 @@ pub fn run(ctx: &BuildContext, args: &RunParallelArgs) -> Result<()>
                     firmware_code_path: &firmware_code,
                     firmware_vars_path: vars_path_for_qemu.as_deref(),
                     cpus,
+                    mem_mib,
                     headless: true,
                     gdb: false,
                     qmp_socket: None,

--- a/xtask/src/commands/test_terminal.rs
+++ b/xtask/src/commands/test_terminal.rs
@@ -126,6 +126,7 @@ pub fn run(ctx: &Context, args: &TestTerminalArgs) -> Result<()>
         firmware_code_path: &firmware_code,
         firmware_vars_path: firmware_vars.as_deref(),
         cpus: args.cpus,
+        mem_mib: args.mem,
         headless: true,
         gdb: false,
         qmp_socket: Some(&sock_path),

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -40,6 +40,8 @@ pub struct QemuLaunchSpec<'a>
     pub firmware_code_path: &'a Path,
     pub firmware_vars_path: Option<&'a Path>,
     pub cpus: u32,
+    /// Guest memory size in MiB.
+    pub mem_mib: u32,
     pub headless: bool,
     pub gdb: bool,
     /// When set, expose a QMP control socket at this path
@@ -54,9 +56,25 @@ pub struct QemuLaunchSpec<'a>
 /// is suitable for `Command::new(binary).args(&argv)`.
 pub fn build_qemu_argv(spec: &QemuLaunchSpec) -> Result<Vec<String>>
 {
+    // The kernel sizes its per-CPU structures from boot-protocol MAX_CPUS;
+    // a guest with more vCPUs than that cannot be represented.
+    let max_cpus = boot_protocol::MAX_CPUS;
+    if spec.cpus == 0 || usize::try_from(spec.cpus).map_or(true, |c| c > max_cpus)
+    {
+        bail!(
+            "--cpus {} out of range: must be 1..={} (boot-protocol MAX_CPUS)",
+            spec.cpus,
+            max_cpus
+        );
+    }
+    if spec.mem_mib == 0
+    {
+        bail!("--mem 0 is not a bootable guest memory size");
+    }
+
     let mut args: Vec<String> = vec![
         "-m".into(),
-        "512M".into(),
+        format!("{}M", spec.mem_mib),
         "-smp".into(),
         spec.cpus.to_string(),
         "-drive".into(),
@@ -395,4 +413,56 @@ fn pad_file_to(path: &Path, target_size: u64) -> Result<()>
             .with_context(|| format!("padding {}", path.display()))?;
     }
     Ok(())
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests
+{
+    use super::*;
+
+    fn riscv_spec(cpus: u32, mem_mib: u32) -> QemuLaunchSpec<'static>
+    {
+        QemuLaunchSpec {
+            arch: Arch::Riscv64,
+            disk_path: Path::new("disk.img"),
+            firmware_code_path: Path::new("code.fd"),
+            firmware_vars_path: Some(Path::new("vars.fd")),
+            cpus,
+            mem_mib,
+            headless: true,
+            gdb: false,
+            qmp_socket: None,
+        }
+    }
+
+    #[test]
+    fn argv_reflects_cpus_and_mem()
+    {
+        let argv = build_qemu_argv(&riscv_spec(4, 512)).unwrap();
+        let m = argv.iter().position(|a| a == "-m").unwrap();
+        assert_eq!(argv[m + 1], "512M");
+        let smp = argv.iter().position(|a| a == "-smp").unwrap();
+        assert_eq!(argv[smp + 1], "4");
+
+        let argv = build_qemu_argv(&riscv_spec(512, 2048)).unwrap();
+        let m = argv.iter().position(|a| a == "-m").unwrap();
+        assert_eq!(argv[m + 1], "2048M");
+        let smp = argv.iter().position(|a| a == "-smp").unwrap();
+        assert_eq!(argv[smp + 1], "512");
+    }
+
+    #[test]
+    fn cpus_out_of_range_rejected()
+    {
+        assert!(build_qemu_argv(&riscv_spec(0, 512)).is_err());
+        assert!(build_qemu_argv(&riscv_spec(513, 512)).is_err());
+    }
+
+    #[test]
+    fn mem_zero_rejected()
+    {
+        assert!(build_qemu_argv(&riscv_spec(4, 0)).is_err());
+    }
 }


### PR DESCRIPTION
## Summary
`run`, `run-parallel`, and `test-terminal` gain `--mem` (guest memory in MiB; previously hardcoded `-m 512M`), and `build_qemu_argv` bounds `--cpus` to `1..=512` (boot-protocol `MAX_CPUS`) with host tests for the argv and both rejection paths. docs/testing.md gains a "Coverage tiers" section: the canonical CI matrix and burn-in are defined against the dimensions they fix (4 vCPUs / 512 MiB / one device set), and high-SMP / memory-variation host runs become a procedural requirement for PRs touching SMP, per-CPU, IPI, scheduler-wakeup, boot, or memory-init paths, with the empirically-established CPU-count boundaries recorded against their tracking Issues (#375, #376, #377). CLAUDE.md's validation section points at the new requirement.

The high-CPU probing behind those boundaries established that no QEMU-side changes are needed for >256 vCPUs (KVM and TCG both accept `-smp 257..512` with the stock argv) — `--cpus` remains a pure `-smp` feed.

## Acceptance
No linked Issue (test-coverage strategy pass requested interactively; boundary findings filed as #375/#376/#377).

## Test plan
- [x] `cargo xtask test` — full host suite passes incl. new `qemu::tests` (argv reflects `--cpus`/`--mem`; cpus 0/513 and mem 0 rejected)
- [x] `cargo xtask build` (x86_64) — full lint gate passes
- [x] `cargo xtask build --arch riscv64` + `compose-bundle --harness ktest` + `run-parallel --cpus 4 --parallel 1 --runs 1` — `ALL TESTS PASSED` (28 s)
- [x] `cargo xtask build` (x86_64) + ktest `run-parallel --cpus 4 --parallel 1 --runs 1` — `ALL TESTS PASSED` (15.6 s)
- [x] `--mem` exercised end-to-end: x86_64 ktest runs at `--mem 1024`/`2048` reached kernel Phase 4 at 257/512 vCPUs (the documented #376 boundary), riscv64 128-hart probes at `--mem 1024` reached the documented #377 boundary
- [x] Coverage-tier boundary list cross-checked against the probe logs (65-hart pass, 128-hart UEFI fatal, 256/512-hart firmware silence, 256-vCPU x86_64 pass/wedge)

## Notes
- The boundary probes that ground the docs ran on a branch with #374 merged in (riscv64 needs the hart-mask fix above 64 harts); this branch itself only touches xtask and docs.
- The `--cpus` bound reads `boot_protocol::MAX_CPUS` directly (xtask already depends on boot-protocol), so the CLI stays in sync if the constant moves.