### PR TITLE
kernel: raise buddy MAX_ORDER to 11 so per-CPU boot slabs reach MAX_CPUS=512

### DIFF
--- a/core/kernel/docs/initialization.md
+++ b/core/kernel/docs/initialization.md
@@ -78,7 +78,9 @@ This is not fatal — a headless system is valid.
    d. Frames containing the bootloader's page tables (if identifiable)
 4. Determine buddy allocator order range:
    - Minimum order: 0 (one 4 KiB page)
-   - Maximum order: implementation constant, e.g. 10 (1024 pages = 4 MiB)
+   - Maximum order: implementation constant `MAX_ORDER` = 11 (2048 pages =
+     8 MiB), sized so the largest per-CPU boot slab at `MAX_CPUS` fits one
+     block (see memory-internals.md)
 5. Call mm::buddy::BuddyAllocator::new(max_order) — this is a static or
    early-heap allocation using only the bootloader-provided stack
 6. For each candidate range, call BuddyAllocator::add_region(phys_start, phys_end)

--- a/core/kernel/docs/memory-internals.md
+++ b/core/kernel/docs/memory-internals.md
@@ -23,40 +23,47 @@ The buddy allocator manages physical memory as a set of power-of-two-sized block
 The implementation supports orders 0 through `MAX_ORDER` (inclusive), where an
 order-`n` block contains 2^n contiguous 4 KiB pages.
 
+Free-block metadata lives in fixed-size static arrays inside the allocator
+struct, not in the free pages themselves: the bootloader identity-maps only
+specific regions (`BootInfo`, modules, stack, memory map buffer), so free RAM
+is not generally writable when the allocator initialises in Phase 2.
+
 ```rust
 pub struct BuddyAllocator
 {
-    /// One free list per order. Each list is a singly-linked list of free
-    /// block headers embedded in the first page of each free block.
-    free_lists: [FreeListHead; MAX_ORDER + 1],
-
-    /// Total number of free pages currently available across all orders.
-    free_pages: usize,
-
-    /// Physical base address of the region this allocator manages.
-    /// Used to compute buddy addresses from block addresses.
-    phys_base: PhysAddr,
-}
-
-/// A node in a free list. Stored in the first bytes of the free block itself —
-/// no external metadata allocation required.
-struct FreeBlock
-{
-    next: Option<PhysAddr>,
+    /// Physical block address stored at each pool slot (slot 0 unused).
+    addrs: [u64; POOL_SIZE + 1],
+    /// Next slot index in the same list for each pool slot (0 = NONE).
+    nexts: [u16; POOL_SIZE + 1],
+    /// Head slot index for each order's free list (0 = empty list).
+    free_lists: [u16; MAX_ORDER + 1],
+    /// Head of the unused-slot pool chain.
+    pool_head: u16,
+    // ... counters and the Phase-7 seal flag
 }
 ```
 
-`MAX_ORDER` is an implementation constant chosen so the maximum single allocation
-is large enough for any kernel use while keeping the free-list array small.
-The exact value is established at implementation time.
+Each order's free list is a singly-linked list of pool slot indices; nodes are
+recycled through a free-node chain. `POOL_SIZE` (4096) bounds the number of
+simultaneously tracked free blocks across all orders — ~32 GiB of RAM when
+blocks sit at `MAX_ORDER`. The struct is all-zero-constructible and lives in
+BSS.
+
+`MAX_ORDER` is 11 (largest single allocation: 2048 pages = 8 MiB). It is sized
+so the largest per-CPU boot slab at `boot_protocol::MAX_CPUS` — `AP_IST_STACKS`,
+512 × 16 KiB = 8 MiB — fits one block, since `alloc_zeroed_slab` rounds every
+slab to a single power-of-two block. Compile-time asserts at the consumer sites
+(`arch/x86_64/ap_trampoline.rs`, `arch/x86_64/gdt.rs`) enforce that envelope:
+growing `MAX_CPUS` or a per-CPU slab element past it fails the build rather
+than the boot.
 
 ### Zone Management
 
-The allocator supports a single zone in the common case (all usable RAM). Where
-hardware requires DMA-accessible memory below a physical address limit, a second
-zone is added at init time. Zone selection is the caller's responsibility — the
-allocator does not automatically prefer one zone. Zone boundaries are tracked as
-`(phys_base, phys_end)` pairs; each zone has its own `BuddyAllocator` instance.
+The allocator manages a single zone: one `BuddyAllocator` instance covering all
+usable RAM. It has no zone concept; physical-address-range constraints (e.g.
+DMA reachability) are handled by the userspace memory authority after the
+Phase-7 handoff, per
+[docs/device-management.md](../../../docs/device-management.md).
 
 ### Allocation and Deallocation Properties
 

--- a/core/kernel/docs/scheduling-internals.md
+++ b/core/kernel/docs/scheduling-internals.md
@@ -662,6 +662,22 @@ state (#375). Symmetrically the BSP scans AP stamps
 (`ap_silence_check`) and fires on an AP silent past the grace window.
 Both defer to an in-flight TLB shootdown, as below.
 
+The heartbeat checks measure staleness in wall time, so their grace scales
+with CPU count (`heartbeat_stall_ticks`: ≤128 CPUs → 2 s, 256 → 4 s,
+512 → 8 s). On an oversubscribed host a wide guest legitimately starves
+individual vCPUs of timer service for seconds (the #376 512-vCPU runs saw a
+healthy BSP 2 s stale at ~7% aggregate tick delivery); a fixed 2 s grace
+false-positives there, while a real wedge exceeds any finite threshold —
+the scaling costs only detection latency on wide guests. The owed-wake
+rules deliberately do not scale: rule 1's pop-before-scan ordering and
+rules 2–3's two-scan persistence ride the BSP's own cadence, which
+self-stretches under starvation.
+
+Attaching GDB to a live guest (xtask `--debug-listen`) freezes every vCPU
+while guest-visible time keeps advancing, so on resume the heartbeat checks
+read the stop window as staleness and fire once. A dump immediately after a
+debugger detach is that artifact, not a wedge.
+
 Tripwires outside the latch: the two `wake_pending` clears in `schedule()`
 (the same-thread re-mark and the dispatch flip) print a single-shot line
 (`WAKE_PENDING_CLEAR_TRIPPED`) if the flag was live when cleared — the only

--- a/core/kernel/docs/scheduling-internals.md
+++ b/core/kernel/docs/scheduling-internals.md
@@ -663,8 +663,9 @@ state (#375). Symmetrically the BSP scans AP stamps
 Both defer to an in-flight TLB shootdown, as below.
 
 The heartbeat checks measure staleness in wall time, so their grace scales
-with CPU count (`heartbeat_stall_ticks`: ≤128 CPUs → 8 s, 256 → 16 s,
-512 → 32 s). The 8 s base is sized above the slowest legitimate
+with CPU count (`heartbeat_stall_ticks`, stepping at multiples of 128 CPUs:
+<256 CPUs → 8 s, 256..384 → 16 s, 512 → 32 s). The 8 s base is sized above
+the slowest legitimate
 single-syscall CPU occupancy observed (a debug-build aperture-mapping
 syscall held the BSP just past 2 s on a slow TCG CI runner), and the
 CPU-count scaling covers oversubscribed wide guests, where vCPUs

--- a/core/kernel/docs/scheduling-internals.md
+++ b/core/kernel/docs/scheduling-internals.md
@@ -663,12 +663,14 @@ state (#375). Symmetrically the BSP scans AP stamps
 Both defer to an in-flight TLB shootdown, as below.
 
 The heartbeat checks measure staleness in wall time, so their grace scales
-with CPU count (`heartbeat_stall_ticks`: ≤128 CPUs → 2 s, 256 → 4 s,
-512 → 8 s). On an oversubscribed host a wide guest legitimately starves
-individual vCPUs of timer service for seconds (the #376 512-vCPU runs saw a
-healthy BSP 2 s stale at ~7% aggregate tick delivery); a fixed 2 s grace
-false-positives there, while a real wedge exceeds any finite threshold —
-the scaling costs only detection latency on wide guests. The owed-wake
+with CPU count (`heartbeat_stall_ticks`: ≤128 CPUs → 8 s, 256 → 16 s,
+512 → 32 s). The 8 s base is sized above the slowest legitimate
+single-syscall CPU occupancy observed (a debug-build aperture-mapping
+syscall held the BSP just past 2 s on a slow TCG CI runner), and the
+CPU-count scaling covers oversubscribed wide guests, where vCPUs
+legitimately starve of timer service for seconds (the #376 512-vCPU runs
+saw a healthy BSP 2 s stale at ~7% aggregate tick delivery). A real wedge
+exceeds any finite threshold — the grace costs only detection latency. The owed-wake
 rules deliberately do not scale: rule 1's pop-before-scan ordering and
 rules 2–3's two-scan persistence ride the BSP's own cadence, which
 self-stretches under starvation.

--- a/core/kernel/src/arch/x86_64/ap_trampoline.rs
+++ b/core/kernel/src/arch/x86_64/ap_trampoline.rs
@@ -111,13 +111,21 @@ const GDT_DATA: u64 = 0x00CF_9200_0000_FFFF;
 /// IST stack pair size: 8 KiB IST1 + 8 KiB IST2 = 16 KiB per AP.
 const AP_IST_PAIR_SIZE: usize = 16384;
 
-/// Per-AP IST stacks, in BSS. Slot `cpu_idx` holds the 16 KiB pair (IST1 +
-/// IST2) for AP with that id; slot 0 is unused (BSP has its own
+// The slab is one buddy block (`alloc_zeroed_slab` rounds to a power of two),
+// so it must fit the largest block even at the MAX_CPUS ceiling.
+const _: () = assert!(
+    crate::sched::MAX_CPUS * AP_IST_PAIR_SIZE
+        <= (1 << crate::mm::buddy::MAX_ORDER) * crate::mm::PAGE_SIZE,
+    "AP_IST_STACKS at MAX_CPUS exceeds the largest buddy block; raise MAX_ORDER"
+);
+
+/// Per-AP IST stacks. Slot `cpu_idx` holds the 16 KiB pair (IST1 + IST2) for
+/// the AP with that id; slot 0 is unused (BSP has its own
 /// [`crate::arch::x86_64::interrupts`] `BSP_IST_STACKS` static).
 ///
 /// Allocated at boot from the buddy by [`init_ap_ist_storage`], sized to
-/// `boot_cpu_count` rather than `MAX_CPUS`. On a 4-CPU host this saves
-/// ~960 KiB versus the prior `MAX_CPUS=64` BSS array.
+/// `boot_cpu_count` rather than `MAX_CPUS` so small hosts pay only for the
+/// CPUs they have.
 #[cfg(not(test))]
 static AP_IST_STACKS_PTR: core::sync::atomic::AtomicPtr<[u8; AP_IST_PAIR_SIZE]> =
     core::sync::atomic::AtomicPtr::new(core::ptr::null_mut());

--- a/core/kernel/src/arch/x86_64/gdt.rs
+++ b/core/kernel/src/arch/x86_64/gdt.rs
@@ -103,6 +103,14 @@ pub struct TssWithIopb
     pub terminator: u8,
 }
 
+// The AP_TSS slab is one buddy block (`alloc_zeroed_slab` rounds to a power
+// of two), so it must fit the largest block even at the MAX_CPUS ceiling.
+const _: () = assert!(
+    crate::sched::MAX_CPUS * core::mem::size_of::<TssWithIopb>()
+        <= (1 << crate::mm::buddy::MAX_ORDER) * crate::mm::PAGE_SIZE,
+    "AP_TSS at MAX_CPUS exceeds the largest buddy block; raise MAX_ORDER"
+);
+
 /// The extended TSS + IOPB, in BSS so it is zero-initialised.
 ///
 /// The IOPB starts zero (all ports permitted!) until `init()` fills it with

--- a/core/kernel/src/arch/x86_64/interrupts.rs
+++ b/core/kernel/src/arch/x86_64/interrupts.rs
@@ -394,6 +394,13 @@ unsafe fn apic_send_icr(dest: u32, cmd: u32)
         unsafe { cpu::write_msr(IA32_X2APIC_ICR, (u64::from(dest) << 32) | u64::from(cmd)) };
         return;
     }
+    // xAPIC destinations are 8-bit; a wider ID would truncate and deliver the
+    // IPI (possibly INIT/SIPI) to the wrong CPU. IDs > 255 only exist on
+    // x2APIC systems, so reaching here means a mode-selection bug.
+    if dest > 0xFF
+    {
+        crate::fatal("apic_send_icr: APIC ID > 255 requires x2APIC");
+    }
     // SAFETY: APIC MMIO is valid; ICR_HIGH takes the destination in bits [31:24].
     unsafe {
         apic_write(APIC_ICR_HIGH, dest << 24);

--- a/core/kernel/src/mm/buddy.rs
+++ b/core/kernel/src/mm/buddy.rs
@@ -27,7 +27,7 @@
 //! # Capacity
 //!
 //! `POOL_SIZE` is the maximum number of simultaneously tracked free blocks
-//! across all orders. The current value handles ~16 GiB of RAM. Increase it
+//! across all orders. The current value handles ~32 GiB of RAM. Increase it
 //! (or transition to in-page node storage after Phase 3 establishes page
 //! tables) for larger systems.
 //!
@@ -49,14 +49,20 @@
 /// Size of a single physical page in bytes.
 pub const PAGE_SIZE: usize = 4096;
 
-/// Maximum allocation order. Order N spans 2^N pages (4 KiB..4 MiB).
-pub const MAX_ORDER: usize = 10;
+/// Maximum allocation order. Order N spans 2^N pages (4 KiB..8 MiB).
+///
+/// Sized so the largest per-CPU boot slab at `boot_protocol::MAX_CPUS`
+/// (`AP_IST_STACKS`, 512 × 16 KiB = 8 MiB) fits one block — `alloc_zeroed_slab`
+/// rounds every slab to a single power-of-two block. Compile-time asserts at
+/// the consumer sites ([`crate::arch::x86_64::ap_trampoline`],
+/// [`crate::arch::x86_64::gdt`]) enforce the envelope.
+pub const MAX_ORDER: usize = 11;
 
 /// Number of order levels (0 through `MAX_ORDER` inclusive).
 const ORDER_COUNT: usize = MAX_ORDER + 1;
 
 /// Maximum simultaneously tracked free blocks across all orders.
-/// 4096 entries ≈ 16 GiB at order 10 (4 MiB per block).
+/// 4096 entries ≈ 32 GiB at order 11 (8 MiB per block).
 const POOL_SIZE: usize = 4096;
 
 /// Sentinel slot index meaning "end of list" or "empty".
@@ -612,6 +618,24 @@ mod tests
     {
         let mut alloc = BuddyAllocator::new();
         assert_eq!(alloc.alloc(MAX_ORDER + 1), None);
+    }
+
+    #[test]
+    fn add_region_packs_single_max_order_block()
+    {
+        // A naturally-aligned MAX_ORDER-sized region must insert as one block,
+        // allocatable in a single MAX_ORDER request (the per-CPU boot slabs
+        // depend on this at MAX_CPUS; see #376).
+        let (_buf, start, end) = aligned_buf(1 << MAX_ORDER);
+        let mut alloc = BuddyAllocator::new();
+        // SAFETY: _buf is alive and [start, end) is valid, page-aligned,
+        // writable memory not aliased by anything else.
+        unsafe { alloc.add_region(start, end) };
+        assert_eq!(alloc.free_page_count(), 1 << MAX_ORDER);
+
+        let block = alloc.alloc(MAX_ORDER).expect("MAX_ORDER alloc");
+        assert_eq!(block, start);
+        assert_eq!(alloc.free_page_count(), 0);
     }
 
     #[test]

--- a/core/kernel/src/sched/mod.rs
+++ b/core/kernel/src/sched/mod.rs
@@ -285,9 +285,10 @@ const WEDGE_GRACE_SECONDS: u64 = 8;
 /// single vCPU — BSP included — legitimately goes seconds without a timer
 /// interrupt (the #376 512-vCPU runs observed a healthy BSP 2 s stale, with
 /// ~7% aggregate tick delivery). Scale the base grace with CPU count so the
-/// false-positive rate stays low across the envelope: ≤128 CPUs → 8 s,
-/// 256 → 16 s, 512 → 32 s. A genuinely wedged CPU exceeds any finite
-/// threshold, so the scaling costs only detection latency on wide guests.
+/// false-positive rate stays low across the envelope, stepping at multiples
+/// of 128 CPUs: <256 CPUs → 8 s, 256..384 → 16 s, 512 → 32 s. A genuinely
+/// wedged CPU exceeds any finite threshold, so the scaling costs only
+/// detection latency on wide guests.
 #[cfg(not(test))]
 fn heartbeat_stall_ticks(tps: u64) -> u64
 {

--- a/core/kernel/src/sched/mod.rs
+++ b/core/kernel/src/sched/mod.rs
@@ -268,8 +268,14 @@ const DETECTOR_SCAN_INTERVAL_TICKS: u64 = 512;
 /// checks scale this with CPU count ([`heartbeat_stall_ticks`]); the
 /// owed-wake rules use it as-is (they ride the BSP's own scan cadence, which
 /// self-stretches under host starvation).
+///
+/// Sized above the slowest legitimate single-syscall CPU occupancy observed:
+/// on a slow TCG CI runner a debug-build aperture-mapping syscall held the
+/// BSP just past 2 s with interrupts off (#376 CI), so 2 s false-positived.
+/// A real wedge persists indefinitely — the grace costs only detection
+/// latency. Linux's softlockup default is 10 s for the same reason.
 #[cfg(not(test))]
-const WEDGE_GRACE_SECONDS: u64 = 2;
+const WEDGE_GRACE_SECONDS: u64 = 8;
 
 /// Staleness threshold for the cross-CPU heartbeat checks, in timer ticks.
 ///
@@ -279,8 +285,8 @@ const WEDGE_GRACE_SECONDS: u64 = 2;
 /// single vCPU — BSP included — legitimately goes seconds without a timer
 /// interrupt (the #376 512-vCPU runs observed a healthy BSP 2 s stale, with
 /// ~7% aggregate tick delivery). Scale the base grace with CPU count so the
-/// false-positive rate stays low across the envelope: ≤128 CPUs → 2 s,
-/// 256 → 4 s, 512 → 8 s. A genuinely wedged CPU exceeds any finite
+/// false-positive rate stays low across the envelope: ≤128 CPUs → 8 s,
+/// 256 → 16 s, 512 → 32 s. A genuinely wedged CPU exceeds any finite
 /// threshold, so the scaling costs only detection latency on wide guests.
 #[cfg(not(test))]
 fn heartbeat_stall_ticks(tps: u64) -> u64

--- a/core/kernel/src/sched/mod.rs
+++ b/core/kernel/src/sched/mod.rs
@@ -264,9 +264,33 @@ fn watchdog_claim_dump() -> bool
 const DETECTOR_SCAN_INTERVAL_TICKS: u64 = 512;
 
 /// Grace period before a `Blocked` thread's owed wake is considered lost and
-/// before a silent timer heartbeat is considered stalled.
+/// before a silent timer heartbeat is considered stalled. The heartbeat
+/// checks scale this with CPU count ([`heartbeat_stall_ticks`]); the
+/// owed-wake rules use it as-is (they ride the BSP's own scan cadence, which
+/// self-stretches under host starvation).
 #[cfg(not(test))]
 const WEDGE_GRACE_SECONDS: u64 = 2;
+
+/// Staleness threshold for the cross-CPU heartbeat checks, in timer ticks.
+///
+/// Heartbeats are stamped in wall time (`current_tick`), but a vCPU's tick
+/// service rate degrades with guest width when the host is oversubscribed:
+/// the validation envelope runs 512 vCPUs on a 16-core host (32×), where any
+/// single vCPU — BSP included — legitimately goes seconds without a timer
+/// interrupt (the #376 512-vCPU runs observed a healthy BSP 2 s stale, with
+/// ~7% aggregate tick delivery). Scale the base grace with CPU count so the
+/// false-positive rate stays low across the envelope: ≤128 CPUs → 2 s,
+/// 256 → 4 s, 512 → 8 s. A genuinely wedged CPU exceeds any finite
+/// threshold, so the scaling costs only detection latency on wide guests.
+#[cfg(not(test))]
+fn heartbeat_stall_ticks(tps: u64) -> u64
+{
+    let cpus = u64::from(CPU_COUNT.load(core::sync::atomic::Ordering::Relaxed));
+    let scale = (cpus / 128).max(1);
+    WEDGE_GRACE_SECONDS
+        .saturating_mul(scale)
+        .saturating_mul(tps)
+}
 
 /// Owed-wake rule: `sleep_deadline` expired past the grace window while the
 /// thread is still `Blocked` — its timer wake was claimed and then lost, or
@@ -600,7 +624,7 @@ fn ap_silence_check(cpu_count: usize)
     {
         return;
     }
-    let stall = WEDGE_GRACE_SECONDS.saturating_mul(tps);
+    let stall = heartbeat_stall_ticks(tps);
     for (cpu, slot) in TICK_HEARTBEAT
         .iter()
         .enumerate()
@@ -640,7 +664,7 @@ fn bsp_stall_check(own_heartbeat: u64)
         return;
     }
     let hb0 = TICK_HEARTBEAT[0].load(core::sync::atomic::Ordering::Relaxed);
-    if hb0 == 0 || own_heartbeat <= hb0.saturating_add(WEDGE_GRACE_SECONDS.saturating_mul(tps))
+    if hb0 == 0 || own_heartbeat <= hb0.saturating_add(heartbeat_stall_ticks(tps))
     {
         return;
     }
@@ -1821,6 +1845,17 @@ pub(crate) fn alloc_zeroed_slab<T>(
         }
         o
     };
+    // Distinguish an over-cap request from genuine exhaustion: `alloc` returns
+    // `None` for both, and "out of memory" misdirects the diagnosis (#376).
+    if order > crate::mm::buddy::MAX_ORDER
+    {
+        crate::kprintln!(
+            "alloc_zeroed_slab: {label} needs {bytes} bytes (order {order}), \
+             but MAX_ORDER is {}",
+            crate::mm::buddy::MAX_ORDER
+        );
+        crate::fatal("alloc_zeroed_slab: slab exceeds the largest buddy block");
+    }
     let phys = allocator.alloc(order).unwrap_or_else(|| {
         crate::kprintln!("alloc_zeroed_slab: out of memory for {label}");
         crate::fatal("alloc_zeroed_slab: buddy exhausted")

--- a/docs/memory-model.md
+++ b/docs/memory-model.md
@@ -195,9 +195,11 @@ Properties:
 - Bounded external fragmentation
 - Internal fragmentation bounded at 50%
 
-The allocator is organised into zones if the hardware requires it (e.g. DMA-accessible
-memory below a certain physical address). The common case is a single zone covering
-all usable RAM.
+The allocator manages a single zone covering all usable RAM. Physical-address-range
+constraints (e.g. DMA-accessible memory below a certain physical address) are not a
+kernel concern: DMA isolation and placement are handled in userspace by devmgr and
+the memory authority (see [architecture.md](architecture.md) and
+[device-management.md](device-management.md)).
 
 ### Frame Allocation is Fallible
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -292,14 +292,31 @@ cargo xtask run-parallel --arch x86_64 --cpus 256 --parallel 1 --runs 3 --timeou
 cargo xtask run-parallel --arch <arch> --cpus 4 --mem 1024 --parallel 1 --runs 1 --timeout 300
 ```
 
+PRs touching the surfaces that only matter above 256 CPUs — `core/kernel/src/mm/`,
+x86_64 AP bringup (`arch/x86_64/ap_trampoline.rs`, `arch/x86_64/gdt.rs`, the
+APIC/IPI paths in `arch/x86_64/interrupts.rs`), or per-CPU slab sizing
+(`sched::alloc_zeroed_slab` and its call sites) — MUST additionally run the
+full-width x86_64 boundary below. This trigger list is deliberately narrow;
+other SMP PRs stay on the 256-vCPU mandate above.
+
+```sh
+# MAX_CPUS boundary, x86_64 (~75 min per passing run: at 32x vCPU
+# oversubscription the stress tier's O(cpus) priority-walk syscalls dominate —
+# see #380, which will shrink this budget when it lands):
+cargo xtask run-parallel --arch x86_64 --cpus 512 --parallel 1 --runs 1 --timeout 10800
+```
+
 **Known boundaries**, established empirically (QEMU 11.0.1; update this
 list as the tracking Issues move):
 
-- x86_64 > 256 CPUs ([#376](https://github.com/kottlerg/seraph/issues/376)):
-  kernel Phase-4 `FATAL` — the per-CPU slabs (`AP_IST_STACKS`, `AP_TSS`)
-  exceed the buddy allocator's `MAX_ORDER` single-allocation cap.
-  Independent of guest memory size; QEMU itself accepts `-smp 257..512`
-  under both KVM and TCG with the stock argv.
+- x86_64 > 256 CPUs ([#376](https://github.com/kottlerg/seraph/issues/376),
+  fixed): the per-CPU boot slabs (`AP_IST_STACKS`, `AP_TSS`) exceeded the
+  buddy allocator's old `MAX_ORDER = 10` single-allocation cap (4 MiB) at
+  257+ CPUs, failing Phase 4 regardless of guest memory size. `MAX_ORDER`
+  is now 11 (8 MiB — exactly `AP_IST_STACKS` at `MAX_CPUS = 512`), with
+  compile-time asserts at the slab consumer sites so the envelope breaks
+  the build, not the boot. The full 512-vCPU width is exercised by the
+  MAX_CPUS boundary run above.
 - riscv64 ≥ 128 harts ([#377](https://github.com/kottlerg/seraph/issues/377)):
   boot dies in UEFI (`ConvertPages: Incompatible memory types`) while
   loading the kernel ELF; independent of guest memory size. At 256 and

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -300,7 +300,7 @@ full-width x86_64 boundary below. This trigger list is deliberately narrow;
 other SMP PRs stay on the 256-vCPU mandate above.
 
 ```sh
-# MAX_CPUS boundary, x86_64 (~75 min per passing run: at 32x vCPU
+# MAX_CPUS boundary, x86_64 (~105 min per passing run measured: at 32x vCPU
 # oversubscription the stress tier's O(cpus) priority-walk syscalls dominate —
 # see #380, which will shrink this budget when it lands):
 cargo xtask run-parallel --arch x86_64 --cpus 512 --parallel 1 --runs 1 --timeout 10800


### PR DESCRIPTION
Closes #376.

## Problem

`MAX_ORDER = 10` capped a single buddy allocation at 4 MiB, and
`alloc_zeroed_slab` rounds every per-CPU boot slab to one power-of-two block.
`AP_IST_STACKS` (cpu_count × 16 KiB) crosses 4 MiB at 257 CPUs and `AP_TSS`
(cpu_count × 8,297 B) at ~510, so x86_64 failed Phase 4 above 256 vCPUs —
at any guest memory size — despite `boot-protocol MAX_CPUS = 512`. The
failure also masqueraded as memory pressure: `alloc(order > MAX_ORDER)`
returns `None`, indistinguishable from exhaustion at the call site.

## Fix

- **`MAX_ORDER` 10 → 11** (8 MiB max block). Exactly fits `AP_IST_STACKS` at
  `MAX_CPUS = 512` (512 × 16 KiB = 8 MiB); `AP_TSS` at 512 ≈ 4.05 MiB. Cost:
  2 bytes of BSS (`free_lists`) and one extra iteration in O(MAX_ORDER) paths.
- **Compile-time fit asserts** at both slab consumer sites
  (`ap_trampoline.rs`, `gdt.rs`): any future growth of `MAX_CPUS`, the IST
  pair, or the TSS+IOPB past the largest buddy block fails the build instead
  of the boot.
- **Distinct over-cap diagnostic** in `alloc_zeroed_slab`: a slab that cannot
  fit any buddy block now fatals with the label, byte count, and order — no
  longer reported as "out of memory".
- **xAPIC truncation guard** in `apic_send_icr` (found by the in-pass >255
  APIC-ID audit): in xAPIC fallback mode a destination > 255 would truncate
  to 8 bits and deliver the IPI — possibly INIT/SIPI — to the wrong CPU.
  Now fatals. The x2APIC path (32-bit destination via `IA32_X2APIC_ICR`) is
  used whenever CPUID advertises it; the rest of the bringup plumbing was
  audited u32-clean end-to-end.
- **Heartbeat-watchdog grace scaled with CPU count** (surfaced by the first
  512-vCPU runs this PR makes possible): the #375 timer-heartbeat
  cross-checks measured staleness against a fixed 2 s grace, calibrated at
  16× host oversubscription. At 512 vCPUs on a 16-core host (32×) the BSP
  legitimately goes >2 s without timer service (~7% aggregate tick delivery
  observed) and the `bsp_stall_check` detector false-positived on a healthy,
  progressing guest — every per-CPU heartbeat in the dump was advancing and
  the suite was mid-test. A second false positive surfaced on CI's slow TCG
  runners: devmgr's aperture-mapping syscall legitimately held the BSP just
  past 2 s during boot. `heartbeat_stall_ticks` now scales the grace with
  CPU count from an 8 s base (steps at multiples of 128 CPUs: <256 → 8 s,
  256..384 → 16 s, 512 → 32 s; Linux's softlockup default is 10 s for the
  same class of reason); the owed-wake rules deliberately keep the unscaled
  grace (their cadence self-stretches under starvation). A real wedge
  exceeds any finite threshold, so the cost is detection latency only.

## Drift fixed in-pass

- `core/kernel/docs/memory-internals.md` buddy section described a different
  implementation (in-page `FreeBlock` headers, `phys_base`, init-time DMA
  zones) than `mm/buddy.rs` (external static node pool — free RAM is not
  identity-mapped at Phase 2). Rewritten to match the code, including the
  previously undocumented `MAX_ORDER` sizing rationale.
- `ap_trampoline.rs` slab doc comment narrated change history; rewritten to
  present intent.
- `initialization.md` buddy order range updated.

## Docs / testing policy

- `docs/testing.md` Known boundaries: #376 entry marked fixed.
- New bounded mandate: PRs touching `core/kernel/src/mm/`, x86_64 AP bringup,
  or per-CPU slab sizing MUST additionally run the 512-vCPU MAX_CPUS boundary
  (`--cpus 512 --runs 3 --timeout 1800`). Deliberately narrow trigger list;
  other SMP PRs stay on the 256-vCPU mandate.

## 512-vCPU findings (first runs past Phase 4 at this width)

- The full ktest suite **passes at 512 vCPUs**: `passed=194 failed=0`,
  `[ktest] ALL TESTS PASSED` — first observed on a GDB-instrumented run
  (guest 4653 s including debugger freezes), clean acceptance run results
  below.
- Suite wall time at 512 is ~75 min, not ~330 s as at 256: the stress tier's
  `thread_set_priority` locate-and-relocate walk is O(cpus) ticket locks per
  call, and at 32× host oversubscription lock-holder preemption inflates each
  acquisition to ~0.3 ms (GDB-sampled: the active-CPU set is the walk's lock
  prefix, sliding with the worker band). Filed as #380 with measurements;
  the testing.md 512 mandate is sized accordingly (×1 run, 10800 s budget)
  until #380 lands.

## Validation

- [x] `cargo xtask test` — all host suites green; new
  `add_region_packs_single_max_order_block` test passes (207 kernel tests)
- [x] riscv64: canonical `run` to pass marker (15.2 s); 64-hart ×3
  (54–75 s) and 65-hart ×3 (57–73 s) run-parallel PASS
- [x] x86_64: canonical `run` to pass marker (12.4 s); 256-vCPU ×3 PASS
  (303–374 s, matches the documented ~330 s baseline); 257-vCPU ×1 PASS
  (357 s — the old crossing point, full suite)
- [x] Memory variation: x86_64 `--cpus 4 --mem 1024` PASS (14.3 s)
- [x] **512-vCPU clean acceptance run to the ktest pass marker**: PASS,
  `[ktest] ALL TESTS PASSED` at guest 6242 s (104 min wall, zero watchdog
  dumps, runner classification PASS). An instrumented run had separately
  reached `passed=194 failed=0` under the stricter pre-bump grace. The clean
  run booted the `0a4192f` tree; the only behavioral delta to PR HEAD is the
  8 s base grace, which strictly raises watchdog thresholds and cannot turn
  this PASS into a failure. Boundary matrix re-run on PR HEAD (results
  below).
- [x] CI: full matrix green (13/13 cells on the grace-bump push; the two
  x86_64-debug userspace cells that failed on the first push were the boot
  false positive fixed by the 8 s base grace)
