### PR TITLE
kernel/sched: fix #375 — load-balancer ticket convoy livelock at high CPU counts; ship wedge diagnostics

### DIFF
--- a/core/kernel/docs/scheduler.md
+++ b/core/kernel/docs/scheduler.md
@@ -316,8 +316,9 @@ Migration uses the shared `sched::migrate_ready_thread`-style helper
 
 ```
 pull_unpinned_ready(src, dst):
-    lock(min(src, dst).scheduler.lock)        // ascending-CPU order
-    lock(max(src, dst).scheduler.lock)
+    if !try_lock(min(src, dst).scheduler.lock): return   // ascending-CPU order
+    if !try_lock(max(src, dst).scheduler.lock):
+        unlock(min); return
     tcb = src.find_runnable(|t| t.cpu_affinity == AFFINITY_ANY)
     if tcb is None: unlock both; return
     src.remove_from_queue(tcb, tcb.priority)  // decrements CPU_LOAD[src]
@@ -329,13 +330,19 @@ pull_unpinned_ready(src, dst):
 ```
 
 Lock order follows scheduling-internals.md § Lock Hierarchy rule 4
-(ascending CPU id). Pinned threads (`cpu_affinity != AFFINITY_ANY`) are
-invisible to the `find_runnable` predicate and are never migrated.
+(ascending CPU id), and both acquisitions are **try-locks**: the pull runs
+from every CPU's timer tick with interrupts disabled, and under a
+pinned-heavy imbalance every idle CPU converges on the same victim every
+tick. Queuing there forms a FIFO ticket convoy of interrupts-off spinners
+that silences ticks, IPIs, and serial output system-wide and livelocks the
+guest under host vCPU oversubscription (#375). A contended pull is simply
+deferred to a later tick. Pinned threads (`cpu_affinity != AFFINITY_ANY`)
+are invisible to the `find_runnable` predicate and are never migrated.
 
 Hot-path cost per CPU per tick:
 - Idle CPU: one Relaxed load per remote CPU to find the heaviest victim.
 - Loaded CPU: one Relaxed increment + one Relaxed load for the victim.
-- Scheduler locks are taken only when an imbalance above
+- Scheduler locks are try-acquired, and only when an imbalance above
   `IMBALANCE_THRESHOLD` is observed.
 
 ---

--- a/core/kernel/docs/scheduling-internals.md
+++ b/core/kernel/docs/scheduling-internals.md
@@ -66,7 +66,7 @@ The following ordering MUST be observed everywhere in the kernel. Acquiring lock
 
 4. **Per-TCB-then-cross-CPU acquisition rule.** A path mutating a TCB's Scheduling field group MUST acquire `(*tcb).sched_lock` FIRST (outermost among the scheduler locks), THEN any per-CPU scheduler.lock(s); when two or more per-CPU scheduler.locks are needed simultaneously, they MUST be taken in ascending-CPU order. Live production sites: `sched::migrate_ready_thread` (used by `sys_thread_set_affinity` active migration and the periodic load balancer; `(*tcb).sched_lock` then the two CPU locks ascending), `dealloc_object(Thread)` (`(*tcb).sched_lock` then the all-CPU walk in ascending order), `sched::set_state_under_all_locks` (lifecycle state writes; same shape), and `sys_thread_set_priority` (priority writes plus locate-and-relocate of the Ready TCB's queue entry; `(*tcb).sched_lock` then the all-CPU walk in ascending order). A path MUST NEVER hold two different TCBs' `sched_lock`s at once — `schedule()`'s outgoing-then-incoming flip releases `current.sched_lock` before acquiring `next.sched_lock`.
 
-5. **`enqueue_and_wake` / `enqueue_ready_thread` acquire `(*tcb).sched_lock` then the target CPU's scheduler.lock.** They MAY be called WITH the source IPC lock still held OR after releasing it, because `source → (*tcb).sched_lock → run-queue lock` is exactly the hierarchy — there is no `source.lock → scheduler.lock` edge to violate. The single-waiter wakers (`notification_send`, `event_queue_post`, `endpoint_call`'s server-wake branch, `endpoint_reply`, and the `event_queue_drop` / `notification_dealloc` single-waiter dealloc wakes) snapshot the payload and set `wake_in_flight` under the source lock, RELEASE the source lock, then call `enqueue_and_wake` — releasing first bounds source-lock hold-time. Between that source-lock claim (waiter slot cleared, payload deposited, `wake_in_flight = 1`) and the waker's post-unlock `enqueue_and_wake`, the wake is half-complete and owned exclusively by the in-flight waker: code executing *as the claimed thread* in that window (it is still live, mid-park) has exactly one legal continuation — fall through to `schedule()`. Consuming the deposited payload and returning to user mode is forbidden; it strands the waker's run-queue link (#352). The `still_waiter` rechecks (the sleep-list arming in `sys_event_recv` / `sys_notification_wait`) respect this: they only add a timer on the not-claimed branch and fall through to `schedule()` on both branches. The `endpoint_dealloc` send/recv drain instead HOLDS `ep.lock` across the per-waiter `enqueue_and_wake` walk (a multi-waiter drain; sound precisely because the order is canonical, and `wake_in_flight = 1` per waiter blocks a racing `dealloc(waiter)` unlink from freeing a TCB mid-wake). `enqueue_and_wake` dispatches its wakeup IPI only after BOTH the run-queue lock and `(*tcb).sched_lock` are released (never IPI under `sched_lock`). `pull_unpinned_ready` is the one site that takes `(*tcb).sched_lock` via `try_lock_raw` while already holding a run-queue lock — the inverse of the canonical order; the `try` backs off on contention (a canonical holder makes it fail), so it is deadlock-free, and the source CPU's run-queue lock pins the candidate so the pointer cannot be freed under it. The wait-set cascade rule is unchanged in spirit: `wait_set_drop` releases its source/ws locks before reporting any zero-refcount source back to `dealloc_object_one`'s cascade worklist, so the source's own dealloc runs after every IPC source/ws lock has been released.
+5. **`enqueue_and_wake` / `enqueue_ready_thread` acquire `(*tcb).sched_lock` then the target CPU's scheduler.lock.** They MAY be called WITH the source IPC lock still held OR after releasing it, because `source → (*tcb).sched_lock → run-queue lock` is exactly the hierarchy — there is no `source.lock → scheduler.lock` edge to violate. The single-waiter wakers (`notification_send`, `event_queue_post`, `endpoint_call`'s server-wake branch, `endpoint_reply`, and the `event_queue_drop` / `notification_dealloc` single-waiter dealloc wakes) snapshot the payload and set `wake_in_flight` under the source lock, RELEASE the source lock, then call `enqueue_and_wake` — releasing first bounds source-lock hold-time. Between that source-lock claim (waiter slot cleared, payload deposited, `wake_in_flight = 1`) and the waker's post-unlock `enqueue_and_wake`, the wake is half-complete and owned exclusively by the in-flight waker: code executing *as the claimed thread* in that window (it is still live, mid-park) has exactly one legal continuation — fall through to `schedule()`. Consuming the deposited payload and returning to user mode is forbidden; it strands the waker's run-queue link (#352). The `still_waiter` rechecks (the sleep-list arming in `sys_event_recv` / `sys_notification_wait`) respect this: they only add a timer on the not-claimed branch and fall through to `schedule()` on both branches. The `endpoint_dealloc` send/recv drain instead HOLDS `ep.lock` across the per-waiter `enqueue_and_wake` walk (a multi-waiter drain; sound precisely because the order is canonical, and `wake_in_flight = 1` per waiter blocks a racing `dealloc(waiter)` unlink from freeing a TCB mid-wake). `enqueue_and_wake` dispatches its wakeup IPI only after BOTH the run-queue lock and `(*tcb).sched_lock` are released (never IPI under `sched_lock`). `pull_unpinned_ready` is the one site that takes `(*tcb).sched_lock` via `try_lock_raw` while already holding a run-queue lock — the inverse of the canonical order; the `try` backs off on contention (a canonical holder makes it fail), so it is deadlock-free, and the source CPU's run-queue lock pins the candidate so the pointer cannot be freed under it. Its two run-queue locks are themselves `try_lock_raw` (ascending order retained): the pull runs from every CPU's tick with interrupts disabled, and blocking there lets every idle CPU queue on one victim's lock — the FIFO ticket convoy that livelocked the guest system-wide under vCPU oversubscription (#375). The wait-set cascade rule is unchanged in spirit: `wait_set_drop` releases its source/ws locks before reporting any zero-refcount source back to `dealloc_object_one`'s cascade worklist, so the source's own dealloc runs after every IPC source/ws lock has been released.
 
 6. **Derivation tree lock is ordered after IPC object locks.** `SYS_CAP_REVOKE` MUST NOT acquire IPC object locks while holding the derivation tree write lock — see [capability-internals.md](capability-internals.md) for the deferred-cleanup pattern.
 
@@ -613,28 +613,74 @@ CPU-set state at the ceiling is carried as bitvectors
 
 ## Softlockup Watchdog
 
-Permanent kernel feature. Detects "every CPU stalled in kernel mode" — the
-failure class userspace cannot observe, because no userspace runs when every
-CPU is wedged.
+Permanent kernel feature: a suite of wedge detectors sharing one
+once-per-boot dump latch (`WATCHDOG_FIRED`, claimed via
+`watchdog_claim_dump`) and one dump body (`watchdog_dump(reason)`). The
+first detector to trip wins; one dump per boot keeps the serial log
+readable, prevents a dump storm when many CPUs observe the same stall, and
+the first dump is the uncontaminated evidence. The dump is callable from
+any CPU in interrupt context: shared structures are read benign-racily or
+via try-lock (`SLEEP_LIST_LOCK`, the registry walk) so a wedged lock holder
+cannot deadlock the dump itself.
 
-**Mechanism (`core/kernel/src/sched/mod.rs`):** `schedule()` updates a per-CPU
+Three detectors feed the latch:
+
+**1. All-idle softlockup (BSP, every tick).** Detects "every CPU stalled in
+kernel mode" — the failure class userspace cannot observe, because no
+userspace runs when every CPU is wedged. `schedule()` updates a per-CPU
 `LAST_NON_IDLE_TICK` whenever it dispatches a non-idle thread; the BSP
-`timer_tick` increments a global tick counter and, once per stall, dumps
-per-CPU TCB state (`current`, `state`, `ipc_state`, `blocked_on_object`,
-priority, preferred_cpu, idle age, non-empty mask) plus the head of
-`SLEEP_LIST` if every CPU's last dispatch is older than
-`WATCHDOG_THRESHOLD_TICKS` (~3 s at the observed ~1 ms tick). Single-shot
-via `WATCHDOG_FIRED`.
+`timer_tick` increments a global tick counter and fires if every CPU's last
+dispatch is older than `WATCHDOG_THRESHOLD_TICKS` (~3 s at the observed
+~1 ms tick).
 
-Each per-CPU line also carries a **spin-site breadcrumb**: a wedged CPU whose
-`current` is `Exited` but which never returned to the scheduler is stuck in a
-bounded protocol-spin, and the breadcrumb (`spin_site_enter`/`spin_site_exit`,
-set around each gate) names which one — `dealloc:not-current`,
-`dealloc:context-saved`, or `dealloc:wake-in-flight`. The `dealloc_object(Thread)`
-gates carried no overlong-duration warning of their own (unlike the `schedule()`
-context-saved spin and the `sys_thread_stop` drain), so a wedge there showed only
-an opaque `current = Exited` in `SYS_CAP_DELETE` (#351); the breadcrumb makes it
-explicit.
+**2. Owed-wake detector (BSP, every `DETECTOR_SCAN_INTERVAL_TICKS` ≈
+0.5 s).** Detects a single `Blocked` thread whose wake is provably owed but
+never arrived — the lost-wakeup wedge signature (#375), invisible to the
+all-idle check whenever any other thread keeps any CPU busy. Walks the
+live-thread registry reading only plain TCB scalars (no IPC-object
+dereference: unlike the dump's `blocked_on` decode, this runs on a LIVE
+system where a blocking object can be freed concurrently). Three rules:
+expired `sleep_deadline` past a 2 s grace window (a healthy sleeper is
+claimed, and its deadline cleared, within one BSP tick); `wake_in_flight`
+stuck set (a waker claimed the thread but its `enqueue_and_wake` never
+completed — normally microseconds); and `wake_pending` observed while
+`Blocked` (a coalesced wake survived the park commit that must consume it).
+The deadline rule is debounced by its grace window; the other two must
+persist across two consecutive scans (`OWED_WAKE_LAST`) so a legitimately
+mid-wake observation cannot false-positive. Indefinite waits (endpoint recv
+loops) match no rule. Each park commit stamps `park_started_tick` for the
+age checks.
+
+**3. Timer-heartbeat cross-checks.** Every CPU stamps `TICK_HEARTBEAT[cpu]`
+with `timer::current_tick()` on each `timer_tick` entry (`current_tick`
+derives from a globally consistent counter on both arches — TSC / `time`
+CSR — so cross-CPU age comparison is sound). Each AP compares the BSP's
+stamp against its own (`bsp_stall_check`): a BSP wedged interrupts-off
+kills the sleep-list waker and every BSP-hosted detector at once — total
+silence — so the AP-side check is the only detector that can name that
+state (#375). Symmetrically the BSP scans AP stamps
+(`ap_silence_check`) and fires on an AP silent past the grace window.
+Both defer to an in-flight TLB shootdown, as below.
+
+Tripwires outside the latch: the two `wake_pending` clears in `schedule()`
+(the same-thread re-mark and the dispatch flip) print a single-shot line
+(`WAKE_PENDING_CLEAR_TRIPPED`) if the flag was live when cleared — the only
+sanctioned consumer of a coalesced wake is `commit_blocked_under_local_lock`
+(§ Wake Protocol Invariants), so a live clear at either site is a lost wake
+named at its exact destruction point.
+
+Each per-CPU dump line carries a **spin-site breadcrumb**: a wedged CPU that
+never returned to the scheduler is stuck in a protocol-spin, and the
+breadcrumb (`spin_site_enter`/`spin_site_exit`, set around each gate) names
+which one — `dealloc:not-current`, `dealloc:context-saved`,
+`dealloc:wake-in-flight`, or `schedule:context-saved`. The
+`dealloc_object(Thread)` gates carried no overlong-duration warning of their
+own, so a wedge there showed only an opaque `current = Exited` in
+`SYS_CAP_DELETE` (#351); the breadcrumb makes it explicit. The `schedule()`
+context-saved dispatch barrier reports both ways: the breadcrumb names it in
+cross-CPU dumps, and its own single-shot warning fires after 100 ms of
+spinning (`CS_SPIN_WARN_US`, time-based so it is meaningful under TCG's
+variable instruction rate).
 
 The dump then walks the live-thread registry (§ Thread Registry) and prints
 every non-running registered thread. For a `Blocked` thread it shows the
@@ -650,37 +696,47 @@ save-window pin holds a `context_saved == 0` thread on its owner). The per-CPU
 — a `Blocked` waiter on an IPC object, or a `Ready` thread stranded in a wedged
 CPU's run queue — were invisible before this enumeration (#351).
 
-**Cost:** one Relaxed counter increment per BSP timer tick, one Relaxed
-store per non-idle context switch, an O(MAX_CPUS) early-exit loop per tick.
-Zero overhead when healthy.
+**Cost:** per tick per CPU, one `current_tick()` read plus one Relaxed
+heartbeat store (APs add one Relaxed load + compare for the BSP check); one
+Relaxed counter increment per BSP tick and an O(`cpu_count`) early-exit
+loop; the registry scan and AP-stamp sweep run only on the 0.5 s cadence;
+one plain stamp store per park commit. Zero dump overhead when healthy.
 
 **Catches:** all-CPUs-idle with work queued (lost-wake bugs); cross-CPU
-`context_saved` deadlock; every TCB incorrectly `Blocked`.
+`context_saved` deadlock; every TCB incorrectly `Blocked`; a single thread
+wedged `Blocked` while the system stays busy (owed-wake rules); a BSP or AP
+wedged interrupts-off while at least one other CPU still ticks (heartbeat
+cross-checks).
 
-**Does NOT catch:** a single CPU spinning IRQ-disabled while peers make
-progress (no all-CPUs notification); BSP hardlockup (BSP timer stops, counter
-stops, detector can't fire). A future hardlockup detector (NMI / always-on
-S-mode timer) would close the latter gap; tracked as issue #33.
+**Does NOT catch:** every CPU wedged interrupts-off simultaneously (no
+heartbeat check runs anywhere — the all-idle detector is also dead because
+its counter stops). Only an NMI / always-on S-mode timer hardlockup
+detector closes that; tracked as issue #33. A `Blocked` thread whose waker
+genuinely never claimed it (no deadline, no `wake_in_flight`, no
+`wake_pending`) is indistinguishable from a legitimate indefinite wait by
+TCB scalars alone and is also not flagged.
 
 **Defers to an in-flight TLB shootdown:** a synchronous shootdown holds every
 participating CPU (initiator preempt-disabled in `wait_for_ack`; peers spinning
 in `pt_lock` or their own shootdown) until all remote CPUs ack. Under heavy
 oversubscription that round-trip can exceed the threshold while still making
-progress, so the detector skips firing while `tlb_shootdown::any_pending()`
-reports any per-CPU request slot with CPUs still to ack. The shootdown's own
-escalation ladder (NMI backtrace at 0.75 s, panic at 5 s in arch
-`wait_for_ack`) is the authoritative detector for a genuinely stuck IPI; a
-non-shootdown stall re-checks on the next tick once the pending slots drain.
+progress, so the all-idle detector and both heartbeat cross-checks skip firing
+while `tlb_shootdown::any_pending()` reports any per-CPU request slot with
+CPUs still to ack. The shootdown's own escalation ladder (NMI backtrace at
+0.75 s, panic at 5 s in arch `wait_for_ack`) is the authoritative detector
+for a genuinely stuck IPI; a non-shootdown stall re-checks on the next tick
+once the pending slots drain.
 
 **Why kernel-side:** when every CPU is in kernel mode, no userspace monitor
 gets dispatched. The dump is also the only path that reads per-CPU
 scheduler state without taking a lock that the stalled CPUs themselves hold.
 
 **Bounded-spin diagnostics elsewhere:** two protocol-required spins (the
-`context_saved` Acquire spin in `schedule()`; the cross-CPU drain spin in
-`sys_thread_stop`) carry single-shot overlong-duration warnings. These are
-not the watchdog; they fire only when the spin overruns and identify the
-stuck participants. Zero overhead in healthy paths.
+`context_saved` Acquire spin in `schedule()`, which also reports a spin-site
+breadcrumb as above; the cross-CPU drain spin in `sys_thread_stop`) carry
+single-shot overlong-duration warnings. These are not the watchdog; they
+fire only when the spin overruns and identify the stuck participants. Zero
+overhead in healthy paths.
 
 ## Thread Registry
 

--- a/core/kernel/src/main.rs
+++ b/core/kernel/src/main.rs
@@ -1057,6 +1057,7 @@ unsafe fn kernel_entry_post_rebase(
                         last_enqueue: None,
                         sched_lock: crate::sync::Spinlock::new(),
                         wake_pending: false,
+                        park_started_tick: 0,
                         ipc_state: sched::thread::IpcThreadState::None,
                         ipc_msg: ipc::message::Message::default(),
                         reply_tcb: core::sync::atomic::AtomicPtr::new(core::ptr::null_mut()),

--- a/core/kernel/src/sched/mod.rs
+++ b/core/kernel/src/sched/mod.rs
@@ -1483,7 +1483,12 @@ pub fn sleep_check_wakeups()
             // enqueue_and_wake reads state under sched_lock and either links a
             // still-Blocked thread or, if dealloc already marked it Exited, aborts
             // the link — both clear wake_in_flight, releasing that gate.
-            let cpu = unsafe { (*tcb).preferred_cpu as usize };
+            //
+            // select_target_cpu, like every other wake path: it honours a hard
+            // affinity changed mid-sleep (raw preferred_cpu would not) and
+            // applies the save-window pin for a cs == 0 waker race.
+            // SAFETY: tcb valid (wake-in-flight gated).
+            let cpu = unsafe { select_target_cpu(tcb) };
             // SAFETY: tcb valid (wake-in-flight gated); enqueue_and_wake commits
             // the transition by state.
             unsafe { enqueue_and_wake(tcb, cpu) };
@@ -2611,8 +2616,10 @@ const LOAD_BALANCE_IMBALANCE_THRESHOLD: u32 = 2;
 /// Hot path cost: 1 Relaxed atomic load (own `current_load`) plus either
 /// (idle CPU) one Relaxed load per remote CPU to find the heaviest, or
 /// (loaded CPU) 1 Relaxed atomic increment (tick counter) + 1 Relaxed
-/// load (random victim). Scheduler locks are acquired only when the
-/// observed imbalance exceeds `LOAD_BALANCE_IMBALANCE_THRESHOLD`.
+/// load (random victim). Scheduler locks are attempted only when the
+/// observed imbalance exceeds `LOAD_BALANCE_IMBALANCE_THRESHOLD`, and only
+/// via try-lock — the pull path never queues on a contended lock (see
+/// `pull_unpinned_ready`, #375).
 ///
 /// Pull-based, victim-selection mode depends on local load:
 /// - **Loaded CPUs (`my_load > 0`)** sample a pseudo-random victim. This
@@ -2702,7 +2709,8 @@ unsafe fn try_pull_balance(this_cpu: usize)
 unsafe fn try_pull_balance(_this_cpu: usize) {}
 
 /// Locate the first unpinned Ready thread on `src_cpu`'s run queues and
-/// migrate it to `dst_cpu` under both scheduler locks (ascending order).
+/// migrate it to `dst_cpu` under both scheduler locks (ascending order,
+/// try-acquired — a contended pull backs off to the next balance tick).
 ///
 /// Pinned threads are invisible to this pull. Caller MUST NOT hold either
 /// scheduler lock.
@@ -2738,10 +2746,31 @@ unsafe fn pull_unpinned_ready(src_cpu: usize, dst_cpu: usize)
     // SAFETY: as above.
     let hi_sched = unsafe { scheduler_for(hi) };
 
-    // SAFETY: paired with unlock_raw below in reverse order.
-    let saved_lo = unsafe { lo_sched.lock.lock_raw() };
-    // SAFETY: ascending-CPU order satisfies lock-hierarchy rule 4.
-    let saved_hi = unsafe { hi_sched.lock.lock_raw() };
+    // Try-lock, never queue: this path runs from every CPU's timer tick with
+    // interrupts disabled, and under a pinned-heavy imbalance every idle CPU
+    // converges on the same victim every tick. A blocking acquisition here
+    // forms a FIFO ticket convoy of interrupts-off spinners — with the lock
+    // held ~always by the queue itself, ticks, IPIs, and serial output stop
+    // system-wide, and under host vCPU oversubscription the handoff latency
+    // exceeds the refill rate and the guest livelocks (#375; captured with
+    // ~55/64 harts queued on one run-queue lock). A balancer pull is optional
+    // work: on contention, back off and retry on a later tick.
+    // SAFETY: paired with unlock_raw below.
+    let Some(saved_lo) = (unsafe { lo_sched.lock.try_lock_raw() })
+    else
+    {
+        return;
+    };
+    // Ascending-CPU order (lock-hierarchy rule 4) is retained; try keeps the
+    // acquisition non-queuing.
+    // SAFETY: paired with unlock_raw below.
+    let Some(saved_hi) = (unsafe { hi_sched.lock.try_lock_raw() })
+    else
+    {
+        // SAFETY: paired with try_lock_raw above.
+        unsafe { lo_sched.lock.unlock_raw(saved_lo) };
+        return;
+    };
 
     // No skip-owner predicate is needed: after eager switch_out_save, a
     // Ready thread can never be any CPU's `fpu_owner`. Ownership is

--- a/core/kernel/src/sched/mod.rs
+++ b/core/kernel/src/sched/mod.rs
@@ -240,6 +240,88 @@ static WATCHDOG_TICK_COUNTER: core::sync::atomic::AtomicU64 = core::sync::atomic
 
 static WATCHDOG_FIRED: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
 
+/// Claim the global once-only watchdog dump latch. The first detector to trip
+/// — all-idle softlockup, owed-wake, or a heartbeat check on any CPU — wins.
+/// One dump per boot keeps the serial log readable, prevents a dump storm when
+/// many CPUs detect the same stall, and the first dump is the uncontaminated
+/// evidence.
+#[cfg(not(test))]
+fn watchdog_claim_dump() -> bool
+{
+    WATCHDOG_FIRED
+        .compare_exchange(
+            false,
+            true,
+            core::sync::atomic::Ordering::Relaxed,
+            core::sync::atomic::Ordering::Relaxed,
+        )
+        .is_ok()
+}
+
+/// Cadence of the owed-wake and AP-silence detector scans, in BSP ticks
+/// (~0.5 s at the observed ~1 ms tick).
+#[cfg(not(test))]
+const DETECTOR_SCAN_INTERVAL_TICKS: u64 = 512;
+
+/// Grace period before a `Blocked` thread's owed wake is considered lost and
+/// before a silent timer heartbeat is considered stalled.
+#[cfg(not(test))]
+const WEDGE_GRACE_SECONDS: u64 = 2;
+
+/// Owed-wake rule: `sleep_deadline` expired past the grace window while the
+/// thread is still `Blocked` — its timer wake was claimed and then lost, or
+/// the sleep machinery never ran.
+#[cfg(not(test))]
+const OWED_RULE_EXPIRED_DEADLINE: u8 = 1;
+/// Owed-wake rule: `wake_in_flight == 1` persisting — a waker claimed the
+/// thread but its `enqueue_and_wake` never completed.
+#[cfg(not(test))]
+const OWED_RULE_WAKE_IN_FLIGHT: u8 = 2;
+/// Owed-wake rule: `wake_pending` observed on a `Blocked` thread — a coalesced
+/// wake survived past a park commit that should have consumed it.
+#[cfg(not(test))]
+const OWED_RULE_WAKE_PENDING: u8 = 3;
+
+/// Suspect capacity per owed-wake scan; a wedge involves a handful of threads.
+#[cfg(not(test))]
+const OWED_WAKE_MAX: usize = 8;
+
+/// `schedule()` context-saved spin: single-shot warning threshold (µs).
+#[cfg(not(test))]
+const CS_SPIN_WARN_US: u64 = 100_000;
+
+/// One-shot latch for the `wake_pending` clear tripwires in `schedule()`. The
+/// re-mark and dispatch-flip arms clear a flag whose only sanctioned consumer
+/// is `commit_blocked_under_local_lock`; a live coalesced wake destroyed at
+/// either site is the #375 lost-wake signature, and the tripwire names it
+/// once.
+#[cfg(not(test))]
+static WAKE_PENDING_CLEAR_TRIPPED: core::sync::atomic::AtomicBool =
+    core::sync::atomic::AtomicBool::new(false);
+
+/// Owed-wake suspects `(thread_id, rule)` recorded by the previous scan, for
+/// the two-scan persistence requirement of the `wake_in_flight` /
+/// `wake_pending` rules. BSP-only access from `owed_wake_scan` (CPU0 timer
+/// context behind an interrupt gate, non-reentrant) — the same single-writer
+/// CPU0-static idiom as `EXPIRED_SCRATCH`.
+#[cfg(not(test))]
+static mut OWED_WAKE_LAST: [(u32, u8); OWED_WAKE_MAX] = [(0, 0); OWED_WAKE_MAX];
+/// Number of live entries in [`OWED_WAKE_LAST`].
+#[cfg(not(test))]
+static mut OWED_WAKE_LAST_COUNT: usize = 0;
+
+/// Per-CPU `timer::current_tick()` stamp of the most recent `timer_tick`
+/// entry. Written by the owning CPU only (one Relaxed store per tick); read
+/// by the cross-CPU heartbeat detectors. Slot 0 (the BSP) hosts the
+/// sleep-list waker and every watchdog scan, so each AP cross-checks it in
+/// `bsp_stall_check`; the BSP symmetrically scans AP slots in
+/// `ap_silence_check`. `current_tick()` derives from a globally consistent
+/// counter on both arches (TSC / `time` CSR), so cross-CPU age comparisons
+/// are sound.
+#[cfg(not(test))]
+static TICK_HEARTBEAT: [core::sync::atomic::AtomicU64; MAX_CPUS] =
+    [const { core::sync::atomic::AtomicU64::new(0) }; MAX_CPUS];
+
 // ── Per-CPU spin-site breadcrumb ──────────────────────────────────────────────
 
 /// Spin-site code: this CPU is not in any bounded protocol-spin.
@@ -253,16 +335,19 @@ pub const SPIN_SITE_DEALLOC_CONTEXT_SAVED: u32 = 2;
 /// `dealloc_object(Thread)` wake-in-flight gate: spinning until a waker's
 /// claimed-but-not-yet-committed `enqueue_and_wake` clears `wake_in_flight`.
 pub const SPIN_SITE_DEALLOC_WAKE_IN_FLIGHT: u32 = 3;
+/// `schedule()` dispatch barrier: spinning until the next thread's previous
+/// CPU publishes its register save (`context_saved == 1`).
+pub const SPIN_SITE_SCHED_CONTEXT_SAVED: u32 = 4;
 
 /// Per-CPU breadcrumb naming the bounded protocol-spin a CPU is currently
 /// executing, for the softlockup watchdog. A wedged CPU (no non-idle dispatch
 /// for the threshold) stuck in a `dealloc_object(Thread)` gate shows the gate
 /// here, turning an opaque `current = Exited` dump into a named site (#351).
 /// Set on gate entry, cleared on exit; [`SPIN_SITE_NONE`] when not spinning.
-/// Only the three `dealloc_object(Thread)` gates report here — they are the
-/// bounded spins that lack an overlong-duration warning of their own (the
-/// `schedule()` context-saved spin and the `sys_thread_stop` drain carry their
-/// own). Diagnostic-only — never gates control flow.
+/// The reporting sites are the three `dealloc_object(Thread)` gates and the
+/// `schedule()` context-saved dispatch barrier — the protocol spins that can
+/// wedge a CPU silently (the `sys_thread_stop` drain carries its own
+/// overlong-duration warning). Diagnostic-only — never gates control flow.
 #[cfg(not(test))]
 static SPIN_SITE: [core::sync::atomic::AtomicU32; MAX_CPUS] =
     [const { core::sync::atomic::AtomicU32::new(SPIN_SITE_NONE) }; MAX_CPUS];
@@ -300,6 +385,7 @@ fn spin_site_name(site: u32) -> &'static str
         SPIN_SITE_DEALLOC_NOT_CURRENT => "dealloc:not-current",
         SPIN_SITE_DEALLOC_CONTEXT_SAVED => "dealloc:context-saved",
         SPIN_SITE_DEALLOC_WAKE_IN_FLIGHT => "dealloc:wake-in-flight",
+        SPIN_SITE_SCHED_CONTEXT_SAVED => "schedule:context-saved",
         _ => "none",
     }
 }
@@ -319,10 +405,11 @@ pub fn watchdog_mark_non_idle(cpu: usize)
     last_non_idle_tick(cpu).store(now, core::sync::atomic::Ordering::Relaxed);
 }
 
-/// BSP-only: tick the global counter; if every CPU's last non-idle
-/// dispatch exceeds the threshold, dump per-CPU TCB state once.
+/// BSP-only: tick the global counter and run the wedge detectors — the
+/// owed-wake registry scan and AP-heartbeat silence check on a coarse
+/// cadence, and the all-idle softlockup check every tick. The first
+/// detector to trip claims the global dump latch (`watchdog_claim_dump`).
 #[cfg(not(test))]
-#[allow(clippy::too_many_lines)]
 fn watchdog_tick_and_check()
 {
     let cpu_count = CPU_COUNT.load(core::sync::atomic::Ordering::Relaxed) as usize;
@@ -332,6 +419,17 @@ fn watchdog_tick_and_check()
     if WATCHDOG_FIRED.load(core::sync::atomic::Ordering::Relaxed)
     {
         return;
+    }
+
+    // Coarse-cadence detectors first; each claims the shared latch itself.
+    if now.is_multiple_of(DETECTOR_SCAN_INTERVAL_TICKS)
+    {
+        owed_wake_scan();
+        ap_silence_check(cpu_count);
+        if WATCHDOG_FIRED.load(core::sync::atomic::Ordering::Relaxed)
+        {
+            return;
+        }
     }
 
     // All CPUs must have last_dispatch older than threshold.
@@ -360,20 +458,226 @@ fn watchdog_tick_and_check()
         return;
     }
 
-    if WATCHDOG_FIRED
-        .compare_exchange(
-            false,
-            true,
-            core::sync::atomic::Ordering::Relaxed,
-            core::sync::atomic::Ordering::Relaxed,
-        )
-        .is_err()
+    if !watchdog_claim_dump()
     {
         return;
     }
 
-    // Stall detected. Dump per-CPU state.
-    crate::kprintln!("=== WATCHDOG: no non-idle dispatch on any CPU for >3s ===");
+    watchdog_dump("no non-idle dispatch on any CPU for >3s");
+}
+
+/// Owed-wake detector: walk the thread registry for `Blocked` threads whose
+/// wake is provably owed but never arrived — the lost-wakeup wedge signature
+/// (#375). Three rules, each on plain TCB scalar reads only (no IPC-object
+/// dereference: unlike the dump's `blocked_on` decode, this runs on a LIVE
+/// system where a blocking object can be freed concurrently):
+///
+/// 1. expired deadline — `sleep_deadline != 0` and past the grace window;
+///    legitimate sleepers are claimed (deadline cleared) within one BSP tick.
+/// 2. `wake_in_flight` stuck — a waker claimed the thread but its
+///    `enqueue_and_wake` never completed. Normally clears in microseconds.
+/// 3. `wake_pending` while `Blocked` — a coalesced wake survived a park
+///    commit that should have consumed it.
+///
+/// Rule 1 is debounced by its grace window; rules 2 and 3 must additionally
+/// persist across two consecutive scans (~0.5 s apart) so a legitimately
+/// mid-wake observation cannot false-positive. Indefinite waits (endpoint
+/// recv loops) match no rule and never fire.
+#[cfg(not(test))]
+fn owed_wake_scan()
+{
+    let now_tick = crate::arch::current::timer::current_tick();
+    let tps = crate::arch::current::timer::ticks_per_second();
+    if now_tick == 0 || tps == 0
+    {
+        return;
+    }
+    let grace = WEDGE_GRACE_SECONDS.saturating_mul(tps);
+
+    let mut suspects = [(0u32, 0u8); OWED_WAKE_MAX];
+    let mut count = 0usize;
+    let collect = |t: *mut ThreadControlBlock| {
+        if count >= OWED_WAKE_MAX
+        {
+            return;
+        }
+        // SAFETY: t is a registry-walked TCB held stable by the registry
+        // lock; plain scalar reads. Torn observations are absorbed by the
+        // grace window (rule 1) and the two-scan persistence (rules 2, 3).
+        let (state, tid, dl, wif, wp, started) = unsafe {
+            (
+                (*t).state,
+                (*t).thread_id,
+                (*t).sleep_deadline,
+                (*t).wake_in_flight
+                    .load(core::sync::atomic::Ordering::Relaxed),
+                (*t).wake_pending,
+                (*t).park_started_tick,
+            )
+        };
+        if state != thread::ThreadState::Blocked
+        {
+            return;
+        }
+        let aged = now_tick > started.saturating_add(grace);
+        let rule = if dl != 0 && now_tick > dl.saturating_add(grace)
+        {
+            OWED_RULE_EXPIRED_DEADLINE
+        }
+        else if wif == 1 && aged
+        {
+            OWED_RULE_WAKE_IN_FLIGHT
+        }
+        else if wp && aged
+        {
+            OWED_RULE_WAKE_PENDING
+        }
+        else
+        {
+            return;
+        };
+        suspects[count] = (tid, rule);
+        count += 1;
+    };
+    // SAFETY: read-only walk; the closure only reads TCB scalars.
+    if !unsafe { thread_registry::try_for_each(collect) }
+    {
+        // Registry contended; keep the previous scan's suspects and retry on
+        // the next cadence.
+        return;
+    }
+
+    let mut fire: Option<(u32, u8)> = None;
+    for &(tid, rule) in suspects.iter().take(count)
+    {
+        // SAFETY: CPU0-static idiom — single writer/reader (this function, on
+        // the BSP, behind an interrupt gate).
+        let persistent = rule == OWED_RULE_EXPIRED_DEADLINE
+            || unsafe { OWED_WAKE_LAST[..OWED_WAKE_LAST_COUNT].contains(&(tid, rule)) };
+        if persistent
+        {
+            fire = Some((tid, rule));
+            break;
+        }
+    }
+
+    // SAFETY: CPU0-static idiom as above.
+    unsafe {
+        OWED_WAKE_LAST[..count].copy_from_slice(&suspects[..count]);
+        OWED_WAKE_LAST_COUNT = count;
+    }
+
+    if let Some((tid, rule)) = fire
+        && watchdog_claim_dump()
+    {
+        let rule_name = match rule
+        {
+            OWED_RULE_EXPIRED_DEADLINE => "sleep deadline expired, never woken",
+            OWED_RULE_WAKE_IN_FLIGHT => "wake claimed (wake_in_flight) but never linked",
+            _ => "wake_pending persisting while Blocked",
+        };
+        crate::kprintln!("watchdog: owed wake lost on tid{}: {}", tid, rule_name);
+        watchdog_dump("Blocked thread whose owed wake never arrived");
+    }
+}
+
+/// BSP side of the heartbeat cross-check: report an AP whose `timer_tick`
+/// heartbeat has gone silent past the grace window. An AP wedged with
+/// interrupts off cannot run its own detectors; this names it from the BSP.
+#[cfg(not(test))]
+fn ap_silence_check(cpu_count: usize)
+{
+    let now_tick = crate::arch::current::timer::current_tick();
+    let tps = crate::arch::current::timer::ticks_per_second();
+    if now_tick == 0 || tps == 0
+    {
+        return;
+    }
+    // A synchronous TLB shootdown can legitimately hold CPUs past the grace
+    // window; its own watchdog ladder (resend / warn / panic) is the
+    // authoritative detector there.
+    if crate::mm::tlb_shootdown::any_pending()
+    {
+        return;
+    }
+    let stall = WEDGE_GRACE_SECONDS.saturating_mul(tps);
+    for (cpu, slot) in TICK_HEARTBEAT
+        .iter()
+        .enumerate()
+        .take(cpu_count.min(MAX_CPUS))
+        .skip(1)
+    {
+        let hb = slot.load(core::sync::atomic::Ordering::Relaxed);
+        if hb != 0 && now_tick > hb.saturating_add(stall) && watchdog_claim_dump()
+        {
+            crate::kprintln!(
+                "watchdog: cpu{} timer heartbeat stalled (last={} now={})",
+                cpu,
+                hb,
+                now_tick
+            );
+            watchdog_dump("AP timer heartbeat stalled");
+            return;
+        }
+    }
+}
+
+/// AP side of the heartbeat cross-check, called from `timer_tick` on every
+/// non-BSP CPU: if the BSP's heartbeat is silent past the grace window, dump
+/// from here. A wedged BSP kills both the sleep-list waker and every
+/// BSP-hosted detector at once — total silence — so this is the only
+/// detector that can name that state (#375).
+#[cfg(not(test))]
+fn bsp_stall_check(own_heartbeat: u64)
+{
+    if WATCHDOG_FIRED.load(core::sync::atomic::Ordering::Relaxed)
+    {
+        return;
+    }
+    let tps = crate::arch::current::timer::ticks_per_second();
+    if own_heartbeat == 0 || tps == 0
+    {
+        return;
+    }
+    let hb0 = TICK_HEARTBEAT[0].load(core::sync::atomic::Ordering::Relaxed);
+    if hb0 == 0 || own_heartbeat <= hb0.saturating_add(WEDGE_GRACE_SECONDS.saturating_mul(tps))
+    {
+        return;
+    }
+    // Defer to the shootdown ladder, as in `ap_silence_check`.
+    if crate::mm::tlb_shootdown::any_pending()
+    {
+        return;
+    }
+    if watchdog_claim_dump()
+    {
+        let cpu = crate::arch::current::cpu::current_cpu();
+        crate::kprintln!(
+            "watchdog: cpu{} observes BSP heartbeat stalled (bsp={} now={})",
+            cpu,
+            hb0,
+            own_heartbeat
+        );
+        watchdog_dump("BSP timer heartbeat stalled — sleep wakeups and BSP detectors dead");
+    }
+}
+
+/// Dump scheduler state for a detected wedge: per-CPU current threads, the
+/// sleep list, and all non-running registered threads. Callable from any CPU
+/// in interrupt context; shared structures are read benign-racily or via
+/// try-lock so a wedged lock holder cannot deadlock the dump.
+#[cfg(not(test))]
+#[allow(clippy::too_many_lines)]
+fn watchdog_dump(reason: &str)
+{
+    let cpu_count = CPU_COUNT.load(core::sync::atomic::Ordering::Relaxed) as usize;
+    let now = WATCHDOG_TICK_COUNTER.load(core::sync::atomic::Ordering::Relaxed);
+    crate::kprintln!("=== WATCHDOG: {} ===", reason);
+    crate::kprintln!(
+        "  bsp_tick={} timer_tick={}",
+        now,
+        crate::arch::current::timer::current_tick()
+    );
     // needless_range_loop: parallel scheduler_for(cpu) accesses below.
     #[allow(clippy::needless_range_loop)]
     for cpu in 0..cpu_count
@@ -422,9 +726,17 @@ fn watchdog_tick_and_check()
             );
             continue;
         }
+        let heartbeat = if cpu < MAX_CPUS
+        {
+            TICK_HEARTBEAT[cpu].load(core::sync::atomic::Ordering::Relaxed)
+        }
+        else
+        {
+            0
+        };
         crate::kprintln!(
             "  cpu{} tid{} state={:?} ipc={:?} blocked_on={:p} prio={} pref={} \
-             idle_age={} mask=0x{:x}",
+             idle_age={} heartbeat={} mask=0x{:x}",
             cpu,
             tid,
             state,
@@ -433,6 +745,7 @@ fn watchdog_tick_and_check()
             prio,
             pref,
             now.saturating_sub(last_tick),
+            heartbeat,
             mask
         );
         // Name the bounded protocol-spin this CPU is wedged in, if any. A CPU
@@ -473,13 +786,24 @@ fn watchdog_tick_and_check()
             crate::kprintln!("    user_pc=0x{:x} syscall_nr={}", tf_ip, tf_syscall_nr);
         }
     }
-    // Dump sleep list.
-    // SAFETY: read-only; SLEEP_LIST_LOCK protects writers.
-    let n = unsafe {
-        let saved = SLEEP_LIST_LOCK.lock_raw();
-        let count = SLEEP_COUNT;
-        SLEEP_LIST_LOCK.unlock_raw(saved);
+    // Dump sleep list. Try-lock: a wedged CPU may hold SLEEP_LIST_LOCK, and
+    // the dump must not deadlock on it.
+    // SAFETY: read-only; paired unlock inside the map closure.
+    let locked_count = unsafe {
+        SLEEP_LIST_LOCK.try_lock_raw().map(|saved| {
+            let count = SLEEP_COUNT;
+            SLEEP_LIST_LOCK.unlock_raw(saved);
+            count
+        })
+    };
+    let n = if let Some(count) = locked_count
+    {
         count
+    }
+    else
+    {
+        crate::kprintln!("  SLEEP_LIST (lock contended; skipped)");
+        0
     };
     crate::kprintln!("  SLEEP_LIST count={}", n);
     // needless_range_loop: SLEEP_LIST is a static; iter().enumerate() obscures.
@@ -533,7 +857,7 @@ fn watchdog_tick_and_check()
             thread::ThreadState::Blocked =>
             {
                 // SAFETY: same contract; reads only plain scalar fields.
-                let (tid, ipc, blocked_on, prio, pref, wake_pending, wake_in_flight, dl) = unsafe {
+                let (tid, ipc, blocked_on, prio, pref, wake_pending, wake_in_flight, dl, started) = unsafe {
                     (
                         (*t).thread_id,
                         (*t).ipc_state,
@@ -544,11 +868,12 @@ fn watchdog_tick_and_check()
                         (*t).wake_in_flight
                             .load(core::sync::atomic::Ordering::Relaxed),
                         (*t).sleep_deadline,
+                        (*t).park_started_tick,
                     )
                 };
                 crate::kprintln!(
                     "    tid{} Blocked ipc={:?} blocked_on={:p} prio={} pref={} \
-                     wake_pending={} wake_in_flight={} dl={}",
+                     wake_pending={} wake_in_flight={} dl={} parked_at={}",
                     tid,
                     ipc,
                     blocked_on,
@@ -556,7 +881,8 @@ fn watchdog_tick_and_check()
                     pref,
                     wake_pending,
                     wake_in_flight,
-                    dl
+                    dl,
+                    started
                 );
                 // SAFETY: same contract; watchdog_decode_blocked_on only reads.
                 unsafe { watchdog_decode_blocked_on(t) };
@@ -719,10 +1045,10 @@ pub static BOOT_TRANSIENT_ACTIVE: core::sync::atomic::AtomicBool =
 
 // ── Sleep list ───────────────────────────────────────────────────────────────
 
-/// Maximum number of concurrently sleeping threads. Bounds the realistic
-/// envelope at `MAX_CPUS = 64` with a few timed waiters per CPU plus
-/// headroom; `sleep_list_add` returns `Err` past this cap rather than
-/// dropping silently.
+/// Maximum number of concurrently sleeping threads the fixed sleep list (and
+/// its expiry scratch buffer) can hold. `sleep_list_add` returns `Err` past
+/// this cap rather than dropping silently; the caller rolls back the park
+/// and the sleep degrades to an immediate return.
 pub const MAX_SLEEPING: usize = 128;
 
 /// Global list of sleeping threads. Protected by its own spinlock.
@@ -1323,6 +1649,7 @@ pub fn init(cpu_count: u32) -> u32
                     last_enqueue: None,
                     sched_lock: crate::sync::Spinlock::new(),
                     wake_pending: false,
+                    park_started_tick: 0,
                     ipc_state: IpcThreadState::None,
                     ipc_msg: crate::ipc::message::Message::default(),
                     reply_tcb: core::sync::atomic::AtomicPtr::new(core::ptr::null_mut()),
@@ -1795,6 +2122,9 @@ pub unsafe fn commit_blocked_under_local_lock(
                     (*tcb).state = thread::ThreadState::Blocked;
                     (*tcb).ipc_state = ipc;
                     (*tcb).blocked_on_object = blocked_on;
+                    // Diagnostic stamp for the owed-wake detector; written
+                    // under sched_lock like the rest of the Scheduling group.
+                    (*tcb).park_started_tick = crate::arch::current::timer::current_tick();
                     // Clear the publication barrier as part of the park commit so
                     // EVERY parker carries context_saved = 0 while Blocked: a
                     // cross-CPU waker's dispatch then spins on the cs barrier
@@ -3214,7 +3544,7 @@ pub unsafe fn schedule(requeue_current: bool)
         if !current.is_null()
         {
             // SAFETY: current is a valid TCB; state written under its sched_lock.
-            unsafe {
+            let (cleared_live_wake, tid) = unsafe {
                 (*current).state = ThreadState::Running;
                 // Still running on THIS CPU: keep preferred_cpu authoritative
                 // (the re-mark, like the local requeue above, must not leave it
@@ -3222,7 +3552,19 @@ pub unsafe fn schedule(requeue_current: bool)
                 (*current).preferred_cpu = cpu as u32;
                 // A running thread carries no pending park-wake (see the
                 // dispatch flip below).
+                let was_pending = (*current).wake_pending;
                 (*current).wake_pending = false;
+                (was_pending, (*current).thread_id)
+            };
+            if cleared_live_wake
+                && !WAKE_PENDING_CLEAR_TRIPPED.swap(true, core::sync::atomic::Ordering::Relaxed)
+            {
+                crate::kprintln!(
+                    "schedule: cpu{} re-mark cleared a live coalesced wake \
+                     on tid{} (#375 tripwire)",
+                    cpu,
+                    tid
+                );
             }
         }
         // Watchdog: count this as a non-idle dispatch so the softlockup
@@ -3319,7 +3661,7 @@ pub unsafe fn schedule(requeue_current: bool)
         if dispatchable
         {
             // SAFETY: under next.sched_lock.
-            unsafe {
+            let (cleared_live_wake, tid) = unsafe {
                 (*next).state = ThreadState::Running;
                 (*next).preferred_cpu = cpu as u32;
                 // A running thread has no outstanding park-wake to honour; clear
@@ -3327,7 +3669,19 @@ pub unsafe fn schedule(requeue_current: bool)
                 // unrelated commit_blocked (defensive — the `Running` coalesce
                 // that sets it is currently unreachable; see
                 // docs/sched-ipc-redesign.md §2.1).
+                let was_pending = (*next).wake_pending;
                 (*next).wake_pending = false;
+                (was_pending, (*next).thread_id)
+            };
+            if cleared_live_wake
+                && !WAKE_PENDING_CLEAR_TRIPPED.swap(true, core::sync::atomic::Ordering::Relaxed)
+            {
+                crate::kprintln!(
+                    "schedule: cpu{} dispatch-flip cleared a live coalesced \
+                     wake on tid{} (#375 tripwire)",
+                    cpu,
+                    tid
+                );
             }
         }
         // SAFETY: paired with lock_raw above.
@@ -3508,8 +3862,19 @@ pub unsafe fn schedule(requeue_current: bool)
     // previous CPU's switch(). On RISC-V RVWMO, without this Acquire the
     // loads in the restore phase could see stale register values. The spin
     // runs lockless (see #144).
-    if !core::ptr::eq(next, sched.idle) && !next.is_null()
+    let cs_unpublished = !core::ptr::eq(next, sched.idle)
+        && !next.is_null()
+        // SAFETY: next is a valid TCB; context_saved field always valid.
+        && unsafe {
+            (*next)
+                .context_saved
+                .load(core::sync::atomic::Ordering::Acquire)
+        } == 0;
+    if cs_unpublished
     {
+        spin_site_enter(SPIN_SITE_SCHED_CONTEXT_SAVED);
+        let start_us = crate::arch::current::timer::elapsed_us();
+        let mut warned = false;
         let mut spins: u64 = 0;
         // SAFETY: next is a valid TCB; context_saved field always valid.
         while unsafe {
@@ -3521,21 +3886,31 @@ pub unsafe fn schedule(requeue_current: bool)
             core::hint::spin_loop();
             spins += 1;
             // Single-shot diagnostic when the publication barrier stalls;
-            // healthy is <100 iter, 100M is ~tens of ms even under TCG.
-            if spins == 100_000_000
+            // healthy is <100 iterations. The time check is throttled so the
+            // spin body stays a cache-local load.
+            if !warned && spins.is_multiple_of(1024)
             {
-                // SAFETY: next is a valid TCB; thread_id is always valid.
-                let tid = unsafe { (*next).thread_id };
-                // SAFETY: next is a valid TCB; preferred_cpu is always valid.
-                let pref = unsafe { (*next).preferred_cpu };
-                crate::kprintln!(
-                    "schedule: cpu{} stuck spinning context_saved on next=tid{} pref={}",
-                    cpu,
-                    tid,
-                    pref
-                );
+                let overdue = match (start_us, crate::arch::current::timer::elapsed_us())
+                {
+                    (Some(start), Some(now_us)) => now_us.saturating_sub(start) > CS_SPIN_WARN_US,
+                    _ => false,
+                };
+                if overdue
+                {
+                    warned = true;
+                    // SAFETY: next is a valid TCB; the fields are always valid.
+                    let (tid, pref) = unsafe { ((*next).thread_id, (*next).preferred_cpu) };
+                    crate::kprintln!(
+                        "schedule: cpu{} stuck >100ms spinning context_saved on \
+                         next=tid{} pref={}",
+                        cpu,
+                        tid,
+                        pref
+                    );
+                }
             }
         }
+        spin_site_exit();
     }
 
     if !current_state.is_null()
@@ -3718,6 +4093,19 @@ pub unsafe fn timer_tick()
     let cpu = crate::arch::current::cpu::current_cpu() as usize;
     let cpu_count = CPU_COUNT.load(core::sync::atomic::Ordering::Relaxed) as usize;
     debug_assert!(cpu < cpu_count, "timer_tick: cpu={cpu} out of range");
+
+    // Cross-CPU liveness heartbeat (one Relaxed store), plus the BSP
+    // cross-check on APs. See [`TICK_HEARTBEAT`].
+    if cpu < MAX_CPUS
+    {
+        let heartbeat = crate::arch::current::timer::current_tick();
+        TICK_HEARTBEAT[cpu].store(heartbeat, core::sync::atomic::Ordering::Relaxed);
+        if cpu != 0
+        {
+            bsp_stall_check(heartbeat);
+        }
+    }
+
     // SAFETY: cpu < cpu_count; scheduler slab initialised by init().
     let sched = unsafe { &mut *scheduler_ptr(cpu) };
 

--- a/core/kernel/src/sched/thread.rs
+++ b/core/kernel/src/sched/thread.rs
@@ -433,6 +433,14 @@ pub struct ThreadControlBlock
     /// accessed under `sched_lock`.
     pub wake_pending: bool,
 
+    /// `timer::current_tick()` stamp of this thread's most recent park commit,
+    /// written under [`sched_lock`](Self::sched_lock) by
+    /// `commit_blocked_under_local_lock`. Diagnostic-only: the owed-wake
+    /// detector ages `Blocked` threads against it (see
+    /// docs/scheduling-internals.md § Softlockup Watchdog); never gates
+    /// control flow.
+    pub park_started_tick: u64,
+
     // === IPC state ===
     /// Current IPC blocking reason (None when not blocked on IPC).
     pub ipc_state: IpcThreadState,

--- a/core/kernel/src/syscall/cap.rs
+++ b/core/kernel/src/syscall/cap.rs
@@ -983,6 +983,7 @@ pub fn sys_cap_create_thread(tf: &mut TrapFrame) -> Result<u64, SyscallError>
                 last_enqueue: None,
                 sched_lock: crate::sync::Spinlock::new(),
                 wake_pending: false,
+                park_started_tick: 0,
                 ipc_state: IpcThreadState::None,
                 ipc_msg: Message::default(),
                 reply_tcb: core::sync::atomic::AtomicPtr::new(core::ptr::null_mut()),

--- a/core/ktest/src/main.rs
+++ b/core/ktest/src/main.rs
@@ -62,8 +62,11 @@ pub static FAIL_COUNT: AtomicUsize = AtomicUsize::new(0);
 /// `$name` must be a string literal (used with `concat!` for zero-cost
 /// log messages). `$body` is an expression evaluating to [`TestResult`].
 ///
-/// Prints one line per test: `ktest: PASS <name>` or `ktest: FAIL <name>`
-/// followed by the failure reason. Tests always continue past failures.
+/// Prints `ktest: RUN <name>` before the body, then one line per test:
+/// `ktest: PASS <name>` or `ktest: FAIL <name>` followed by the failure
+/// reason. Tests always continue past failures. The RUN line means a test
+/// that hangs identifies itself in the serial log instead of leaving only
+/// the previous test's PASS line as the last output.
 ///
 /// To add a new unit test: write a function returning `TestResult`, then
 /// call `run_test!("subsystem::test_name", fn_name(ctx))` in the relevant
@@ -71,6 +74,7 @@ pub static FAIL_COUNT: AtomicUsize = AtomicUsize::new(0);
 #[macro_export]
 macro_rules! run_test {
     ($name:literal, $body:expr) => {{
+        $crate::log(concat!("ktest: RUN ", $name));
         let result: $crate::TestResult = { $body };
         match result
         {

--- a/core/ktest/src/stress/load_balance_handoff_steal.rs
+++ b/core/ktest/src/stress/load_balance_handoff_steal.rs
@@ -71,6 +71,14 @@
 //! is a smoke check. Reverting the `context_saved == 1` load-balancer gate
 //! reintroduces the steal, surfaced by a kernel guard the harness reports as
 //! FAIL.
+//!
+//! The migration assertion applies only at `cpus <= MIGRATION_GUARD_MAX_CPUS`:
+//! above that the one-hot `u32` CPU witness aliases indices mod 32, and the
+//! oversubscription premise (`2 * NUM_PAIRS ≫ cpus`) is inverted — run-queue
+//! depths rarely exceed the balancer's imbalance threshold, so the steal path
+//! legitimately may never arm and the guard becomes a coin flip. The kernel
+//! guards above remain the regression signal at every CPU count; the witness
+//! values are still logged.
 
 use core::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 
@@ -103,6 +111,12 @@ const SAMPLE_EVERY: usize = 64;
 
 /// Controller warmup yields so servers reach `ipc_recv` before clients call.
 const SETTLE_YIELDS: usize = 8;
+
+/// Widest guest for which the `migrations >= 1` guard is asserted: the bound of
+/// the one-hot `u32` CPU witness (`sample_cpu_bit` masks indices mod 32), and
+/// comfortably inside the oversubscription envelope the guard was tuned for
+/// (see the module doc's Pass criterion).
+const MIGRATION_GUARD_MAX_CPUS: u64 = 32;
 
 /// Notification signal right (bit 7) — what a client needs to `notification_send`.
 const RIGHTS_SIGNAL: u64 = 1 << 7;
@@ -275,7 +289,7 @@ pub fn run(ctx: &TestContext) -> TestResult
     {
         return Err("stress::load_balance_handoff_steal: not all round-trips completed");
     }
-    if migrations == 0
+    if migrations == 0 && cpus <= MIGRATION_GUARD_MAX_CPUS
     {
         return Err(
             "stress::load_balance_handoff_steal: no client observed on 2+ CPUs (steal path unarmed)",

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -281,10 +281,12 @@ cargo xtask compose-bundle --harness ktest --arch riscv64
 cargo xtask run-parallel --arch riscv64 --cpus 64 --parallel 1 --runs 3 --timeout 600
 cargo xtask run-parallel --arch riscv64 --cpus 65 --parallel 1 --runs 3 --timeout 600
 
-# Boundary CPU counts, x86_64 (KVM hosts boot in seconds):
+# Boundary CPU counts, x86_64 (~330 s per passing run on a 16-core KVM
+# host — boot is seconds, but the stress tier runs at 16x vCPU
+# oversubscription; the 900 s budget is for HANG classification):
 cargo xtask build
 cargo xtask compose-bundle --harness ktest
-cargo xtask run-parallel --arch x86_64 --cpus 256 --parallel 1 --runs 3 --timeout 300
+cargo xtask run-parallel --arch x86_64 --cpus 256 --parallel 1 --runs 3 --timeout 900
 
 # Memory variation (either arch):
 cargo xtask run-parallel --arch <arch> --cpus 4 --mem 1024 --parallel 1 --runs 1 --timeout 300

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -303,12 +303,14 @@ list as the tracking Issues move):
   loading the kernel ELF; independent of guest memory size. At 256 and
   512 harts under TCG the firmware produces no serial output within 20
   and 30 minutes respectively.
-- Both arches, high CPU counts ([#375](https://github.com/kottlerg/seraph/issues/375)):
-  intermittent silent wedge in `thread::load_balancer_skips_pinned`
-  (~1/3 of runs at 64-65 harts riscv64; observed once at 256 vCPUs
-  x86_64/KVM). A HANG at that marker reproduces on master and is not
-  evidence against the change under test — re-run, and attribute to
-  #375.
+- Both arches, high CPU counts ([#375](https://github.com/kottlerg/seraph/issues/375),
+  fixed): the intermittent silent wedge around the `thread::load_balancer`
+  and `stress::double_enqueue_storm` tests was a load-balancer ticket-lock
+  convoy — every idle CPU queuing interrupts-off on one victim's run-queue
+  lock every tick; the pull path now try-locks and backs off. A new silent
+  high-CPU HANG should instead produce a `=== WATCHDOG` dump (owed-wake /
+  heartbeat detectors) naming the wedged state; file it with the preserved
+  log rather than attributing it to #375.
 
 ---
 

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -234,7 +234,9 @@ cargo xtask run-parallel \
     [--mem MIB] \
     [--pass REGEX] \
     [--fail REGEX] \
-    [--fail-grace-secs SECONDS]
+    [--fail-grace-secs SECONDS] \
+    [--debug-listen] \
+    [--hold-on-hang]
 ```
 
 | Option | Default | Description |
@@ -246,8 +248,10 @@ cargo xtask run-parallel \
 | `--cpus` | `4` | vCPUs per guest (bounded by `1..=512`, the boot-protocol `MAX_CPUS`) |
 | `--mem` | `512` | Guest memory size in MiB |
 | `--pass` | `ALL TESTS PASSED` | Regex marking a successful run. The default matches the cross-harness terminal marker `[<harness>] ALL TESTS PASSED` standardised in [docs/testing.md](../docs/testing.md). On match the log is discarded and the run is classified `PASS` |
-| `--fail` | `SOME TESTS FAILED\|KERNEL EXCEPTION\|FATAL:\|PANIC( at \|: )` | Regex marking a failed run; the **first** match wins. Matches the cross-harness terminal marker `[<harness>] SOME TESTS FAILED` ([docs/testing.md](../docs/testing.md)) plus the kernel's own death markers (`KERNEL EXCEPTION` + `FATAL:` for a hardware trap, `PANIC at`/`PANIC:` for a Rust `panic!`) so a crash classifies `FAIL` rather than `HANG`. The benign `USERSPACE FAULT` path matches none of these. On match the log is preserved as `FAIL-<run>.log`. Failure takes precedence over success. Override with a never-matching pattern (e.g. `'$.^'`) to disable |
+| `--fail` | `SOME TESTS FAILED\|KERNEL EXCEPTION\|FATAL:\|PANIC( at \|: )\|=== WATCHDOG` | Regex marking a failed run; the **first** match wins. Matches the cross-harness terminal marker `[<harness>] SOME TESTS FAILED` ([docs/testing.md](../docs/testing.md)) plus the kernel's own death markers (`KERNEL EXCEPTION` + `FATAL:` for a hardware trap, `PANIC at`/`PANIC:` for a Rust `panic!`, `=== WATCHDOG` for a scheduler wedge-detector dump) so a crash classifies `FAIL` rather than `HANG`. The benign `USERSPACE FAULT` path matches none of these. On match the log is preserved as `FAIL-<run>.log`. Failure takes precedence over success. Override with a never-matching pattern (e.g. `'$.^'`) to disable |
 | `--fail-grace-secs` | `10` | After the first `--fail` match, wait this many seconds (bounded by `--timeout`) before SIGKILL, so the trailing fault dump still lands in the log. A crashed run thus aborts ~grace seconds after the first match instead of idling to `--timeout` |
+| `--debug-listen` | off | Expose each guest's gdbstub without pausing it (QEMU `-s`, tcp::1234) so a wedged guest can be attached post-hoc: `gdb -ex 'target remote :1234'`. Requires `--parallel 1` (one gdbstub port) |
+| `--hold-on-hang` | off | On a hard-timeout `HANG` (no `--fail` match), do not kill QEMU: print the attach instructions and block until the instance is terminated externally, preserving the wedged guest for a debugger. Pair with `--debug-listen`. Requires `--parallel 1` |
 
 **Mode-agnostic**: xtask does not know about ktest, svctest, or any other
 rootfs configuration. Pass/fail markers come from the invoker. The default

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -274,7 +274,8 @@ pub enum TestComponent
 /// classified FAIL rather than HANG. `KERNEL EXCEPTION` + `FATAL:` cover the
 /// hardware-trap path; `PANIC( at |: )` covers the Rust `#[panic_handler]`.
 /// The benign `USERSPACE FAULT` path matches none of these.
-pub const DEFAULT_FAIL_REGEX: &str = r"SOME TESTS FAILED|KERNEL EXCEPTION|FATAL:|PANIC( at |: )";
+pub const DEFAULT_FAIL_REGEX: &str =
+    r"SOME TESTS FAILED|KERNEL EXCEPTION|FATAL:|PANIC( at |: )|=== WATCHDOG";
 
 #[derive(Parser)]
 pub struct RunParallelArgs
@@ -318,12 +319,29 @@ pub struct RunParallelArgs
     /// `[<harness>] SOME TESTS FAILED` ([`docs/testing.md`](../../docs/testing.md)) plus the kernel's
     /// own death markers, so a crash classifies as FAIL rather than HANG: a
     /// hardware trap prints `KERNEL EXCEPTION` then `FATAL:`
-    /// (`core/kernel/src/main.rs` `fatal()`), and a Rust `panic!` prints
-    /// `PANIC at`/`PANIC:` (the `#[panic_handler]`). The benign userspace
-    /// fault path prints `USERSPACE FAULT`, which none of these match.
-    /// Override with a never-matching pattern (e.g. `'$.^'`) to disable.
+    /// (`core/kernel/src/main.rs` `fatal()`), a Rust `panic!` prints
+    /// `PANIC at`/`PANIC:` (the `#[panic_handler]`), and the scheduler's
+    /// wedge detectors print a dump headed `=== WATCHDOG` (a kernel that
+    /// detected its own stall is a failure, not a hang). The benign
+    /// userspace fault path prints `USERSPACE FAULT`, which none of these
+    /// match. Override with a never-matching pattern (e.g. `'$.^'`) to
+    /// disable.
     #[arg(long, default_value = DEFAULT_FAIL_REGEX)]
     pub fail: String,
+
+    /// Expose each guest's gdbstub without pausing it (QEMU `-s`,
+    /// `tcp::1234`), so a wedged guest can be attached to post-hoc:
+    /// `gdb -ex 'target remote :1234'`. Requires `--parallel 1` (one
+    /// gdbstub port).
+    #[arg(long)]
+    pub debug_listen: bool,
+
+    /// On a hard-timeout HANG, do not kill the QEMU instance: print the
+    /// attach instructions and block until it is terminated externally,
+    /// preserving the wedged guest for inspection (pair with
+    /// `--debug-listen`). Requires `--parallel 1`.
+    #[arg(long)]
+    pub hold_on_hang: bool,
 
     /// Grace window, in seconds, after the first `--fail` match before the
     /// run is `SIGKILLed`. A kernel fault dump is multi-line and may be

--- a/xtask/src/commands/run.rs
+++ b/xtask/src/commands/run.rs
@@ -21,7 +21,7 @@ use crate::cli::RunArgs;
 use crate::context::Context as BuildContext;
 use crate::firmware::find_ovmf_code;
 use crate::qemu::{
-    QemuLaunchSpec, build_qemu_argv, prepare_riscv_firmware, validate_sysroot_for_launch,
+    GdbMode, QemuLaunchSpec, build_qemu_argv, prepare_riscv_firmware, validate_sysroot_for_launch,
 };
 use crate::term::filter::FilterWriter;
 use crate::term::guard::TerminalGuard;
@@ -69,7 +69,14 @@ pub fn run(ctx: &BuildContext, args: &RunArgs) -> Result<()>
         cpus: args.cpus,
         mem_mib: args.mem,
         headless: args.headless,
-        gdb: args.gdb,
+        gdb: if args.gdb
+        {
+            GdbMode::Freeze
+        }
+        else
+        {
+            GdbMode::Off
+        },
         qmp_socket: None,
     };
     let qemu_args = build_qemu_argv(&spec)?;

--- a/xtask/src/commands/run_parallel.rs
+++ b/xtask/src/commands/run_parallel.rs
@@ -30,7 +30,7 @@ use crate::cli::RunParallelArgs;
 use crate::context::Context as BuildContext;
 use crate::firmware::find_ovmf_code;
 use crate::qemu::{
-    QemuLaunchSpec, build_qemu_argv, prepare_riscv_firmware, validate_sysroot_for_launch,
+    GdbMode, QemuLaunchSpec, build_qemu_argv, prepare_riscv_firmware, validate_sysroot_for_launch,
 };
 use crate::term::filter::FilterWriter;
 use crate::util::{require_tool, step};
@@ -171,6 +171,8 @@ pub fn run(ctx: &BuildContext, args: &RunParallelArgs) -> Result<()>
             let arch = args.arch;
             let cpus = args.cpus;
             let mem_mib = args.mem;
+            let debug_listen = args.debug_listen;
+            let hold_on_hang = args.hold_on_hang;
             let timeout = Duration::from_secs(args.timeout);
             let fail_grace = Duration::from_secs(args.fail_grace_secs);
             let pass_re = pass_re.clone();
@@ -215,7 +217,14 @@ pub fn run(ctx: &BuildContext, args: &RunParallelArgs) -> Result<()>
                     cpus,
                     mem_mib,
                     headless: true,
-                    gdb: false,
+                    gdb: if debug_listen
+                    {
+                        GdbMode::Listen
+                    }
+                    else
+                    {
+                        GdbMode::Off
+                    },
                     qmp_socket: None,
                 };
                 let qemu_args = build_qemu_argv(&spec)?;
@@ -250,8 +259,14 @@ pub fn run(ctx: &BuildContext, args: &RunParallelArgs) -> Result<()>
                     .context("QEMU stdout was piped but unavailable")?;
                 let forwarder = spawn_stdout_forwarder(qemu_stdout, log_file, slot)?;
 
-                let (exit_rc, hung) =
-                    wait_with_timeout(&mut child, timeout, &log_path, &fail_re, fail_grace)?;
+                let (exit_rc, hung) = wait_with_timeout(
+                    &mut child,
+                    timeout,
+                    &log_path,
+                    &fail_re,
+                    fail_grace,
+                    hold_on_hang,
+                )?;
                 // Drain the forwarder before reading the log so classify()
                 // sees the complete byte stream even when the watchdog
                 // killed QEMU mid-write.
@@ -333,6 +348,10 @@ fn validate_args(args: &RunParallelArgs) -> Result<()>
     if args.timeout == 0
     {
         bail!("--timeout must be >= 1");
+    }
+    if (args.debug_listen || args.hold_on_hang) && args.parallel != 1
+    {
+        bail!("--debug-listen / --hold-on-hang require --parallel 1 (one gdbstub port)");
     }
     Ok(())
 }
@@ -438,12 +457,19 @@ fn join_forwarder(handle: JoinHandle<Result<()>>, run_id: u32)
 /// `was_hung` marks any watchdog kill (hard timeout or grace). `classify`
 /// disambiguates — a grace kill carries the `--fail` marker in the final
 /// log read, so it resolves to `FAIL`, not `HANG`.
+///
+/// With `hold_on_hang`, a hard-timeout expiry (no `--fail` marker seen)
+/// does not kill the instance: the attach instructions are printed and the
+/// call blocks until QEMU is terminated externally, preserving the wedged
+/// guest for a debugger. Grace-window kills (a crash already diagnosed in
+/// the log) are unaffected.
 fn wait_with_timeout(
     child: &mut Child,
     timeout: Duration,
     log_path: &Path,
     fail_re: &Regex,
     fail_grace: Duration,
+    hold_on_hang: bool,
 ) -> Result<(i32, bool)>
 {
     let deadline = Instant::now() + timeout;
@@ -465,6 +491,20 @@ fn wait_with_timeout(
         let effective = grace_deadline.map_or(deadline, |g| g.min(deadline));
         if Instant::now() >= effective
         {
+            if hold_on_hang && grace_deadline.is_none()
+            {
+                eprintln!(
+                    "run-parallel: HANG at timeout; holding QEMU (pid {}) for inspection.\n\
+                     run-parallel:   log: {}\n\
+                     run-parallel:   attach: gdb -ex 'target remote :1234' (with --debug-listen)\n\
+                     run-parallel:   resume the harness by terminating QEMU (kill {})",
+                    child.id(),
+                    log_path.display(),
+                    child.id()
+                );
+                let status = child.wait().context("waiting on held child")?;
+                return Ok((exit_status_rc(status), true));
+            }
             let _ = child.kill();
             let status = child.wait().context("reaping killed child")?;
             return Ok((status.code().unwrap_or(137), true));

--- a/xtask/src/commands/test_terminal.rs
+++ b/xtask/src/commands/test_terminal.rs
@@ -38,7 +38,7 @@ use crate::cli::TestTerminalArgs;
 use crate::context::Context;
 use crate::firmware::find_ovmf_code;
 use crate::qemu::{
-    QemuLaunchSpec, build_qemu_argv, prepare_riscv_firmware, validate_sysroot_for_launch,
+    GdbMode, QemuLaunchSpec, build_qemu_argv, prepare_riscv_firmware, validate_sysroot_for_launch,
 };
 use crate::qmp;
 use crate::util::{require_tool, step};
@@ -128,7 +128,7 @@ pub fn run(ctx: &Context, args: &TestTerminalArgs) -> Result<()>
         cpus: args.cpus,
         mem_mib: args.mem,
         headless: true,
-        gdb: false,
+        gdb: GdbMode::Off,
         qmp_socket: Some(&sock_path),
     };
     let qemu_args = build_qemu_argv(&spec)?;

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -28,6 +28,19 @@ use crate::sysroot;
 /// QEMU virt machine requires pflash images to be exactly 32 MiB.
 const PFLASH_SIZE: u64 = 32 * 1024 * 1024;
 
+/// GDB stub exposure for a QEMU launch.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum GdbMode
+{
+    /// No gdbstub.
+    Off,
+    /// Expose the gdbstub (`-s`, `tcp::1234`) without pausing the guest, so a
+    /// host debugger can attach after a hang is observed.
+    Listen,
+    /// Expose the gdbstub and freeze at the first instruction (`-s -S`).
+    Freeze,
+}
+
 /// Specification for one QEMU launch.
 ///
 /// `firmware_code_path` is the readonly pflash (OVMF on x86, `RISCV_VIRT_CODE`
@@ -43,7 +56,7 @@ pub struct QemuLaunchSpec<'a>
     /// Guest memory size in MiB.
     pub mem_mib: u32,
     pub headless: bool,
-    pub gdb: bool,
+    pub gdb: GdbMode,
     /// When set, expose a QMP control socket at this path
     /// (`-qmp unix:<path>,server,nowait`) so a host harness can drive the
     /// guest — the interactive-input test injects keys this way.
@@ -107,9 +120,12 @@ pub fn build_qemu_argv(spec: &QemuLaunchSpec) -> Result<Vec<String>>
         ]);
     }
 
-    if spec.gdb
+    match spec.gdb
     {
-        args.extend(["-s".into(), "-S".into()]);
+        GdbMode::Off =>
+        {}
+        GdbMode::Listen => args.push("-s".into()),
+        GdbMode::Freeze => args.extend(["-s".into(), "-S".into()]),
     }
 
     let accel = accel::detect_for_arch(spec.arch);
@@ -432,7 +448,7 @@ mod tests
             cpus,
             mem_mib,
             headless: true,
-            gdb: false,
+            gdb: GdbMode::Off,
             qmp_socket: None,
         }
     }


### PR DESCRIPTION
Closes #375.

## Root cause (captured, not inferred)

The "silent wedge" was a **load-balancer ticket-lock convoy livelock**, captured live with the new `--debug-listen --hold-on-hang` tooling on a wedged 64-hart riscv64 ktest run (wedged in `stress::double_enqueue_storm`, 240 s of total serial silence) and confirmed by GDB hart-PC capture:

- 55 of 64 harts were spinning **inside `try_pull_balance`'s inlined `pull_unpinned_ready`**, all called from `timer_tick`, all with interrupts disabled: ~47 queued on the victim's (lo) run-queue ticket lock, 8 more holding lo and spinning on hi. Disassembly identifies the two spin PCs as the two `Spinlock::lock_raw` ticket acquisitions.
- Every spinner's `sip` showed the timer interrupt **pending but masked** (`sip=0x20`, `sstatus.SIE=0`). CPU 0 (BSP) was in the convoy — killing the sleep-list waker, the softlockup watchdog, the new detectors, and all serial output simultaneously. Hence the total silence.
- Remaining harts: several mid-`trap_entry` (about to join), one in `timer_tick`'s own lock entry, two in OpenSBI (timer re-arm — bystanders).

Mechanism: the load-balancer tests pin spinners to CPU 0, making it the permanent max-load victim with **nothing pullable**. Every idle CPU's tick (`try_pull_balance` idle scan) converges on CPU 0 every ~1 ms, takes a FIFO ticket on its run-queue lock interrupts-off, finds no `AFFINITY_ANY` candidate, releases, and re-queues on the next tick. Under host vCPU oversubscription (64 vCPUs on a 16-core TCG host; 256 on KVM) the FIFO handoff latency exceeds the queue refill rate and guest throughput collapses to ~zero. The KVM x86_64 repro is the same textbook virtualized-spinlock pathology (lock-holder vCPU preemption vs FIFO ticket fairness). The ~1/3 intermittency is the stochastic threshold crossing (queue depth × handoff latency vs drain rate, set by tick phase alignment).

Full GDB capture posted in the issue thread.

## Fix

`pull_unpinned_ready` now **try-locks** both run-queue locks (ascending-CPU order retained; `try_lock_raw` is CAS-based and takes no ticket on failure). A balancer pull is optional work — on contention it backs off to a later tick, so no queue can form and tick delivery stays live everywhere.

## Hardening (in-pass)

`sleep_check_wakeups` now routes its wake target through `select_target_cpu` like every other wake path, instead of raw `preferred_cpu` — honouring a hard affinity changed mid-sleep and the save-window pin.

## Permanent diagnostics (shipped; these found the bug)

- **Watchdog detector suite** sharing one once-per-boot dump latch: the existing all-idle check, a new **owed-wake registry scan** (expired sleep deadline / stuck `wake_in_flight` / `wake_pending`-while-Blocked, with two-scan persistence; new TCB field `park_started_tick`), and **cross-CPU timer heartbeats** (APs detect a stalled BSP — previously an undetectable single point of failure hosting both the sleep waker and all detectors; the BSP symmetrically reports silent APs).
- Dump callable from any CPU; the sleep-list read is now try-lock so a wedged holder cannot deadlock the dump (latent bug in the existing watchdog).
- `schedule()` context-saved spin: spin-site breadcrumb + elapsed-time (100 ms) warning replacing the 100M-iteration counter.
- Tripwires on the two `wake_pending` clears outside the park commit.
- ktest `run_test!` prints `ktest: RUN <name>` so a hung test identifies itself.
- xtask run-parallel: `--debug-listen` (gdbstub without freeze) and `--hold-on-hang` (preserve a wedged guest for attach); the default `--fail` regex matches `=== WATCHDOG` so a self-detected wedge classifies FAIL fast.

## Test calibration found during validation

- `stress::load_balance_handoff_steal`'s probabilistic `migrations >= 1` guard is now asserted only at ≤ 32 CPUs: its one-hot `u32` CPU witness aliases indices mod 32 above that, and its oversubscription premise (32 threads ≫ vCPUs) is inverted at 256 vCPUs, where the guard flaked 1-in-4 (the steal path legitimately may never arm on a mostly-idle 256-CPU guest). Kernel-side guards remain the regression signal at every width.
- docs/testing.md's x86_64 256-vCPU boundary command used a 300 s timeout below the measured ~330 s full-suite duration; now 900 s with the measured figure noted.

## Validation

- [x] riscv64 64 harts × 10 consecutive: **10/10 PASS** (55–72 s each; pre-fix wedge rate ~1/3)
- [x] riscv64 65 harts × 10 consecutive: **10/10 PASS** (55–72 s each)
- [x] x86_64 256 vCPUs (KVM) × 10 consecutive: **10/10 PASS** (293–361 s each)
- [x] Canonical 4-CPU ktest run to pass marker, both arches (x86_64 14.3 s, riscv64 21.2 s)
- [x] Coverage-tier memory variation: riscv64 `--cpus 4 --mem 1024` PASS
- [x] `cargo xtask test` host suite: 21 suites green
- [x] Negative control: pre-fix wedge self-captured by the shipped tooling (two HANGs reproduced; GDB hart dump in the issue)

Note: the riscv64 soaks ran the kernel at `be40c03`; the only later delta (`a8c1a2c`) touches ktest's >32-CPU guard gating and docs — kernel binary identical. The PR's CI run covers the canonical cells on the final tree.

Note for the record: the load-balancer missing-IPI suspicion from the issue's early analysis does not exist at HEAD — `pull_unpinned_ready` already sends `wake_idle_cpu(dst)` on success.
