### PR TITLE
kernel/cap: host test for stale-SlotId epoch fail-fast (#174)

### DIFF
--- a/core/kernel/src/cap/mod.rs
+++ b/core/kernel/src/cap/mod.rs
@@ -2691,4 +2691,73 @@ mod tests
             (2, vec![(0x8000, 0x3000), (0x1000, 0x1000)])
         );
     }
+
+    /// `CSpaceId` reserved for the recycle test below. No other host
+    /// `#[test]` populates `CSPACE_REGISTRY` — every other
+    /// `register_cspace`/`unregister_cspace` call site is `#[cfg(not(test))]`
+    /// (boot, syscall, dealloc) — so there is no shared-static race; a high
+    /// id is used purely for clarity.
+    const RECYCLE_TEST_ID: CSpaceId = (MAX_CSPACES as u32) - 1;
+
+    /// A `SlotId` stamped before a `CSpace` id is recycled must fail
+    /// `lookup_cspace` (epoch mismatch) even after the id is reused by a new
+    /// tenant, while a freshly stamped `SlotId` resolves. Couples the real
+    /// stamp (`SlotId::current` → `registry_epoch`) and validation
+    /// (`lookup_cspace`) paths; only the epoch bump is simulated, because
+    /// `free_cspace_id` and the free list are `#[cfg(not(test))]`.
+    #[test]
+    fn cspace_recycle_invalidates_stale_slotid()
+    {
+        use core::num::NonZeroU32;
+
+        let id = RECYCLE_TEST_ID;
+        let idx = NonZeroU32::new(1).unwrap();
+        // Sentinel backing pointers; `lookup_cspace` only null-checks them
+        // and never dereferences. Two distinct addresses model two tenants.
+        let tenant_a = NonNull::<CSpace>::dangling().as_ptr();
+        let tenant_b = tenant_a.wrapping_byte_add(0x1000);
+
+        // Tenant A live; stamp a SlotId the way derivation write sites do.
+        let epoch_a = register_cspace(id, tenant_a).expect("register tenant A");
+        let stale = SlotId::current(id, idx);
+        assert_eq!(
+            stale.epoch, epoch_a,
+            "SlotId::current must stamp the live epoch"
+        );
+        assert!(
+            lookup_cspace(stale.cspace_id, stale.epoch).is_some(),
+            "fresh SlotId must resolve against the live tenant"
+        );
+
+        // Destroy A and recycle the id. `free_cspace_id` is
+        // `#[cfg(not(test))]` (touches the host-absent free list); replicate
+        // its one registry mutation — the epoch bump — directly.
+        // `unregister_cspace` clears the ptr. #248 will randomize this bump;
+        // the assertions below check the property (epoch changed ⇒ stale
+        // fails), not the arithmetic, so only this line tracks #248.
+        unregister_cspace(id);
+        CSPACE_REGISTRY[id as usize]
+            .epoch
+            .fetch_add(1, Ordering::AcqRel);
+
+        // Tenant B reuses the id at the bumped epoch.
+        let epoch_b = register_cspace(id, tenant_b).expect("register tenant B");
+        assert_ne!(epoch_b, epoch_a, "recycle must advance the epoch");
+        let fresh = SlotId::current(id, idx);
+        assert_eq!(fresh.epoch, epoch_b);
+
+        // The property #174 asks for: the stale SlotId fails fast even though
+        // the id is live again, while the fresh SlotId resolves (proving the
+        // None is epoch mismatch, not entry absence).
+        assert!(
+            lookup_cspace(stale.cspace_id, stale.epoch).is_none(),
+            "stale epoch must not resolve against the recycled tenant"
+        );
+        assert!(
+            lookup_cspace(fresh.cspace_id, fresh.epoch).is_some(),
+            "current epoch must resolve"
+        );
+
+        unregister_cspace(id); // leave the shared registry slot clean
+    }
 }


### PR DESCRIPTION
## Summary

Adds positive coverage for the CSpace-id recycling epoch backstop (#137/#171):
a `SlotId` stamped before a `CSpace` id is recycled must fail `lookup_cspace`
(epoch mismatch) while a freshly stamped `SlotId` resolves — proving a recycled
id cannot mis-target a stale reference.

One host `#[cfg(test)]` unit test added to the existing `mod tests` in
`core/kernel/src/cap/mod.rs`. It is compiled only by `cargo test -p kernel`;
`cfg(test)` is false in every cross-compiled QEMU/production build, so the change
is **inert for every shipped artifact** (x86_64 and riscv64 binaries are identical
to master).

The test couples the **real** production stamp (`SlotId::current` → `registry_epoch`)
and validation (`lookup_cspace`) paths and asserts the end-to-end contract, so a
regression in any of them fails it (verified by mutation — see Test plan). Only the
epoch bump is simulated, because `free_cspace_id` and the free list are
`#[cfg(not(test))]` on host; that real recycle path is already covered on both arches
by `stress::cspace_recycle` (#171, 10000 cycles/boot).

## Re-scope of #174

The issue's original QEMU-ktest framing (stash a kernel-internal `SlotId`) is **not
implementable** under the no-test-syscall / no-feature-gate constraints:

- `ktest` is a standalone userspace binary; it does not link the kernel crate and has
  no in-kernel phase, so it cannot call `crate::cap::lookup_cspace` directly.
- Observing the `None` from userspace needs a kernel hook; gating it off production
  requires a cargo feature + xtask/CI plumbing (both disallowed).
- The derivation drain (`drain_dying_cspace`) maintains the invariant that no surviving
  stale `SlotId` is reachable through the public syscall ABI — the state can't even be
  constructed from userspace.

#174's acceptance criteria were amended accordingly (host-test scope) before this PR.

## Test plan

- `cargo xtask test` → `cap::tests::cspace_recycle_invalidates_stale_slotid` passes
  (kernel suite: 220 passed, 0 failed).
- Mutation check: weakening `lookup_cspace`'s epoch comparison (`if false && …`) makes
  the test fail on `"stale epoch must not resolve against the recycled tenant"`;
  reverted. Confirms the test is not trivially true.
- `cargo xtask build` succeeds on x86_64 and riscv64 (`cargo xtask clean` between
  arches). `run` is unaffected — the change is `#[cfg(test)]`-only; the full ktest /
  svctest / usertest harnesses on both arches × profiles in CI provide the boot
  validation.

Closes #174.

https://claude.ai/code/session_0138Xuumvs1KNVHpv6UywDzV
