### PR TITLE
boot: fix riscv64 UEFI load-fault via static-PIE self-relocation

### DIFF
--- a/core/boot/docs/riscv-uefi-boot.md
+++ b/core/boot/docs/riscv-uefi-boot.md
@@ -36,7 +36,7 @@ Offset   Size   Content
 0x040     4     PE signature = "PE\0\0"
 0x044    20     COFF file header
                   Machine          = 0x5064 (IMAGE_FILE_MACHINE_RISCV64)
-                  NumberOfSections = 2 (.text, .reloc)
+                  NumberOfSections = 3 (.text, .data, .reloc)
                   TimeDateStamp    = 0 (reproducible builds)
                   SizeOfOptionalHeader = sizeof(optional header)
                   Characteristics  = 0x020E
@@ -56,14 +56,23 @@ Offset   Size   Content
                   SizeOfRawData    = _etext - _start
                   PointerToRawData = offset of _start in flat binary
                   Characteristics  = 0x60000020 (code, executable, readable)
-0x170    40     .reloc section header
+0x170    40     .data section header
+                  Name             = ".data\0\0\0"
+                  VirtualAddress   = RVA of _etext
+                  SizeOfRawData    = _ebss - _etext
+                  Characteristics  = 0xC0000040 (initialised data, readable, writable)
+0x198    40     .reloc section header
                   Name             = ".reloc\0\0"
                   VirtualAddress   = RVA of _reloc_start
                   SizeOfRawData    = 8 (one empty block, header only)
                   Characteristics  = 0x42000040 (initialised data, discardable, readable)
-0x198   ~1640   Padding to 0x1000 (page boundary)
-0x1000   —      .text section: entry trampoline (_start) followed by compiled Rust code
-  ...    —      .reloc section: minimal base-relocation block (8 bytes)
+0x1C0   ~1600   Padding to 0x1000 (page boundary)
+0x1000   —      .text section: entry trampoline (_start) + compiled Rust code
+                  only (RX); ends at the _etext page boundary
+  ...    —      .data section: .rodata / .data.rel.ro, the .dynamic / .rela.dyn
+                  relocation metadata, .got, initialised data, .bss zero-fill
+                  (RW — the self-relocation loop writes the reloc targets here)
+  ...    —      .reloc section: empty PE base-relocation block (8 bytes)
 ```
 
 The `Characteristics` field in the COFF file header is `0x020E`:
@@ -90,18 +99,39 @@ asm.
 
 ---
 
-## Minimal Base-Relocation Block
+## Relocation: static-PIE self-relocation
 
-UEFI checks that the loaded image has a `.reloc` section before loading
-it. The section must contain at least one base-relocation block. The
-bootloader is compiled as a PIC ELF (no absolute addresses), so there
-are no actual relocations to apply — the `.reloc` section holds a single
-empty block (8 bytes: `VirtualAddress = 0`, `SizeOfBlock = 8`, zero
-relocation entries). An empty block is valid per the PE/COFF
-specification; its presence satisfies the UEFI loader's requirement for
-a `.reloc` section without altering the image's runtime behaviour. See
-[`boot/src/arch/riscv64/header.S`](../src/arch/riscv64/header.S) for the
-asm.
+The bootloader is linked as a position-independent executable (`-pie`).
+Position-independence makes *code* references PC-relative, but absolute
+*data* pointers — slice data pointers, `&str`, fn-pointer / vtable tables,
+`core::fmt` infrastructure, and any GOT slots — are recorded as
+`R_RISCV_RELATIVE` dynamic relocations in `.rela.dyn`, each with an addend
+relative to image base 0. They must be fixed up by adding the runtime load
+bias, or dereferencing them faults at a low link-time address (the failure
+mode that motivated this design; see issue #399).
+
+UEFI firmware does not understand RISC-V `R_RISCV_RELATIVE` entries, so the
+bootloader applies them itself. The entry trampoline at `_start` runs a
+PC-relative-only assembly loop *before any Rust code executes*: it computes
+the load bias from `lla pecoff_header_start` (linked at 0, so its runtime
+address is the bias), walks the `Elf64_Rela` array between
+`__rela_dyn_start` and `__rela_dyn_end`, and for each `R_RISCV_RELATIVE`
+entry writes `*(bias + r_offset) = bias + r_addend`. The loop touches only
+data (`.rodata`/`.data.rel.ro`/`.got`), never instructions, so no `fence.i`
+is needed. The relocation *targets* live in `.rodata` / `.data.rel.ro` /
+`.got`, which the linker script places in the **writable** PE `.data`
+section range (`[_etext, _ebss)`); EDK2 maps the RX `.text` section
+read-only, so the loop could not store fixups if those targets stayed
+there. `.rela.dyn` and `.dynamic` share that `.data` range, so UEFI maps
+them without a dedicated PE section header.
+
+The PE `.reloc` section is retained but left as a single empty block
+(8 bytes: `VirtualAddress = 0`, `SizeOfBlock = 8`, zero entries). UEFI
+checks for a `.reloc` section before loading an image at a non-preferred
+base; an empty block satisfies that check (valid per the PE/COFF
+specification) while the real fixups are applied by the self-relocation
+loop. See [`boot/src/arch/riscv64/header.S`](../src/arch/riscv64/header.S)
+for the asm.
 
 ---
 
@@ -110,11 +140,17 @@ asm.
 [`boot/linker/riscv64-uefi.ld`](../linker/riscv64-uefi.ld) controls the
 layout of the flat binary. It places `.pecoff_header` at output offset
 `0x0`, pins `.text` at `0x1000` (aligned to the PE32+ section
-granularity) with `_start` as the first symbol, follows with the
-standard `.rodata` / `.data` / `.bss` tails, emits a `.reloc` section
-for UEFI to find, and discards `.eh_frame`, `.note.*`, `.comment`, and
-`.gnu.*` sections that would otherwise inflate the flat binary.
-`ENTRY(_start)` selects the entry symbol. The script is the
+granularity) with `_start` as the first symbol and **code only**, then
+sets `_etext` at the next page boundary (end of the RX `.text` PE
+section). Everything after `_etext` is in the **writable** `.data` PE
+section: `.rodata` / `.data.rel.ro` (relocation targets), the `.dynamic`
+/ `.rela.dyn` metadata, `.got`, then the `.data` / `.bss` tails. They are
+placed after `_etext` precisely so EDK2 maps them RW and the
+self-relocation loop can write the fixups. The script emits the empty
+`.reloc` section for UEFI to find, and discards `.eh_frame`, `.note.*`,
+`.comment`, and the dynamic-linking metadata (`.interp` / `.dynsym` /
+`.dynstr` / hash tables) that a self-relocating static-PIE never consults
+at runtime. `ENTRY(_start)` selects the entry symbol. The script is the
 authoritative layout description — do not duplicate it here.
 
 The key symbols exported by the linker script for use in `header.S`:
@@ -123,10 +159,11 @@ The key symbols exported by the linker script for use in `header.S`:
 |---|---|
 | `_start` | First byte of the entry trampoline; also `AddressOfEntryPoint` RVA |
 | `_etext` | End of the `.text` section; used to compute `SizeOfCode` |
+| `__rela_dyn_start` / `__rela_dyn_end` | Bound the `.rela.dyn` array walked by the self-relocation loop |
 | `_reloc_start` | Start of the `.reloc` section; base-relocation VirtualAddress |
 | `_reloc_end` | End of the `.reloc` section |
 | `_image_end` | End of the entire image; used for `SizeOfImage` |
-| `pecoff_header_start` | Byte 0 of the image; all RVAs are relative to this symbol |
+| `pecoff_header_start` | Byte 0 of the image; runtime address equals the load bias |
 
 ---
 
@@ -148,10 +185,15 @@ The RISC-V bootloader uses a custom Cargo target specification,
 | `linker-flavor` | `"ld.lld"` | `"ld.lld"` |
 | `pre-link-args` | custom linker script | custom linker script |
 
-The `relocation-model: "pic"` setting is critical — it instructs LLVM to emit PIC
-code (PC-relative addressing, no absolute symbols). This is required because UEFI
-loads the image at an arbitrary address chosen at runtime; the assembled flat binary
-must be position-independent.
+The `relocation-model: "pic"` setting (with `-pie`,
+`position-independent-executables`, and `static-position-independent-executables`)
+is critical. It makes code PC-relative and, crucially, causes absolute *data*
+pointers to be emitted as `R_RISCV_RELATIVE` entries in `.rela.dyn` rather than
+baked-in link-time constants. This is required because UEFI loads the image at an
+arbitrary address chosen at runtime; the self-relocation loop in `header.S` then
+applies those relocations at entry (see "Relocation: static-PIE self-relocation").
+`-Bsymbolic` and `--no-dynamic-linker` keep `.rela.dyn` free of symbolic entries
+so every relocation is a base-relative `R_RISCV_RELATIVE`.
 
 ---
 

--- a/core/boot/linker/riscv64-uefi.ld
+++ b/core/boot/linker/riscv64-uefi.ld
@@ -39,25 +39,60 @@ SECTIONS
         KEEP(*(.text.trampoline))
         KEEP(*(.text.trampoline.*))
         *(.text .text.*)
-    }
-
-    .rodata : ALIGN(8) {
-        *(.rodata .rodata.*)
+        /* PLT/iplt stubs: expected empty under plt-by-default:no + -Bsymbolic;
+         * captured here (RX) so they never land as an orphan section. */
+        *(.plt)
+        *(.plt.*)
+        *(.iplt)
     }
 
     /* Advance the location counter to a page boundary and record it as
-     * _etext. This is where the PE .text section (RX) ends and the PE
-     * .data section (RW) begins. Using ". = ALIGN" (not "symbol = ALIGN")
+     * _etext. This is where the PE .text section (RX, code only) ends and the
+     * PE .data section (RW) begins. Using ". = ALIGN" (not "symbol = ALIGN")
      * is required to actually advance the LMA/VMA before the next section. */
     . = ALIGN(0x1000);
     _etext = .;
 
+    /* Everything from here lives in the RW PE .data section. The static-PIE
+     * R_RISCV_RELATIVE relocations target absolute data pointers held in
+     * .rodata / .data.rel.ro / .got; the self-relocation loop in header.S
+     * WRITES those targets at entry, so they must be in a writable region.
+     * EDK2 maps the RX .text PE section read-only, so .rodata cannot stay
+     * there. W^X is preserved: code is RX (above), this data region is RW+NX. */
+    .rodata : ALIGN(8) {
+        *(.rodata .rodata.*)
+        *(.srodata .srodata.*)
+        *(.data.rel.ro .data.rel.ro.*)
+    }
+
+    /* Relocation metadata. The self-relocation loop only reads these, but they
+     * share this RW .data PE region with the targets below (no separate RO
+     * mapping). Bounded by __rela_dyn_start/__rela_dyn_end. */
+    .dynamic : ALIGN(8) {
+        __dynamic_start = .;
+        *(.dynamic)
+        __dynamic_end = .;
+    }
+
+    .rela.dyn : ALIGN(8) {
+        __rela_dyn_start = .;
+        *(.rela .rela.*)
+        __rela_dyn_end = .;
+    }
+
     .data : ALIGN(8) {
+        /* GOT entries are written by the self-relocation loop (each holds an
+         * R_RISCV_RELATIVE address). Under -z notext + plt-by-default:no it is
+         * usually empty; placed here defensively. */
+        *(.got)
+        *(.got.plt)
         *(.data .data.*)
+        *(.sdata .sdata.*)
     }
 
     .bss : ALIGN(8) {
         *(.bss .bss.*)
+        *(.sbss .sbss.*)
         *(COMMON)
     }
 
@@ -77,10 +112,21 @@ SECTIONS
     /* _image_end: total image size in memory, aligned to SectionAlignment. */
     _image_end = ALIGN(0x1000);
 
+    /* Dynamic-linking metadata that a static-PIE never consults at runtime.
+     * Discarding these keeps them from becoming ALLOC sections placed outside
+     * [_start, _ebss) (which UEFI would not map). Safe only while .rela.dyn is
+     * RELATIVE-only (no symbolic entries reference .dynsym/.dynstr); verified
+     * post-build via `llvm-readobj --dyn-relocations`. */
     /DISCARD/ : {
         *(.eh_frame)
         *(.note.*)
         *(.comment)
         *(.riscv.attributes)
+        *(.interp)
+        *(.hash)
+        *(.gnu.hash)
+        *(.dynsym)
+        *(.dynstr)
+        *(.gnu.version*)
     }
 }

--- a/core/boot/src/arch/riscv64/header.S
+++ b/core/boot/src/arch/riscv64/header.S
@@ -19,12 +19,13 @@
 //   0x040: PE signature (4 bytes)
 //   0x044: COFF file header (20 bytes)
 //   0x058: PE32+ optional header (240 bytes)
-//   0x148: .text  section header (40 bytes) — code + rodata, RX
-//   0x170: .data  section header (40 bytes) — data + bss,   RW
+//   0x148: .text  section header (40 bytes) — code only, RX
+//   0x170: .data  section header (40 bytes) — rodata + relocs + data + bss, RW
 //   0x198: .reloc section header (40 bytes) — base relocs,  discardable
 //   0x1C0: padding to 0x1000 (page boundary)
-//   0x1000: .text section — entry trampoline, then Rust code, then .rodata
-//   _etext: .data section — initialised data (_edata), then BSS (virtual only)
+//   0x1000: .text section — entry trampoline, then Rust code (RX, code only)
+//   _etext: .data section — .rodata/.data.rel.ro, .dynamic/.rela.dyn, .got,
+//           initialised data, then BSS (RW; reloc targets, written at entry)
 //   _ebss:  .reloc section — minimal base-relocation block
 //
 // References:
@@ -70,8 +71,8 @@ opt_hdr:
     .short  0x020B                                  // Magic: PE32+
     .byte   0                                       // MajorLinkerVersion
     .byte   0                                       // MinorLinkerVersion
-    .long   _etext - _start                         // SizeOfCode (code + rodata only)
-    .long   _ebss  - _etext                         // SizeOfInitializedData (data + bss, in file)
+    .long   _etext - _start                         // SizeOfCode (code only)
+    .long   _ebss  - _etext                         // SizeOfInitializedData (rodata + relocs + data + bss, in file)
     .long   0                                       // SizeOfUninitializedData (bss zero-fill included above)
     .long   _start - pecoff_header_start            // AddressOfEntryPoint (RVA)
     .long   _start - pecoff_header_start            // BaseOfCode (RVA)
@@ -124,9 +125,9 @@ opt_hdr_end:
 
 // ── Section headers (3 × 40 bytes) ────────────────────────────────────────────
 
-    // .text section header — code + .rodata, read+execute only.
+    // .text section header — code only, read+execute only.
     .ascii  ".text\0\0\0"                           // Name (8 bytes, zero-padded)
-    .long   _etext - _start                         // VirtualSize (code + rodata)
+    .long   _etext - _start                         // VirtualSize (code only)
     .long   _start - pecoff_header_start            // VirtualAddress (RVA)
     .long   _etext - _start                         // SizeOfRawData (all present in file)
     .long   _start - pecoff_header_start            // PointerToRawData (file offset)
@@ -140,7 +141,8 @@ opt_hdr_end:
     //   IMAGE_SCN_MEM_READ                0x40000000
     .long   0x60000020
 
-    // .data section header — .data + .bss, read+write.
+    // .data section header — .rodata/.data.rel.ro, reloc metadata, .got, .data,
+    // .bss; read+write so the entry self-relocation loop can write reloc targets.
     // llvm-objcopy -O binary zero-fills ALLOC/NOBITS regions (.bss), so the
     // flat binary contains bytes for the entire [_etext, _ebss) range.
     // Using SizeOfRawData = _ebss - _etext (page-aligned, always non-zero) avoids
@@ -196,6 +198,46 @@ opt_hdr_end:
     .section ".text.entry", "ax"
     .global _start
 _start:
+    // ── Static-PIE self-relocation ────────────────────────────────────────────
+    //
+    // UEFI loads this flat image at an arbitrary base. The bootloader is linked
+    // as a position-independent executable, so absolute data pointers (slice
+    // data pointers, &str, fn-ptr/vtable tables, GOT slots) are recorded as
+    // R_RISCV_RELATIVE entries in .rela.dyn with addends relative to image base
+    // 0. Apply them here, before any Rust code runs, using only PC-relative
+    // addressing so this loop itself needs no relocation.
+    //
+    // a0 = image_handle, a1 = system_table — preserved for efi_main (only the
+    // t0..t5 temporaries are used).
+    //
+    // Elf64_Rela is 24 bytes: r_offset (+0), r_info (+8), r_addend (+16).
+    // R_RISCV_RELATIVE == 3 (low 32 bits of r_info; symbol index 0). Fixup:
+    //   *(u64 *)(bias + r_offset) = bias + r_addend
+    //
+    // pecoff_header_start is linked at 0, so its runtime address == the load
+    // bias.
+    lla     t0, pecoff_header_start     // t0 = load bias
+    lla     t1, __rela_dyn_start        // t1 = cursor
+    lla     t2, __rela_dyn_end          // t2 = end
+1:
+    bgeu    t1, t2, 2f                  // while (cursor < end)
+    ld      t3, 8(t1)                   // t3 = r_info
+    slli    t4, t3, 32
+    srli    t4, t4, 32                  // t4 = r_info & 0xffffffff = r_type
+    li      t5, 3                       // R_RISCV_RELATIVE
+    bne     t4, t5, 3f                  // skip non-RELATIVE entries defensively
+    ld      t3, 0(t1)                   // t3 = r_offset
+    ld      t4, 16(t1)                  // t4 = r_addend
+    add     t3, t3, t0                  // t3 = bias + r_offset (target address)
+    add     t4, t4, t0                  // t4 = bias + r_addend (relocated value)
+    sd      t4, 0(t3)                   // store fixup
+3:
+    addi    t1, t1, 24                  // cursor += sizeof(Elf64_Rela)
+    j       1b
+2:
+    // Only .rodata/.data/.got were patched (data, never instruction-fetched),
+    // so no fence.i is required before transferring control.
+    //
     // Tail-call into the Rust UEFI entry point.
     // `tail` is a PC-relative far jump using t1; does not save ra.
     tail    efi_main
@@ -203,9 +245,10 @@ _start:
 // ── Minimal base-relocation block ─────────────────────────────────────────────
 //
 // The EFI loader checks for a .reloc section to confirm the image is
-// relocatable. Since the bootloader uses static relocation-model with PC-relative
-// addressing (medany/medium code model, no GOT, no absolute addresses), the
-// block is empty (SizeOfBlock = 8 = header only, zero relocation entries).
+// relocatable and to permit loading at a non-preferred base. Firmware does not
+// understand RISC-V R_RISCV_RELATIVE entries, so this PE base-relocation table
+// is left empty (SizeOfBlock = 8 = header only, zero entries); the actual
+// fixups are applied by the self-relocation loop in _start from .rela.dyn.
 //
 // BaseRelocationBlock layout:
 //   uint32_t VirtualAddress   -- page RVA covered by this block

--- a/core/boot/src/console.rs
+++ b/core/boot/src/console.rs
@@ -5,10 +5,10 @@
 
 //! Boot console: dual serial + framebuffer output.
 //!
-//! Provides `init_serial()`, `init_framebuffer()`, and `console_write_str()`
-//! used by the `bprint!`/`bprintln!` macros. Output goes to both the serial
-//! port and the framebuffer (when available). All state is static; the
-//! bootloader is single-threaded and never runs concurrent code.
+//! Provides `init_serial()`, `init_framebuffer()`, and `console_write_fmt()` /
+//! `console_write_str()` used by the `bprint!`/`bprintln!` macros. Output goes
+//! to both the serial port and the framebuffer (when available). All state is
+//! static; the bootloader is single-threaded and never runs concurrent code.
 
 use crate::arch::current::serial::{serial_init, serial_write_byte};
 use crate::framebuffer::FramebufferWriter;
@@ -105,98 +105,63 @@ pub unsafe fn console_write_str(s: &str)
     }
 }
 
-/// Write a u64 as a 0x-prefixed 16-digit lowercase hex string.
+/// `core::fmt::Write` sink over the dual serial + framebuffer console.
 ///
-/// All 16 hex digits are always emitted (zero-padded). No vtable dispatch;
-/// bytes are written directly through `console_write_str`.
-///
-/// # Safety
-/// Serial backend must be initialized before calling.
-pub unsafe fn console_write_hex64(n: u64)
-{
-    const HEX: &[u8; 16] = b"0123456789abcdef";
-    let mut buf = [0u8; 18]; // "0x" + 16 hex digits
-    buf[0] = b'0';
-    buf[1] = b'x';
-    for i in 0..16usize
-    {
-        buf[2 + i] = HEX[((n >> (60 - i * 4)) & 0xF) as usize];
-    }
-    // SAFETY: buf contains only ASCII hex characters; valid UTF-8.
-    let s = unsafe { core::str::from_utf8_unchecked(&buf) };
-    // SAFETY: caller ensures serial initialized.
-    unsafe {
-        console_write_str(s);
-    }
-}
+/// Zero-sized; each write forwards to `console_write_str`, which performs the
+/// `\n` → `\r\n` serial translation. Backs the `bprint!` / `bprintln!` macros.
+struct ConsoleWriter;
 
-/// Write a u32 as a decimal string with no padding or prefix.
-///
-/// Writes "0" for zero. No vtable dispatch.
-///
-/// # Safety
-/// Serial backend must be initialized before calling.
-pub unsafe fn console_write_dec32(n: u32)
+impl core::fmt::Write for ConsoleWriter
 {
-    if n == 0
+    fn write_str(&mut self, s: &str) -> core::fmt::Result
     {
-        // SAFETY: caller ensures serial initialized.
+        // SAFETY: single-threaded bootloader; output before init is dropped.
         unsafe {
-            console_write_str("0");
+            console_write_str(s);
         }
-        return;
-    }
-    let mut buf = [0u8; 10]; // max 10 decimal digits for u32
-    let mut pos = 10usize;
-    let mut v = n;
-    while v > 0
-    {
-        pos -= 1;
-        buf[pos] = b'0' + (v % 10) as u8;
-        v /= 10;
-    }
-    // SAFETY: buf[pos..] contains only ASCII digit characters; valid UTF-8.
-    let s = unsafe { core::str::from_utf8_unchecked(&buf[pos..]) };
-    // SAFETY: caller ensures serial initialized.
-    unsafe {
-        console_write_str(s);
+        Ok(())
     }
 }
 
-/// Print a literal string to the boot console.
+/// Render `core::fmt` arguments to both console backends.
 ///
-/// Accepts a single `&str` expression (including `concat!(...)` for compile-time
-/// string concatenation). Never uses `core::fmt::Write` or creates trait objects,
-/// so no vtable entries are emitted — required for RISC-V UEFI where the PE
-/// `.reloc` section is empty and absolute addresses are never patched.
+/// Backs the `bprint!`/`bprintln!` macros. The bootloader is a static-PIE whose
+/// absolute pointers are fixed up at entry, so `core::fmt` formatting (which
+/// dispatches through vtables and fn-pointer tables) is safe here. Output before
+/// `init_serial`/`init_framebuffer` is silently dropped, so this function is
+/// safe to call at any point.
+pub fn console_write_fmt(args: core::fmt::Arguments)
+{
+    use core::fmt::Write;
+    // ConsoleWriter::write_str is infallible, so the Result is always Ok.
+    let _ = ConsoleWriter.write_fmt(args);
+}
+
+/// Print formatted output to the boot console.
 ///
-/// To add: extend with another `bprint!("...")` call immediately after.
+/// Accepts `core::fmt` formatting syntax (`bprint!("base={:#x}", addr)`), a
+/// bare string literal, or `concat!(...)`. Output is rendered through
+/// `core::fmt` into the dual serial + framebuffer sink.
 #[macro_export]
 macro_rules! bprint {
-    ($s:expr) => {{
-        let s: &str = $s;
-        // SAFETY: console is initialized before any macro usage.
-        unsafe {
-            $crate::console::console_write_str(s);
-        }
-    }};
+    ($($arg:tt)*) => {
+        $crate::console::console_write_fmt(::core::format_args!($($arg)*))
+    };
 }
 
-/// Print a literal string followed by `\r\n` to the boot console.
+/// Print formatted output followed by `\r\n` to the boot console.
 ///
-/// Accepts a single `&str` expression or no argument (bare newline). Never
-/// uses `core::fmt::Write`; see `bprint!` for the rationale.
+/// Accepts `core::fmt` formatting syntax or no argument (bare newline).
 #[macro_export]
 macro_rules! bprintln {
-    ($s:expr) => {{
-        let s: &str = $s;
+    () => {{
         // SAFETY: console is initialized before any macro usage.
         unsafe {
-            $crate::console::console_write_str(s);
             $crate::console::console_write_str("\r\n");
         }
     }};
-    () => {{
+    ($($arg:tt)*) => {{
+        $crate::console::console_write_fmt(::core::format_args!($($arg)*));
         // SAFETY: console is initialized before any macro usage.
         unsafe {
             $crate::console::console_write_str("\r\n");

--- a/core/boot/src/error.rs
+++ b/core/boot/src/error.rs
@@ -9,10 +9,11 @@
 //! Every error is fatal; the top-level handler in `main.rs` prints the message
 //! and halts. There is no recovery path.
 
+use crate::bprintln;
+
 /// All error conditions that can occur during the boot sequence.
 ///
 /// String payloads are `&'static str` because the bootloader has no allocator.
-/// The console printing path accepts only `&'static str` and ASCII literals.
 #[derive(Debug)]
 pub enum BootError
 {
@@ -107,6 +108,23 @@ impl BootError
     }
 }
 
+impl core::fmt::Display for BootError
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+    {
+        f.write_str(self.message())?;
+        if let Some(detail) = self.detail()
+        {
+            write!(f, ": {detail}")?;
+        }
+        if let BootError::UefiError(code) = self
+        {
+            write!(f, ": status={code:#018x}")?;
+        }
+        Ok(())
+    }
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -191,30 +209,10 @@ mod tests
 
 /// Print a fatal boot error message via the console and halt.
 ///
-/// Uses `console_write_str` / `console_write_hex64` directly to avoid
-/// vtable dispatch. On RISC-V the PE `.reloc` section is currently empty,
-/// so vtable-based formatting (`bprintln!("{}", err)`) would fault;
-/// direct writes are safe on both architectures.
-///
 /// Never returns.
 pub fn fatal_error(err: &BootError) -> !
 {
-    // SAFETY: console is initialized by init_serial() at bootloader entry.
-    unsafe {
-        crate::console::console_write_str("SERAPH BOOT FATAL: ");
-        crate::console::console_write_str(err.message());
-        if let Some(detail) = err.detail()
-        {
-            crate::console::console_write_str(": ");
-            crate::console::console_write_str(detail);
-        }
-        if let BootError::UefiError(code) = err
-        {
-            crate::console::console_write_str(": status=");
-            crate::console::console_write_hex64(*code as u64);
-        }
-        crate::console::console_write_str("\r\n");
-    }
+    bprintln!("SERAPH BOOT FATAL: {err}");
     loop
     {
         core::hint::spin_loop(); // halt; no recovery from fatal boot error
@@ -228,22 +226,11 @@ use core::panic::PanicInfo;
 #[panic_handler]
 fn panic(info: &PanicInfo) -> !
 {
-    // Print location if available. The panic message is a core::fmt::Arguments
-    // value, which requires vtable dispatch to print — omit it to avoid faulting
-    // on RISC-V where PE relocations are not yet generated. The file:line is
-    // sufficient to locate the panic in source.
-    // SAFETY: console is initialized by init_serial() at bootloader entry.
-    unsafe {
-        crate::console::console_write_str("SERAPH BOOT PANIC");
-        if let Some(loc) = info.location()
-        {
-            crate::console::console_write_str(": ");
-            crate::console::console_write_str(loc.file());
-            crate::console::console_write_str(":");
-            crate::console::console_write_dec32(loc.line());
-        }
-        crate::console::console_write_str("\r\n");
-    }
+    // The bootloader is a static-PIE with relocations applied at entry, so
+    // core::fmt now works; print the full PanicInfo (location + message). The
+    // message was previously omitted because the unrelocated fmt pointer tables
+    // would fault.
+    bprintln!("SERAPH BOOT PANIC: {info}");
     loop
     {
         core::hint::spin_loop(); // halt; panics are unrecoverable in the bootloader

--- a/core/boot/src/main.rs
+++ b/core/boot/src/main.rs
@@ -343,15 +343,11 @@ unsafe fn step1_locate_uefi_protocols(
     }
     if framebuffer.physical_base != 0
     {
-        // SAFETY: the serial console backend is initialized before this step,
-        // so direct console writes are valid here.
-        unsafe {
-            crate::console::console_write_str("[--------] boot: GOP: present ");
-            crate::console::console_write_dec32(framebuffer.width);
-            crate::console::console_write_str("x");
-            crate::console::console_write_dec32(framebuffer.height);
-            crate::console::console_write_str("\r\n");
-        }
+        bprintln!(
+            "[--------] boot: GOP: present {}x{}",
+            framebuffer.width,
+            framebuffer.height
+        );
     }
     else
     {
@@ -404,12 +400,7 @@ unsafe fn step2_load_bundle(ctx: &UefiContext) -> Result<BundleLoad, BootError>
     // SAFETY: file is open at position 0; buf is the correct size.
     unsafe { file_read(file, buf)? };
 
-    bprint!("[--------] boot: bundle size=");
-    // SAFETY: console initialized.
-    unsafe {
-        crate::console::console_write_hex64(len as u64);
-    }
-    bprintln!(" bytes");
+    bprintln!("[--------] boot: bundle size={:#018x} bytes", len as u64);
 
     Ok(BundleLoad {
         phys,
@@ -447,26 +438,12 @@ unsafe fn step3_load_kernel(ctx: &UefiContext) -> Result<KernelLoad, BootError>
     // SAFETY: bs is valid; kernel_buf is the complete ELF file.
     let info = unsafe { load_kernel(ctx.bs, kernel_buf, arch::current::EXPECTED_ELF_MACHINE)? };
 
-    // Direct-write helpers avoid format-arg vtable dispatch — on RISC-V the
-    // PE .reloc section is currently empty, so the firmware does not patch
-    // vtable entries when relocating the image and core::fmt's fat-pointer
-    // write_str faults.
-    bprint!("[--------] boot: kernel base=");
-    // SAFETY: console initialized.
-    unsafe {
-        crate::console::console_write_hex64(info.physical_base);
-    }
-    bprint!("  entry=");
-    // SAFETY: console initialized.
-    unsafe {
-        crate::console::console_write_hex64(info.entry_virtual);
-    }
-    bprint!("  size=");
-    // SAFETY: console initialized.
-    unsafe {
-        crate::console::console_write_hex64(info.size);
-    }
-    bprintln!(" bytes");
+    bprintln!(
+        "[--------] boot: kernel base={:#018x}  entry={:#018x}  size={:#018x} bytes",
+        info.physical_base,
+        info.entry_virtual,
+        info.size
+    );
 
     Ok(KernelLoad {
         info,
@@ -560,17 +537,11 @@ unsafe fn step4_parse_bundle(
             // SAFETY: bs is valid; body is the complete ELF file slice.
             let image = unsafe { load_init(ctx.bs, body, arch::current::EXPECTED_ELF_MACHINE)? };
             init_image = Some(image);
-            bprint!("[--------] boot: init entry=");
-            // SAFETY: console initialized.
-            unsafe {
-                crate::console::console_write_hex64(image.entry_point);
-            }
-            bprint!("  size=");
-            // SAFETY: console initialized.
-            unsafe {
-                crate::console::console_write_hex64(entry.size);
-            }
-            bprintln!(" bytes");
+            bprintln!(
+                "[--------] boot: init entry={:#018x}  size={:#018x} bytes",
+                image.entry_point,
+                entry.size
+            );
         }
         else
         {
@@ -645,10 +616,7 @@ unsafe fn step5_discover_cpu_topology(ctx: &UefiContext, firm: &FirmwareInfo) ->
     {
         // SAFETY: acpi_rsdp is identity-mapped; parse_cpu_topology validates the table.
         let (count, _, cpu_ids) = unsafe { acpi::parse_cpu_topology(firm.acpi_rsdp, bsp_id) };
-        bprint!("[--------] boot: ACPI: ");
-        // SAFETY: console initialized.
-        unsafe { crate::console::console_write_dec32(count) };
-        bprintln!(" CPU(s) found via MADT");
+        bprintln!("[--------] boot: ACPI: {count} CPU(s) found via MADT");
         CpuTopology {
             boot_hart_id,
             bsp_id,
@@ -662,10 +630,7 @@ unsafe fn step5_discover_cpu_topology(ctx: &UefiContext, firm: &FirmwareInfo) ->
         let (count, hart_ids) = unsafe { dtb::parse_cpu_count(firm.device_tree) };
         if count > 0
         {
-            bprint!("[--------] boot: DTB: ");
-            // SAFETY: console initialized.
-            unsafe { crate::console::console_write_dec32(count) };
-            bprintln!(" hart(s) found");
+            bprintln!("[--------] boot: DTB: {count} hart(s) found");
             let mut cpu_ids = [0u32; MAX_CPUS];
             cpu_ids[0] = bsp_id;
             let mut ap_idx = 1usize;
@@ -722,10 +687,7 @@ unsafe fn step5b_alloc_ap_trampoline(ctx: &UefiContext) -> u64
     // SAFETY: ctx.bs is valid.
     if let Some(phys) = unsafe { arch::current::allocate_ap_trampoline(ctx.bs) }
     {
-        bprint!("[--------] boot: AP trampoline page: ");
-        // SAFETY: console initialized.
-        unsafe { crate::console::console_write_hex64(phys) };
-        bprintln!("");
+        bprintln!("[--------] boot: AP trampoline page: {phys:#018x}");
         phys
     }
     else
@@ -1106,13 +1068,7 @@ unsafe fn step9_populate_boot_info(
     let aperture_count = unsafe {
         memory_map::derive_mmio_apertures(uefi_map, &aperture_seed[..seed_count], apertures_buf)
     };
-    bprint!("[--------] boot: MMIO apertures: ");
-    #[allow(clippy::cast_possible_truncation)]
-    // SAFETY: console initialized.
-    unsafe {
-        crate::console::console_write_dec32(aperture_count as u32);
-    }
-    bprintln!(" derived");
+    bprintln!("[--------] boot: MMIO apertures: {aperture_count} derived");
 
     // Build the reclaim-after-Phase-7 array in the dedicated 4 KiB page at
     // `allocs.reclaim_array_phys`. AP trampoline is handled by kernel-side
@@ -1219,13 +1175,7 @@ unsafe fn step9_populate_boot_info(
     // The reclaim-array page itself is reclaim-safe once the kernel has
     // walked it — record it last so the kernel processes it in order.
     push_reclaim(allocs.reclaim_array_phys, 1, 0);
-    bprint!("[--------] boot: reclaim_ranges: ");
-    #[allow(clippy::cast_possible_truncation)]
-    // SAFETY: console initialized.
-    unsafe {
-        crate::console::console_write_dec32(reclaim_len as u32);
-    }
-    bprintln!(" entries recorded");
+    bprintln!("[--------] boot: reclaim_ranges: {reclaim_len} entries recorded");
 
     // Write the populated BootInfo.
     // SAFETY: boot_info_phys is a valid 4 KiB allocation; BootInfo fits in one page.

--- a/xtask/targets/riscv64imac-seraph-uefi.json
+++ b/xtask/targets/riscv64imac-seraph-uefi.json
@@ -12,11 +12,23 @@
     "panic-strategy": "abort",
     "features": "+m,+a,+c",
     "code-model": "medium",
-    "relocation-model": "static",
+    "relocation-model": "pic",
+    "position-independent-executables": true,
+    "static-position-independent-executables": true,
+    "plt-by-default": false,
     "llvm-abiname": "lp64",
     "max-atomic-width": 64,
     "pre-link-args": {
-        "ld.lld": ["--gc-sections"]
+        "ld.lld": [
+            "--gc-sections",
+            "-pie",
+            "--no-dynamic-linker",
+            "-z",
+            "notext",
+            "-z",
+            "norelro",
+            "-Bsymbolic"
+        ]
     },
     "emit-debug-gdb-scripts": false
 }


### PR DESCRIPTION
## Summary

Fixes #399 — the riscv64 bootloader load-faulting in non-headless mode once console output crosses one screenful (the first framebuffer scroll).

**Root cause (not framebuffer geometry, as the issue suspected):** the riscv64 bootloader was built `relocation-model: static` with `code-model: medium` (medany). medany makes *code* references PC-relative, but absolute *data* pointers — slice fat-pointers, `&str`, fn-pointer/vtable tables, `core::fmt` infrastructure — were baked at link time and never relocated. The PE `.reloc` was a hand-crafted empty stub. UEFI loads the flat image at a non-preferred base, so any stored absolute pointer dereferenced as boot output grew faulted at a low link-time address. The image carried **301 such unrelocated pointers**; the happy path only avoided them because it was pure PC-relative code + PC-relative font indexing. The framebuffer/`memmove`/font scroll code was never the cause.

x86_64 boot is unaffected: `x86_64-unknown-uefi` already emits PE base relocations (508 DIR64 entries).

## Approach: static-PIE + self-relocation at entry

- **Target** (`xtask/targets/riscv64imac-seraph-uefi.json`): `relocation-model: pic` + static-PIE flags + link args (`-pie`, `--no-dynamic-linker`, `-z notext`, `-z norelro`, `-Bsymbolic`). The linker now records `R_RISCV_RELATIVE` relocations in `.rela.dyn`.
- **Entry** (`core/boot/src/arch/riscv64/header.S`): a PC-relative-only asm loop at `_start` applies every `R_RISCV_RELATIVE` fixup (`*(bias+r_offset) = bias+r_addend`) before any Rust runs, then `tail efi_main`. Matches the Linux RISC-V EFI-stub pattern.
- **Linker** (`core/boot/linker/riscv64-uefi.ld`): relocation targets (`.rodata`/`.data.rel.ro`/`.got`) move into the **writable** `.data` PE region, because EDK2 maps the RX `.text` section read-only and the loop must write them. **W^X preserved** (code RX, data RW-NX). The PE `.reloc` stays an empty stub (firmware can't apply RISC-V relocs; we self-apply).

## Workaround removal (now that relocations work)

The fmt/vtable avoidance the bug forced is removed — this also serves as an end-to-end proof the fix works (`core::fmt` dispatches through the exact fn-pointer/vtable tables that were broken):
- `console.rs`: `bprint!`/`bprintln!` use `core::fmt` via `format_args!`; manual hex/dec helpers deleted.
- `error.rs`: `BootError: Display`; `fatal_error` and the panic handler print via fmt (the panic **message** is no longer suppressed).
- Docs/comments corrected (`riscv-uefi-boot.md`, `header.S`, `console.rs`), plus pre-existing PE section-table drift fixed.

The bootloader's no-heap design (no `#[global_allocator]`) is independent of relocations and is unchanged.

## Test plan

All on both arches.

- **Static gates** (`llvm-readobj`): image is `DYN`; **301 relocations, all `R_RISCV_RELATIVE`, 0 symbolic**; every target inside the writable `[_etext, _ebss)` region; no `INTERP`; flat image starts `MZ`. Disassembly confirms the self-reloc loop (`t0`=load bias, applies fixups, `tail efi_main`).
- **riscv64**: headless boot → shell prompt; **non-headless (GOP 1280×720) boot → shell prompt, zero EDK2 exceptions**; **forced >1-screen framebuffer scroll** (the #399 repro: 50 lines, multiple scrolls) → no fault; `ktest` **ALL TESTS PASSED** (194/0).
- **x86_64** (shares the new fmt console): non-headless boot → shell prompt; `ktest` **ALL TESTS PASSED** (194/0).
- **Host**: `cargo xtask test` passes.

> Note: CI is headless and cannot catch a regression of this specific (non-headless) bug; the non-headless riscv64 run is the authoritative check and was performed locally.

Closes #399

https://claude.ai/code/session_012CvRm92kFfT4RRCTq9fCZd