### PR TITLE
boot: load the kernel image as a dynamically placed span

### DIFF
--- a/core/boot/README.md
+++ b/core/boot/README.md
@@ -69,12 +69,14 @@ the re-exports in `arch/mod.rs`.
 `shared/elf/` is the workspace's authoritative ELF format decoder
 (header validation, `PT_LOAD` segment iteration, entry point, TLS).
 `boot/src/elf.rs` is a thin UEFI-allocation layer over it: for the kernel
-image it allocates each `PT_LOAD` segment at the ELF-declared `p_paddr`
-via `AllocatePages(AllocateAddress, …)`; for the init image it allocates
-at any available address while preserving the in-page byte offset of
-`p_vaddr`, then constructs the `BootInfo.init_image` ABI surface so the
-kernel never needs an ELF parser. Boot modules are loaded as opaque flat
-binaries with no parsing.
+image it allocates one contiguous span at any available physical base via
+`AllocatePages(AllocateAnyPages, …)` and places each `PT_LOAD` segment at
+its ELF-relative offset within the span, so kernel placement tolerates any
+firmware memory layout; for the init image it allocates at any available
+address while preserving the in-page byte offset of `p_vaddr`, then
+constructs the `BootInfo.init_image` ABI surface so the kernel never needs
+an ELF parser. Boot modules are loaded as opaque flat binaries with no
+parsing.
 
 W^X policy is enforced by the bootloader's page-table builder
 (`boot/src/paging.rs` and `boot/src/arch/*/paging.rs`); a `PT_LOAD`

--- a/core/boot/docs/boot-flow.md
+++ b/core/boot/docs/boot-flow.md
@@ -50,9 +50,10 @@ Detail: [uefi-environment.md](uefi-environment.md)
 ### Step 3: Load Kernel ELF
 
 The kernel ELF is loaded from the hardcoded path `\EFI\seraph\kernel`.
-The ELF header is validated, LOAD segments are mapped into physical
-memory allocated via `AllocatePages`, and the kernel virtual addresses
-and entry point are recorded.
+The ELF header is validated, the LOAD segments are placed in a single
+contiguous span allocated at any free physical base (so loading tolerates
+any firmware memory layout), and the kernel virtual addresses, entry point,
+and chosen physical base (`BootInfo.kernel_physical_base`) are recorded.
 
 W^X is enforced during loading: any ELF segment requesting both writable
 and executable permissions is a fatal error.

--- a/core/boot/docs/elf-loading.md
+++ b/core/boot/docs/elf-loading.md
@@ -7,7 +7,8 @@ Partition: kernel ELF, init ELF, and boot modules.
 
 ## Categories
 
-- **Kernel ELF** — fully validated and loaded at ELF-specified physical addresses.
+- **Kernel ELF** — fully validated and loaded as a single contiguous span at a
+  bootloader-chosen physical base, preserving the ELF's relative segment offsets.
 - **Init ELF** — fully validated and ELF-parsed; segments allocated at any available
   physical address. Result is an `InitImage` passed to the kernel in `BootInfo.init_image`.
 - **Boot modules** — opaque flat binaries loaded verbatim into physical memory and
@@ -45,12 +46,20 @@ change.
 
 ## ELF Validation
 
-ELF-header and program-header validation is performed by the shared ELF crate; the
-ruleset (magic, class, data encoding, version, type, machine, program-header
-geometry, entry-point-in-LOAD) is owned by
+ELF-header and program-header *format* validation is performed by the shared ELF crate;
+the ruleset (magic, class, data encoding, version, type, machine, program-header
+geometry) is owned by
 [`shared/elf/README.md`](../../../shared/elf/README.md). Any
 `elf::ElfError` returned by the shared crate is surfaced by the bootloader as
 [`BootError::InvalidElf`](../src/error.rs).
+
+The kernel image carries an additional *placement* ruleset enforced by the bootloader
+(`validate_kernel_layout` in [`boot/src/elf.rs`](../src/elf.rs)), because the image is
+relocated to a dynamically chosen base and the relocation is sound only if it holds:
+every `PT_LOAD` segment is 4 KiB-aligned in both `p_vaddr` and `p_paddr`, all segments
+share one `p_vaddr → p_paddr` offset, no two segments' physical ranges overlap, and the
+entry point lies within a `PT_LOAD` segment. A violation is surfaced as
+`BootError::InvalidElf`.
 
 The same validation applies to the kernel ELF and the init ELF. Boot modules (the
 `BootInfo.modules` slice) are not ELF-validated by the bootloader — they are loaded
@@ -67,11 +76,13 @@ on each segment:
 1. Enforce W^X: a segment with both `PF_W` and `PF_X` is rejected when its
    first page is mapped and surfaced as [`BootError::WxViolation`](../src/error.rs).
 2. Allocate physical frames via `AllocatePages`, classified `EfiLoaderData`:
-   - **Kernel ELF** — `AllocateAddress` at `p_paddr` (the kernel chooses its
-     own load address).
-   - **Init ELF** — `AllocateAnyPages`, preserving the in-page byte offset
-     of `p_vaddr` so the kernel can identity-map each segment without a
-     second copy.
+   - **Kernel ELF** — one `AllocateAnyPages` span covering the whole image at
+     any free physical base; each segment is copied to
+     `span_base + (p_paddr - link_phys)`, preserving the ELF's relative
+     offsets. The chosen base is recorded in `BootInfo.kernel_physical_base`.
+   - **Init ELF** — `AllocateAnyPages` per segment, preserving the in-page
+     byte offset of `p_vaddr` so the kernel can identity-map each segment
+     without a second copy.
 3. Copy `p_filesz` bytes from the file into the allocated region.
 4. Zero the BSS tail (`p_memsz - p_filesz` bytes).
 
@@ -92,33 +103,24 @@ the entire allocation is produced by step 4.
 
 ---
 
-## Entry Point Extraction
+## Entry Point
 
-The kernel entry point is `e_entry` from the ELF header. This is a virtual address.
-The corresponding physical address (needed for the initial jump before paging is
-active) is computed by finding the LOAD segment whose virtual range contains `e_entry`
-and applying the `p_vaddr → p_paddr` offset for that segment:
-
-```
-physical_entry = e_entry - segment.p_vaddr + segment.p_paddr
-```
-
-Both the virtual and physical entry point addresses are recorded. The bootloader jumps
-to the physical address if paging is not yet enabled; it jumps to the virtual address
-after page tables are installed.
-
-In practice, the page tables are installed in the bootloader before the jump
-([page-tables.md](page-tables.md)), so the jump target is the ELF virtual address.
+The kernel entry point is `e_entry` from the ELF header — a virtual address recorded as
+[`KernelInfo.entry_virtual`](../src/elf.rs). The bootloader installs the kernel's initial
+page tables ([page-tables.md](page-tables.md)) before transferring control, so the jump
+target is always this virtual address; no physical entry address is computed or used.
+`validate_kernel_layout` confirms `e_entry` falls within a `PT_LOAD` segment.
 
 ---
 
 ## Init ELF Loading
 
-Init is loaded and pre-parsed into an `InitImage` for the kernel. The procedure
-differs from kernel loading in one key respect: init is a userspace ELF whose
-`p_paddr` values are in low memory already occupied by UEFI firmware, so segments
-are allocated at any available physical address via `AllocateAnyPages` rather than
-`AllocateAddress`.
+Init is loaded and pre-parsed into an `InitImage` for the kernel. Like the kernel
+image, init segments are allocated via `AllocateAnyPages` (init is a userspace ELF
+whose `p_paddr` values fall in low memory already occupied by UEFI firmware). Unlike
+the kernel — placed as one contiguous span — each init segment is allocated
+independently and the in-page byte offset of `p_vaddr` is preserved, so the kernel
+can identity-map each segment without a second copy.
 
 ```
 For each PT_LOAD segment:

--- a/core/boot/docs/memory-map.md
+++ b/core/boot/docs/memory-map.md
@@ -68,7 +68,7 @@ therefore surfaces as `MemoryType::Loaded`. The kernel treats `Loaded`
 regions as in-use until it explicitly reclaims them in Phase 3 (kernel
 page-table replacement). Specifically:
 
-- Kernel image LOAD segments, placed at ELF `p_paddr`.
+- Kernel image LOAD segments, placed in a bootloader-chosen contiguous span.
 - Init image LOAD segments, placed at any free physical address.
 - Boot-module file buffers, placed at any free physical address.
 - `BootInfo` structure page.

--- a/core/boot/docs/uefi-environment.md
+++ b/core/boot/docs/uefi-environment.md
@@ -70,13 +70,17 @@ bundle format itself is specified in
 All allocation before `ExitBootServices` goes through `AllocatePages`. Two allocation
 modes are used:
 
-**`AllocateAnyPages`** — used for data whose physical address does not matter:
-`BootInfo` structure, `MmioAperture` array, memory map buffer, `MemoryMapEntry`
-array. The firmware selects a free physical page range.
+**`AllocateAnyPages`** — the firmware selects a free physical page range. Used for
+everything whose absolute address does not matter: the kernel image span, init image
+segments, boot-module buffers, page-table frames, the `BootInfo` structure, the
+`MmioAperture` array, the memory map buffer, and the `MemoryMapEntry` array. The kernel
+image is placed as one contiguous span and its base recorded in
+`BootInfo.kernel_physical_base`, so kernel placement tolerates any firmware memory
+layout.
 
-**`AllocateAddress`** — used for ELF LOAD segments that specify a physical address
-in their `p_paddr` field. If the requested address range is already in use,
-allocation fails fatally. Page table frames use `AllocateAnyPages`.
+**`AllocateMaxAddress`** — the firmware selects a free range with a physical base at or
+below a bound. Used only by the x86-64 AP-startup trampoline, whose SIPI vector must
+reside below 1 MiB.
 
 All allocation uses memory type `EfiLoaderData`. UEFI memory map entries for
 `EfiLoaderData` regions translate to `MemoryType::Loaded` in the boot protocol,

--- a/core/boot/src/elf.rs
+++ b/core/boot/src/elf.rs
@@ -10,8 +10,10 @@
 //!
 //! - Allocate physical pages via UEFI for each `PT_LOAD` segment, copy
 //!   file data in, and zero the BSS tail.
-//! - For the kernel: place segments at their ELF-declared `p_paddr` via
-//!   `AllocatePages(AllocateAddress, …)`.
+//! - For the kernel: allocate one contiguous span at any available physical
+//!   base via `AllocatePages(AllocateAnyPages, …)` and place each segment at
+//!   its ELF-relative offset within the span, so kernel placement tolerates
+//!   any firmware memory layout.
 //! - For init: place segments at any available physical address while
 //!   preserving the in-page byte offset of `p_vaddr`, so the kernel can
 //!   identity-map a page without a second copy.
@@ -77,21 +79,125 @@ pub struct KernelInfo
 
 // ── Kernel loading ────────────────────────────────────────────────────────────
 
+/// Physical span and link-time bases of a kernel image, derived from its
+/// `PT_LOAD` segments by [`validate_kernel_layout`].
+///
+/// The loader allocates one contiguous region of `span_bytes` at any free
+/// physical base and places each segment at `span_base + (p_paddr -
+/// link_phys)`, preserving the ELF's relative layout.
+struct KernelSpan
+{
+    /// Lowest `p_paddr` across all segments — the ELF's link-time physical origin.
+    link_phys: u64,
+    /// Lowest `p_vaddr` across all segments — the kernel's link-time virtual base.
+    link_virt: u64,
+    /// Span from `link_phys` to the end of the highest segment (`p_paddr + p_memsz`).
+    span_bytes: u64,
+}
+
+/// Validate the kernel `PT_LOAD` layout and compute its physical span.
+///
+/// The kernel image is placed as a single contiguous span at a dynamically
+/// chosen physical base (issue #377: a fixed `p_paddr` collides with
+/// hart-scaled firmware allocations). That relocation is sound only if the
+/// segments form one linearly-offset, page-aligned, non-overlapping block: the
+/// kernel maps every page at `pa = va - link_virt + span_base`
+/// (`map_kernel_image`), and the per-segment copy below places each segment by
+/// the same offset. These checks guarantee both hold.
+///
+/// # Errors
+///
+/// Returns [`BootError::InvalidElf`] if `segs` is empty, any segment has
+/// `p_memsz < p_filesz`, any `p_vaddr`/`p_paddr` is not 4 KiB-aligned, the
+/// segments do not share a single `p_vaddr → p_paddr` offset, any two segments'
+/// physical ranges overlap, or `entry` lies outside every segment.
+fn validate_kernel_layout(segs: &[elf::LoadSegment], entry: u64) -> Result<KernelSpan, BootError>
+{
+    if segs.is_empty()
+    {
+        return Err(BootError::InvalidElf("kernel ELF has no PT_LOAD segments"));
+    }
+
+    let link_phys = segs.iter().map(|s| s.paddr).fold(u64::MAX, u64::min);
+    let link_virt = segs.iter().map(|s| s.vaddr).fold(u64::MAX, u64::min);
+
+    for s in segs
+    {
+        if s.memsz < s.filesz
+        {
+            return Err(BootError::InvalidElf("LOAD segment: p_memsz < p_filesz"));
+        }
+        if s.vaddr % 4096 != 0 || s.paddr % 4096 != 0
+        {
+            return Err(BootError::InvalidElf(
+                "LOAD segment: p_vaddr or p_paddr not 4 KiB-aligned",
+            ));
+        }
+        // A single linear offset is what lets span placement and the kernel's
+        // `pa = va - link_virt + span_base` mapping agree.
+        if s.paddr.wrapping_sub(link_phys) != s.vaddr.wrapping_sub(link_virt)
+        {
+            return Err(BootError::InvalidElf(
+                "LOAD segments do not share one p_vaddr->p_paddr offset",
+            ));
+        }
+    }
+
+    // Pairwise physical non-overlap (≤ 8 segments; O(n²) is trivial).
+    // Overlapping segments would corrupt the copy into the single span.
+    for (i, a) in segs.iter().enumerate()
+    {
+        let a_end = a.paddr.saturating_add(a.memsz);
+        for b in &segs[i + 1..]
+        {
+            let b_end = b.paddr.saturating_add(b.memsz);
+            if a.paddr < b_end && b.paddr < a_end
+            {
+                return Err(BootError::InvalidElf(
+                    "LOAD segments overlap in physical memory",
+                ));
+            }
+        }
+    }
+
+    if !segs
+        .iter()
+        .any(|s| entry >= s.vaddr && entry < s.vaddr.saturating_add(s.memsz))
+    {
+        return Err(BootError::InvalidElf(
+            "entry point not within any LOAD segment",
+        ));
+    }
+
+    let phys_end = segs
+        .iter()
+        .map(|s| s.paddr.saturating_add(s.memsz))
+        .fold(0u64, u64::max);
+
+    Ok(KernelSpan {
+        link_phys,
+        link_virt,
+        span_bytes: phys_end.saturating_sub(link_phys),
+    })
+}
+
 /// Load the kernel ELF from `data` into physical memory allocated via UEFI.
 ///
-/// For each `PT_LOAD` segment: allocates physical pages at `p_paddr` via
-/// `AllocateAddress`, copies `p_filesz` bytes of file data into the region,
-/// and zeroes the BSS tail (`p_memsz - p_filesz` bytes).
+/// The image is placed as a single contiguous span allocated at any free
+/// physical base via `AllocateAnyPages`; each `PT_LOAD` segment is copied to
+/// `span_base + (p_paddr - link_phys)`, preserving the ELF's relative offsets,
+/// and its BSS tail (`p_memsz - p_filesz` bytes) is zeroed. Dynamic placement
+/// tolerates any firmware memory layout (issue #377); the kernel learns the
+/// chosen base through `BootInfo.kernel_physical_base`.
 ///
 /// Up to 8 `PT_LOAD` segments are supported; an ELF with more returns
 /// `InvalidElf`.
 ///
 /// # Errors
 ///
-/// - `BootError::InvalidElf` — header or segment constraint check failed
-///   (bridged from `elf::ElfError`).
-/// - `BootError::OutOfMemory` — `AllocatePages(AllocateAddress)` returned
-///   failure (typically because the requested physical range is occupied).
+/// - `BootError::InvalidElf` — header check failed (bridged from
+///   `elf::ElfError`), or the segment layout failed [`validate_kernel_layout`].
+/// - `BootError::OutOfMemory` — no free contiguous span of the required size.
 ///
 /// # Safety
 ///
@@ -106,14 +212,17 @@ pub unsafe fn load_kernel(
 {
     let ehdr = elf::validate(data, expected_machine)?;
 
-    let mut segments: [LoadedSegment; MAX_LOAD_SEGMENTS] =
-        core::array::from_fn(|_| LoadedSegment {
-            phys_base: 0,
-            virt_base: 0,
-            size: 0,
-            writable: false,
-            executable: false,
-        });
+    // Collect the PT_LOAD segments (skipping pure-padding entries) before any
+    // allocation, so the whole layout can be validated as a unit.
+    let mut raw = [elf::LoadSegment {
+        vaddr: 0,
+        paddr: 0,
+        offset: 0,
+        filesz: 0,
+        memsz: 0,
+        writable: false,
+        executable: false,
+    }; MAX_LOAD_SEGMENTS];
     let mut segment_count: usize = 0;
 
     for seg in elf::load_segments(ehdr, data)
@@ -123,24 +232,41 @@ pub unsafe fn load_kernel(
         {
             continue;
         }
-        if seg.memsz < seg.filesz
-        {
-            return Err(BootError::InvalidElf("LOAD segment: p_memsz < p_filesz"));
-        }
         if segment_count >= MAX_LOAD_SEGMENTS
         {
             return Err(BootError::InvalidElf("ELF has more than 8 LOAD segments"));
         }
+        raw[segment_count] = seg;
+        segment_count += 1;
+    }
 
-        // p_memsz → usize: 64-bit on all supported UEFI targets; cast is exact.
-        #[allow(clippy::cast_possible_truncation)]
-        let page_count = (seg.memsz as usize).div_ceil(4096);
-        // SAFETY: `bs` is valid boot services per the function's safety contract.
-        // `seg.paddr` is the ELF-specified physical base; UEFI fails if the
-        // range is already occupied, which we surface as `OutOfMemory`.
-        unsafe { crate::uefi::allocate_address(bs, seg.paddr, page_count)? };
+    let span = validate_kernel_layout(&raw[..segment_count], elf::entry_point(ehdr))?;
 
-        // Copy file data (filesz bytes) into the allocated physical region.
+    // One contiguous allocation for the whole image, placed wherever the
+    // firmware has free RAM.
+    // span_bytes → usize: 64-bit on all supported UEFI targets; cast is exact.
+    #[allow(clippy::cast_possible_truncation)]
+    let page_count = (span.span_bytes as usize).div_ceil(4096);
+    // SAFETY: `bs` is valid boot services per the function's safety contract.
+    let span_base = unsafe { crate::uefi::allocate_pages(bs, page_count)? };
+
+    let mut segments: [LoadedSegment; MAX_LOAD_SEGMENTS] =
+        core::array::from_fn(|_| LoadedSegment {
+            phys_base: 0,
+            virt_base: 0,
+            size: 0,
+            writable: false,
+            executable: false,
+        });
+
+    for (i, seg) in raw[..segment_count].iter().enumerate()
+    {
+        // Destination preserves the ELF's relative physical offset. Page-aligned
+        // because `span_base` and `(paddr - link_phys)` are both 4 KiB multiples
+        // (the latter validated).
+        let dst_phys = span_base + (seg.paddr - span.link_phys);
+
+        // Copy file data (filesz bytes) into the placed region.
         // p_offset / p_filesz → usize: 64-bit targets only; cast is exact.
         #[allow(clippy::cast_possible_truncation)]
         let file_off = seg.offset as usize;
@@ -149,13 +275,13 @@ pub unsafe fn load_kernel(
         if file_sz > 0
         {
             let src = data[file_off..].as_ptr();
-            let dst = seg.paddr as *mut u8;
+            let dst = dst_phys as *mut u8;
             // SAFETY: `src` points into `data`; `elf::load_segments` already
             // validated that `[file_off, file_off + file_sz)` is in bounds
-            // (yields SegmentOverflow otherwise). `dst` is a freshly UEFI-
-            // allocated region of `page_count * 4096 ≥ memsz ≥ filesz` bytes,
-            // identity-mapped in the bootloader address space and disjoint
-            // from the temporary read buffer.
+            // (yields SegmentOverflow otherwise). `dst` lies within the single
+            // span allocation (`page_count * 4096 ≥ span_bytes ≥ (paddr -
+            // link_phys) + memsz ≥ … + filesz`), identity-mapped in the
+            // bootloader address space and disjoint from the read buffer.
             unsafe { core::ptr::copy_nonoverlapping(src, dst, file_sz) };
         }
 
@@ -165,54 +291,26 @@ pub unsafe fn load_kernel(
         let bss_sz = (seg.memsz - seg.filesz) as usize;
         if bss_sz > 0
         {
-            let bss_ptr = (seg.paddr + seg.filesz) as *mut u8;
-            // SAFETY: `bss_ptr` is `filesz` bytes past the segment's physical
-            // base, which is within the allocated region (`memsz` bytes total).
-            // `bss_sz = memsz - filesz` bytes remain. UEFI does not guarantee
-            // pages are zeroed; we must zero BSS here.
+            let bss_ptr = (dst_phys + seg.filesz) as *mut u8;
+            // SAFETY: `bss_ptr` is `filesz` bytes into the segment's placed
+            // region, which spans `memsz` bytes within the span allocation.
+            // UEFI does not guarantee zeroed pages; we must zero BSS here.
             unsafe { core::ptr::write_bytes(bss_ptr, 0, bss_sz) };
         }
 
-        segments[segment_count] = LoadedSegment {
-            phys_base: seg.paddr,
+        segments[i] = LoadedSegment {
+            phys_base: dst_phys,
             virt_base: seg.vaddr,
             size: seg.memsz,
             writable: seg.writable,
             executable: seg.executable,
         };
-        segment_count += 1;
     }
-
-    if segment_count == 0
-    {
-        return Err(BootError::InvalidElf(
-            "ELF has no PT_LOAD segments with non-zero p_memsz",
-        ));
-    }
-
-    let init_segs = &segments[..segment_count];
-
-    let physical_base = init_segs
-        .iter()
-        .map(|s| s.phys_base)
-        .fold(u64::MAX, u64::min);
-
-    let virtual_base = init_segs
-        .iter()
-        .map(|s| s.virt_base)
-        .fold(u64::MAX, u64::min);
-
-    let phys_end = init_segs
-        .iter()
-        .map(|s| s.phys_base.saturating_add(s.size))
-        .fold(0u64, u64::max);
-
-    let size = phys_end.saturating_sub(physical_base);
 
     Ok(KernelInfo {
-        physical_base,
-        virtual_base,
-        size,
+        physical_base: span_base,
+        virtual_base: span.link_virt,
+        size: span.span_bytes,
         entry_virtual: elf::entry_point(ehdr),
         segments,
         segment_count,
@@ -361,3 +459,111 @@ pub unsafe fn load_init(
 // Boot modules are exposed in place by referencing the single bundle UEFI
 // allocation in `BootModule.physical_base`; only the `init` entry is ELF-
 // loaded (via [`load_init`]). See `main.rs::step4_parse_bundle`.
+
+#[cfg(test)]
+mod tests
+{
+    use super::*;
+
+    // A realistic kernel link layout: one linear vaddr→paddr offset, 4 KiB-aligned.
+    const VBASE: u64 = 0xFFFF_FFFF_8000_0000;
+    const PBASE: u64 = 0x8020_0000;
+
+    fn seg(vaddr: u64, paddr: u64, filesz: u64, memsz: u64) -> elf::LoadSegment
+    {
+        elf::LoadSegment {
+            vaddr,
+            paddr,
+            offset: 0,
+            filesz,
+            memsz,
+            writable: false,
+            executable: false,
+        }
+    }
+
+    // text / rodata / data / bss, page-contiguous, BSS tail extends past a page.
+    fn contiguous_layout() -> [elf::LoadSegment; 4]
+    {
+        [
+            seg(VBASE, PBASE, 0x1000, 0x1000),
+            seg(VBASE + 0x1000, PBASE + 0x1000, 0x1000, 0x1000),
+            seg(VBASE + 0x2000, PBASE + 0x2000, 0x1000, 0x1000),
+            seg(VBASE + 0x3000, PBASE + 0x3000, 0x800, 0x1800),
+        ]
+    }
+
+    #[test]
+    fn valid_layout_yields_link_bases_and_span()
+    {
+        let span = validate_kernel_layout(&contiguous_layout(), VBASE).expect("valid layout");
+        assert_eq!(span.link_phys, PBASE);
+        assert_eq!(span.link_virt, VBASE);
+        // phys_end = PBASE + 0x3000 + 0x1800; span = 0x4800.
+        assert_eq!(span.span_bytes, 0x4800);
+    }
+
+    #[test]
+    fn span_covers_unaligned_final_segment_end()
+    {
+        // Last segment ends at a non-page boundary; span must still reach it.
+        let segs = [seg(VBASE, PBASE, 0x10, 0x10)];
+        let span = validate_kernel_layout(&segs, VBASE).expect("valid layout");
+        assert_eq!(span.span_bytes, 0x10);
+    }
+
+    #[test]
+    fn empty_segment_slice_is_rejected()
+    {
+        assert!(validate_kernel_layout(&[], VBASE).is_err());
+    }
+
+    #[test]
+    fn memsz_less_than_filesz_is_rejected()
+    {
+        let segs = [seg(VBASE, PBASE, 0x2000, 0x1000)];
+        assert!(validate_kernel_layout(&segs, VBASE).is_err());
+    }
+
+    #[test]
+    fn unaligned_vaddr_is_rejected()
+    {
+        let segs = [seg(VBASE + 0x100, PBASE, 0x1000, 0x1000)];
+        assert!(validate_kernel_layout(&segs, VBASE + 0x100).is_err());
+    }
+
+    #[test]
+    fn unaligned_paddr_is_rejected()
+    {
+        let segs = [seg(VBASE, PBASE + 0x100, 0x1000, 0x1000)];
+        assert!(validate_kernel_layout(&segs, VBASE).is_err());
+    }
+
+    #[test]
+    fn inconsistent_linear_offset_is_rejected()
+    {
+        // Second segment's paddr offset (0x2000) differs from its vaddr offset (0x1000).
+        let segs = [
+            seg(VBASE, PBASE, 0x1000, 0x1000),
+            seg(VBASE + 0x1000, PBASE + 0x2000, 0x1000, 0x1000),
+        ];
+        assert!(validate_kernel_layout(&segs, VBASE).is_err());
+    }
+
+    #[test]
+    fn overlapping_physical_ranges_are_rejected()
+    {
+        // Consistent linear offset, but segment 0's memsz overruns into segment 1.
+        let segs = [
+            seg(VBASE, PBASE, 0x800, 0x2000),
+            seg(VBASE + 0x1000, PBASE + 0x1000, 0x800, 0x1000),
+        ];
+        assert!(validate_kernel_layout(&segs, VBASE).is_err());
+    }
+
+    #[test]
+    fn entry_outside_all_segments_is_rejected()
+    {
+        assert!(validate_kernel_layout(&contiguous_layout(), VBASE + 0x10000).is_err());
+    }
+}

--- a/core/boot/src/main.rs
+++ b/core/boot/src/main.rs
@@ -434,7 +434,12 @@ unsafe fn step3_load_kernel(ctx: &UefiContext) -> Result<KernelLoad, BootError>
     // PE .reloc section is currently empty, so the firmware does not patch
     // vtable entries when relocating the image and core::fmt's fat-pointer
     // write_str faults.
-    bprint!("[--------] boot: kernel entry=");
+    bprint!("[--------] boot: kernel base=");
+    // SAFETY: console initialized.
+    unsafe {
+        crate::console::console_write_hex64(info.physical_base);
+    }
+    bprint!("  entry=");
     // SAFETY: console initialized.
     unsafe {
         crate::console::console_write_hex64(info.entry_virtual);

--- a/core/boot/src/uefi.rs
+++ b/core/boot/src/uefi.rs
@@ -37,8 +37,6 @@ pub const ALLOCATE_ANY_PAGES: u32 = 0;
 /// SIPI trampoline. Public because the x86-64 helper in
 /// `arch::current::allocate_ap_trampoline` lives in a different module.
 pub const ALLOCATE_MAX_ADDRESS: u32 = 1;
-/// Allocate pages at a specified physical address.
-pub const ALLOCATE_ADDRESS: u32 = 2;
 
 /// Memory type used for all bootloader allocations.
 ///
@@ -648,35 +646,6 @@ pub unsafe fn allocate_pages(bs: *mut EfiBootServices, count: usize) -> Result<u
         return Err(BootError::OutOfMemory);
     }
     Ok(addr)
-}
-
-/// Allocate `count` pages at the specified physical address.
-///
-/// Fails if the address range is already in use. Uses `EfiLoaderData`.
-///
-/// # Safety
-/// `bs` must be valid boot services. `addr` must be page-aligned.
-pub unsafe fn allocate_address(
-    bs: *mut EfiBootServices,
-    addr: u64,
-    count: usize,
-) -> Result<(), BootError>
-{
-    let mut out_addr = addr;
-    // SAFETY: bs is valid; out_addr is an in-out parameter (ALLOCATE_ADDRESS mode).
-    let status = unsafe {
-        ((*bs).allocate_pages)(
-            ALLOCATE_ADDRESS,
-            EFI_LOADER_DATA,
-            count,
-            core::ptr::addr_of_mut!(out_addr),
-        )
-    };
-    if status != EFI_SUCCESS
-    {
-        return Err(BootError::OutOfMemory);
-    }
-    Ok(())
 }
 
 /// Allocate `count` pages at or below `max_phys` physical address.

--- a/core/kernel/linker/riscv64.ld
+++ b/core/kernel/linker/riscv64.ld
@@ -8,10 +8,12 @@
  * Mirrors the x86-64 layout: kernel image at 0xFFFFFFFF80000000, physical direct map at
  * 0xFFFF800000000000 (established at runtime). Uses the medany code model.
  *
- * AT() clauses set p_paddr for each section to a low physical address
- * (KERNEL_PBASE), while p_vaddr remains at KERNEL_VBASE. The bootloader
- * allocates physical frames at p_paddr via AllocateAddress and maps them
- * at p_vaddr in the initial page tables.
+ * AT() clauses set each section's p_paddr relative to KERNEL_PBASE, defining
+ * the image's relative physical layout; p_vaddr stays at KERNEL_VBASE. The
+ * bootloader allocates one contiguous span at any free physical address,
+ * places the sections at their relative offsets, and maps them at p_vaddr in
+ * the initial page tables. KERNEL_PBASE is the link-time origin only, not a
+ * runtime placement contract.
  */
 
 KERNEL_VBASE = 0xFFFFFFFF80000000;

--- a/core/kernel/linker/x86_64.ld
+++ b/core/kernel/linker/x86_64.ld
@@ -8,10 +8,12 @@
  * at 0xFFFFFFFF80000000; the physical direct map is established at runtime
  * at 0xFFFF800000000000.
  *
- * AT() clauses set p_paddr for each section to a low physical address
- * (KERNEL_PBASE), while p_vaddr remains at KERNEL_VBASE. The bootloader
- * allocates physical frames at p_paddr via AllocateAddress and maps them
- * at p_vaddr in the initial page tables.
+ * AT() clauses set each section's p_paddr relative to KERNEL_PBASE, defining
+ * the image's relative physical layout; p_vaddr stays at KERNEL_VBASE. The
+ * bootloader allocates one contiguous span at any free physical address,
+ * places the sections at their relative offsets, and maps them at p_vaddr in
+ * the initial page tables. KERNEL_PBASE is the link-time origin only, not a
+ * runtime placement contract.
  */
 
 KERNEL_VBASE = 0xFFFFFFFF80000000;

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -306,6 +306,23 @@ other SMP PRs stay on the 256-vCPU mandate above.
 cargo xtask run-parallel --arch x86_64 --cpus 512 --parallel 1 --runs 1 --timeout 10800
 ```
 
+PRs touching the bootloader's kernel-placement path — `core/boot/src/elf.rs`
+(kernel ELF span allocation), `core/boot/src/uefi.rs` (UEFI page allocation),
+or the boot page-table builders (`core/boot/src/paging.rs`,
+`core/boot/src/arch/*/paging.rs`) — MUST additionally run the riscv64 128-hart
+boundary below. It is the riscv64 analogue of the full-width x86_64 run: the
+hart count at which hart-scaled firmware allocations once collided with the
+kernel image's load address ([#377](https://github.com/kottlerg/seraph/issues/377)).
+This trigger list is deliberately narrow; other SMP PRs stay on the 64/65-hart
+mandate above.
+
+```sh
+# Kernel-placement boundary, riscv64 (~475 s per passing run measured at 8x hart
+# oversubscription on a 16-core host; the 1800 s budget is for HANG
+# classification):
+cargo xtask run-parallel --arch riscv64 --cpus 128 --parallel 1 --runs 1 --timeout 1800
+```
+
 **Known boundaries**, established empirically (QEMU 11.0.1; update this
 list as the tracking Issues move):
 
@@ -317,11 +334,22 @@ list as the tracking Issues move):
   compile-time asserts at the slab consumer sites so the envelope breaks
   the build, not the boot. The full 512-vCPU width is exercised by the
   MAX_CPUS boundary run above.
-- riscv64 ≥ 128 harts ([#377](https://github.com/kottlerg/seraph/issues/377)):
-  boot dies in UEFI (`ConvertPages: Incompatible memory types`) while
-  loading the kernel ELF; independent of guest memory size. At 256 and
-  512 harts under TCG the firmware produces no serial output within 20
-  and 30 minutes respectively.
+- riscv64 ≥ 128 harts ([#377](https://github.com/kottlerg/seraph/issues/377),
+  fixed): boot died in UEFI (`ConvertPages: Incompatible memory types`) while
+  loading the kernel ELF, because the bootloader requested the image at a fixed
+  `p_paddr` (`0x80200000`) that hart-scaled firmware allocations had already
+  claimed — independent of guest memory size. The kernel image is now placed as
+  one contiguous span allocated anywhere (`AllocateAnyPages`), so loading
+  tolerates any firmware layout; `validate_kernel_layout` enforces the
+  relocation invariants (single offset, alignment, non-overlap, entry-in-image)
+  at load time. 128 harts now boots clean (3×, ~475 s/run at 8× hart
+  oversubscription on a 16-core host). The residual ceiling is upstream and
+  pre-bootloader: at 192, 256, and 512 harts under TCG the edk2 firmware emits
+  no serial output at all (192: nothing in 60 min; 256/512: nothing in 20/30
+  min) — an MP-init crawl that runs before Seraph's bootloader and cannot be
+  addressed in-tree. High-hart cross-architecture parity is therefore
+  theoretical, with real testing on hold pending faster firmware, KVM-capable
+  RISC-V emulation, or real hardware.
 - Both arches, high CPU counts ([#375](https://github.com/kottlerg/seraph/issues/375),
   fixed): the intermittent silent wedge around the `thread::load_balancer`
   and `stress::double_enqueue_storm` tests was a load-balancer ticket-lock

--- a/shared/elf/src/lib.rs
+++ b/shared/elf/src/lib.rs
@@ -146,8 +146,9 @@ pub struct Elf64Phdr
     /// Physical address of the segment.
     ///
     /// Userspace loaders ignore this field (they place segments at any
-    /// available physical address). The bootloader honours it for the
-    /// kernel image, where the ELF dictates a fixed physical placement.
+    /// available physical address). For the kernel image it defines the
+    /// segment's offset within the image; the bootloader places the image at
+    /// a dynamically chosen base and preserves those relative offsets.
     pub p_paddr: u64,
     /// Number of bytes in the file image of the segment.
     pub p_filesz: u64,
@@ -171,8 +172,9 @@ pub struct LoadSegment
     /// Physical address declared by the ELF (`p_paddr`).
     ///
     /// Userspace loaders ignore this and pick any available physical
-    /// address. The bootloader honours it for the kernel image, which
-    /// requires fixed placement.
+    /// address. For the kernel image it defines each segment's relative
+    /// offset; the bootloader places the image at a dynamically chosen base
+    /// and preserves those offsets. No consumer requires fixed placement.
     pub paddr: u64,
     /// Byte offset within the ELF file where segment data starts.
     pub offset: u64,


### PR DESCRIPTION
## Summary

riscv64 could not boot at ≥128 harts: the bootloader loaded each kernel `PT_LOAD`
segment at its ELF-declared `p_paddr` via `AllocatePages(AllocateAddress)`, and the
linker pins `KERNEL_PBASE = 0x80200000`. At ≥128 harts edk2's hart-scaled firmware
allocations have already claimed that range, so the fixed-address request failed with
`ConvertPages: Incompatible memory types` → `SERAPH BOOT FATAL: physical memory
allocation failed`, independent of guest memory size.

The kernel was already placement-agnostic (it reads `BootInfo.kernel_physical_base` and
derives every mapping from it; `0x80200000` lived only in the two linker scripts). The
fix is bootloader-side: **load the kernel image as one contiguous span allocated at any
free physical base (`AllocateAnyPages`)**, placing each segment at
`span_base + (p_paddr - link_phys)`. This is always-dynamic — exercised on every boot of
both architectures, not a fallback — so the firmware-layout-collision class is removed
outright.

Closes #377.

## Change

- **`core/boot/src/elf.rs`** — `load_kernel` now collects the `PT_LOAD` segments, validates
  the layout, makes one `AllocateAnyPages` allocation for the whole image span, and places
  each segment at its ELF-relative offset. A new pure, host-tested `validate_kernel_layout`
  reasserts the invariants that fixed-address allocation used to enforce implicitly and that
  the kernel's own image mapping assumes: non-empty, `p_memsz ≥ p_filesz`, 4 KiB alignment,
  a single `p_vaddr → p_paddr` offset, pairwise physical non-overlap, and entry-in-image.
  A malformed kernel ELF now fails with a precise `InvalidElf` at load instead of silently
  corrupting a copy or faulting after handoff.
- **`core/boot/src/uefi.rs`** — removed the now-unused `allocate_address` wrapper and
  `ALLOCATE_ADDRESS` constant (the kernel loader was its only caller).
- **`core/boot/src/main.rs`** — step-3 boot log now prints the chosen `base=` alongside
  `entry=`/`size=`; the dynamic placement is visible in boot logs (#377 was misdiagnosable
  precisely because placement was invisible).
- **Linker scripts** (`riscv64.ld`, `x86_64.ld`) — head comments corrected: `AT()` clauses
  define the image's *relative* physical layout; `KERNEL_PBASE` is the link-time origin
  only, not a runtime placement contract. No semantic change.
- **Docs** — `shared/elf` field docs, boot `README.md`, `elf-loading.md` (incl. rewriting
  the "Entry Point Extraction" section, which described a `physical_entry` computation that
  does not exist in code), `uefi-environment.md`, `memory-map.md`, `boot-flow.md` updated to
  present intent. `docs/testing.md` gains a bounded riscv64 128-hart mandate (the analogue
  of the x86_64 512 tier, ×1, triggered only by `core/boot/` placement PRs) and a rewritten
  #377 Known-boundaries entry.

## Acceptance (#377)

- [x] (a) Bootloader kernel-ELF placement tolerant of hart-scaled firmware layout —
  single `AllocateAnyPages` span; verified on both arches at every tested count.
- [x] (b) riscv64 boots at 128 harts to the ktest pass marker — 3/3 PASS, ~474 s/run.
- [x] (c) Hart ceiling and firmware-crawl behavior documented in `docs/testing.md`
  "Known boundaries".

## Test plan

Host: `cargo xtask test` — full workspace green, including 9 new `validate_kernel_layout`
unit tests.

The `base=` boot diagnostic confirms dynamic placement on both arches (kernel no longer at
the fixed link base):

| Arch | Run | Result | `base=` |
|---|---|---|---|
| riscv64 | canonical (4 vCPU, 512 MiB) | PASS | `0x9e108000` |
| riscv64 | 64 harts ×3 | 3/3 PASS (~60–69 s) | — |
| riscv64 | 65 harts ×3 | 3/3 PASS (~69–75 s) | — |
| riscv64 | 128 harts ×3 | 3/3 PASS (~474 s) | — |
| riscv64 | 192 harts ×1 | HANG — firmware crawl, no serial in 60 min (upstream) | — |
| riscv64 | 4 vCPU, 1024 MiB | PASS | `0xbe108000` |
| riscv64 | 4 vCPU, 4096 MiB | placement OK (Phases 0–8); see note | `0x17e10f000` (≈ 6.13 GiB, **above 4 GiB**) |
| x86_64 | canonical (4 vCPU, 512 MiB) | PASS | `0x1d192000` |
| x86_64 | 256 vCPU ×3 | 3/3 PASS (~294–312 s) | — |
| x86_64 | 4 vCPU, 1024 MiB | PASS | `0x3d1a4000` |
| x86_64 | 4 vCPU, 6144 MiB | PASS | `0x7d1cd000` (OVMF keeps the span < 2 GiB regardless of total RAM) |

The riscv64 `--mem 4096` run is the only above-4-GiB placement exercised (OVMF keeps x86_64
spans low). The kernel loaded and ran through Phase 8 at base ≈ 6.13 GiB — confirming the
dynamic-placement path handles a >4 GiB base — then hit a pre-existing, RAM-size-driven
limit unrelated to this change: `FATAL: Phase 9: InitInfo region too large`. **master fails
identically** at `--mem 4096` (kernel at the fixed `0x80200000`), so it is not a regression.
4 GiB is well beyond the mandated configs (512 MiB CI, 1024 MiB mandate, both passing). This
is a separate surface (init handover / InitInfo sizing), tracked in #383.

The x86_64 512 mandate is **not** triggered — this PR touches `core/boot/`, not
`core/kernel/src/mm/`, x86_64 AP bringup, or per-CPU slab sizing.

## Residual ceiling (not in scope)

At 192/256/512 harts under TCG the edk2 firmware emits no serial output at all — an MP-init
crawl that runs before Seraph's bootloader and cannot be addressed in-tree. High-hart
cross-architecture parity is theoretical pending faster firmware, KVM-capable RISC-V
emulation, or real hardware (documented in `docs/testing.md`).
