### PR TITLE
kernel: coalesce drained RAM blocks before minting init Memory caps (#383)

### DIFF
--- a/core/kernel/src/cap/mod.rs
+++ b/core/kernel/src/cap/mod.rs
@@ -868,17 +868,100 @@ pub(crate) unsafe fn drain_and_install_seed(out: &mut [RamBlock]) -> usize
         };
     }
 
+    // Coalesce physically-adjacent drained blocks into the fewest contiguous
+    // extents so the per-block Memory-cap / CapDescriptor fan-out tracks
+    // memory-map fragmentation, not total RAM. Without this the Phase-9
+    // InitInfo descriptor array overflows INIT_INFO_MAX_PAGES at large guest
+    // RAM — one descriptor per order-11 buddy block.
+    let coalesced = coalesce_ram_blocks(&mut out[..block_count]);
+
     crate::kprintln!(
-        "Phase 7: drained {} pages across {} blocks; seed reserve {} KiB",
+        "Phase 7: drained {} pages across {} blocks, coalesced to {} contiguous \
+         regions; seed reserve {} KiB",
         drained_pages,
         block_count,
+        coalesced,
         SEED_RESERVE_BYTES / 1024,
     );
 
     let pool_remaining = crate::mm::kernel_pt_pool::remaining_pages();
     crate::kprintln!("kernel_pt_pool: {pool_remaining} pages installed");
 
-    block_count
+    coalesced
+}
+
+/// Merge physically-adjacent drained RAM blocks into the fewest contiguous
+/// extents and promote the largest extent to index 0; returns the reduced
+/// count.
+///
+/// Drained blocks are pairwise disjoint (each is a distinct popped buddy block;
+/// the seed tail is a sub-range of one block with its front pinned out), so
+/// after sorting by base, block `i` is contiguous with `i + 1` iff
+/// `base[i] + size[i] == base[i + 1]`. All bases and sizes are `PAGE_SIZE`
+/// multiples (buddy blocks are page-aligned; `SEED_RESERVE_BYTES` is a whole
+/// page count), so merged extents stay page-aligned and a [`MemoryObject`]
+/// tolerates the larger size (the seed-tail cap is already non-power-of-two).
+///
+/// The seed-tail entry's base sits above its pinned `SEED_RESERVE_BYTES`
+/// reserve, leaving a hole below it, so nothing merges *into* it from below —
+/// only upward.
+///
+/// The largest extent is then moved to index 0 so `populate_cspace` assigns it
+/// to `memory_base`. Sorting by base would otherwise make `memory_base` the
+/// lowest-address (possibly small) fragment; the pre-coalesce drain emitted the
+/// highest-order block first, and ktest (`frame_pool`, `fund_boot_aspace_pt`,
+/// and the retype-heavy stress tests) bump-allocates every kernel object it
+/// creates from `memory_base`, so it must stay the large cap. Consumers that
+/// take the whole range (init, memmgr) read each cap's size/base individually
+/// and do not depend on the order.
+fn coalesce_ram_blocks(blocks: &mut [RamBlock]) -> usize
+{
+    if blocks.len() <= 1
+    {
+        return blocks.len();
+    }
+
+    // The drain pops order-by-order (high→low), so `blocks` is not
+    // address-sorted; sort before the single linear merge pass.
+    blocks.sort_unstable_by_key(|&(base, _)| base);
+
+    // `w` is the write cursor (last kept run); `r` scans the remainder.
+    let mut w = 0usize;
+    for r in 1..blocks.len()
+    {
+        let (cur_base, cur_size) = blocks[w];
+        let (next_base, next_size) = blocks[r];
+        debug_assert!(
+            cur_base + cur_size <= next_base,
+            "drained blocks must be disjoint and sorted"
+        );
+        if cur_base + cur_size == next_base
+        {
+            blocks[w].1 = cur_size + next_size;
+        }
+        else
+        {
+            w += 1;
+            blocks[w] = (next_base, next_size);
+        }
+    }
+
+    let count = w + 1;
+
+    // Promote the largest contiguous extent to index 0 → `memory_base`. Strict
+    // `>` keeps the earliest extent on ties, so the address-sorted order is
+    // preserved unless a strictly larger extent exists.
+    let mut largest = 0usize;
+    for i in 1..count
+    {
+        if blocks[i].1 > blocks[largest].1
+        {
+            largest = i;
+        }
+    }
+    blocks.swap(0, largest);
+
+    count
 }
 
 /// Boot-time helper: retype an `init_pages`-page slab from `seed` and
@@ -2513,5 +2596,99 @@ fn insert_or_fatal(
         // In test mode, panic with the message instead of halting the CPU.
         #[cfg(test)]
         Err(e) => panic!("{}: {:?}", msg, e),
+    }
+}
+
+#[cfg(test)]
+mod tests
+{
+    use super::*;
+
+    /// Coalesce a fixed array and return `(count, kept_runs)`.
+    fn coalesce(mut blocks: Vec<RamBlock>) -> (usize, Vec<RamBlock>)
+    {
+        let count = coalesce_ram_blocks(&mut blocks);
+        blocks.truncate(count);
+        (count, blocks)
+    }
+
+    #[test]
+    fn empty_yields_zero()
+    {
+        assert_eq!(coalesce(vec![]), (0, vec![]));
+    }
+
+    #[test]
+    fn single_block_unchanged()
+    {
+        assert_eq!(
+            coalesce(vec![(0x1000, 0x1000)]),
+            (1, vec![(0x1000, 0x1000)])
+        );
+    }
+
+    #[test]
+    fn adjacent_blocks_merge()
+    {
+        assert_eq!(
+            coalesce(vec![(0x1000, 0x1000), (0x2000, 0x1000)]),
+            (1, vec![(0x1000, 0x2000)])
+        );
+    }
+
+    #[test]
+    fn gap_keeps_blocks_separate()
+    {
+        // 0x1000..0x2000 then a hole, 0x3000..0x4000.
+        assert_eq!(
+            coalesce(vec![(0x1000, 0x1000), (0x3000, 0x1000)]),
+            (2, vec![(0x1000, 0x1000), (0x3000, 0x1000)])
+        );
+    }
+
+    #[test]
+    fn unsorted_input_is_sorted_then_merged()
+    {
+        // Three adjacent extents supplied out of address order, as the
+        // order-by-order drain emits them.
+        assert_eq!(
+            coalesce(vec![(0x3000, 0x1000), (0x1000, 0x1000), (0x2000, 0x1000)]),
+            (1, vec![(0x1000, 0x3000)])
+        );
+    }
+
+    #[test]
+    fn seed_tail_hole_blocks_downward_merge_allows_upward()
+    {
+        // Models the seed block: its front SEED_RESERVE_BYTES is pinned out,
+        // so the seed-tail base sits a reserve above a block that ends at the
+        // seed block's true base — that hole must prevent a downward merge,
+        // while a block starting at the seed-tail's end merges upward.
+        let reserve = 0x1000u64;
+        let seed_block_base = 0x2000u64;
+        let block_below = (0x0u64, 0x2000u64); // ends exactly at seed_block_base
+        let seed_tail = (seed_block_base + reserve, 0x1000u64); // 0x3000..0x4000
+        let block_above = (0x4000u64, 0x1000u64); // starts at seed-tail end
+        assert_eq!(
+            coalesce(vec![block_above, block_below, seed_tail]),
+            (2, vec![(0x0, 0x2000), (0x3000, 0x2000)])
+        );
+    }
+
+    #[test]
+    fn largest_extent_promoted_to_front()
+    {
+        // A strictly larger extent (formed by merging 0x8000..0xb000) must land
+        // at index 0 so it becomes `memory_base`, even though a smaller
+        // lower-address fragment sorts ahead of it.
+        assert_eq!(
+            coalesce(vec![
+                (0x1000, 0x1000),
+                (0x8000, 0x1000),
+                (0x9000, 0x1000),
+                (0xa000, 0x1000),
+            ]),
+            (2, vec![(0x8000, 0x3000), (0x1000, 0x1000)])
+        );
     }
 }

--- a/core/kernel/src/main.rs
+++ b/core/kernel/src/main.rs
@@ -695,6 +695,14 @@ unsafe fn kernel_entry_post_rebase(
             // backing the slice.
             if info_pages > init_protocol::INIT_INFO_MAX_PAGES
             {
+                kprintln!(
+                    "Phase 9: InitInfo region needs {} pages ({} descriptors, {} bytes) \
+                     but INIT_INFO_MAX_PAGES = {}",
+                    info_pages,
+                    desc_count,
+                    total_bytes,
+                    init_protocol::INIT_INFO_MAX_PAGES,
+                );
                 fatal("Phase 9: InitInfo region too large");
             }
             // Round to next power of two for buddy allocation; for

--- a/core/kernel/src/mm/buddy.rs
+++ b/core/kernel/src/mm/buddy.rs
@@ -141,6 +141,15 @@ impl BuddyAllocator
         );
         debug_assert!(end.is_multiple_of(PAGE_SIZE as u64), "end not page-aligned");
 
+        // Reserve physical frame 0. The PT- and CSpace-pool intrusive free
+        // lists ([`AddressSpaceObject`]/[`CSpaceKernelObject`]) use a physical
+        // address of 0 as the "list empty" sentinel, so a pool frame at phys 0
+        // is indistinguishable from an empty pool. Firmware can legitimately
+        // mark `[0, PAGE_SIZE)` usable; admitting it lets a pool chunk that
+        // happens to cover frame 0 silently zero its own list head. Excluding
+        // the zero page (one frame) keeps it out of every pool.
+        let start = start.max(PAGE_SIZE as u64);
+
         if start >= end
         {
             return;
@@ -563,6 +572,35 @@ mod tests
         let mut alloc = BuddyAllocator::new();
         unsafe { alloc.add_region(start, end) };
         assert_eq!(alloc.free_page_count(), 16);
+    }
+
+    #[test]
+    fn add_region_based_at_zero_excludes_frame_zero()
+    {
+        // A region starting below PAGE_SIZE loses its zero page: the buddy
+        // reserves frame 0 so phys 0 (the PT/CSpace pool empty-sentinel) is
+        // never a real pool frame. add_region records block addresses in its
+        // own free lists and never dereferences [start, end), so a synthetic
+        // base of 0 is sound here.
+        let mut alloc = BuddyAllocator::new();
+        // SAFETY: add_region only records addresses; it never reads or writes
+        // the [start, end) range, so a non-backed synthetic base is valid.
+        unsafe { alloc.add_region(0, (PAGE_SIZE * 8) as u64) };
+        // 8 pages offered, frame 0 excluded → 7 manageable pages.
+        assert_eq!(alloc.free_page_count(), 7);
+        assert_eq!(alloc.total_page_count(), 7);
+    }
+
+    #[test]
+    fn add_region_single_zero_page_adds_nothing()
+    {
+        // The only page is frame 0; after the clamp start == end, so the
+        // region collapses to empty rather than admitting phys 0.
+        let mut alloc = BuddyAllocator::new();
+        // SAFETY: as above — add_region never accesses [start, end).
+        unsafe { alloc.add_region(0, PAGE_SIZE as u64) };
+        assert_eq!(alloc.free_page_count(), 0);
+        assert_eq!(alloc.total_page_count(), 0);
     }
 
     #[test]

--- a/core/ktest/src/main.rs
+++ b/core/ktest/src/main.rs
@@ -249,8 +249,9 @@ pub extern "C" fn _start(info_ptr: u64) -> !
 /// footprint; ktest additionally maps the framebuffer and serial MMIO and runs
 /// the `mem_map` suite against this AS, so it needs a modest top-up. Source the
 /// slabs from spare RAM caps — every inherited RAM cap except `memory_base`,
-/// which `frame_pool` and the retype-heavy tests draw from. The drain leaves one
-/// large cap plus many smaller fragments, so accumulate across several augments.
+/// which `frame_pool` and the retype-heavy tests draw from. The kernel coalesces
+/// drained RAM and places the largest extent at `memory_base`, leaving the
+/// smaller extents as spares, so accumulate across several augments.
 /// Best-effort: a partial top-up still helps; failures surface in the tests.
 fn fund_boot_aspace_pt(info: &init_protocol::InitInfo)
 {

--- a/docs/memory-model.md
+++ b/docs/memory-model.md
@@ -201,6 +201,12 @@ kernel concern: DMA isolation and placement are handled in userspace by devmgr a
 the memory authority (see [architecture.md](architecture.md) and
 [device-management.md](device-management.md)).
 
+Physical frame 0 (the zero page) is excluded from the allocator. The page-table and
+CSpace growth pools use a physical address of 0 as their free-list "empty" sentinel,
+so admitting frame 0 as a pool page would make an occupied list indistinguishable from
+an empty one. Excluding it (one frame) keeps the sentinel unambiguous regardless of
+how firmware classifies `[0, PAGE_SIZE)`.
+
 ### Frame Allocation is Fallible
 
 Frame allocation can fail. Every call site must handle `None` or an error result

--- a/docs/process-lifecycle.md
+++ b/docs/process-lifecycle.md
@@ -63,7 +63,10 @@ The kernel hands init the maximal capability set in init's CSpace
 Distribution") and the `InitInfo` page at `INIT_INFO_VADDR` describing
 it. `InitInfo.memory_base` and `InitInfo.memory_count`
 identify the contiguous slot range in init's CSpace holding the RAM
-Memory caps.
+Memory caps. The kernel coalesces physically-adjacent drained RAM into the
+fewest contiguous extents and places the largest at `memory_base`, so the
+first cap is the largest; consumers that take the whole range read each
+cap's size individually and do not depend on the order of the rest.
 
 Init never gives up the kernel-minted root caps directly — it derives
 intermediaries (the "derive twice" pattern in

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -360,6 +360,21 @@ list as the tracking Issues move):
   high-CPU HANG should instead produce a `=== WATCHDOG` dump (owed-wake /
   heartbeat detectors) naming the wedged state; file it with the preserved
   log rather than attributing it to #375.
+- Both arches, guest RAM ≥ ~4 GiB ([#383](https://github.com/kottlerg/seraph/issues/383),
+  fixed): boot died at Phase 9 (`FATAL: Phase 9: InitInfo region too large`)
+  because the kernel minted one userspace Memory cap — and one `CapDescriptor`
+  — per drained buddy block, and the buddy's largest block is order-11 (8 MiB),
+  so the descriptor array grew ~linearly with RAM (≈64 descriptors at 512 MiB,
+  ≈512 at 4 GiB) and overflowed the `INIT_INFO_MAX_PAGES = 4` (16 KiB) Phase-9
+  InitInfo region — independent of where the kernel image is placed.
+  `drain_and_install_seed` now coalesces physically-adjacent drained blocks
+  into the fewest contiguous Memory caps before minting, so the descriptor
+  count tracks memory-map fragmentation (a small fixed number of usable extents
+  plus reservation holes), not total RAM. The Phase-9 size check now logs the
+  descriptor count, page need, and `INIT_INFO_MAX_PAGES` before fatal-ing, so
+  any residual overflow on a pathologically fragmented map is diagnosable rather
+  than bare. Verified booting clean to the ktest pass marker on both arches at
+  `--mem 4096`.
 
 ---
 

--- a/docs/userspace-memory-model.md
+++ b/docs/userspace-memory-model.md
@@ -39,7 +39,10 @@ not delegate further to anyone.
 The handoff is total. At Phase 7 the kernel reserves its fixed
 contributors (PT-pool seed, idle-thread stacks, the `InitInfo` block,
 init's user stack, the SEED arena) from the pristine buddy, then drains
-**every** remaining page into userspace Memory caps and *seals* the buddy.
+**every** remaining page into userspace Memory caps — coalescing
+physically-adjacent drained blocks into the fewest contiguous caps so the
+cap count tracks memory-map fragmentation, not total RAM — and *seals* the
+buddy.
 After the seal the buddy is an inert boot artifact: it holds no free
 pages, allocates nothing, and must receive no frees. Every page of RAM is
 therefore either a bounded fixed kernel reserve or owned by memmgr's pool

--- a/services/memmgr/docs/memory-pool.md
+++ b/services/memmgr/docs/memory-pool.md
@@ -10,11 +10,13 @@ runs to sustain contiguous-allocation success.
 ## Pool Ingest
 
 memmgr receives the userspace RAM memory-cap pool from init at boot. The
-kernel populates init's CSpace with one Memory capability per usable
-physical-RAM region in `BootInfo` (see
+kernel populates init's CSpace with one Memory capability per contiguous
+usable physical-RAM extent (it coalesces physically-adjacent drained buddy
+blocks before minting, so the cap count tracks memory-map fragmentation, not
+total RAM) (see
 [`docs/capability-model.md`](../../../docs/capability-model.md) §"Initial
 Capability Distribution"). Memory cap sizes vary — they reflect the firmware
-memory map and may be multiple MiB each. Init copies the entire RAM
+memory map and may span many MiB each. Init copies the entire RAM
 range into memmgr's CSpace via the derive-twice pattern, then transfers
 the slot range `(memory_base, memory_count)` to memmgr in a
 single bootstrap IPC round.

--- a/services/memmgr/docs/memory-pool.md
+++ b/services/memmgr/docs/memory-pool.md
@@ -11,9 +11,9 @@ runs to sustain contiguous-allocation success.
 
 memmgr receives the userspace RAM memory-cap pool from init at boot. The
 kernel populates init's CSpace with one Memory capability per contiguous
-usable physical-RAM extent (it coalesces physically-adjacent drained buddy
+usable physical-RAM extent: it coalesces physically-adjacent drained buddy
 blocks before minting, so the cap count tracks memory-map fragmentation, not
-total RAM) (see
+total RAM (see
 [`docs/capability-model.md`](../../../docs/capability-model.md) §"Initial
 Capability Distribution"). Memory cap sizes vary — they reflect the firmware
 memory map and may span many MiB each. Init copies the entire RAM


### PR DESCRIPTION
## Problem

At ≥~4 GiB guest RAM, boot died at Phase 9 with `FATAL: Phase 9: InitInfo region too large`. The Phase-9 InitInfo region holds the `InitInfo` header plus a trailing `CapDescriptor` array bounded by `init_protocol::INIT_INFO_MAX_PAGES = 4` (16 KiB). `populate_cspace` minted one usable-RAM `Memory` cap — and one descriptor — per drained buddy block, and the buddy's largest block is order-11 (8 MiB), so the descriptor array grew ~linearly with RAM (≈64 descriptors at 512 MiB, ≈512+ at 4 GiB) and overflowed the 4-page region. Placement-independent; pre-existing on master.

Confirmed on master (control): riscv64 `--mem 4096` drained **685 blocks** → `FATAL: Phase 9: InitInfo region too large`.

## Fix

- **Coalesce before minting** (`core/kernel/src/cap/mod.rs`): `drain_and_install_seed` now calls a new `coalesce_ram_blocks` — sort the drained `(base, size)` blocks by base, merge exact-adjacency runs in place — so the descriptor count tracks memory-map fragmentation, not total RAM. `MemoryObject` is base+size and `buddy::free_range` already handles arbitrary contiguous extents (the seed tail is already non-power-of-two); the buddy is sealed post-drain, so coalescing changes no live free behaviour.
- **Largest-first** promotion: `coalesce_ram_blocks` moves the largest extent to index 0 so it lands at `memory_base`. The pre-coalesce highest-order-first drain made `memory_base` a large cap; ktest (`frame_pool`, `fund_boot_aspace_pt`, retype-heavy stress tests) bump-allocates every kernel object it creates from `memory_base`, so it must stay large. Sorting purely by base regressed ktest (15 `stress::*` failures from `memory_base` byte exhaustion) — caught during validation, fixed here. init/memmgr take the whole range generically and do not depend on cap order.
- **Sized diagnostic** (`core/kernel/src/main.rs`): the Phase-9 check logs `info_pages`, descriptor count, total bytes, and `INIT_INFO_MAX_PAGES` before fatal-ing.
- **Docs**: `docs/testing.md` Known-boundaries entry; `docs/process-lifecycle.md` `memory_base` largest-first note; `services/memmgr/docs/memory-pool.md` and `docs/userspace-memory-model.md` prose corrections.

`INIT_PROTOCOL_VERSION` is **not** bumped: `InitInfo`/`CapDescriptor`/`INIT_INFO_MAX_PAGES` are unchanged; the descriptor array is the same shape with fewer entries.

## Incidental fix — physical frame 0 reservation (scope expansion)

The largest-first promotion surfaced a latent, pre-existing bug. The page-table and CSpace growth pools (`AddressSpaceObject` / `CSpaceKernelObject`) use a physical address of `0` as their intrusive free-list "empty" sentinel. When firmware marks `[0, PAGE_SIZE)` usable, frame 0 enters the buddy allocator; promoting the low extent to `memory_base` then routed frame 0 into devmgr's ECAM page-table pool, where `pool_push(0)` is indistinguishable from an empty list and silently zeroed the list head — manifesting as `[devmgr] failed to map ECAM region` and failing **x86_64 svctest / usertest** in CI (ktest, which never maps ECAM, was unaffected; riscv64 firmware does not offer frame 0, so it was green).

`BuddyAllocator::add_region` now excludes the zero page (`core/kernel/src/mm/buddy.rs`), so frame 0 never reaches any allocation. The invariant is recorded in `docs/memory-model.md` § Buddy Allocator. Cost: one frame; the zero page is conventionally reserved. Surfaced by this change and fixed in the same pass per the project's completeness rule.

## Acceptance (#383)

- [x] riscv64 and x86_64 boot to the harness pass marker at ≥4 GiB guest RAM — see test plan.
- [x] InitInfo sizing no longer scales linearly with buddy-block count — coalescing collapses it to a small fragmentation-bounded count; the bound is also enforced gracefully (sized diagnostic) rather than a bare fatal.
- [x] `docs/testing.md` "Known boundaries" records the resolution.

## Test plan (all via `cargo xtask`; results observed)

CI: all cells green on both arches × {debug, release} × {ktest, svctest, usertest} + host-tests (run 27741409069).

| Config | Result |
|---|---|
| `cargo xtask test` (7 new `cap::tests::*` coalesce cases + full suite) | pass |
| x86_64 ktest `--mem 512` / `--mem 4096` | `ALL TESTS PASSED` (219→31 / 411→28 regions) |
| riscv64 ktest `--mem 512` / `--mem 4096` | `ALL TESTS PASSED` (206→26 / 684→33 regions, 65 descriptors, 1 page) |
| x86_64 svctest `--mem 512` (×3) | `ALL TESTS PASSED` (≈8.2 s) — validates the frame-0 / ECAM path |
| x86_64 svctest `--mem 4096` | `ALL TESTS PASSED` — coalescing + frame-0 fix together at 4 GiB |
| master riscv64 `--mem 4096` (control) | `FATAL: Phase 9: InitInfo region too large` (685 blocks) — bug + fix confirmed |

Closes #383.
