### PR TITLE
shared: in-OS crypto primitives — SHA-512 + Ed25519 verify (#247)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,6 +261,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
+name = "crypto"
+version = "0.1.0"
+
+[[package]]
 name = "ctrlc"
 version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,6 +576,7 @@ dependencies = [
 name = "ktest"
 version = "0.1.0"
 dependencies = [
+ "crypto",
  "font",
  "init-protocol",
  "ipc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ members = [
     "abi/process-abi",
     "abi/syscall",
     "shared/ansi",
+    "shared/crypto",
     "shared/elf",
     "shared/font",
     "shared/mmio",

--- a/core/ktest/Cargo.toml
+++ b/core/ktest/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 test = false
 
 [dependencies]
+crypto        = { path = "../../shared/crypto" }
 font          = { workspace = true }
 init-protocol = { path = "../../abi/init-protocol" }
 ipc           = { path = "../../shared/ipc" }

--- a/core/ktest/src/unit/crypto.rs
+++ b/core/ktest/src/unit/crypto.rs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// ktest/src/unit/crypto.rs
+
+//! Tier 1 tests for the shared `crypto` crate (SHA-512, Ed25519 verify).
+//!
+//! These run the crate's own known-answer vectors on the live target so the
+//! primitives are validated under QEMU on both `x86_64` and `riscv64`, not only
+//! by host `cargo test`. The vector tables and assertions live in `shared/crypto`
+//! (`run_sha512_kats` / `run_ed25519_kats`); this module is a thin on-target
+//! entry point so host and on-target runs exercise identical logic.
+
+use crate::{TestContext, TestResult};
+
+/// SHA-512 known-answer tests: FIPS 180-4 vectors plus incremental and
+/// padding-boundary self-consistency.
+pub fn sha512_kats(_ctx: &TestContext) -> TestResult
+{
+    crypto::run_sha512_kats()
+}
+
+/// Ed25519 verification known-answer tests: RFC 8032 §7.1 positive vectors
+/// plus tamper negatives (flipped signature/message, wrong key, non-canonical
+/// S, invalid public key).
+pub fn ed25519_kats(_ctx: &TestContext) -> TestResult
+{
+    crypto::run_ed25519_kats()
+}

--- a/core/ktest/src/unit/mod.rs
+++ b/core/ktest/src/unit/mod.rs
@@ -32,9 +32,13 @@
 //! - `fpu.rs`      — FPU / SIMD / V extended-state isolation across preemption and cross-CPU migration
 //! - `hw.rs`       — MMIO, IRQ, I/O ports, SBI
 //! - `sysinfo.rs`  — system info queries and debug log
+//! - `crypto.rs`   — shared `crypto` crate KATs (SHA-512, Ed25519 verify),
+//!   run on-target so the primitives are validated on both arches (not a
+//!   kernel syscall surface, but ktest is the only both-arch on-target harness)
 
 pub mod cap;
 pub mod cap_info;
+pub mod crypto;
 pub mod event;
 pub mod fpu;
 pub mod hw;
@@ -505,4 +509,8 @@ pub fn run_all(ctx: &TestContext)
     run_test!("sysinfo::elapsed_us", sysinfo::elapsed_us(ctx));
     run_test!("sysinfo::current_cpu", sysinfo::current_cpu(ctx));
     run_test!("sysinfo::cpu_count_smp", sysinfo::cpu_count_smp(ctx));
+
+    // ── Shared crypto primitives ──────────────────────────────────────────────
+    run_test!("crypto::sha512_kats", crypto::sha512_kats(ctx));
+    run_test!("crypto::ed25519_kats", crypto::ed25519_kats(ctx));
 }

--- a/shared/README.md
+++ b/shared/README.md
@@ -5,6 +5,7 @@ Internal utility crates with no cross-boundary stability obligation. See
 
 | Crate | Purpose |
 |---|---|
+| `crypto/` | In-OS crypto primitives — SHA-512 hashing and Ed25519 signature verification, `no_std`, zero-dependency |
 | `elf/` | ELF64 parser — header validation, segment enumeration |
 | `font/` | Embedded 9×20 bitmap font for early console output |
 | `ipc/` | IPC helpers — `IpcMessage` snapshot type, `ipc_call`/`recv`/`reply` wrappers, bootstrap protocol, and the `RecvGuard` receive-failure policy for blocking recv loops (see [docs/ipc-design.md](../docs/ipc-design.md)) |

--- a/shared/crypto/Cargo.toml
+++ b/shared/crypto/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "crypto"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+# no_std: vetted hash (SHA-512) and Ed25519 signature verification for the
+# boot/loader and service integrity paths. Pure core, no external deps.
+[lib]
+test = true
+doctest = false
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/shared/crypto/README.md
+++ b/shared/crypto/README.md
@@ -1,0 +1,81 @@
+# shared/crypto
+
+In-OS cryptographic primitives for Seraph: SHA-512 hashing and Ed25519
+signature verification.
+
+`no_std`, no allocation, no external dependencies. Provides a vetted hash and a
+verify-only signature primitive usable by the bootloader/loader and userspace
+services. Does no I/O and holds no keys.
+
+The crate is the reusable primitive that the per-binary signing chain of trust
+(#124) builds on; #124 owns key management, the `.seraph.sig` ELF section, and
+xtask signing, and is the consumer of `ed25519_verify`.
+
+---
+
+## Surface
+
+| Item | Purpose |
+|---|---|
+| `sha512(&[u8]) -> [u8; 64]` | One-shot SHA-512 (FIPS 180-4). |
+| `Sha512` (`new`/`update`/`finalize`) | Incremental SHA-512, so large inputs (e.g. module bodies) hash without being buffered whole. |
+| `ed25519_verify(&[u8;32], &[u8], &[u8;64]) -> Result<(), VerifyError>` | RFC 8032 Ed25519 verification. Verify-only; no signing or key generation. |
+| `VerifyError` | `BadPublicKey`, `NonCanonicalS`, `Mismatch`. |
+
+### Design notes
+
+- **SHA-512 only.** Ed25519 mandates SHA-512 internally (RFC 8032 §5.1); one
+  core serves both the public hash and the signature's internal hashing.
+  SHA-256/BLAKE-family hashes are not provided (no consumer).
+- **Verify-only, variable-time.** Verification touches only public data
+  (public key, signature, message), so the field arithmetic is variable-time
+  by design and carries no side-channel obligation. The mandatory `S < L`
+  range check (RFC 8032 §5.1.7) runs first; every failure path is a single
+  terminal `Err` with no fallback.
+- **Field representation.** Field elements are 16 signed limbs of radix 2^16
+  (the `TweetNaCl` `gf` model) — the most conservative basis for a
+  from-scratch verifier, keeping every intermediate product inside `i64`.
+- **Independent of the kernel entropy subsystem.** The kernel's
+  `entropy/{keccak,sponge}` Keccak/SHAKE256 sponge is kernel-internal and
+  coupled to the CSPRNG; it is intentionally not shared with this crate.
+  Consolidating hash primitives is out of scope.
+
+### Validation
+
+Known-answer tests run identically on host (`cargo xtask test`) and on-target
+under QEMU on both x86_64 and riscv64 (ktest `crypto::sha512_kats` /
+`crypto::ed25519_kats`): FIPS 180-4 SHA-512 vectors and RFC 8032 §7.1 Ed25519
+vectors, plus tamper negatives (flipped signature/message, wrong key,
+non-canonical S, invalid public key).
+
+---
+
+## Source Layout
+
+```
+shared/crypto/
+├── Cargo.toml                  # Workspace member; no_std library; no dependencies
+├── README.md
+└── src/
+    ├── lib.rs                  # Crate doc, public re-exports
+    ├── sha512.rs               # SHA-512 (one-shot + incremental) + KATs
+    ├── ed25519.rs              # ed25519_verify, VerifyError + KATs
+    ├── field.rs                # GF(2^255-19) field arithmetic
+    ├── edwards.rs              # edwards25519 group: points, scalar mul, decompression
+    └── scalar.rs               # arithmetic mod L: S<L check, 64-byte reduction
+```
+
+---
+
+## Relevant Design Documents
+
+| Document | Content |
+|---|---|
+| [docs/capability-model.md](../../docs/capability-model.md) | System security model the signing chain layers onto |
+| [docs/coding-standards.md](../../docs/coding-standards.md) | Formatting, naming, safety rules |
+
+---
+
+## Summarized By
+
+None

--- a/shared/crypto/src/ed25519.rs
+++ b/shared/crypto/src/ed25519.rs
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// shared/crypto/src/ed25519.rs
+
+//! Ed25519 signature verification (RFC 8032).
+//!
+//! [`ed25519_verify`] checks `[S]B = R + [k]A` with `k = SHA512(R‖A‖M) mod L`,
+//! using the cofactorless equation and a canonical re-encoding compare so the
+//! result matches the RFC 8032 §7.1 test vectors exactly. The mandatory
+//! `S < L` range check (RFC 8032 §5.1.7) runs first. Every failure path is a
+//! single terminal `Err`; there is no fallback or warn-and-continue.
+
+use crate::edwards;
+use crate::scalar;
+use crate::sha512::Sha512;
+
+/// Why a signature failed verification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VerifyError
+{
+    /// The public key did not decode to a curve point.
+    BadPublicKey,
+    /// The signature scalar S was not in `{0, …, L-1}` (RFC 8032 §5.1.7).
+    NonCanonicalS,
+    /// The verification equation did not hold.
+    Mismatch,
+}
+
+/// Verify an Ed25519 signature over `message`.
+///
+/// # Errors
+///
+/// Returns [`VerifyError`] identifying the first failing check. A returned
+/// `Ok(())` means the signature is valid for `public_key` and `message`.
+pub fn ed25519_verify(
+    public_key: &[u8; 32],
+    message: &[u8],
+    signature: &[u8; 64],
+) -> Result<(), VerifyError>
+{
+    let mut r_bytes = [0u8; 32];
+    r_bytes.copy_from_slice(&signature[..32]);
+    let mut s_bytes = [0u8; 32];
+    s_bytes.copy_from_slice(&signature[32..]);
+
+    // RFC 8032 §5.1.7: reject S ∉ {0, …, L-1} before any curve work.
+    if !scalar::is_canonical(&s_bytes)
+    {
+        return Err(VerifyError::NonCanonicalS);
+    }
+
+    // Decode the public key to -A so the equation becomes a single addition.
+    let Some(neg_a) = edwards::decompress_neg(public_key)
+    else
+    {
+        return Err(VerifyError::BadPublicKey);
+    };
+
+    // k = SHA512(R ‖ A ‖ M) mod L. Order is load-bearing; stream to avoid
+    // buffering the (possibly large) message.
+    let mut hasher = Sha512::new();
+    hasher.update(&r_bytes);
+    hasher.update(public_key);
+    hasher.update(message);
+    let k = scalar::reduce_512(&hasher.finalize());
+
+    // r_check = [S]B + [k](-A) = [S]B - [k]A.
+    let mut r_check = edwards::scalar_mul(&neg_a, &k);
+    let sb = edwards::scalar_mul_base(&s_bytes);
+    edwards::add(&mut r_check, &sb);
+
+    if edwards::pack(&r_check) == r_bytes
+    {
+        Ok(())
+    }
+    else
+    {
+        Err(VerifyError::Mismatch)
+    }
+}
+
+// ── Known-answer tests ───────────────────────────────────────────────────────
+
+/// One RFC 8032 §7.1 verification vector, stored as hex to keep the byte
+/// layout auditable against the RFC.
+struct Ed25519Vec
+{
+    public_key: &'static str,
+    message: &'static str,
+    signature: &'static str,
+}
+
+/// RFC 8032 §7.1 vectors: TEST 1/2/3, the 1024-byte message, and SHA(abc).
+const RFC8032_VECTORS: &[Ed25519Vec] = &[
+    Ed25519Vec {
+        public_key: "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        message: "",
+        signature: "e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b",
+    },
+    Ed25519Vec {
+        public_key: "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        message: "72",
+        signature: "92a009a9f0d4cab8720e820b5f642540a2b27b5416503f8fb3762223ebdb69da085ac1e43e15996e458f3613d0f11d8c387b2eaeb4302aeeb00d291612bb0c00",
+    },
+    Ed25519Vec {
+        public_key: "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        message: "af82",
+        signature: "6291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a",
+    },
+    Ed25519Vec {
+        public_key: "278117fc144c72340f67d0f2316e8386ceffbf2b2428c9c51fef7c597f1d426e",
+        message: "08b8b2b733424243760fe426a4b54908632110a66c2f6591eabd3345e3e4eb98fa6e264bf09efe12ee50f8f54e9f77b1e355f6c50544e23fb1433ddf73be84d879de7c0046dc4996d9e773f4bc9efe5738829adb26c81b37c93a1b270b20329d658675fc6ea534e0810a4432826bf58c941efb65d57a338bbd2e26640f89ffbc1a858efcb8550ee3a5e1998bd177e93a7363c344fe6b199ee5d02e82d522c4feba15452f80288a821a579116ec6dad2b3b310da903401aa62100ab5d1a36553e06203b33890cc9b832f79ef80560ccb9a39ce767967ed628c6ad573cb116dbefefd75499da96bd68a8a97b928a8bbc103b6621fcde2beca1231d206be6cd9ec7aff6f6c94fcd7204ed3455c68c83f4a41da4af2b74ef5c53f1d8ac70bdcb7ed185ce81bd84359d44254d95629e9855a94a7c1958d1f8ada5d0532ed8a5aa3fb2d17ba70eb6248e594e1a2297acbbb39d502f1a8c6eb6f1ce22b3de1a1f40cc24554119a831a9aad6079cad88425de6bde1a9187ebb6092cf67bf2b13fd65f27088d78b7e883c8759d2c4f5c65adb7553878ad575f9fad878e80a0c9ba63bcbcc2732e69485bbc9c90bfbd62481d9089beccf80cfe2df16a2cf65bd92dd597b0707e0917af48bbb75fed413d238f5555a7a569d80c3414a8d0859dc65a46128bab27af87a71314f318c782b23ebfe808b82b0ce26401d2e22f04d83d1255dc51addd3b75a2b1ae0784504df543af8969be3ea7082ff7fc9888c144da2af58429ec96031dbcad3dad9af0dcbaaaf268cb8fcffead94f3c7ca495e056a9b47acdb751fb73e666c6c655ade8297297d07ad1ba5e43f1bca32301651339e22904cc8c42f58c30c04aafdb038dda0847dd988dcda6f3bfd15c4b4c4525004aa06eeff8ca61783aacec57fb3d1f92b0fe2fd1a85f6724517b65e614ad6808d6f6ee34dff7310fdc82aebfd904b01e1dc54b2927094b2db68d6f903b68401adebf5a7e08d78ff4ef5d63653a65040cf9bfd4aca7984a74d37145986780fc0b16ac451649de6188a7dbdf191f64b5fc5e2ab47b57f7f7276cd419c17a3ca8e1b939ae49e488acba6b965610b5480109c8b17b80e1b7b750dfc7598d5d5011fd2dcc5600a32ef5b52a1ecc820e308aa342721aac0943bf6686b64b2579376504ccc493d97e6aed3fb0f9cd71a43dd497f01f17c0e2cb3797aa2a2f256656168e6c496afc5fb93246f6b1116398a346f1a641f3b041e989f7914f90cc2c7fff357876e506b50d334ba77c225bc307ba537152f3f1610e4eafe595f6d9d90d11faa933a15ef1369546868a7f3a45a96768d40fd9d03412c091c6315cf4fde7cb68606937380db2eaaa707b4c4185c32eddcdd306705e4dc1ffc872eeee475a64dfac86aba41c0618983f8741c5ef68d3a101e8a3b8cac60c905c15fc910840b94c00a0b9d0",
+        signature: "0aab4c900501b3e24d7cdf4663326a3a87df5e4843b2cbdb67cbf6e460fec350aa5371b1508f9f4528ecea23c436d94b5e8fcd4f681e30a6ac00a9704a188a03",
+    },
+    Ed25519Vec {
+        public_key: "ec172b93ad5e563bf4932c70e1245034c35467ef2efd4d64ebf819683467e2bf",
+        message: "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f",
+        signature: "dc2a4459e7369633a52b1bf277839a00201009a3efbf3ecb69bea2186c26b58909351fc9ac90b3ecfdfbc7c66431e0303dca179c138ac17ad9bef1177331a704",
+    },
+];
+
+/// Maximum message length across the vectors (the 1024-byte test is 1023 B).
+const MSG_SCRATCH: usize = 1024;
+
+fn hex_nibble(c: u8) -> Option<u8>
+{
+    match c
+    {
+        b'0'..=b'9' => Some(c - b'0'),
+        b'a'..=b'f' => Some(c - b'a' + 10),
+        b'A'..=b'F' => Some(c - b'A' + 10),
+        _ => None,
+    }
+}
+
+/// Decode `hex` into `out`, returning the byte count, or `None` on bad input
+/// or overflow.
+fn parse_hex(hex: &str, out: &mut [u8]) -> Option<usize>
+{
+    let bytes = hex.as_bytes();
+    if !bytes.len().is_multiple_of(2) || bytes.len() / 2 > out.len()
+    {
+        return None;
+    }
+    let mut i = 0;
+    while i < bytes.len() / 2
+    {
+        let hi = hex_nibble(bytes[2 * i])?;
+        let lo = hex_nibble(bytes[2 * i + 1])?;
+        out[i] = (hi << 4) | lo;
+        i += 1;
+    }
+    Some(bytes.len() / 2)
+}
+
+/// Parse a vector's fields and run verification.
+fn verify_vector(
+    v: &Ed25519Vec,
+    msg_buf: &mut [u8; MSG_SCRATCH],
+) -> Result<Result<(), VerifyError>, &'static str>
+{
+    let mut pk = [0u8; 32];
+    let mut sig = [0u8; 64];
+    let pk_len = parse_hex(v.public_key, &mut pk).ok_or("ed25519: bad pk hex")?;
+    let sig_len = parse_hex(v.signature, &mut sig).ok_or("ed25519: bad sig hex")?;
+    let msg_len = parse_hex(v.message, msg_buf).ok_or("ed25519: bad msg hex")?;
+    if pk_len != 32 || sig_len != 64
+    {
+        return Err("ed25519: wrong field length");
+    }
+    Ok(ed25519_verify(&pk, &msg_buf[..msg_len], &sig))
+}
+
+/// Run the Ed25519 known-answer tests (RFC 8032 §7.1 positives plus tamper
+/// negatives). Returns the first failure as an error string. Compiled in all
+/// builds so host and on-target (ktest) runs share identical logic.
+///
+/// # Errors
+///
+/// Returns a descriptive `&'static str` on the first failing case.
+pub fn run_ed25519_kats() -> Result<(), &'static str>
+{
+    let mut msg = [0u8; MSG_SCRATCH];
+
+    // Positive: every RFC vector must verify.
+    for v in RFC8032_VECTORS
+    {
+        if verify_vector(v, &mut msg)? != Ok(())
+        {
+            return Err("ed25519: valid signature rejected");
+        }
+    }
+
+    // Reparse TEST 2 (non-empty, short) as a base for tamper tests.
+    let base = &RFC8032_VECTORS[1];
+    let mut pk = [0u8; 32];
+    let mut sig = [0u8; 64];
+    let _ = parse_hex(base.public_key, &mut pk).ok_or("ed25519: bad pk hex")?;
+    let _ = parse_hex(base.signature, &mut sig).ok_or("ed25519: bad sig hex")?;
+    let mut bmsg = [0u8; MSG_SCRATCH];
+    let bmsg_len = parse_hex(base.message, &mut bmsg).ok_or("ed25519: bad msg hex")?;
+
+    // Flipped R byte of the signature → Mismatch.
+    let mut bad_sig = sig;
+    bad_sig[0] ^= 0x01;
+    if ed25519_verify(&pk, &bmsg[..bmsg_len], &bad_sig) != Err(VerifyError::Mismatch)
+    {
+        return Err("ed25519: tampered signature accepted");
+    }
+
+    // Flipped message byte → Mismatch.
+    let mut bad_msg = bmsg;
+    bad_msg[0] ^= 0x01;
+    if ed25519_verify(&pk, &bad_msg[..bmsg_len], &sig) != Err(VerifyError::Mismatch)
+    {
+        return Err("ed25519: tampered message accepted");
+    }
+
+    // Different valid public key → Mismatch.
+    let mut other_pk = [0u8; 32];
+    let _ = parse_hex(RFC8032_VECTORS[2].public_key, &mut other_pk).ok_or("ed25519: bad pk hex")?;
+    if ed25519_verify(&other_pk, &bmsg[..bmsg_len], &sig) != Err(VerifyError::Mismatch)
+    {
+        return Err("ed25519: wrong-key signature accepted");
+    }
+
+    // S == L → NonCanonicalS (the mandatory range check).
+    let mut sl_sig = sig;
+    sl_sig[32..].copy_from_slice(&scalar::L);
+    if ed25519_verify(&pk, &bmsg[..bmsg_len], &sl_sig) != Err(VerifyError::NonCanonicalS)
+    {
+        return Err("ed25519: non-canonical S accepted");
+    }
+
+    // Public key that is not a curve point → BadPublicKey.
+    let mut not_a_point = [0u8; 32];
+    not_a_point[0] = 2;
+    if ed25519_verify(&not_a_point, &bmsg[..bmsg_len], &sig) != Err(VerifyError::BadPublicKey)
+    {
+        return Err("ed25519: invalid public key accepted");
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests
+{
+    use super::*;
+
+    #[test]
+    fn kats_pass()
+    {
+        assert_eq!(run_ed25519_kats(), Ok(()));
+    }
+}

--- a/shared/crypto/src/edwards.rs
+++ b/shared/crypto/src/edwards.rs
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// shared/crypto/src/edwards.rs
+
+//! The edwards25519 group: points in extended coordinates, addition, scalar
+//! multiplication, decompression, and encoding.
+//!
+//! A [`Point`] is `[X, Y, Z, T]` with affine `x = X/Z`, `y = Y/Z`, and
+//! `T = XY/Z` (Hisil–Wong–Carter–Dawson extended coordinates). Scalar
+//! multiplication is a constant-shape conditional-swap ladder; constant time
+//! is not required for verification, but the swap form is simple and correct.
+
+// many_single_char_names: the addition formula uses the standard a..h
+// extended-coordinate working names; renaming would obscure the published math.
+#![allow(clippy::many_single_char_names)]
+
+use crate::field::{self, Fe, GF0, GF1};
+
+/// A curve point in extended coordinates `[X, Y, Z, T]`.
+pub(crate) type Point = [Fe; 4];
+
+/// The group identity `(0, 1, 1, 0)`.
+const IDENTITY: Point = [GF0, GF1, GF1, GF0];
+
+/// In-place point addition: `p ← p + q` (extended-coordinate unified formula).
+pub(crate) fn add(p: &mut Point, q: &Point)
+{
+    let mut a = GF0;
+    let mut b = GF0;
+    let mut c = GF0;
+    let mut d = GF0;
+    let mut t = GF0;
+    let mut e = GF0;
+    let mut f = GF0;
+    let mut g = GF0;
+    let mut h = GF0;
+
+    field::sub(&mut a, &p[1], &p[0]);
+    field::sub(&mut t, &q[1], &q[0]);
+    let tmp = a;
+    field::mul(&mut a, &tmp, &t);
+
+    field::add(&mut b, &p[0], &p[1]);
+    field::add(&mut t, &q[0], &q[1]);
+    let tmp = b;
+    field::mul(&mut b, &tmp, &t);
+
+    field::mul(&mut c, &p[3], &q[3]);
+    let tmp = c;
+    field::mul(&mut c, &tmp, &field::D2);
+
+    field::mul(&mut d, &p[2], &q[2]);
+    let tmp = d;
+    field::add(&mut d, &tmp, &tmp);
+
+    field::sub(&mut e, &b, &a);
+    field::sub(&mut f, &d, &c);
+    field::add(&mut g, &d, &c);
+    field::add(&mut h, &b, &a);
+
+    field::mul(&mut p[0], &e, &f);
+    field::mul(&mut p[1], &h, &g);
+    field::mul(&mut p[2], &g, &f);
+    field::mul(&mut p[3], &e, &h);
+}
+
+/// Conditional swap of two points when `swap == 1`.
+fn cswap(p: &mut Point, q: &mut Point, swap: u8)
+{
+    let mut i = 0;
+    while i < 4
+    {
+        field::cswap(&mut p[i], &mut q[i], swap);
+        i += 1;
+    }
+}
+
+/// `[s] q` for a little-endian scalar `s`.
+pub(crate) fn scalar_mul(q: &Point, s: &[u8; 32]) -> Point
+{
+    let mut p = IDENTITY;
+    let mut q = *q;
+    let mut i = 256usize;
+    while i > 0
+    {
+        i -= 1;
+        let bit = (s[i >> 3] >> (i & 7)) & 1;
+        cswap(&mut p, &mut q, bit);
+        let pc = p;
+        add(&mut q, &pc);
+        add(&mut p, &pc);
+        cswap(&mut p, &mut q, bit);
+    }
+    p
+}
+
+/// `[s] B` for a little-endian scalar `s`, where `B` is the base point.
+pub(crate) fn scalar_mul_base(s: &[u8; 32]) -> Point
+{
+    let mut bt = GF0;
+    field::mul(&mut bt, &field::BX, &field::BY);
+    let base: Point = [field::BX, field::BY, GF1, bt];
+    scalar_mul(&base, s)
+}
+
+/// Decompress a 32-byte public key into the **negated** point `-A`.
+///
+/// Returns `None` if the bytes do not decode to a curve point. Returning the
+/// negation directly lets the verifier compute `[S]B + [k](-A)` in one
+/// addition. Follows RFC 8032 §5.1.3 for the square-root recovery, with the
+/// sign condition inverted to select `-A`.
+pub(crate) fn decompress_neg(pk: &[u8; 32]) -> Option<Point>
+{
+    let mut r: Point = [GF0, GF0, GF1, GF0];
+    field::unpack(&mut r[1], pk);
+
+    let mut num = GF0;
+    field::sqr(&mut num, &r[1]); // y^2
+    let mut den = GF0;
+    field::mul(&mut den, &num, &field::D); // d*y^2
+    let tmp = num;
+    field::sub(&mut num, &tmp, &r[2]); // y^2 - 1
+    let tmp = den;
+    field::add(&mut den, &r[2], &tmp); // 1 + d*y^2
+
+    // x = (num/den) recovered as num * den^3 * (num * den^7)^((p-5)/8).
+    let mut den2 = GF0;
+    field::sqr(&mut den2, &den);
+    let mut den4 = GF0;
+    field::sqr(&mut den4, &den2);
+    let mut den6 = GF0;
+    field::mul(&mut den6, &den4, &den2);
+
+    let mut t = GF0;
+    field::mul(&mut t, &den6, &num);
+    let tmp = t;
+    field::mul(&mut t, &tmp, &den); // num * den^7
+
+    let tmp = t;
+    field::pow2523(&mut t, &tmp); // (num*den^7)^((p-5)/8)
+    let tmp = t;
+    field::mul(&mut t, &tmp, &num);
+    let tmp = t;
+    field::mul(&mut t, &tmp, &den);
+    let tmp = t;
+    field::mul(&mut t, &tmp, &den);
+    field::mul(&mut r[0], &t, &den); // candidate x
+
+    // Verify x^2 * den == num, else multiply by sqrt(-1) and retry.
+    let mut chk = GF0;
+    field::sqr(&mut chk, &r[0]);
+    let tmp = chk;
+    field::mul(&mut chk, &tmp, &den);
+    if !field::eq(&chk, &num)
+    {
+        let tmp = r[0];
+        field::mul(&mut r[0], &tmp, &field::SQRTM1);
+    }
+
+    field::sqr(&mut chk, &r[0]);
+    let tmp = chk;
+    field::mul(&mut chk, &tmp, &den);
+    if !field::eq(&chk, &num)
+    {
+        // No square root: not a valid curve point.
+        return None;
+    }
+
+    // Select the sign giving -A: negate when the parity already matches the
+    // encoded sign bit (the inverse of the standard decompression rule).
+    if field::parity(&r[0]) == (pk[31] >> 7)
+    {
+        let tmp = r[0];
+        field::sub(&mut r[0], &GF0, &tmp);
+    }
+
+    let mut tt = GF0;
+    field::mul(&mut tt, &r[0], &r[1]);
+    r[3] = tt;
+    Some(r)
+}
+
+/// Encode a point as its 32-byte little-endian compressed form.
+pub(crate) fn pack(p: &Point) -> [u8; 32]
+{
+    let mut zi = GF0;
+    field::invert(&mut zi, &p[2]);
+    let mut tx = GF0;
+    field::mul(&mut tx, &p[0], &zi); // x = X/Z
+    let mut ty = GF0;
+    field::mul(&mut ty, &p[1], &zi); // y = Y/Z
+    let mut out = [0u8; 32];
+    field::pack(&mut out, &ty);
+    out[31] ^= field::parity(&tx) << 7;
+    out
+}
+
+#[cfg(test)]
+mod tests
+{
+    use super::*;
+    use crate::scalar::L;
+
+    /// Compressed encoding of the base point B (RFC 8032).
+    const BASE_ENCODED: [u8; 32] = [
+        0x58, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66,
+        0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66,
+        0x66, 0x66,
+    ];
+
+    /// Encoding of the identity point (y = 1, x = 0).
+    const IDENTITY_ENCODED: [u8; 32] = [
+        0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0,
+    ];
+
+    fn scalar_one() -> [u8; 32]
+    {
+        let mut s = [0u8; 32];
+        s[0] = 1;
+        s
+    }
+
+    #[test]
+    fn base_times_one_is_base()
+    {
+        assert_eq!(pack(&scalar_mul_base(&scalar_one())), BASE_ENCODED);
+    }
+
+    #[test]
+    fn order_times_base_is_identity()
+    {
+        assert_eq!(pack(&scalar_mul_base(&L)), IDENTITY_ENCODED);
+    }
+
+    #[test]
+    fn decompress_rejects_non_curve_point()
+    {
+        // y = 2 is not the y-coordinate of any curve point; decompression
+        // must fail rather than return a bogus point.
+        let mut pk = [0u8; 32];
+        pk[0] = 2;
+        assert!(decompress_neg(&pk).is_none());
+    }
+}

--- a/shared/crypto/src/field.rs
+++ b/shared/crypto/src/field.rs
@@ -1,0 +1,318 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// shared/crypto/src/field.rs
+
+//! Arithmetic in the prime field GF(2^255 - 19) for Ed25519.
+//!
+//! Elements are 16 signed limbs of radix 2^16 ([`Fe`]). This compact
+//! representation (the `TweetNaCl` `gf` model) keeps every intermediate product
+//! comfortably inside `i64` and makes carry handling uniform, which is the
+//! safest basis for a from-scratch verifier. Verification touches only public
+//! data, so the arithmetic is variable-time by design.
+//!
+//! Limbs are kept loosely bounded between explicit carry passes; multiply and
+//! pack run enough carry rounds to renormalise. All public-facing encodings
+//! (`pack`/`unpack`) are little-endian per RFC 8032 §5.1.2.
+
+// Field code casts between i64 and byte/limb widths after masking; the masks
+// bound every value, so truncation and sign-loss are intentional here.
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_sign_loss)]
+// many_single_char_names: limb/loop variables (a, b, c, t, i, j, …) follow the
+// reference field-arithmetic naming; descriptive names would only add noise.
+#![allow(clippy::many_single_char_names)]
+
+/// A field element: 16 limbs, value = Σ limb[i] · 2^(16·i).
+pub(crate) type Fe = [i64; 16];
+
+/// Field constant 0.
+pub(crate) const GF0: Fe = [0; 16];
+
+/// Field constant 1.
+pub(crate) const GF1: Fe = [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+
+/// Curve constant d = -121665/121666.
+pub(crate) const D: Fe = [
+    0x78a3, 0x1359, 0x4dca, 0x75eb, 0xd8ab, 0x4141, 0x0a4d, 0x0070, 0xe898, 0x7779, 0x4079, 0x8cc7,
+    0xfe73, 0x2b6f, 0x6cee, 0x5203,
+];
+
+/// 2·d, used by the extended-coordinate addition formula.
+pub(crate) const D2: Fe = [
+    0xf159, 0x26b2, 0x9b94, 0xebd6, 0xb156, 0x8283, 0x149a, 0x00e0, 0xd130, 0xeef3, 0x80f2, 0x198e,
+    0xfce7, 0x56df, 0xd9dc, 0x2406,
+];
+
+/// Base-point x-coordinate.
+pub(crate) const BX: Fe = [
+    0xd51a, 0x8f25, 0x2d60, 0xc956, 0xa7b2, 0x9525, 0xc760, 0x692c, 0xdc5c, 0xfdd6, 0xe231, 0xc0a4,
+    0x53fe, 0xcd6e, 0x36d3, 0x2169,
+];
+
+/// Base-point y-coordinate (= 4/5).
+pub(crate) const BY: Fe = [
+    0x6658, 0x6666, 0x6666, 0x6666, 0x6666, 0x6666, 0x6666, 0x6666, 0x6666, 0x6666, 0x6666, 0x6666,
+    0x6666, 0x6666, 0x6666, 0x6666,
+];
+
+/// sqrt(-1) = 2^((p-1)/4), the alternate root used in point decompression.
+pub(crate) const SQRTM1: Fe = [
+    0xa0b0, 0x4a0e, 0x1b27, 0xc4ee, 0xe478, 0xad2f, 0x1806, 0x2f43, 0xd7a7, 0x3dfb, 0x0099, 0x2b4d,
+    0xdf0b, 0x4fc1, 0x2480, 0x2b83,
+];
+
+/// One carry/reduce pass (radix-2^16 with the 2^256 ≡ 38 (mod p) fold).
+pub(crate) fn carry(o: &mut Fe)
+{
+    let mut i = 0;
+    while i < 16
+    {
+        o[i] += 1 << 16;
+        let c = o[i] >> 16;
+        if i < 15
+        {
+            o[i + 1] += c - 1;
+        }
+        else
+        {
+            o[0] += 38 * (c - 1);
+        }
+        o[i] -= c << 16;
+        i += 1;
+    }
+}
+
+/// Field addition (limb-wise; result left un-normalised).
+pub(crate) fn add(o: &mut Fe, a: &Fe, b: &Fe)
+{
+    let mut i = 0;
+    while i < 16
+    {
+        o[i] = a[i] + b[i];
+        i += 1;
+    }
+}
+
+/// Field subtraction (limb-wise; result left un-normalised, may be negative).
+pub(crate) fn sub(o: &mut Fe, a: &Fe, b: &Fe)
+{
+    let mut i = 0;
+    while i < 16
+    {
+        o[i] = a[i] - b[i];
+        i += 1;
+    }
+}
+
+/// Field multiplication, fully reduced.
+pub(crate) fn mul(o: &mut Fe, a: &Fe, b: &Fe)
+{
+    let mut t = [0i64; 31];
+    let mut i = 0;
+    while i < 16
+    {
+        let mut j = 0;
+        while j < 16
+        {
+            t[i + j] += a[i] * b[j];
+            j += 1;
+        }
+        i += 1;
+    }
+    let mut i = 0;
+    while i < 15
+    {
+        t[i] += 38 * t[i + 16];
+        i += 1;
+    }
+    o.copy_from_slice(&t[..16]);
+    carry(o);
+    carry(o);
+}
+
+/// Field squaring.
+pub(crate) fn sqr(o: &mut Fe, a: &Fe)
+{
+    mul(o, a, a);
+}
+
+/// Multiplicative inverse via Fermat: a^(p-2). Returns 0 for input 0.
+pub(crate) fn invert(o: &mut Fe, a: &Fe)
+{
+    let mut c = *a;
+    let mut i = 253i32;
+    while i >= 0
+    {
+        let t = c;
+        sqr(&mut c, &t);
+        if i != 2 && i != 4
+        {
+            let t = c;
+            mul(&mut c, &t, a);
+        }
+        i -= 1;
+    }
+    *o = c;
+}
+
+/// Raise to (p-5)/8 — the square-root candidate exponent (RFC 8032 §5.1.3).
+pub(crate) fn pow2523(o: &mut Fe, a: &Fe)
+{
+    let mut c = *a;
+    let mut i = 250i32;
+    while i >= 0
+    {
+        let t = c;
+        sqr(&mut c, &t);
+        if i != 1
+        {
+            let t = c;
+            mul(&mut c, &t, a);
+        }
+        i -= 1;
+    }
+    *o = c;
+}
+
+/// Constant-shape conditional swap of `p` and `q` when `swap == 1`.
+pub(crate) fn cswap(p: &mut Fe, q: &mut Fe, swap: u8)
+{
+    let mask = !(i64::from(swap) - 1);
+    let mut i = 0;
+    while i < 16
+    {
+        let t = mask & (p[i] ^ q[i]);
+        p[i] ^= t;
+        q[i] ^= t;
+        i += 1;
+    }
+}
+
+/// Encode a field element as 32 little-endian bytes (fully reduced).
+pub(crate) fn pack(out: &mut [u8; 32], n: &Fe)
+{
+    let mut t = *n;
+    carry(&mut t);
+    carry(&mut t);
+    carry(&mut t);
+    // Two conditional subtractions of p bring t into the canonical range.
+    let mut round = 0;
+    while round < 2
+    {
+        let mut m: Fe = [0; 16];
+        m[0] = t[0] - 0xffed;
+        let mut i = 1;
+        while i < 15
+        {
+            m[i] = t[i] - 0xffff - ((m[i - 1] >> 16) & 1);
+            m[i - 1] &= 0xffff;
+            i += 1;
+        }
+        m[15] = t[15] - 0x7fff - ((m[14] >> 16) & 1);
+        let b = (m[15] >> 16) & 1;
+        m[14] &= 0xffff;
+        cswap(&mut t, &mut m, (1 - b) as u8);
+        round += 1;
+    }
+    let mut i = 0;
+    while i < 16
+    {
+        out[2 * i] = (t[i] & 0xff) as u8;
+        out[2 * i + 1] = ((t[i] >> 8) & 0xff) as u8;
+        i += 1;
+    }
+}
+
+/// Decode 32 little-endian bytes into a field element, masking the top bit
+/// (the sign bit, not field data).
+pub(crate) fn unpack(o: &mut Fe, n: &[u8; 32])
+{
+    let mut i = 0;
+    while i < 16
+    {
+        o[i] = i64::from(n[2 * i]) + (i64::from(n[2 * i + 1]) << 8);
+        i += 1;
+    }
+    o[15] &= 0x7fff;
+}
+
+/// Low bit of the canonical encoding (the `x_0` sign bit).
+pub(crate) fn parity(a: &Fe) -> u8
+{
+    let mut d = [0u8; 32];
+    pack(&mut d, a);
+    d[0] & 1
+}
+
+/// Equality after canonical reduction.
+pub(crate) fn eq(a: &Fe, b: &Fe) -> bool
+{
+    let mut da = [0u8; 32];
+    let mut db = [0u8; 32];
+    pack(&mut da, a);
+    pack(&mut db, b);
+    da == db
+}
+
+#[cfg(test)]
+mod tests
+{
+    use super::*;
+
+    fn from_u64(v: u64) -> Fe
+    {
+        let mut f = GF0;
+        f[0] = (v & 0xffff) as i64;
+        f[1] = ((v >> 16) & 0xffff) as i64;
+        f[2] = ((v >> 32) & 0xffff) as i64;
+        f[3] = ((v >> 48) & 0xffff) as i64;
+        f
+    }
+
+    #[test]
+    fn inverse_roundtrip()
+    {
+        let a = from_u64(0x0123_4567_89ab_cdef);
+        let mut inv = GF0;
+        invert(&mut inv, &a);
+        let mut prod = GF0;
+        mul(&mut prod, &a, &inv);
+        assert!(eq(&prod, &GF1));
+    }
+
+    #[test]
+    fn mul_is_associative()
+    {
+        let a = from_u64(0xdead_beef);
+        let b = from_u64(0x1234_5678_9abc);
+        let c = from_u64(0xfeed_face_cafe);
+        let (mut ab, mut bc, mut left, mut right) = (GF0, GF0, GF0, GF0);
+        mul(&mut ab, &a, &b);
+        mul(&mut left, &ab, &c);
+        mul(&mut bc, &b, &c);
+        mul(&mut right, &a, &bc);
+        assert!(eq(&left, &right));
+    }
+
+    #[test]
+    fn pack_unpack_roundtrip()
+    {
+        let a = from_u64(0x9e37_79b9_7f4a_7c15);
+        let mut bytes = [0u8; 32];
+        pack(&mut bytes, &a);
+        let mut b = GF0;
+        unpack(&mut b, &bytes);
+        assert!(eq(&a, &b));
+    }
+
+    #[test]
+    fn sqrt_minus_one_squares_to_minus_one()
+    {
+        let mut sq = GF0;
+        sqr(&mut sq, &SQRTM1);
+        let mut neg_one = GF0;
+        sub(&mut neg_one, &GF0, &GF1);
+        assert!(eq(&sq, &neg_one));
+    }
+}

--- a/shared/crypto/src/lib.rs
+++ b/shared/crypto/src/lib.rs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// shared/crypto/src/lib.rs
+
+//! In-OS cryptographic primitives: SHA-512 hashing and Ed25519 signature
+//! verification.
+//!
+//! `no_std`, no allocation, no external dependencies. Two primitives:
+//!
+//! - [`sha512`] / [`Sha512`] — FIPS 180-4 SHA-512, one-shot and incremental.
+//!   The incremental form hashes large inputs (e.g. boot-module bodies)
+//!   without buffering them.
+//! - [`ed25519_verify`] — RFC 8032 Ed25519 signature *verification*. There is
+//!   no signing or key generation here; verification operates only on public
+//!   data (public key, signature, message), so the field arithmetic is
+//!   variable-time by design and carries no side-channel obligation. Failure
+//!   is terminal: a single `Err` exit, no fallback, no warn-and-continue.
+//!
+//! SHA-512 is the only hash provided because Ed25519 mandates it internally
+//! (RFC 8032 §5.1); one core serves both the public hash and the signature's
+//! internal hashing.
+//!
+//! Non-goal: the kernel's `entropy` subsystem carries its own Keccak/SHAKE256
+//! sponge for the CSPRNG. That primitive is kernel-internal and is not shared
+//! with or consumed by this crate; consolidating hash primitives is out of
+//! scope here.
+
+#![no_std]
+
+pub mod sha512;
+
+mod ed25519;
+mod edwards;
+mod field;
+mod scalar;
+
+pub use ed25519::{VerifyError, ed25519_verify, run_ed25519_kats};
+pub use sha512::{Sha512, run_sha512_kats, sha512};

--- a/shared/crypto/src/scalar.rs
+++ b/shared/crypto/src/scalar.rs
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// shared/crypto/src/scalar.rs
+
+//! Arithmetic modulo the Ed25519 group order
+//! L = 2^252 + 27742317777372353535851937790883648493.
+//!
+//! Two operations suffice for verification: the canonical range check on the
+//! signature scalar S (RFC 8032 §5.1.7) and reduction of the 64-byte hash
+//! `SHA512(R‖A‖M)` to a scalar mod L. Both treat scalars as little-endian.
+
+// Reduction works in signed limbs and casts back to bytes after masking.
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_sign_loss)]
+
+/// L in little-endian bytes (32 bytes; the top limb is 0x10).
+pub(crate) const L: [u8; 32] = [
+    0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58, 0xd6, 0x9c, 0xf7, 0xa2, 0xde, 0xf9, 0xde, 0x14,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10,
+];
+
+/// True iff the little-endian scalar `s` is strictly less than L.
+///
+/// Mandatory before verification (RFC 8032 §5.1.7): S must lie in `{0, …,
+/// L-1}`. `s == L` and anything larger is rejected, blocking signature
+/// malleability.
+pub(crate) fn is_canonical(s: &[u8; 32]) -> bool
+{
+    let mut i = 31i32;
+    while i >= 0
+    {
+        let idx = i as usize;
+        if s[idx] < L[idx]
+        {
+            return true;
+        }
+        if s[idx] > L[idx]
+        {
+            return false;
+        }
+        i -= 1;
+    }
+    // s == L exactly: not canonical.
+    false
+}
+
+/// Reduce a 64-byte little-endian value mod L into a 32-byte scalar.
+pub(crate) fn reduce_512(h: &[u8; 64]) -> [u8; 32]
+{
+    let mut x = [0i64; 64];
+    let mut i = 0;
+    while i < 64
+    {
+        x[i] = i64::from(h[i]);
+        i += 1;
+    }
+    let mut r = [0u8; 32];
+    mod_l(&mut r, &mut x);
+    r
+}
+
+/// Barrett-style folding of the high half into the low half, then two
+/// conditional subtractions of L. Operates in signed radix-2^8 limbs.
+fn mod_l(r: &mut [u8; 32], x: &mut [i64; 64])
+{
+    let mut i = 63usize;
+    while i >= 32
+    {
+        let mut carry = 0i64;
+        let base = i - 32;
+        let mut j = base;
+        while j < i - 12
+        {
+            x[j] += carry - 16 * x[i] * i64::from(L[j - base]);
+            carry = (x[j] + 128) >> 8;
+            x[j] -= carry << 8;
+            j += 1;
+        }
+        // j == i - 12 here.
+        x[j] += carry;
+        x[i] = 0;
+        i -= 1;
+    }
+
+    let mut carry = 0i64;
+    let mut j = 0;
+    while j < 32
+    {
+        x[j] += carry - (x[31] >> 4) * i64::from(L[j]);
+        carry = x[j] >> 8;
+        x[j] &= 255;
+        j += 1;
+    }
+    let mut j = 0;
+    while j < 32
+    {
+        x[j] -= carry * i64::from(L[j]);
+        j += 1;
+    }
+    let mut i = 0;
+    while i < 32
+    {
+        x[i + 1] += x[i] >> 8;
+        r[i] = (x[i] & 255) as u8;
+        i += 1;
+    }
+}
+
+#[cfg(test)]
+mod tests
+{
+    use super::*;
+
+    #[test]
+    fn canonical_boundaries()
+    {
+        assert!(is_canonical(&[0u8; 32]));
+
+        let mut l_minus_1 = L;
+        l_minus_1[0] -= 1;
+        assert!(is_canonical(&l_minus_1));
+
+        // S == L must be rejected.
+        assert!(!is_canonical(&L));
+
+        // S > L must be rejected.
+        let mut too_big = L;
+        too_big[31] += 1;
+        assert!(!is_canonical(&too_big));
+    }
+
+    #[test]
+    fn reduce_passes_through_small_scalar()
+    {
+        // A value below L (top byte 0) reduces to itself.
+        let mut v = [0u8; 32];
+        let mut i = 0;
+        while i < 31
+        {
+            v[i] = (i as u8).wrapping_mul(7).wrapping_add(3);
+            i += 1;
+        }
+        v[31] = 0x00;
+        let mut h = [0u8; 64];
+        h[..32].copy_from_slice(&v);
+        assert_eq!(reduce_512(&h), v);
+    }
+
+    #[test]
+    fn reduce_of_l_is_zero()
+    {
+        let mut h = [0u8; 64];
+        h[..32].copy_from_slice(&L);
+        assert_eq!(reduce_512(&h), [0u8; 32]);
+    }
+}

--- a/shared/crypto/src/sha512.rs
+++ b/shared/crypto/src/sha512.rs
@@ -1,0 +1,450 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// shared/crypto/src/sha512.rs
+
+//! SHA-512 (FIPS 180-4).
+//!
+//! 1024-bit (128-byte) blocks, 64-bit words, 80 rounds, big-endian byte and
+//! word convention throughout. Provides a one-shot [`sha512`] and an
+//! incremental [`Sha512`] so large inputs hash without being buffered whole.
+//!
+//! Correctness is anchored by the known-answer tests in [`run_sha512_kats`]
+//! (FIPS 180-4 Appendix C vectors plus incremental/padding-boundary
+//! self-consistency checks).
+
+/// Output length in bytes.
+pub const DIGEST_LEN: usize = 64;
+
+/// Block length in bytes (1024-bit).
+const BLOCK_LEN: usize = 128;
+
+/// Initial hash value (FIPS 180-4 §5.3.5): first 64 bits of the fractional
+/// parts of the square roots of the first eight primes.
+const IV: [u64; 8] = [
+    0x6a09_e667_f3bc_c908,
+    0xbb67_ae85_84ca_a73b,
+    0x3c6e_f372_fe94_f82b,
+    0xa54f_f53a_5f1d_36f1,
+    0x510e_527f_ade6_82d1,
+    0x9b05_688c_2b3e_6c1f,
+    0x1f83_d9ab_fb41_bd6b,
+    0x5be0_cd19_137e_2179,
+];
+
+/// Round constants (FIPS 180-4 §4.2.3): first 64 bits of the fractional parts
+/// of the cube roots of the first eighty primes.
+const K: [u64; 80] = [
+    0x428a_2f98_d728_ae22,
+    0x7137_4491_23ef_65cd,
+    0xb5c0_fbcf_ec4d_3b2f,
+    0xe9b5_dba5_8189_dbbc,
+    0x3956_c25b_f348_b538,
+    0x59f1_11f1_b605_d019,
+    0x923f_82a4_af19_4f9b,
+    0xab1c_5ed5_da6d_8118,
+    0xd807_aa98_a303_0242,
+    0x1283_5b01_4570_6fbe,
+    0x2431_85be_4ee4_b28c,
+    0x550c_7dc3_d5ff_b4e2,
+    0x72be_5d74_f27b_896f,
+    0x80de_b1fe_3b16_96b1,
+    0x9bdc_06a7_25c7_1235,
+    0xc19b_f174_cf69_2694,
+    0xe49b_69c1_9ef1_4ad2,
+    0xefbe_4786_384f_25e3,
+    0x0fc1_9dc6_8b8c_d5b5,
+    0x240c_a1cc_77ac_9c65,
+    0x2de9_2c6f_592b_0275,
+    0x4a74_84aa_6ea6_e483,
+    0x5cb0_a9dc_bd41_fbd4,
+    0x76f9_88da_8311_53b5,
+    0x983e_5152_ee66_dfab,
+    0xa831_c66d_2db4_3210,
+    0xb003_27c8_98fb_213f,
+    0xbf59_7fc7_beef_0ee4,
+    0xc6e0_0bf3_3da8_8fc2,
+    0xd5a7_9147_930a_a725,
+    0x06ca_6351_e003_826f,
+    0x1429_2967_0a0e_6e70,
+    0x27b7_0a85_46d2_2ffc,
+    0x2e1b_2138_5c26_c926,
+    0x4d2c_6dfc_5ac4_2aed,
+    0x5338_0d13_9d95_b3df,
+    0x650a_7354_8baf_63de,
+    0x766a_0abb_3c77_b2a8,
+    0x81c2_c92e_47ed_aee6,
+    0x9272_2c85_1482_353b,
+    0xa2bf_e8a1_4cf1_0364,
+    0xa81a_664b_bc42_3001,
+    0xc24b_8b70_d0f8_9791,
+    0xc76c_51a3_0654_be30,
+    0xd192_e819_d6ef_5218,
+    0xd699_0624_5565_a910,
+    0xf40e_3585_5771_202a,
+    0x106a_a070_32bb_d1b8,
+    0x19a4_c116_b8d2_d0c8,
+    0x1e37_6c08_5141_ab53,
+    0x2748_774c_df8e_eb99,
+    0x34b0_bcb5_e19b_48a8,
+    0x391c_0cb3_c5c9_5a63,
+    0x4ed8_aa4a_e341_8acb,
+    0x5b9c_ca4f_7763_e373,
+    0x682e_6ff3_d6b2_b8a3,
+    0x748f_82ee_5def_b2fc,
+    0x78a5_636f_4317_2f60,
+    0x84c8_7814_a1f0_ab72,
+    0x8cc7_0208_1a64_39ec,
+    0x90be_fffa_2363_1e28,
+    0xa450_6ceb_de82_bde9,
+    0xbef9_a3f7_b2c6_7915,
+    0xc671_78f2_e372_532b,
+    0xca27_3ece_ea26_619c,
+    0xd186_b8c7_21c0_c207,
+    0xeada_7dd6_cde0_eb1e,
+    0xf57d_4f7f_ee6e_d178,
+    0x06f0_67aa_7217_6fba,
+    0x0a63_7dc5_a2c8_98a6,
+    0x113f_9804_bef9_0dae,
+    0x1b71_0b35_131c_471b,
+    0x28db_77f5_2304_7d84,
+    0x32ca_ab7b_40c7_2493,
+    0x3c9e_be0a_15c9_bebc,
+    0x431d_67c4_9c10_0d4c,
+    0x4cc5_d4be_cb3e_42b6,
+    0x597f_299c_fc65_7e2a,
+    0x5fcb_6fab_3ad6_faec,
+    0x6c44_198c_4a47_5817,
+];
+
+#[inline]
+fn ch(x: u64, y: u64, z: u64) -> u64
+{
+    (x & y) ^ (!x & z)
+}
+
+#[inline]
+fn maj(x: u64, y: u64, z: u64) -> u64
+{
+    (x & y) ^ (x & z) ^ (y & z)
+}
+
+#[inline]
+fn big_sigma0(x: u64) -> u64
+{
+    x.rotate_right(28) ^ x.rotate_right(34) ^ x.rotate_right(39)
+}
+
+#[inline]
+fn big_sigma1(x: u64) -> u64
+{
+    x.rotate_right(14) ^ x.rotate_right(18) ^ x.rotate_right(41)
+}
+
+#[inline]
+fn small_sigma0(x: u64) -> u64
+{
+    x.rotate_right(1) ^ x.rotate_right(8) ^ (x >> 7)
+}
+
+#[inline]
+fn small_sigma1(x: u64) -> u64
+{
+    x.rotate_right(19) ^ x.rotate_right(61) ^ (x >> 6)
+}
+
+/// Compress one 128-byte block into the chaining state `h` (FIPS 180-4 §6.4).
+// many_single_char_names: a..h are the FIPS 180-4 working-variable names;
+// renaming them would obscure the published algorithm.
+#[allow(clippy::many_single_char_names)]
+fn compress(h: &mut [u64; 8], block: &[u8; BLOCK_LEN])
+{
+    let mut w = [0u64; 80];
+    let mut t = 0;
+    while t < 16
+    {
+        let off = t * 8;
+        w[t] = u64::from_be_bytes([
+            block[off],
+            block[off + 1],
+            block[off + 2],
+            block[off + 3],
+            block[off + 4],
+            block[off + 5],
+            block[off + 6],
+            block[off + 7],
+        ]);
+        t += 1;
+    }
+    while t < 80
+    {
+        w[t] = small_sigma1(w[t - 2])
+            .wrapping_add(w[t - 7])
+            .wrapping_add(small_sigma0(w[t - 15]))
+            .wrapping_add(w[t - 16]);
+        t += 1;
+    }
+
+    let mut a = h[0];
+    let mut b = h[1];
+    let mut c = h[2];
+    let mut d = h[3];
+    let mut e = h[4];
+    let mut f = h[5];
+    let mut g = h[6];
+    let mut hh = h[7];
+
+    let mut i = 0;
+    while i < 80
+    {
+        let t1 = hh
+            .wrapping_add(big_sigma1(e))
+            .wrapping_add(ch(e, f, g))
+            .wrapping_add(K[i])
+            .wrapping_add(w[i]);
+        let t2 = big_sigma0(a).wrapping_add(maj(a, b, c));
+        hh = g;
+        g = f;
+        f = e;
+        e = d.wrapping_add(t1);
+        d = c;
+        c = b;
+        b = a;
+        a = t1.wrapping_add(t2);
+        i += 1;
+    }
+
+    h[0] = h[0].wrapping_add(a);
+    h[1] = h[1].wrapping_add(b);
+    h[2] = h[2].wrapping_add(c);
+    h[3] = h[3].wrapping_add(d);
+    h[4] = h[4].wrapping_add(e);
+    h[5] = h[5].wrapping_add(f);
+    h[6] = h[6].wrapping_add(g);
+    h[7] = h[7].wrapping_add(hh);
+}
+
+/// Incremental SHA-512 state.
+#[derive(Clone)]
+pub struct Sha512
+{
+    h: [u64; 8],
+    buf: [u8; BLOCK_LEN],
+    buf_len: usize,
+    total_len: u128,
+}
+
+impl Sha512
+{
+    /// Start a fresh hash.
+    #[must_use]
+    pub fn new() -> Self
+    {
+        Self {
+            h: IV,
+            buf: [0u8; BLOCK_LEN],
+            buf_len: 0,
+            total_len: 0,
+        }
+    }
+
+    /// Absorb `data`. May be called any number of times.
+    pub fn update(&mut self, data: &[u8])
+    {
+        self.total_len = self.total_len.wrapping_add(data.len() as u128);
+        let mut data = data;
+
+        // Top up a partial buffer first.
+        if self.buf_len > 0
+        {
+            let take = core::cmp::min(BLOCK_LEN - self.buf_len, data.len());
+            self.buf[self.buf_len..self.buf_len + take].copy_from_slice(&data[..take]);
+            self.buf_len += take;
+            data = &data[take..];
+            if self.buf_len == BLOCK_LEN
+            {
+                let block = self.buf;
+                compress(&mut self.h, &block);
+                self.buf_len = 0;
+            }
+        }
+
+        // Consume whole blocks straight from the input.
+        while data.len() >= BLOCK_LEN
+        {
+            let mut block = [0u8; BLOCK_LEN];
+            block.copy_from_slice(&data[..BLOCK_LEN]);
+            compress(&mut self.h, &block);
+            data = &data[BLOCK_LEN..];
+        }
+
+        // Stash the remainder.
+        if !data.is_empty()
+        {
+            self.buf[..data.len()].copy_from_slice(data);
+            self.buf_len = data.len();
+        }
+    }
+
+    /// Pad and emit the 64-byte digest, consuming the state.
+    #[must_use]
+    pub fn finalize(mut self) -> [u8; DIGEST_LEN]
+    {
+        // FIPS 180-4 §5.1.2: append 0x80, zero-pad so the length lands in the
+        // final 16 bytes of a block, then the 128-bit big-endian bit length.
+        let bit_len: u128 = self.total_len << 3;
+
+        let mut pad = self.buf_len;
+        self.buf[pad] = 0x80;
+        pad += 1;
+
+        if pad > BLOCK_LEN - 16
+        {
+            // Length field spills into a second block: flush this one first.
+            for byte in &mut self.buf[pad..BLOCK_LEN]
+            {
+                *byte = 0;
+            }
+            let block = self.buf;
+            compress(&mut self.h, &block);
+            pad = 0;
+        }
+
+        for byte in &mut self.buf[pad..BLOCK_LEN - 16]
+        {
+            *byte = 0;
+        }
+        self.buf[BLOCK_LEN - 16..].copy_from_slice(&bit_len.to_be_bytes());
+        let block = self.buf;
+        compress(&mut self.h, &block);
+
+        let mut out = [0u8; DIGEST_LEN];
+        for (i, word) in self.h.iter().enumerate()
+        {
+            out[i * 8..i * 8 + 8].copy_from_slice(&word.to_be_bytes());
+        }
+        out
+    }
+}
+
+impl Default for Sha512
+{
+    fn default() -> Self
+    {
+        Self::new()
+    }
+}
+
+/// One-shot SHA-512 of `data`.
+#[must_use]
+pub fn sha512(data: &[u8]) -> [u8; DIGEST_LEN]
+{
+    let mut s = Sha512::new();
+    s.update(data);
+    s.finalize()
+}
+
+// ── Known-answer tests ───────────────────────────────────────────────────────
+
+struct Sha512Kat
+{
+    msg: &'static [u8],
+    digest: [u8; DIGEST_LEN],
+}
+
+/// FIPS 180-4 Appendix C vectors plus the empty-string vector.
+const SHA512_KATS: &[Sha512Kat] = &[
+    // SHA-512("")
+    Sha512Kat {
+        msg: b"",
+        digest: [
+            0xcf, 0x83, 0xe1, 0x35, 0x7e, 0xef, 0xb8, 0xbd, 0xf1, 0x54, 0x28, 0x50, 0xd6, 0x6d,
+            0x80, 0x07, 0xd6, 0x20, 0xe4, 0x05, 0x0b, 0x57, 0x15, 0xdc, 0x83, 0xf4, 0xa9, 0x21,
+            0xd3, 0x6c, 0xe9, 0xce, 0x47, 0xd0, 0xd1, 0x3c, 0x5d, 0x85, 0xf2, 0xb0, 0xff, 0x83,
+            0x18, 0xd2, 0x87, 0x7e, 0xec, 0x2f, 0x63, 0xb9, 0x31, 0xbd, 0x47, 0x41, 0x7a, 0x81,
+            0xa5, 0x38, 0x32, 0x7a, 0xf9, 0x27, 0xda, 0x3e,
+        ],
+    },
+    // FIPS 180-4 C.1: SHA-512("abc")
+    Sha512Kat {
+        msg: b"abc",
+        digest: [
+            0xdd, 0xaf, 0x35, 0xa1, 0x93, 0x61, 0x7a, 0xba, 0xcc, 0x41, 0x73, 0x49, 0xae, 0x20,
+            0x41, 0x31, 0x12, 0xe6, 0xfa, 0x4e, 0x89, 0xa9, 0x7e, 0xa2, 0x0a, 0x9e, 0xee, 0xe6,
+            0x4b, 0x55, 0xd3, 0x9a, 0x21, 0x92, 0x99, 0x2a, 0x27, 0x4f, 0xc1, 0xa8, 0x36, 0xba,
+            0x3c, 0x23, 0xa3, 0xfe, 0xeb, 0xbd, 0x45, 0x4d, 0x44, 0x23, 0x64, 0x3c, 0xe8, 0x0e,
+            0x2a, 0x9a, 0xc9, 0x4f, 0xa5, 0x4c, 0xa4, 0x9f,
+        ],
+    },
+    // FIPS 180-4 C.2: the 112-byte two-block message.
+    Sha512Kat {
+        msg: b"abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu",
+        digest: [
+            0x8e, 0x95, 0x9b, 0x75, 0xda, 0xe3, 0x13, 0xda, 0x8c, 0xf4, 0xf7, 0x28, 0x14, 0xfc,
+            0x14, 0x3f, 0x8f, 0x77, 0x79, 0xc6, 0xeb, 0x9f, 0x7f, 0xa1, 0x72, 0x99, 0xae, 0xad,
+            0xb6, 0x88, 0x90, 0x18, 0x50, 0x1d, 0x28, 0x9e, 0x49, 0x00, 0xf7, 0xe4, 0x33, 0x1b,
+            0x99, 0xde, 0xc4, 0xb5, 0x43, 0x3a, 0xc7, 0xd3, 0x29, 0xee, 0xb6, 0xdd, 0x26, 0x54,
+            0x5e, 0x96, 0xe5, 0x5b, 0x87, 0x4b, 0xe9, 0x09,
+        ],
+    },
+];
+
+/// Run the SHA-512 known-answer tests. Returns the first failing case as an
+/// error string, or `Ok(())` if all pass. Compiled in all builds so host and
+/// on-target (ktest) runs share identical logic.
+///
+/// # Errors
+///
+/// Returns a descriptive `&'static str` on the first mismatch.
+pub fn run_sha512_kats() -> Result<(), &'static str>
+{
+    for kat in SHA512_KATS
+    {
+        if sha512(kat.msg) != kat.digest
+        {
+            return Err("sha512: KAT digest mismatch");
+        }
+    }
+
+    // Incremental must equal one-shot regardless of chunk boundaries.
+    let mut s = Sha512::new();
+    s.update(b"a");
+    s.update(b"bc");
+    if s.finalize() != sha512(b"abc")
+    {
+        return Err("sha512: incremental != one-shot");
+    }
+
+    // Padding-boundary self-consistency: one-shot must equal byte-at-a-time for
+    // lengths around the 112/128 padding edges and across multiple blocks.
+    let scratch = [0x61u8; 300];
+    for &len in &[
+        0usize, 1, 55, 56, 63, 64, 111, 112, 127, 128, 129, 200, 256, 300,
+    ]
+    {
+        let msg = &scratch[..len];
+        let mut inc = Sha512::new();
+        for b in msg
+        {
+            inc.update(core::slice::from_ref(b));
+        }
+        if inc.finalize() != sha512(msg)
+        {
+            return Err("sha512: padding-boundary inconsistency");
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests
+{
+    use super::*;
+
+    #[test]
+    fn kats_pass()
+    {
+        assert_eq!(run_sha512_kats(), Ok(()));
+    }
+}


### PR DESCRIPTION
## Summary

Adds `shared/crypto`, a `no_std`, zero-external-dependency crate providing the reusable cryptographic primitive that #124 (per-binary signing chain of trust) stands on. Closes the primitive half of #247.

- **SHA-512** (FIPS 180-4): one-shot `sha512(&[u8]) -> [u8;64]` and incremental `Sha512` (`new`/`update`/`finalize`), so large inputs (e.g. module bodies) hash without being buffered whole.
- **Ed25519 verification** (RFC 8032): `ed25519_verify(&[u8;32], &[u8], &[u8;64]) -> Result<(), VerifyError>`. Verify-only (no signing/keygen), variable-time by design (operates only on public data — no side-channel obligation), mandatory `S < L` canonical check (§5.1.7) first, single-exit-on-failure.

Internals are layered: field `GF(2^255-19)` → edwards25519 group → scalar mod L → protocol. SHA-512 is the only hash because Ed25519 mandates it internally, so one core serves both. Independent of the kernel's `entropy` Keccak/SHAKE sponge (kernel-internal; consolidation is a documented non-goal).

## Design decisions

- **SHA-512 only** — Ed25519 needs it internally; a second hash would have no consumer (KISS/YAGNI).
- **Field representation: 16-limb radix-2^16** (the TweetNaCl `gf` model). This differs from the tentative 5×51 in the plan; chosen for from-scratch correctness (every intermediate product stays inside `i64`), strictly within the plan's "easiest to get correct" principle. Public API, properties, and tests are unchanged.
- **Consumption handed to #124** (per the issue's acceptance OR-clause). #124 owns key management, the `.seraph.sig` ELF section, and xtask signing, and is the real consumer of `ed25519_verify`. No boot-format change here.

## Validation

Known-answer tests run identically on host and on-target (the bodies are always-compiled `no_std` functions; ktest calls the same `run_*_kats`):

- **Vectors**: FIPS 180-4 SHA-512 (empty/`abc`/two-block) + incremental and padding-boundary self-consistency; RFC 8032 §7.1 Ed25519 (TEST 1/2/3, 1024-byte, SHA(abc)).
- **Negatives**: flipped signature byte, flipped message byte, wrong public key (→ `Mismatch`); `S = L` (→ `NonCanonicalS`); non-curve public key (→ `BadPublicKey`).

Results:

- `cargo xtask test` (host): 12 crypto tests pass.
- `cargo xtask build` + `compose-bundle --harness ktest` + `run`, **x86_64**: `crypto::sha512_kats` PASS, `crypto::ed25519_kats` PASS, `[ktest] ALL TESTS PASSED` (196/0).
- Same on **riscv64**: both PASS, `[ktest] ALL TESTS PASSED` (196/0).
- Both target builds are clean under the xtask lint pass (`cargo fmt --all` + `cargo clippy -- -D warnings`).

## Acceptance (#247)

- [x] `shared/crypto`: hash + Ed25519 verify, `no_std`, usable by boot/loader and services.
- [x] Known-answer test vectors; both arches (host + ktest on x86_64 and riscv64).
- [x] Consumed by a real path **or explicitly handed to #124** — handed to #124, documented in this PR description. (A hand-off comment on #124 listing the consumption points is drafted but not yet posted, pending authorization to comment on that issue.)

https://claude.ai/code/session_014QWGHC3dX2149UxF52vADb