### PR TITLE
services: randomize cross-boundary badge/correlator values (#249)

### DIFF
--- a/runtime/ruststd/src/sys/fs/release_handler.rs
+++ b/runtime/ruststd/src/sys/fs/release_handler.rs
@@ -23,7 +23,6 @@
 
 use crate::collections::BTreeMap;
 use crate::io;
-use crate::sync::atomic::{AtomicU64, Ordering};
 use crate::sync::{Arc, Mutex, OnceLock, PoisonError};
 use crate::thread;
 use crate::vec::Vec;
@@ -62,7 +61,6 @@ pub(super) struct ReleaseState
     /// tear down every fs-side derived child atomically.
     release_ep: u32,
     registry: Mutex<BTreeMap<u64, Arc<FileEntry>>>,
-    next_badge: AtomicU64,
     /// Process aspace cap, captured at init for the handler's
     /// `mem_unmap` calls. Equal to `StartupInfo::self_aspace`.
     aspace: u32,
@@ -99,7 +97,6 @@ pub(super) fn ensure_started() -> io::Result<&'static ReleaseState>
         ReleaseState {
             release_ep,
             registry: Mutex::new(BTreeMap::new()),
-            next_badge: AtomicU64::new(1),
             aspace,
         }
     });
@@ -135,15 +132,23 @@ pub(super) fn release_endpoint(state: &ReleaseState) -> u32
     state.release_ep
 }
 
-/// Allocate a fresh non-zero per-`File` badge.
-pub(super) fn allocate_badge(state: &ReleaseState) -> u64
+/// Allocate a fresh non-zero per-`File` release-endpoint badge: a random `u64`
+/// from the kernel entropy pool, redrawn off the reserved `0` value (an
+/// unbadged SEND carries badge 0). Random rather than monotonic so the
+/// file-open count it would otherwise leak to the fs driver — which receives
+/// the badged SEND and echoes the badge in `FS_RELEASE_MEMORY` — stays
+/// unguessable; the handler keys its registry by badge value, not index.
+/// Returns `None` if the entropy draw fails (a kernel-contract violation).
+pub(super) fn allocate_badge() -> Option<u64>
 {
-    let mut t = state.next_badge.fetch_add(1, Ordering::Relaxed);
-    while t == 0
+    loop
     {
-        t = state.next_badge.fetch_add(1, Ordering::Relaxed);
+        let t = syscall::random_u64().ok()?;
+        if t != 0
+        {
+            return Some(t);
+        }
     }
-    t
 }
 
 /// Register a `File` with the handler, returning its `FileEntry`.

--- a/runtime/ruststd/src/sys/fs/seraph.rs
+++ b/runtime/ruststd/src/sys/fs/seraph.rs
@@ -1199,7 +1199,12 @@ impl File
                 return Err(e);
             }
         };
-        let badge = release_handler::allocate_badge(state);
+        let Some(badge) = release_handler::allocate_badge()
+        else
+        {
+            let _ = syscall::cap_delete(file_cap);
+            return Err(io::Error::other("seraph fs: release-badge entropy draw failed"));
+        };
         let entry = release_handler::register(state, badge);
 
         let release_ep = release_handler::release_endpoint(state);
@@ -1349,7 +1354,11 @@ impl File
     fn read_frame(&self, buf: &mut [u8], pos: u64) -> io::Result<usize>
     {
         let ipc_buf = crate::os::seraph::current_ipc_buf();
-        let cookie = next_cookie();
+        let Some(cookie) = next_cookie()
+        else
+        {
+            return Err(io::Error::other("seraph fs: read cookie entropy draw failed"));
+        };
         // First FS_READ_MEMORY for this File carries the per-process
         // release-endpoint SEND in caps[0]; the driver records it on
         // the OpenFile slot's first allocation so the eviction worker
@@ -1631,15 +1640,22 @@ impl Drop for File
     }
 }
 
-fn next_cookie() -> u64
+/// Per-request correlation cookie for `FS_READ_MEMORY`: a random `u64` from the
+/// kernel entropy pool, redrawn off the reserved `0` value (the driver rejects
+/// cookie 0 as its outstanding-page `None` sentinel). Random rather than
+/// monotonic so the read-memory request count it would otherwise leak to the fs
+/// driver stays unguessable; the cookie is opaque and matched by value, never an
+/// index. Returns `None` if the entropy draw fails (a kernel-contract violation).
+fn next_cookie() -> Option<u64>
 {
-    static NEXT: AtomicU64 = AtomicU64::new(1);
-    let mut c = NEXT.fetch_add(1, Ordering::Relaxed);
-    while c == 0
+    loop
     {
-        c = NEXT.fetch_add(1, Ordering::Relaxed);
+        let c = syscall::random_u64().ok()?;
+        if c != 0
+        {
+            return Some(c);
+        }
     }
-    c
 }
 
 /// Map a [`NsError`] reply label to an `io::Error` per the error

--- a/services/devmgr/src/main.rs
+++ b/services/devmgr/src/main.rs
@@ -1380,6 +1380,11 @@ fn spawn_virtio_blk(
             }
             *catalog.count += 1;
         }
+        // Deliberately index-derived (not randomized like the cross-boundary
+        // service badges, #249): this badge names a specific device-catalog
+        // slot — the driver enforces its own badge per registered device — so
+        // it is a semantically-meaningful identity, not an enumerable
+        // correlator.
         let device_badge = (dev_idx as u64) + 1;
 
         let bar_info = find_virtio_bar_cap(pci_dev, caps);

--- a/services/devmgr/src/spawn.rs
+++ b/services/devmgr/src/spawn.rs
@@ -142,8 +142,22 @@ impl Drop for ChildGuard
     }
 }
 
-/// Monotonic counter for driver-child bootstrap badges.
-static NEXT_BOOTSTRAP_BADGE: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(1);
+/// Draw a fresh non-zero driver-child bootstrap badge: a random `u64` from the
+/// kernel entropy pool, redrawn off the reserved `0` value (an unbadged SEND
+/// carries badge 0). Random rather than monotonic so the driver-spawn count it
+/// would otherwise leak stays unguessable; both spawn paths match the bootstrap
+/// round by badge value, not index. Returns `None` if the entropy draw fails.
+fn mint_bootstrap_badge() -> Option<u64>
+{
+    loop
+    {
+        let b = syscall::random_u64().ok()?;
+        if b != 0
+        {
+            return Some(b);
+        }
+    }
+}
 
 /// Per-device BAR capability set delivered to a driver. `bases` and `sizes`
 /// parallel `caps` and are retained for future multi-BAR drivers; only the
@@ -222,7 +236,12 @@ pub fn spawn_driver(config: &DriverSpawnConfig, ipc_buf: *mut u64) -> bool
     let device_badge = config.device_badge;
 
     // Allocate a bootstrap badge for the child.
-    let child_badge = NEXT_BOOTSTRAP_BADGE.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+    let Some(child_badge) = mint_bootstrap_badge()
+    else
+    {
+        std::os::seraph::log!("driver spawn: entropy draw failed");
+        return false;
+    };
     let Ok(badged_creator) =
         syscall::cap_derive_badge(bootstrap_ep, syscall::RIGHTS_SEND, child_badge)
     else
@@ -500,7 +519,13 @@ pub fn spawn_simple_device(
         return false;
     }
 
-    let child_badge = NEXT_BOOTSTRAP_BADGE.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+    let Some(child_badge) = mint_bootstrap_badge()
+    else
+    {
+        std::os::seraph::log!("simple-device spawn: entropy draw failed");
+        cleanup_on_fail(hw_cap, devmgr_query_ep, source_cap_to_clean);
+        return false;
+    };
     let Ok(badged_creator) =
         syscall::cap_derive_badge(bootstrap_ep, syscall::RIGHTS_SEND, child_badge)
     else

--- a/services/fs/fat/src/main.rs
+++ b/services/fs/fat/src/main.rs
@@ -58,7 +58,15 @@ use ipc::{IpcMessage, fs_labels, ns_labels};
 use namespace_protocol::{GateError, NamespaceRights, NodeId, NodeKind, gate, pack as pack_badge};
 use syscall_abi::{PAGE_SIZE, RIGHTS_MAP_READ};
 
-/// Monotonic counter for badge allocation. Starts at 1 (0 = unbadged).
+/// Monotonic counter for open-file slot identity. Starts at 1 (0 = unbadged).
+///
+/// Deliberately kept monotonic (not randomized like the cross-boundary
+/// service badges): this value is fat-internal — the eviction worker addresses
+/// a slot through `find_by_badge`, but the slot is reached on the cap-native
+/// path via `FatNode.open_slot`, so the badge never crosses an IPC boundary
+/// (see `file::OpenFile::badge`). With no external observer there is nothing to
+/// enumerate, so randomization would add an entropy syscall per open for no
+/// anti-enumeration benefit.
 static NEXT_BADGE: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(1);
 
 // ── Bootstrap ──────────────────────────────────────────────────────────────

--- a/services/init/src/bootstrap.rs
+++ b/services/init/src/bootstrap.rs
@@ -587,7 +587,7 @@ pub fn bootstrap_memmgr(
     // Badged creator endpoint for memmgr (init serves the bootstrap round
     // for memmgr, so memmgr's `request_round` lands on init's bootstrap ep
     // tagged with this badge).
-    let memmgr_badge = NEXT_BOOTSTRAP_BADGE.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+    let memmgr_badge = mint_bootstrap_badge()?;
     let badged_creator =
         syscall::cap_derive_badge(init_bootstrap_ep, syscall::RIGHTS_SEND, memmgr_badge).ok()?;
     let mm_creator_slot =
@@ -606,8 +606,7 @@ pub fn bootstrap_memmgr(
     // Mint procmgr's badged SEND cap on memmgr's endpoint. Memmgr will
     // recognise calls bearing this badge as authorised for the
     // procmgr-only labels.
-    let procmgr_badge_on_mm =
-        NEXT_BOOTSTRAP_BADGE.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+    let procmgr_badge_on_mm = mint_bootstrap_badge()?;
     let procmgr_send_cap = syscall::cap_derive_badge(
         mm_service_ep,
         syscall::RIGHTS_SEND_GRANT,
@@ -1116,9 +1115,23 @@ pub struct ProcmgrBootstrap
     pub arena_cap: u32,
 }
 
-/// Monotonic counter for init-side bootstrap badges.
-pub static NEXT_BOOTSTRAP_BADGE: core::sync::atomic::AtomicU64 =
-    core::sync::atomic::AtomicU64::new(1);
+/// Mint a fresh init-side bootstrap badge: a random `u64` from the kernel
+/// entropy pool, redrawn off the reserved `0` value (an unbadged SEND carries
+/// badge 0). Random rather than monotonic so the service-bringup count it would
+/// otherwise leak stays unguessable; each child matches its bootstrap round by
+/// badge value, not index. Returns `None` if the entropy draw fails (a
+/// kernel-contract violation), aborting the affected bringup step.
+pub fn mint_bootstrap_badge() -> Option<u64>
+{
+    loop
+    {
+        let b = syscall::random_u64().ok()?;
+        if b != 0
+        {
+            return Some(b);
+        }
+    }
+}
 
 /// Create and start procmgr from its boot module ELF image.
 ///
@@ -1219,7 +1232,7 @@ pub fn bootstrap_procmgr(
     log("loaded procmgr ELF");
 
     // Derive badged creator endpoint for procmgr.
-    let procmgr_badge = NEXT_BOOTSTRAP_BADGE.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+    let procmgr_badge = mint_bootstrap_badge()?;
     let badged_creator =
         syscall::cap_derive_badge(init_bootstrap_ep, syscall::RIGHTS_SEND, procmgr_badge).ok()?;
     let pm_creator_slot =

--- a/services/init/src/service.rs
+++ b/services/init/src/service.rs
@@ -11,7 +11,6 @@
 //! requests on init's bootstrap endpoint to deliver their per-service
 //! capability set.
 
-use crate::bootstrap::NEXT_BOOTSTRAP_BADGE;
 use crate::idle_loop;
 use crate::logging::log;
 use crate::walk;
@@ -41,7 +40,7 @@ pub struct ServiceThreadCaps
 
 fn derive_badged_creator(bootstrap_ep: u32) -> Option<(u32, u64)>
 {
-    let badge = NEXT_BOOTSTRAP_BADGE.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+    let badge = crate::bootstrap::mint_bootstrap_badge()?;
     let badged = syscall::cap_derive_badge(bootstrap_ep, syscall::RIGHTS_SEND, badge).ok()?;
     Some((badged, badge))
 }

--- a/services/memmgr/src/main.rs
+++ b/services/memmgr/src/main.rs
@@ -15,8 +15,6 @@
 // cast_possible_truncation: targets 64-bit only; u64/usize conversions lossless.
 #![allow(clippy::cast_possible_truncation)]
 
-use core::sync::atomic::{AtomicU64, Ordering};
-
 use free_pool::{DemandRegion, FreePool, FreeRun, chunk_for, region_contains, regions_overlap};
 use ipc::{IpcMessage, memmgr_errors, memmgr_labels};
 use process_abi::{
@@ -695,9 +693,25 @@ impl ProcessTable
     }
 }
 
-/// Badge counter for memmgr-minted process identities. Each
-/// `REGISTER_PROCESS` call consumes one.
-static NEXT_BADGE: AtomicU64 = AtomicU64::new(1);
+/// Mint a fresh memmgr-minted process-identity badge: a random `u64` from the
+/// kernel entropy pool, redrawn off the reserved values a live record must
+/// never alias — `0` (the free-slot marker; see `ProcessTable`) and the
+/// well-known reserved records `MEMMGR_SELF_BADGE` / `INIT_SELF_BADGE`. Random
+/// rather than monotonic so the process-registration count it would otherwise
+/// leak across the `REGISTER_PROCESS` boundary stays unguessable; the badge is
+/// matched by equality scan, never used as an array index. Returns `None` if
+/// the entropy draw fails (a kernel-contract violation).
+fn mint_process_badge() -> Option<u64>
+{
+    loop
+    {
+        let b = syscall::random_u64().ok()?;
+        if b != 0 && b != MEMMGR_SELF_BADGE && b != INIT_SELF_BADGE
+        {
+            return Some(b);
+        }
+    }
+}
 
 // Per-process tracking and the free pool live in statics so the bookkeeping
 // never lands on a syscall stack frame. memmgr is single-threaded — its only
@@ -739,14 +753,14 @@ fn table_mut() -> &'static mut ProcessTable
 const BOOTSTRAP_MAX_MEMORY_CAPS: usize = ipc::memmgr_bootstrap::MAX_MEMORY_CAPS;
 
 /// Reserved process-table badge for memmgr's own bootstrap-backing record.
-/// Out of range of every minted badge (memmgr's `NEXT_BADGE` and init's
-/// bootstrap badges both start at 1), so no real caller can match it.
+/// `mint_process_badge` explicitly excludes this value, so no
+/// `REGISTER_PROCESS` caller can ever be assigned it.
 const MEMMGR_SELF_BADGE: u64 = u64::MAX;
 
 /// Reserved process-table badge for init's orphaned bootstrap-backing record.
 /// init exits at reap, so no live process owns its arena; its pages stay
-/// parked and accounted here. Like `MEMMGR_SELF_BADGE`, far out of minted-badge
-/// range, so no real caller can match it.
+/// parked and accounted here. Like `MEMMGR_SELF_BADGE`, excluded from
+/// `mint_process_badge`, so no minted badge can collide.
 const INIT_SELF_BADGE: u64 = u64::MAX - 1;
 
 /// Scratch VA in memmgr's address space for mapping the bootstrap
@@ -1236,7 +1250,14 @@ fn handle_register_process(req: &IpcMessage, ipc_buf: *mut u64, service_ep: u32,
     }
 
     let table = table_mut();
-    let new_badge = NEXT_BADGE.fetch_add(1, Ordering::Relaxed);
+    let Some(new_badge) = mint_process_badge()
+    else
+    {
+        // Unreachable: the entropy pool is seeded before any userspace runs.
+        // Surface it as a registration failure (procmgr fails the spawn).
+        reply_label(ipc_buf, memmgr_errors::TOO_MANY_PROCESSES);
+        return;
+    };
 
     if table.insert(new_badge).is_none()
     {

--- a/services/memmgr/src/main.rs
+++ b/services/memmgr/src/main.rs
@@ -646,9 +646,10 @@ impl ProcessRecord
     }
 }
 
-/// Process tracking table: dense array of records, indexed by an internal
-/// monotonically-incremented badge (held externally as the procmgr-minted
-/// process identity).
+/// Process tracking table: dense array of records keyed by a random
+/// per-process ledger badge (memmgr-minted in `REGISTER_PROCESS`, returned to
+/// the registrant and threaded back as its memmgr / fault badge). Records are
+/// found by equality scan, not array index.
 struct ProcessTable
 {
     /// Slots are stored inline; a slot is free iff `badge == 0` (every minted

--- a/services/procmgr/process-table/src/lib.rs
+++ b/services/procmgr/process-table/src/lib.rs
@@ -265,25 +265,28 @@ impl Default for ProcessTable
 
 /// Whether a candidate badge may be handed out as a process badge.
 ///
-/// The low 32 bits of the badge become the death-EQ correlator (the binding
-/// API takes a `u32`). A badge is rejected when those low bits equal a
-/// reserved correlator value:
-/// - `0` — the kernel's "no correlator" sentinel (a death observer bound with
-///   correlator `0` posts the bare exit reason with no high-word tag, which
-///   `dispatch_death` cannot route to a table entry).
-/// - `reserved_low32` — the init-reap correlator (`INIT_REAP_CORRELATOR`),
-///   which `dispatch_death` routes to the init teardown branch.
+/// The low 32 bits of a process badge serve double duty — the death-EQ
+/// correlator (the binding API takes a `u32`) and the logd source badge — so
+/// they must clear every reserved low-word value:
+/// - **below `min_low`** — the reserved log-badge range. `log_badges` reserves
+///   `0..LOG_BADGE_FIRST_CHILD` for system specials: the kernel's `0`
+///   "no correlator" death sentinel, init (`1`), procmgr (`2`), and `3..16`.
+///   A badge whose low word lands here would bind an unroutable death
+///   correlator or evict/contaminate a reserved logd slot — logd evicts every
+///   slot whose low word matches a death correlator.
+/// - **equal to `reserved_low32`** — the init-reap correlator
+///   (`INIT_REAP_CORRELATOR`), which `dispatch_death` routes to init teardown.
 ///
-/// Both are reachable under random badge minting (each ~2⁻³² per draw),
-/// unlike the old monotonic counter which only hit them at u32 wrap.
+/// All are reachable under random badge minting; the old monotonic counter
+/// started at `LOG_BADGE_FIRST_CHILD` and so upheld the floor structurally.
 #[must_use]
-pub fn badge_is_acceptable(badge: u64, reserved_low32: u32) -> bool
+pub fn badge_is_acceptable(badge: u64, min_low: u64, reserved_low32: u32) -> bool
 {
     // The low-32 extraction is intentional: only the truncated u32 reaches
-    // the correlator-bearing death-EQ API, so only the low word can collide.
+    // the correlator-bearing death-EQ API and the logd badge.
     #[allow(clippy::cast_possible_truncation)]
     let low = badge as u32;
-    low != 0 && low != reserved_low32
+    u64::from(low) >= min_low && low != reserved_low32
 }
 
 #[cfg(test)]
@@ -315,27 +318,30 @@ mod tests
     {
         // A bare match and a high-bits-set u64 whose low word equals the
         // sentinel must both be rejected — proving the `as u32` narrowing
-        // rather than a full-u64 compare.
-        assert!(!badge_is_acceptable(u64::from(u32::MAX), u32::MAX));
-        assert!(!badge_is_acceptable(0x0000_0005_FFFF_FFFF, u32::MAX));
+        // rather than a full-u64 compare. (Floor 16 = LOG_BADGE_FIRST_CHILD.)
+        assert!(!badge_is_acceptable(u64::from(u32::MAX), 16, u32::MAX));
+        assert!(!badge_is_acceptable(0x0000_0005_FFFF_FFFF, 16, u32::MAX));
     }
 
     #[test]
-    fn badge_is_rejected_when_low_32_bits_are_zero()
+    fn badge_is_rejected_when_low_word_below_floor()
     {
-        // Low word zero is the kernel's "no correlator" sentinel; reject it
-        // regardless of the high word so every minted badge carries a routable
-        // correlator.
-        assert!(!badge_is_acceptable(0, u32::MAX));
-        assert!(!badge_is_acceptable(0x0000_0007_0000_0000, u32::MAX));
+        // The reserved log-badge / no-correlator range (low word 0..16) is
+        // rejected regardless of the high word, so every minted badge carries
+        // a routable correlator and never aliases a reserved logd slot.
+        assert!(!badge_is_acceptable(0, 16, u32::MAX));
+        assert!(!badge_is_acceptable(1, 16, u32::MAX));
+        assert!(!badge_is_acceptable(2, 16, u32::MAX));
+        assert!(!badge_is_acceptable(15, 16, u32::MAX));
+        assert!(!badge_is_acceptable(0x0000_0007_0000_000F, 16, u32::MAX));
     }
 
     #[test]
-    fn badge_is_accepted_when_low_32_bits_differ_from_reserved_correlator()
+    fn badge_is_accepted_when_low_word_clears_floor_and_correlator()
     {
-        assert!(badge_is_acceptable(16, u32::MAX));
-        // High bits set, low word clear of the sentinel: still acceptable.
-        assert!(badge_is_acceptable(0x0000_0001_0000_0010, u32::MAX));
+        assert!(badge_is_acceptable(16, 16, u32::MAX));
+        // High bits set, low word clears the floor and the sentinel: accepted.
+        assert!(badge_is_acceptable(0x0000_0001_0000_0010, 16, u32::MAX));
     }
 
     #[test]

--- a/services/procmgr/process-table/src/lib.rs
+++ b/services/procmgr/process-table/src/lib.rs
@@ -265,21 +265,25 @@ impl Default for ProcessTable
 
 /// Whether a candidate badge may be handed out as a process badge.
 ///
-/// A badge is rejected when its low 32 bits equal `reserved_low32` — the
-/// reserved death-EQ correlator (currently `INIT_REAP_CORRELATOR`). The
-/// death-EQ binding API takes a `u32` correlator while process badges are
-/// `u64`; without this guard the truncated correlator could match the
-/// reserved value at u32 wrap (~4.3B spawns) and the matching child's death
-/// would be silently absorbed by the init-reap branch in `dispatch_death`.
+/// The low 32 bits of the badge become the death-EQ correlator (the binding
+/// API takes a `u32`). A badge is rejected when those low bits equal a
+/// reserved correlator value:
+/// - `0` — the kernel's "no correlator" sentinel (a death observer bound with
+///   correlator `0` posts the bare exit reason with no high-word tag, which
+///   `dispatch_death` cannot route to a table entry).
+/// - `reserved_low32` — the init-reap correlator (`INIT_REAP_CORRELATOR`),
+///   which `dispatch_death` routes to the init teardown branch.
+///
+/// Both are reachable under random badge minting (each ~2⁻³² per draw),
+/// unlike the old monotonic counter which only hit them at u32 wrap.
 #[must_use]
 pub fn badge_is_acceptable(badge: u64, reserved_low32: u32) -> bool
 {
     // The low-32 extraction is intentional: only the truncated u32 reaches
     // the correlator-bearing death-EQ API, so only the low word can collide.
     #[allow(clippy::cast_possible_truncation)]
-    {
-        (badge as u32) != reserved_low32
-    }
+    let low = badge as u32;
+    low != 0 && low != reserved_low32
 }
 
 #[cfg(test)]
@@ -314,6 +318,16 @@ mod tests
         // rather than a full-u64 compare.
         assert!(!badge_is_acceptable(u64::from(u32::MAX), u32::MAX));
         assert!(!badge_is_acceptable(0x0000_0005_FFFF_FFFF, u32::MAX));
+    }
+
+    #[test]
+    fn badge_is_rejected_when_low_32_bits_are_zero()
+    {
+        // Low word zero is the kernel's "no correlator" sentinel; reject it
+        // regardless of the high word so every minted badge carries a routable
+        // correlator.
+        assert!(!badge_is_acceptable(0, u32::MAX));
+        assert!(!badge_is_acceptable(0x0000_0007_0000_0000, u32::MAX));
     }
 
     #[test]

--- a/services/procmgr/src/process.rs
+++ b/services/procmgr/src/process.rs
@@ -26,39 +26,31 @@ const CHILD_IPC_BUF_VA: u64 = 0x0000_7FFF_FFFE_0000;
 /// Max file data bytes per VFS read IPC. Word 0 = `bytes_read`, words 1..63 = data.
 const VFS_CHUNK_SIZE: u64 = 63 * 8; // 504 bytes
 
-/// Next badge value (monotonically increasing, never zero). Starts at
-/// `LOG_BADGE_FIRST_CHILD` so per-child log badges never collide with
-/// the reserved system-special badges (init=1, procmgr=2, 3..15
-/// reserved). The same value is procmgr's process badge, memmgr's
-/// per-process ledger key, the badged SEND-cap badge on the log
-/// endpoint, and procmgr's death-EQ correlator — one u64, four roles.
-static NEXT_BADGE: std::sync::atomic::AtomicU64 =
-    std::sync::atomic::AtomicU64::new(ipc::log_badges::LOG_BADGE_FIRST_CHILD);
-
-/// Reserve the next process badge. Single allocation point so the
-/// value can be threaded to `populate_child_info` (writes it into
-/// `pi.log_send_cap`'s badged SEND derivation) AND `finalize_creation`
-/// (uses it as the table key, death-EQ correlator, and process-handle
-/// badge).
+/// Mint a fresh process badge: a random `u64` drawn from the kernel entropy
+/// pool ([`syscall::random_u64`]). The same value is procmgr's process-table
+/// key, the badged SEND-cap badge on the log endpoint (logd keys slots by the
+/// full `u64`), and procmgr's death-EQ correlator (low 32 bits). Drawing it at
+/// random — rather than the former monotonic counter — keeps the per-process
+/// identifier and the spawn rate it would otherwise leak unguessable; the
+/// capability is still the sole authority, so this is defense-in-depth.
 ///
-/// Skips badges whose lower 32 bits would collide with reserved
-/// death-EQ correlators (currently `INIT_REAP_CORRELATOR = u32::MAX`).
-/// The death-EQ binding API takes a `u32` correlator while process
-/// badges are `u64`; without this guard the truncated correlator
-/// could match the reserved value at u32 wrap (~4.3B spawns) and
-/// the matching child's death would be silently absorbed by the
-/// init-reap branch in `dispatch_death`.
-fn next_process_badge() -> u64
+/// Single allocation point so the value threads to `populate_child_info`
+/// (writes the badged SEND derivation into `pi.log_send_cap`) AND
+/// `finalize_creation` (table key, death-EQ correlator, process-handle badge).
+///
+/// Redraws on the rare value whose low 32 bits hit a reserved death-EQ
+/// correlator (`0` or `INIT_REAP_CORRELATOR`); see [`badge_is_acceptable`].
+/// Returns `None` if the entropy draw fails (a kernel-contract violation),
+/// failing the spawn rather than minting a weak badge.
+fn next_process_badge() -> Option<u64>
 {
     loop
     {
-        let t = NEXT_BADGE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let t = syscall::random_u64().ok()?;
         if badge_is_acceptable(t, ipc::procmgr_labels::INIT_REAP_CORRELATOR)
         {
-            return t;
+            return Some(t);
         }
-        // Skip the reserved correlator and try again. (Unreachable in
-        // v0.1.0 fleet sizes; cheap guard against a real-life wrap.)
     }
 }
 
@@ -1255,7 +1247,7 @@ fn create_process_from_bytes(
         MainTls::default()
     };
 
-    let process_badge = next_process_badge();
+    let process_badge = next_process_badge()?;
     let pi_memory_cap = populate_child_info(
         self_aspace,
         child_aspace,
@@ -1338,18 +1330,22 @@ pub fn create_process(
     result
 }
 
-/// Monotonic cookie counter for `FS_READ_MEMORY`. Skips zero — fatfs
-/// rejects cookie 0 as the `OutstandingPage::None` sentinel.
-static NEXT_MEMORY_COOKIE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
-
-fn next_memory_cookie() -> u64
+/// Per-request correlation cookie for `FS_READ_MEMORY`: a random `u64` from
+/// the kernel entropy pool, redrawn off the reserved `0` value (fatfs rejects
+/// cookie 0 as the `OutstandingPage::None` sentinel). Random rather than
+/// monotonic so the read-memory request count/rate it would otherwise leak to
+/// the fs stays unguessable; the cookie is opaque and never indexes a table.
+/// Returns `None` if the entropy draw fails (a kernel-contract violation).
+fn next_memory_cookie() -> Option<u64>
 {
-    let mut c = NEXT_MEMORY_COOKIE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    while c == 0
+    loop
     {
-        c = NEXT_MEMORY_COOKIE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let c = syscall::random_u64().ok()?;
+        if c != 0
+        {
+            return Some(c);
+        }
     }
-    c
 }
 
 /// Issue `FS_READ_MEMORY` at byte `offset`.
@@ -1370,7 +1366,7 @@ fn vfs_read_memory(
     offset: u64,
 ) -> Option<(u32, usize, usize, u64)>
 {
-    let cookie = next_memory_cookie();
+    let cookie = next_memory_cookie()?;
     let msg = IpcMessage::builder(ipc::fs_labels::FS_READ_MEMORY)
         .word(0, offset)
         .word(1, cookie)
@@ -2026,7 +2022,7 @@ pub fn create_process_from_file(
         demand_paged,
         self_memmgr_ep: ctx.memmgr_ep,
     };
-    let process_badge = next_process_badge();
+    let process_badge = next_process_badge().ok_or(procmgr_errors::OUT_OF_MEMORY)?;
     let pi_memory_cap = populate_child_info(
         self_aspace,
         child_objs.aspace(),

--- a/services/procmgr/src/process.rs
+++ b/services/procmgr/src/process.rs
@@ -38,16 +38,26 @@ const VFS_CHUNK_SIZE: u64 = 63 * 8; // 504 bytes
 /// (writes the badged SEND derivation into `pi.log_send_cap`) AND
 /// `finalize_creation` (table key, death-EQ correlator, process-handle badge).
 ///
-/// Redraws on the rare value whose low 32 bits hit a reserved death-EQ
-/// correlator (`0` or `INIT_REAP_CORRELATOR`); see [`badge_is_acceptable`].
-/// Returns `None` if the entropy draw fails (a kernel-contract violation),
-/// failing the spawn rather than minting a weak badge.
+/// Redraws until the low 32 bits clear `LOG_BADGE_FIRST_CHILD` — keeping the
+/// badge out of the reserved log-badge / no-correlator range that the old
+/// monotonic counter held structurally by starting at 16 — and avoid the
+/// reserved init-reap correlator; see [`badge_is_acceptable`]. Because the
+/// death-EQ correlator is only the low 32 bits, two *live* processes can collide
+/// there at ~2⁻³² (≤`MAX_PROCESSES` live), which `take_by_correlator` resolves
+/// to the first match: an accepted, vanishingly-rare narrowing of the former
+/// monotonic uniqueness. Returns `None` if the entropy draw fails (a
+/// kernel-contract violation), failing the spawn rather than minting a weak
+/// badge.
 fn next_process_badge() -> Option<u64>
 {
     loop
     {
         let t = syscall::random_u64().ok()?;
-        if badge_is_acceptable(t, ipc::procmgr_labels::INIT_REAP_CORRELATOR)
+        if badge_is_acceptable(
+            t,
+            ipc::log_badges::LOG_BADGE_FIRST_CHILD,
+            ipc::procmgr_labels::INIT_REAP_CORRELATOR,
+        )
         {
             return Some(t);
         }

--- a/services/svcmgr/src/definitions/reconcile.rs
+++ b/services/svcmgr/src/definitions/reconcile.rs
@@ -262,6 +262,11 @@ fn handle_definition(
     }
     let idx = *service_count;
     *service_count += 1;
+    // Deliberately the service-table index, not a randomized correlator (#249):
+    // it is opaque to the kernel, delivered only to svcmgr's own private death
+    // EQ (never in an IPC body, cap, or logged value), and consumed directly as
+    // `services[idx]` on death dispatch. With no untrusted observer there is
+    // nothing to enumerate, and a (random-epoch, index) split would buy nothing.
     let correlator = idx as u32;
 
     let Some(launched) = launch::launch(def, ctx, registry, Some((deaths_eq, correlator)))

--- a/services/svcmgr/src/restart.rs
+++ b/services/svcmgr/src/restart.rs
@@ -40,13 +40,6 @@ pub enum DeathOutcome
     Unrecoverable,
 }
 
-/// Monotonic counter for child bootstrap badges. Shared between the
-/// restart path and the post-handover launch path: every child that
-/// receives its bootstrap round on svcmgr's `bootstrap_ep` gets a
-/// distinct badge so svcmgr can correlate the round to the right
-/// service entry.
-static NEXT_BOOTSTRAP_BADGE: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(1);
-
 /// Result of a successful `CREATE_FROM_FILE` reply, shared by the
 /// restart path and the post-handover launch path.
 pub struct CreatedProcess
@@ -56,11 +49,21 @@ pub struct CreatedProcess
     pub child_badge: u64,
 }
 
-/// Allocate a fresh bootstrap badge and mint a badged SEND on
-/// `bootstrap_ep` for a soon-to-spawn child.
+/// Allocate a fresh bootstrap badge — a random `u64` from the kernel entropy
+/// pool, redrawn off the reserved `0` value (an unbadged SEND carries badge 0)
+/// — and mint a badged SEND on `bootstrap_ep` for a soon-to-spawn child. Every
+/// child that receives its bootstrap round on svcmgr's `bootstrap_ep` gets a
+/// distinct badge so svcmgr can correlate the round to the right service entry.
+/// Random rather than monotonic so the service-spawn count it would otherwise
+/// leak stays unguessable; svcmgr matches the round by exact badge value, never
+/// by index. Returns `None` if the entropy draw or cap derivation fails.
 pub fn mint_child_creator(bootstrap_ep: u32) -> Option<(u64, u32)>
 {
-    let badge = NEXT_BOOTSTRAP_BADGE.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+    let mut badge = syscall::random_u64().ok()?;
+    while badge == 0
+    {
+        badge = syscall::random_u64().ok()?;
+    }
     let badged = syscall::cap_derive_badge(bootstrap_ep, syscall::RIGHTS_SEND, badge).ok()?;
     Some((badge, badged))
 }

--- a/services/vfsd/src/driver.rs
+++ b/services/vfsd/src/driver.rs
@@ -30,15 +30,10 @@
 //! fatfs is never handed the whole-disk cap and cannot escape the partition
 //! regardless of what sector number it computes.
 
-use std::sync::atomic::{AtomicU64, Ordering};
-
 use ipc::{FS_LABELS_VERSION, IpcMessage, fs_labels, procmgr_labels};
 
 use crate::VfsdCaps;
 use crate::worker_pool::{BootstrapOrder, CreateFromFileOrder, WorkOrder, WorkerPool};
-
-/// Monotonic counter for fatfs-child bootstrap badges.
-static NEXT_BOOTSTRAP_BADGE: AtomicU64 = AtomicU64::new(1);
 
 /// Spawn a fatfs driver instance for a partition and return its `SEND_GRANT`
 /// service endpoint. `module_cap` is non-zero only for the root mount; pass
@@ -69,11 +64,17 @@ pub fn spawn_fatfs_driver(
     let driver_ep_for_child = syscall::cap_derive(driver_ep, syscall::RIGHTS_ALL).ok()?;
     let driver_send = syscall::cap_derive(driver_ep, syscall::RIGHTS_SEND_GRANT).ok()?;
 
-    // Allocate a bootstrap badge and a badged SEND on the worker-owned
-    // bootstrap endpoint. The child receives the badged cap as its
-    // `creator_endpoint` and uses it to fetch its caps via the bootstrap
-    // protocol; the bootstrap worker matches by badge.
-    let badge = NEXT_BOOTSTRAP_BADGE.fetch_add(1, Ordering::Relaxed);
+    // Allocate a bootstrap badge — a random `u64` from the kernel entropy pool,
+    // redrawn off the reserved `0` value (an unbadged SEND carries badge 0) — and
+    // a badged SEND on the worker-owned bootstrap endpoint. The child receives the
+    // badged cap as its `creator_endpoint` and uses it to fetch its caps via the
+    // bootstrap protocol; the bootstrap worker matches by badge value, not index,
+    // so a random badge keeps the fatfs-spawn count unguessable.
+    let mut badge = syscall::random_u64().ok()?;
+    while badge == 0
+    {
+        badge = syscall::random_u64().ok()?;
+    }
     let badged_creator =
         syscall::cap_derive_badge(caps.bootstrap_ep, syscall::RIGHTS_SEND, badge).ok()?;
     let bootstrap = BootstrapOrder {

--- a/shared/syscall/src/lib.rs
+++ b/shared/syscall/src/lib.rs
@@ -52,7 +52,7 @@ use syscall_abi::{
     SYS_THREAD_EXIT, SYS_THREAD_READ_REGS, SYS_THREAD_SET_AFFINITY, SYS_THREAD_SET_FAULT_HANDLER,
     SYS_THREAD_SET_PRIORITY, SYS_THREAD_SLEEP, SYS_THREAD_START, SYS_THREAD_STOP,
     SYS_THREAD_WRITE_REGS, SYS_THREAD_YIELD, SYS_WAIT_SET_ADD, SYS_WAIT_SET_REMOVE,
-    SYS_WAIT_SET_WAIT,
+    SYS_WAIT_SET_WAIT, SyscallError,
 };
 
 pub use syscall_abi::{
@@ -2080,6 +2080,38 @@ pub fn getrandom(buf: *mut u8, len: usize) -> Result<u64, i64>
     // kernel validates the span and writes only within [buf, buf+len).
     let ret = unsafe { syscall2(SYS_GETRANDOM, buf as u64, len as u64) };
     if ret < 0 { Err(ret) } else { Ok(ret as u64) }
+}
+
+/// Draw a single cryptographically-secure random `u64` from the kernel
+/// entropy pool.
+///
+/// Convenience over [`getrandom`] for the common "I need one random integer"
+/// case (badge/correlator minting): fills a fixed 8-byte buffer and assembles
+/// it native-endian. The value is raw — callers apply their own non-zero or
+/// reserved-value filters.
+///
+/// # Errors
+/// Returns the same negative `i64` codes as [`getrandom`]. For this fixed
+/// 8-byte in-bounds draw the only reachable failure is a kernel-contract
+/// violation (the pool is seeded before any userspace runs and the length is
+/// well under `MAX_GETRANDOM_LEN`); it is surfaced as `Err` rather than
+/// panicking so callers handle it on their own fallible path.
+#[inline]
+pub fn random_u64() -> Result<u64, i64>
+{
+    let mut b = [0u8; 8];
+    let n = getrandom(b.as_mut_ptr(), b.len())?;
+    if n == b.len() as u64
+    {
+        Ok(u64::from_ne_bytes(b))
+    }
+    else
+    {
+        // Unreachable: the kernel fills a valid in-bounds buffer completely or
+        // errors (it never returns a short count). Surface the contract
+        // violation as `Err` rather than panic.
+        Err(SyscallError::InvalidState as i64)
+    }
 }
 
 // ── SBI ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #249. Sibling of #248 (kernel-minted handles); depends only on the
already-merged userspace randomness exposure (`SYS_GETRANDOM`, #246).

## Summary

Userspace services minted badge / correlator values as monotonic counters.
A monotonic value that is **observable across an IPC boundary** leaks service
activity (spawn / registration / request counts and rates) and admits
stale-badge confusion in a service's own bookkeeping. The capability remains
the sole authority — a guessed badge grants nothing — so this is
anti-enumeration **defense-in-depth**, mirroring #248.

New helper `syscall::random_u64() -> Result<u64, i64>` (typed wrapper over
`SYS_GETRANDOM`). Per coding-standards it returns `Result` rather than
panicking; every randomized site is on a fallible path and propagates the
(unreachable) draw failure. Each site keeps its existing non-zero /
reserved-value filter.

## Per-service badge inventory (Acceptance #1, #3)

| Service | Site | Scheme (before) | Observability | Index? | Class | Action |
|---|---|---|---|---|---|---|
| procmgr | `next_process_badge` | monotonic `AtomicU64` (from 16) | log badge + death-EQ correlator | no (scan) | **randomize** | random; low-32 ≥ `LOG_BADGE_FIRST_CHILD` and ≠ `INIT_REAP_CORRELATOR` |
| procmgr | `next_memory_cookie` (`FS_READ_MEMORY`) | monotonic `AtomicU64` | cross-IPC to fatfs | no | **randomize** | random; skip 0 |
| memmgr | ledger `NEXT_BADGE` | monotonic `AtomicU64` | `REGISTER_PROCESS` ledger key (returned in reply word) | no (scan) | **randomize** | random; exclude {0, `MEMMGR_SELF_BADGE`, `INIT_SELF_BADGE`} |
| svcmgr | `mint_child_creator` bootstrap | monotonic `AtomicU64` | bootstrap handshake | no | **randomize** | random; skip 0 |
| vfsd | bootstrap badge | monotonic `AtomicU64` | bootstrap handshake | no | **randomize** | random; skip 0 |
| devmgr | bootstrap badges (×2) | monotonic `AtomicU64` | bootstrap handshake | no | **randomize** | random; skip 0 |
| init | bootstrap badges (×4, shared static) | monotonic `AtomicU64` | bootstrap handshake | no | **randomize** | random; skip 0 |
| ruststd | `allocate_badge` (release ep) | monotonic `AtomicU64` | badged SEND to fs, echoed in `FS_RELEASE_MEMORY` | no (map) | **randomize** | random; skip 0 |
| ruststd | `next_cookie` (`FS_READ_MEMORY`) | monotonic `AtomicU64` | cross-IPC to fatfs | no | **randomize** | random; skip 0 |
| svcmgr | restart-rebind correlator | service-table `idx` | kernel-private death EQ only | **yes** (`services[idx]`) | **keep** | documented |
| svcmgr | `*_AUTHORITY` / `LOG_BADGE_*` | fixed protocol bits/constants | protocol gate bits | n/a | **keep** | semantically fixed |
| devmgr | `device_badge = idx + 1` | index-derived | per-device, driver-enforced | derived | **keep** | documented device identity |
| fat | open-file slot badge | monotonic `AtomicU64` | **never on the wire** (intra-process) | no | **keep** | documented internal |
| fat | node-cap `NodeId` | index-derived | node-cap badge | **yes** (`entries[]`) | **keep** | namespace addressing |
| virtio-blk | `next_partition_badge` | monotonic `u64` | **minter-only** (cap holder cannot read the badge; only blk reads `msg.badge`) | no (scan) | **keep** | stable partition enumeration, driver-scope, bit-disjoint from `MOUNT_AUTHORITY` |
| ruststd | reaper correlator | `(slot<<26)\|gen` | death-EQ correlator | yes (slot) | **keep (split)** | already a correct index+generation split |

### Notes
- **Reserved-low-word floor:** `badge_is_acceptable` is the complete
  process-badge predicate — it rejects any badge whose low-32 word is below
  `LOG_BADGE_FIRST_CHILD` (the reserved log-badge / `0` no-correlator range:
  init=1, procmgr=2, 3..15) or equals `INIT_REAP_CORRELATOR`. The process badge
  doubles as the logd source badge, and logd evicts every slot whose low word
  matches a death correlator, so a low badge could evict/contaminate a reserved
  logd slot; the old monotonic counter (start 16) held this floor structurally.
  New host tests cover the floor and the correlator rejection.
- **Scope addition (completeness):** the two `FS_READ_MEMORY` cookies
  (procmgr + ruststd) were surfaced by the audit as the same monotonic
  cross-IPC correlator class and randomized alongside the badges.
- **Low-32 collision:** death-EQ correlators truncate the badge to 32 bits, so
  two random badges collide in the low word at ~2⁻³²; with ≤32 live processes
  this is negligible and matches the documented per-slot ABA convention.

## Validation

`cargo xtask` on **x86_64** and **riscv64**:
- `build` ✓ both arches
- host tests ✓ (process-table badge predicate incl. floor + correlator rejection)
- `svctest` ✓ both arches (random-divergence phase passes)
- `usertest` ✓ both arches

https://claude.ai/code/session_01VxXf6T5Fw2R3TbVPrH88a9