### PR TITLE
docs/releases: author v0.1.0 release notes (#113)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
             exit 1
           fi
           for h in "## Highlights" "## Components Shipped" "## ABI and Protocol Versions" \
-                   "## Breaking Changes" "## Known Issues" "## Verification" "## Validation"; do
+                   "## Breaking Changes" "## Known Issues" "## Verification"; do
             if ! grep -qxF "$h" "${NOTES}"; then
               echo "::error::${NOTES} missing TEMPLATE.md section: $h" >&2
               exit 1

--- a/docs/documentation-standards.md
+++ b/docs/documentation-standards.md
@@ -69,6 +69,13 @@ If no non-structural document summarizes this document:
 None
 ```
 
+**Exception — release notes.** The per-tag release notes under `docs/releases/`
+(`<tag>.md`) and the `docs/releases/TEMPLATE.md` skeleton they are copied from are
+release records, not authoritative documents: they sit outside the hierarchy above,
+carry no content another document summarizes, and (for `<tag>.md`) are frozen at their
+tag. They MUST NOT carry a `## Summarized By` section. `docs/releases/README.md`, which
+governs release-notes discipline, is an ordinary authoritative document and keeps its own.
+
 ### Change propagation procedure
 
 When implementation changes invalidate documentation:

--- a/docs/releases/TEMPLATE.md
+++ b/docs/releases/TEMPLATE.md
@@ -11,13 +11,12 @@
 
 ## Components Shipped
 
-Summarize notable changes grouped by area (kernel mechanisms, core services, drivers,
-storage, runtime, userspace programs). Describe what changed per area; do not enumerate
+Summarize notable changes as short descriptive paragraphs grouped by area (kernel
+mechanisms, core services, drivers, storage, runtime, userspace programs) — one paragraph
+per area, led by the area name in bold. Describe what changed per area; do not enumerate
 every crate. For the initial release, describe each area's initial state rather than a delta.
 
-| Area / component | Change since previous release |
-|---|---|
-| <area or component> | <what changed; "initial" for the first release> |
+**<Area>** — <what changed in this area; its initial state for the first release.>
 
 ## ABI and Protocol Versions
 

--- a/docs/releases/TEMPLATE.md
+++ b/docs/releases/TEMPLATE.md
@@ -36,7 +36,12 @@ project version (the tag) and is not listed here.
 
 ## Known Issues
 
-- <Specific failure mode or limitation with a link to the tracking Issue.>
+Defects and regressions present in the shipped build of this release only: behaviour that
+is broken, degraded, or unreliable in the tagged artifacts. Missing or planned functionality
+is NOT a known issue and MUST NOT be listed here — absent features belong in the issue
+tracker, not in release notes. Use `None` when the release ships no known defects.
+
+- <Defect or regression in this release, with a link to its tracking Issue.>
 
 ## Verification
 
@@ -46,14 +51,3 @@ Disk images:
 - `seraph-v<X>.<Y>.<Z>-riscv64.img.zst`
 
 Verify with `sha256sum -c SHA256SUMS` against the attached `SHA256SUMS` file.
-
-## Validation
-
-- Burn-in workflow (`burnin.yml`) on this tag: <run URL>
-- Build-test workflow (`build-test.yml`) on the tagged commit: <run URL>
-
----
-
-## Summarized By
-
-None

--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -9,7 +9,7 @@ userspace service stack, booting on x86-64 and RISC-V under UEFI/QEMU.
 
 - Capability-based microkernel providing only mechanism — IPC, scheduling, memory,
   and capabilities — with all drivers, filesystems, and services running in userspace.
-  Boots on x86-64 and riscv64.
+  Boots on x86-64 and RISC-V.
 - Userspace bring-up: `init` hands off to the process, memory, service, and device
   managers, which start the driver and filesystem stack and an interactive console.
 - Storage stack: a virtual filesystem (`vfsd`) over a FAT driver and a virtio-blk
@@ -33,7 +33,7 @@ over endpoints, a priority scheduler with SMP and CPU affinity, physical and vir
 memory management (buddy allocator, paging, address spaces), and a capability system
 with generation-tagged handles. It also exposes the syscall surface, IRQ handling, an
 event-queue / wait-set primitive, and the userspace fault-handler protocol.
-Architecture-specific code (x86-64, riscv64) sits behind a shared arch-dispatch surface.
+Architecture-specific code (x86-64, RISC-V) sits behind a shared arch-dispatch surface.
 See [architecture.md](../architecture.md), [memory-model.md](../memory-model.md),
 [ipc-design.md](../ipc-design.md), [capability-model.md](../capability-model.md),
 [fault-handling.md](../fault-handling.md).
@@ -54,7 +54,7 @@ lifecycle; `logd`, `timed`, and `pwrmgr` provide logging, time, and power. See
 
 **Drivers** (`services/drivers/`) — serial and framebuffer console drivers; the virtio
 family (core transport, block, input); and real-time clocks (CMOS on x86-64, goldfish
-on riscv64). See [console-model.md](../console-model.md),
+on RISC-V). See [console-model.md](../console-model.md),
 [device-management.md](../device-management.md).
 
 **Storage** (`services/fs`, `services/vfsd`) — a FAT filesystem driver and a GPT

--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -1,0 +1,100 @@
+# Seraph v0.1.0
+
+The first tagged Seraph release: a capability-based microkernel and an early
+userspace service stack, booting on x86-64 and RISC-V under UEFI/QEMU.
+
+---
+
+## Highlights
+
+- Capability-based microkernel providing only mechanism — IPC, scheduling, memory,
+  and capabilities — with all drivers, filesystems, and services running in userspace.
+  Boots on x86-64 and riscv64.
+- Userspace bring-up: `init` hands off to the process, memory, service, and device
+  managers, which start the driver and filesystem stack and an interactive console.
+- Storage stack: a virtual filesystem (`vfsd`) over a FAT driver and a virtio-blk
+  block device, with GPT role-GUID partition discovery and mounting.
+- Userspace fault-handler (pager) protocol with demand paging, per-thread fault
+  endpoints, and suspend/resume/kill semantics.
+- Standard language runtimes (`libc`, `ruststd`) so userspace is written against
+  ordinary Rust `std`, not a bespoke ABI shim.
+- Interactive console over serial and framebuffer, with a primitive `terminal` and
+  `shell` (each independently versioned at `0.0.1`).
+- Three in-tree QEMU test harnesses — `ktest`, `svctest`, `usertest` — gating every
+  change across both architectures, debug and release, in CI.
+
+## Components Shipped
+
+The initial release; each area is described in its initial shipped state rather than
+as a delta. The linked design docs are authoritative for detail.
+
+**Kernel** (`core/kernel`) — Provides mechanism only: synchronous and asynchronous IPC
+over endpoints, a priority scheduler with SMP and CPU affinity, physical and virtual
+memory management (buddy allocator, paging, address spaces), and a capability system
+with generation-tagged handles. It also exposes the syscall surface, IRQ handling, an
+event-queue / wait-set primitive, and the userspace fault-handler protocol.
+Architecture-specific code (x86-64, riscv64) sits behind a shared arch-dispatch surface.
+See [architecture.md](../architecture.md), [memory-model.md](../memory-model.md),
+[ipc-design.md](../ipc-design.md), [capability-model.md](../capability-model.md),
+[fault-handling.md](../fault-handling.md).
+
+**Bootloader** (`core/boot`) — A UEFI bootloader that loads the boot bundle, sets up the
+framebuffer, and hands the kernel a boot-protocol structure. See
+[bootstrap.md](../bootstrap.md).
+
+**Core services** (`services/`) — `init` performs the userspace bootstrap and
+ProcessInfo / InitInfo handover; `procmgr` owns the process table and lifecycle;
+`memmgr` is the userspace memory authority (free-pool, page reservation, demand paging);
+`svcmgr` manages service registration and discovery; `devmgr` enumerates the platform,
+binds drivers, and governs DMA; `vfsd` provides the virtual filesystem and mount
+lifecycle; `logd`, `timed`, and `pwrmgr` provide logging, time, and power. See
+[process-lifecycle.md](../process-lifecycle.md),
+[userspace-memory-model.md](../userspace-memory-model.md),
+[device-management.md](../device-management.md), [namespace-model.md](../namespace-model.md).
+
+**Drivers** (`services/drivers/`) — serial and framebuffer console drivers; the virtio
+family (core transport, block, input); and real-time clocks (CMOS on x86-64, goldfish
+on riscv64). See [console-model.md](../console-model.md),
+[device-management.md](../device-management.md).
+
+**Storage** (`services/fs`, `services/vfsd`) — a FAT filesystem driver and a GPT
+partition layer compose with `vfsd` and the virtio-blk driver to provide mounted,
+role-GUID-discovered storage. See [storage.md](../storage.md).
+
+**Runtime** (`runtime/`) — `libc` and `ruststd` layers that let userspace target
+Seraph's native interfaces through standard language runtimes.
+
+**Userspace programs** (`programs/`) — a primitive `terminal` and `shell` (independently
+versioned at `0.0.1`), alongside the demo and test programs the harnesses drive.
+
+## ABI and Protocol Versions
+
+The cross-boundary protocol constants that define the shipped ABI surface, at their
+current values. These evolved during pre-release development; `initial` marks the first
+release to record them, not a bump within a release series. The kernel version equals
+the project version (this tag) and is not listed here.
+
+| Constant | Value | Bumped this release? |
+|---|---|---|
+| `BOOT_PROTOCOL_VERSION` | 8 | initial |
+| `PROCESS_ABI_VERSION` | 20 | initial |
+| `INIT_PROTOCOL_VERSION` | 13 | initial |
+| `FRAMEBUFFER_INFO_VERSION` | 1 | initial |
+| boot bundle format `VERSION` | 1 | initial |
+
+## Breaking Changes
+
+- None (initial release).
+
+## Known Issues
+
+- None.
+
+## Verification
+
+Disk images:
+
+- `seraph-v0.1.0-x86_64.img.zst`
+- `seraph-v0.1.0-riscv64.img.zst`
+
+Verify with `sha256sum -c SHA256SUMS` against the attached `SHA256SUMS` file.


### PR DESCRIPTION
## Summary

Authors the first tagged release's notes and finalizes the release-notes standard. Structured-by-area, descriptive `docs/releases/v0.1.0.md`, plus three standard refinements surfaced while writing it (Known Issues scope, Validation section, Summarized By exemption).

Closes #113

## Acceptance

(from #113)
- [x] `docs/releases/v0.1.0.md` exists, sourced from `TEMPLATE.md`.
- [x] All template sections are filled (no placeholders remain).
- [x] `[workspace.package] version = "0.1.0"`. Reconciliation: the workspace version was already `0.1.0` on `master` (the bump landed in an earlier session), so the tagged commit carries `0.1.0`. The literal "lands in the same PR" wording is moot — the condition that matters (version matches the `v0.1.0` tag at the tagged commit) holds.

## Test plan
- [x] CI preflight mirrored locally: `docs/releases/v0.1.0.md` has the exact title `# Seraph v0.1.0` and the six required `##` headings; no angle-bracket placeholders remain.
- [x] `release.yml` preflight heading list updated to match (Validation removed); `TEMPLATE.md` and `v0.1.0.md` both conform.
- [x] No build/runtime code touched — docs + one CI workflow only; the prep PR (#387) already validated the code changes on both arches.

## Notes
- **Known Issues** now scopes to defects/regressions in the shipped build only; missing features are excluded. v0.1.0 ships `None` (zero open `bug`-class issues, CI green both arches).
- **Validation section dropped** from the template and the `release.yml` preflight: the notes file *is* the GitHub Release body, so per-tag run URLs are self-referential and can't exist at authoring time; the burn-in publish gate is already documented in `conventions.md` / `releases/README.md`.
- **Summarized By exemption** added to `documentation-standards.md`: per-tag notes and `TEMPLATE.md` are records/skeletons outside the design-doc hierarchy.
- Tagging `v0.1.0` (which fires `release.yml`/`burnin.yml`) is a separate, maintainer-driven step after this merges.