### PR TITLE
cleanup: v0.1.0 release prep — KERNEL_VERSION, app versioning, release template

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,18 +925,18 @@ dependencies = [
 
 [[package]]
 name = "shell"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "shell-path",
 ]
 
 [[package]]
 name = "shell-path"
-version = "0.1.0"
+version = "0.0.1"
 
 [[package]]
 name = "shell-tester"
-version = "0.1.0"
+version = "0.0.1"
 
 [[package]]
 name = "shlex"
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "terminal"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "ansi",
  "ipc",

--- a/abi/syscall/README.md
+++ b/abi/syscall/README.md
@@ -6,8 +6,11 @@ Defines `SYS_*` syscall number constants, the `SyscallError` enum, and all
 scheduling and message constants that cross the kernel/userspace boundary.
 
 **Constraints:** `no_std`, `#[repr(C)]` for all cross-boundary types, no
-dependencies outside `core`. Changes to this crate are ABI breaks and MUST
-increment the kernel version major or minor field accordingly.
+dependencies outside `core`. While the kernel is pre-stable the syscall ABI is
+fluid and may change freely between releases; `KERNEL_VERSION` here tracks the
+project version (see [docs/conventions.md](../../docs/conventions.md)), not
+syscall-ABI breaks. Protocols that carry an explicit `*_VERSION` constant are
+gated by that constant.
 
 Both the kernel and all userspace components import this crate. The bootloader
 does not.

--- a/abi/syscall/src/lib.rs
+++ b/abi/syscall/src/lib.rs
@@ -759,19 +759,33 @@ pub const FAULT_CLASS_ALL: u64 = !0u64;
 
 // ── System info ───────────────────────────────────────────────────────────────
 
+/// Pack a dotted `X.Y.Z` version string into the [`KERNEL_VERSION`] layout.
+///
+/// Reads the three leading numeric components, stopping at the first byte that
+/// is neither a digit nor a `.`, so any semver pre-release/build suffix is
+/// ignored. `const` so the value is fixed at compile time.
+const fn pack_project_version(s: &str) -> u64
+{
+    let b = s.as_bytes();
+    let mut parts = [0u64; 3]; // major, minor, patch
+    let mut i = 0;
+    let mut part = 0;
+    while i < b.len() && part < 3
+    {
+        match b[i]
+        {
+            d @ b'0'..=b'9' => parts[part] = parts[part] * 10 + (d - b'0') as u64,
+            b'.' => part += 1,
+            _ => break,
+        }
+        i += 1;
+    }
+    (parts[0] << 32) | (parts[1] << 16) | parts[2]
+}
+
 /// Kernel version packed as a single `u64`.
 ///
-/// Layout: `(major as u64) << 32 | (minor as u64) << 16 | (patch as u64)`
-///
-/// Versioning semantics (semver-style):
-/// - **major** — incremented on breaking syscall ABI changes (syscall removed,
-///   argument layout changed, error code semantics changed). Once the kernel
-///   ABI stabilises this will be `>= 1`; while major is `0` the ABI is
-///   explicitly unstable and may change freely between any releases.
-/// - **minor** — incremented when new syscalls are added without breaking
-///   existing ones.
-/// - **patch** — incremented for bug fixes that do not affect the ABI.
-///
+/// Layout: `(major as u64) << 32 | (minor as u64) << 16 | (patch as u64)`.
 /// Userspace extracts components with:
 /// ```text
 /// major = version >> 32
@@ -779,17 +793,13 @@ pub const FAULT_CLASS_ALL: u64 = !0u64;
 /// patch = version & 0xFFFF
 /// ```
 ///
-/// The version is `0.0.3` during initial kernel development. Major will remain
-/// `0` until the kernel reaches a meaningful level of completeness; during this
-/// phase all ABI changes are considered fully fluid regardless of minor/patch.
-/// `0.0.3` introduced the generation-tagged capability handle format (#349):
-/// a handle is `(generation << CAP_INDEX_BITS) | index`; a stale handle to a
-/// recycled slot fails with `InvalidCapability`.
-// Encode as (major << 32) | (minor << 16) | patch. The zero shifts are retained
-// to preserve the positional structure; they will carry non-zero values when
-// the ABI stabilises.
-#[allow(clippy::identity_op, clippy::eq_op)]
-pub const KERNEL_VERSION: u64 = (0u64 << 32) | (0u64 << 16) | 3u64; // 0.0.3
+/// The value is the Seraph project version, parsed from `CARGO_PKG_VERSION`
+/// (the workspace `version`) at compile time: kernel version and project
+/// version are one number, governed by the project-version semantics in
+/// `docs/conventions.md`. Syscall-ABI compatibility is not expressed here; it
+/// is tracked per protocol by the dedicated `*_VERSION` constants in the
+/// `abi/` crates.
+pub const KERNEL_VERSION: u64 = pack_project_version(env!("CARGO_PKG_VERSION"));
 
 /// Discriminant for `SYS_SYSTEM_INFO` queries.
 ///

--- a/core/kernel/docs/syscalls.md
+++ b/core/kernel/docs/syscalls.md
@@ -1386,9 +1386,9 @@ pub enum SystemInfoType
 {
     /// Kernel version packed as `(major as u64) << 32 | (minor as u64) << 16 | patch`.
     ///
-    /// Semver semantics: major=breaking ABI change, minor=new syscalls added,
-    /// patch=bug fix. Major is 0 while the kernel ABI is pre-stable and
-    /// may change freely between any releases.
+    /// Equals the Seraph project version (the workspace `version`), parsed from
+    /// `CARGO_PKG_VERSION` at build time; see `docs/conventions.md` for its
+    /// semantics. It does not gate syscall-ABI compatibility.
     ///
     /// Userspace extracts components with:
     ///   major = version >> 32

--- a/core/ktest/src/unit/sysinfo.rs
+++ b/core/ktest/src/unit/sysinfo.rs
@@ -17,8 +17,8 @@ use crate::{TestContext, TestResult};
 
 /// `system_info(KernelVersion)` returns the expected version constant.
 ///
-/// The kernel version is `0.0.3` (packed as `3`). See `KERNEL_VERSION` in
-/// `abi/syscall/src/lib.rs` for the encoding details.
+/// The kernel version tracks the Seraph project version. See `KERNEL_VERSION`
+/// in `abi/syscall/src/lib.rs` for the encoding and source.
 pub fn kernel_version(_ctx: &TestContext) -> TestResult
 {
     let ver = system_info(SystemInfoType::KernelVersion as u64)

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -18,13 +18,16 @@ The top-level identifier. Workspace-inherited Cargo crate version and git tag at
 
 The workspace root `Cargo.toml` carries `[workspace.package] version = "X.Y.Z"`. Every workspace member declares `version.workspace = true` and inherits the project version.
 
-A workspace member MAY declare its own independent `version = "..."` only when **all** of the following hold:
+A workspace member MAY declare its own independent `version = "..."` only when **both** of the following hold:
 
-- The member has distinct identity as a user-facing program that would be recognized as a separate thing (shell, editor, network tool, package manager).
-- The member evolves on its own cadence independent of the kernel-and-service cohort.
-- The member would plausibly be packaged or shipped separately.
+- The member has distinct identity as a user-facing program that would be recognized as a separate thing (shell, terminal, editor, network tool, package manager) — not a demo, benchmark, or test fixture.
+- The member is not core to the OS: the system boots and runs without it. It is the kind of component that could plausibly be optional, swapped for an alternative, or distributed separately — now or in the far future — even if today it is tightly interconnected with the rest of the tree and still primitive.
 
-OS-internal services, kernel, bootloader, ABI crates, shared utility crates, `xtask`, and runtime shims do not qualify and MUST stay workspace-inherited. The opt-out is a one-time decision per member, recorded with a comment in that member's `Cargo.toml` naming the criterion that justifies it.
+OS-internal services, kernel, bootloader, ABI crates, shared utility crates, `xtask`, runtime shims, and the demo/benchmark/test programs do not qualify and MUST stay workspace-inherited. The opt-out is a one-time decision per member, recorded with a comment in that member's `Cargo.toml` naming the criterion that justifies it.
+
+An opted-out member's version is independent of the project version and MAY sit below it — a still-primitive `terminal` and `shell` at `0.0.1` while the project is at `0.1.0` is expected, not an error.
+
+The opt-out covers the program's whole subtree: any internal library extracted from the program (for testability or structure) and the program's own test harness carry the **same** explicit version as the program and bump in lockstep with it. They are not independent version axes. Cargo cannot enforce this lockstep across separate manifests, so it is maintained by hand and noted in each child's `Cargo.toml`.
 
 ### ABI / wire-protocol versions
 

--- a/docs/releases/TEMPLATE.md
+++ b/docs/releases/TEMPLATE.md
@@ -11,28 +11,24 @@
 
 ## Components Shipped
 
-| Component | State |
+Summarize notable changes grouped by area (kernel mechanisms, core services, drivers,
+storage, runtime, userspace programs). Describe what changed per area; do not enumerate
+every crate. For the initial release, describe each area's initial state rather than a delta.
+
+| Area / component | Change since previous release |
 |---|---|
-| kernel | <delta vs previous release; "no change" if applicable> |
-| bootloader | <delta vs previous release> |
-| init | <delta vs previous release> |
-| procmgr | <delta vs previous release> |
-| memmgr | <delta vs previous release> |
-| vfsd | <delta vs previous release> |
-| svcmgr | <delta vs previous release> |
-| devmgr | <delta vs previous release> |
-| drivers/virtio-blk | <delta vs previous release> |
-| fs/fat | <delta vs previous release> |
-| runtime/ruststd | <delta vs previous release> |
+| <area or component> | <what changed; "initial" for the first release> |
 
 ## ABI and Protocol Versions
 
+List each ABI/protocol version constant whose value changed this release; omit constants
+that did not change. For the initial release, list the constants that define the shipped
+ABI surface with their initial values, marked `initial`. The kernel version equals the
+project version (the tag) and is not listed here.
+
 | Constant | Value | Bumped this release? |
 |---|---|---|
-| `BOOT_PROTOCOL_VERSION` | <n> | <yes/no> |
-| `PROCESS_ABI_VERSION` | <n> | <yes/no> |
-| `INIT_PROTOCOL_VERSION` | <n> | <yes/no> |
-| `<NAMESPACE>_LABELS_VERSION` | <n> | <yes/no> |
+| `<CONSTANT>` | <n> | <yes / no / initial> |
 
 ## Breaking Changes
 

--- a/programs/shell/Cargo.toml
+++ b/programs/shell/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "shell"
-version.workspace = true
+# Independent version: distinct, non-core user-facing program (docs/conventions.md
+# §Versioning). The system boots without it; it could one day be optional or replaced.
+version = "0.0.1"
 edition.workspace = true
 publish.workspace = true
 

--- a/programs/shell/path/Cargo.toml
+++ b/programs/shell/path/Cargo.toml
@@ -3,7 +3,9 @@
 
 [package]
 name = "shell-path"
-version.workspace = true
+# Tracks `shell`: the shell's extracted internal library, versioned in lockstep
+# with it (docs/conventions.md §Versioning).
+version = "0.0.1"
 edition.workspace = true
 publish.workspace = true
 

--- a/programs/shell/tester/Cargo.toml
+++ b/programs/shell/tester/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "shell-tester"
-version.workspace = true
+# Tracks `shell`: the shell's test harness, versioned in lockstep with it
+# (docs/conventions.md §Versioning).
+version = "0.0.1"
 edition.workspace = true
 publish.workspace = true
 

--- a/programs/terminal/Cargo.toml
+++ b/programs/terminal/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "terminal"
-version.workspace = true
+# Independent version: distinct, non-core user-facing program (docs/conventions.md
+# §Versioning). The system boots without it; it could one day be optional or replaced.
+version = "0.0.1"
 edition.workspace = true
 publish.workspace = true
 


### PR DESCRIPTION
## Summary

Pre-release groundwork for the first tag (`v0.1.0`); standalone, closes no Issue. The `v0.1.0.md` release notes land in a separate, final PR (#113) once this is merged. Three independent changes:

- **`KERNEL_VERSION` derives from the project version.** The hand-maintained `0.0.3` constant predated workspace versioning and had drifted from the workspace `0.1.0`. It is now parsed from `CARGO_PKG_VERSION` at compile time, so kernel version == project version by construction. The packed encoding and the `SystemInfoType::KernelVersion` syscall are unchanged (queryable kernel version stays a stable ABI surface).
- **terminal and shell versioned independently at `0.0.1`.** Distinct, non-core user-facing programs opt out of the workspace version per `conventions.md`; this matches the `v0.0.1` they already self-describe in source (#111). `shell-path` (extracted lib) and `shell-tester` (harness) are children of shell and track it in lockstep.
- **`conventions.md` + release template.** Opt-out criteria reframed (not-core-to-the-OS instead of "packaged separately"; child-crate lockstep rule; may sit below project version). `TEMPLATE.md`'s two exhaustive tables replaced with descriptive guidance + a one-row skeleton (CI preflight checks only the title/headings, both preserved).

## Acceptance

N/A — closes no Issue. (#113 tracks the release-notes authoring, which is the follow-up PR.)

## Test plan
- [x] `cargo xtask build` (x86_64)
- [x] `cargo xtask run` (x86_64), ktest `ALL TESTS PASSED`
- [x] `cargo xtask build --arch riscv64`
- [x] `cargo xtask run --arch riscv64`, ktest `ALL TESTS PASSED`; boot banner `Seraph kernel v0.1.0 (riscv64)`; `ktest: kernel version v0.1.0`
- [x] additional: `cargo xtask test` (host) green; `cargo metadata` confirms terminal/shell/shell-path/shell-tester at `0.0.1`, rest at `0.1.0`

## Notes
- The `Components Shipped` table previously enumerated 11 named components and the ABI table 4 named constants; both are now generic so the template does not rot as the tree changes. The descriptive-by-area style is the reference the `v0.1.0.md` notes will follow.
- Commit messages omit any assistant-attribution trailer per `conventions.md` §Commit Messages › Style.