### PR TITLE
docs/releases, ci: drop duplicate title H1 from release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,10 +47,6 @@ jobs:
           fi
           # -qxF: fixed-string whole-line matches, so a body bullet merely
           # quoting a heading cannot satisfy the structure check.
-          if ! grep -qxF "# Seraph ${TAG}" "${NOTES}"; then
-            echo "::error::${NOTES}: title must be '# Seraph ${TAG}' per TEMPLATE.md" >&2
-            exit 1
-          fi
           for h in "## Highlights" "## Components Shipped" "## ABI and Protocol Versions" \
                    "## Breaking Changes" "## Known Issues" "## Verification"; do
             if ! grep -qxF "$h" "${NOTES}"; then

--- a/docs/documentation-standards.md
+++ b/docs/documentation-standards.md
@@ -73,8 +73,11 @@ None
 (`<tag>.md`) and the `docs/releases/TEMPLATE.md` skeleton they are copied from are
 release records, not authoritative documents: they sit outside the hierarchy above,
 carry no content another document summarizes, and (for `<tag>.md`) are frozen at their
-tag. They MUST NOT carry a `## Summarized By` section. `docs/releases/README.md`, which
-governs release-notes discipline, is an ordinary authoritative document and keeps its own.
+tag. Their structure is defined by `TEMPLATE.md` and validated by the release workflow,
+not by the Required Structure rules below: they carry neither a `# Title` heading (the
+GitHub Release name supplies the title) nor a `## Summarized By` section.
+`docs/releases/README.md`, which governs release-notes discipline, is an ordinary
+authoritative document and follows the standard structure.
 
 ### Change propagation procedure
 

--- a/docs/releases/TEMPLATE.md
+++ b/docs/releases/TEMPLATE.md
@@ -1,5 +1,3 @@
-# Seraph v<X>.<Y>.<Z>
-
 <One-sentence summary of the milestone or patch.>
 
 ---

--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -1,5 +1,3 @@
-# Seraph v0.1.0
-
 The first tagged Seraph release: a capability-based microkernel and an early
 userspace service stack, booting on x86-64 and RISC-V under UEFI/QEMU.
 


### PR DESCRIPTION
## Summary

The release-notes file is passed to `gh release create --notes-file`, so it *is* the GitHub Release body. GitHub renders the Release *name* (`Seraph <tag>`) as the page heading, so the body's `# Seraph <tag>` H1 duplicated it. Since the file is the body verbatim, the fix is to drop the H1 from both — and update what enforced it:

- `docs/releases/v0.1.0.md`, `docs/releases/TEMPLATE.md` — remove the `# Seraph …` H1; the file now opens at the one-sentence summary.
- `.github/workflows/release.yml` — drop the preflight title check. The six `##`-heading check and the version-matches-tag check still validate structure; the publish step keeps `--title "Seraph ${TAG}"` (that Release name is now the sole page title).
- `docs/documentation-standards.md` — extend the existing release-notes exemption to also waive the Required-Structure `# Title` rule (records, not authoritative docs; the Release name supplies the title).

Closes no Issue — standard refinement for the first release.

## Context (why a shipped release's notes are edited)

This is Phase 1 of a deliberate, maintainer-authorized one-time correction of the very first release. `conventions.md`'s ban on moving tags stays in place. Phase 2 (separate, manual) deletes the published `v0.1.0` Release and re-cuts the tag at this corrected commit, so tag/body/artifacts all originate from a single clean commit. Safe only because there is zero post-tag work and no downstream consumers; it is not a precedent for editing past releases.

## Test plan
- [x] Updated preflight mirrored locally: `v0.1.0.md` has the six required `##` headings, no `# ` H1, no `<...>` placeholders; `release.yml` is valid YAML.
- [x] No build/runtime code touched — docs + one CI workflow only.

## Notes
- Net effect going forward: the Release page shows `Seraph <tag>` once (the name), body starts at content; no template/preflight reintroduces a duplicate H1.