### PR TITLE
release: cut v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ dependencies = [
 
 [[package]]
 name = "ansi"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "anstream"
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "boot"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "boot-protocol",
  "elf",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "boot-protocol"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "bumpalo"
@@ -135,7 +135,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "capexhaust"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ipc",
  "syscall",
@@ -218,7 +218,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmos-rtc"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ipc",
  "syscall",
@@ -239,7 +239,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crasher"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ipc",
  "syscall",
@@ -262,7 +262,7 @@ checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crypto"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "ctrlc"
@@ -277,11 +277,11 @@ dependencies = [
 
 [[package]]
 name = "demandpaged"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "devmgr"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "boot-protocol",
  "ipc",
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "elf"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "process-abi",
 ]
@@ -319,7 +319,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "fatfs"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "fatfs-parse",
  "ipc",
@@ -342,11 +342,11 @@ dependencies = [
 
 [[package]]
 name = "fatfs-parse"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "fb-charset"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "find-msvc-tools"
@@ -362,11 +362,11 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "font"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "framebuffer"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "boot-protocol",
  "font",
@@ -378,7 +378,7 @@ dependencies = [
 
 [[package]]
 name = "fsbench"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "futures-core"
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "goldfish-rtc"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ipc",
  "syscall",
@@ -461,11 +461,11 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hello"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "hello-tester"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "iana-time-zone"
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "init"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "elf",
  "init-protocol",
@@ -525,11 +525,11 @@ dependencies = [
 
 [[package]]
 name = "init-protocol"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "ipc"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "rustc-std-workspace-core",
  "syscall",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "kernel"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "boot-protocol",
  "font",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "ktest"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "crypto",
  "font",
@@ -599,7 +599,7 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "log"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ipc",
  "rustc-std-workspace-core",
@@ -615,7 +615,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "logd"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ipc",
  "syscall",
@@ -630,7 +630,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmgr"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ipc",
  "memmgr-free-pool",
@@ -641,18 +641,18 @@ dependencies = [
 
 [[package]]
 name = "memmgr-free-pool"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "syscall-abi",
 ]
 
 [[package]]
 name = "mmio"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "namespace-protocol"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ipc",
  "rustc-std-workspace-core",
@@ -674,7 +674,7 @@ dependencies = [
 
 [[package]]
 name = "ns-client"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ipc",
  "syscall",
@@ -724,15 +724,15 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pipefault"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "pipestress"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "pipestress-tester"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "syscall",
  "syscall-abi",
@@ -759,14 +759,14 @@ dependencies = [
 
 [[package]]
 name = "process-abi"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "rustc-std-workspace-core",
 ]
 
 [[package]]
 name = "procmgr"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "elf",
  "ipc",
@@ -779,11 +779,11 @@ dependencies = [
 
 [[package]]
 name = "procmgr-process-table"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "pwrmgr"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ipc",
  "syscall",
@@ -836,11 +836,11 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "registry"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "registry-client"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ipc",
  "rustc-std-workspace-core",
@@ -856,7 +856,7 @@ checksum = "aa9c45b374136f52f2d6311062c7146bff20fec063c3f5d46a410bd937746955"
 
 [[package]]
 name = "ruststd-argv-env"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "rustc-std-workspace-core",
 ]
@@ -875,7 +875,7 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "seraph-wrapper-shim"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "serde"
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "serial"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ipc",
  "syscall",
@@ -951,7 +951,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shmem"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "rustc-std-workspace-core",
  "syscall",
@@ -972,15 +972,15 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "stackoverflow"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "stdiotest"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "stdiotest-tester"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "strsim"
@@ -990,7 +990,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "svcmgr"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ipc",
  "namespace-protocol",
@@ -1001,7 +1001,7 @@ dependencies = [
 
 [[package]]
 name = "svctest"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ipc",
  "namespace-protocol",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "syscall"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "rustc-std-workspace-core",
  "syscall-abi",
@@ -1030,7 +1030,7 @@ dependencies = [
 
 [[package]]
 name = "syscall-abi"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "rustc-std-workspace-core",
 ]
@@ -1046,7 +1046,7 @@ dependencies = [
 
 [[package]]
 name = "test-orphan"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ipc",
  "syscall",
@@ -1054,14 +1054,14 @@ dependencies = [
 
 [[package]]
 name = "text"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "font",
 ]
 
 [[package]]
 name = "threadchurn"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "syscall",
  "syscall-abi",
@@ -1069,19 +1069,19 @@ dependencies = [
 
 [[package]]
 name = "threadchurn-tester"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "threadstack"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "threadstack-tester"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "timed"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ipc",
  "syscall",
@@ -1102,7 +1102,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "usertest"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ipc",
 ]
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "vfsd"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "boot-protocol",
  "ipc",
@@ -1138,11 +1138,11 @@ dependencies = [
 
 [[package]]
 name = "vfsd-gpt"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "virtio-blk"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ipc",
  "syscall",
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "virtio-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ipc",
  "mmio",
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "virtio-input"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ipc",
  "syscall",
@@ -1511,7 +1511,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "boot-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ members = [
 default-members = ["xtask"]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 publish = false
 

--- a/docs/releases/v0.1.1.md
+++ b/docs/releases/v0.1.1.md
@@ -1,0 +1,81 @@
+An entropy and security-hardening patch over v0.1.0: a foundational kernel CSPRNG,
+firmware boot-seed entropy, userspace randomness, in-OS cryptographic primitives, and
+randomized cross-boundary identifiers, plus a RISC-V UEFI boot fix.
+
+---
+
+## Highlights
+
+- Foundational kernel entropy subsystem: an entropy pool seeded from a hardware RNG
+  mixed with timing jitter under health gating, feeding a per-CPU CSPRNG. Degrades to
+  jitter-only where no hardware source is available.
+- Firmware-provided early-boot entropy: the bootloader obtains a conditioned seed from
+  UEFI `EFI_RNG_PROTOCOL` and hands it to the kernel through the boot protocol; the
+  kernel absorbs it and scrubs it from the reclaimed BootInfo page before that page is
+  donated to userspace.
+- Userspace randomness via a `SYS_GETRANDOM` syscall, wired into `ruststd` (including
+  HashMap seeding).
+- In-OS cryptographic primitives: a new `shared/crypto` crate providing SHA-512 and
+  Ed25519 signature verification.
+- Structural unguessability for cross-boundary handles: randomized capability recycling
+  epochs and thread-id correlators in the kernel, and randomized badge/correlator values
+  minted by core services.
+- RISC-V UEFI boot fix: the non-headless framebuffer console no longer load-faults after
+  the first screenful of output, resolved via static-PIE self-relocation.
+- Documentation: `syscalls.md` error codes resynced to `abi/syscall`, with per-syscall
+  error lists audited.
+
+## Components Shipped
+
+**Kernel** (`core/kernel`) — New entropy subsystem: a health-gated entropy pool (raw
+hardware RNG mixed with timing jitter) feeding a per-CPU CSPRNG, with per-tick and
+per-IRQ refill hooks and a self-test that scores only online CPUs. The firmware boot
+seed is absorbed into the pool at boot Phase 5 and then scrubbed from the reclaimed
+BootInfo page. Cross-boundary handles gain structural unguessability: capability
+recycling epochs and thread-id correlators are randomized. A new `SYS_GETRANDOM`
+syscall exposes the CSPRNG to userspace.
+
+**Bootloader** (`core/boot`) — Acquires a conditioned early-boot entropy seed from UEFI
+`EFI_RNG_PROTOCOL` while boot services are live and passes it to the kernel via the boot
+protocol (`BOOT_PROTOCOL_VERSION` 9; `boot_entropy_len` is `0` when no source is
+available). The RISC-V loader performs static-PIE self-relocation, fixing a UEFI
+load-fault that crashed the non-headless framebuffer console after the first screenful
+of output.
+
+**Core services** (`services/`) — Cross-boundary badge and correlator values minted by
+core services are randomized; `procmgr` excludes the reserved log-badge range when
+drawing random process badges.
+
+**Shared** (`shared/`) — New `shared/crypto` crate: in-OS SHA-512 hashing and Ed25519
+signature verification, usable across the tree.
+
+**Documentation** (`docs/`) — `syscalls.md` Error Codes resynced to `abi/syscall`, with
+per-syscall error lists audited against the kernel.
+
+## ABI and Protocol Versions
+
+| Constant | Value | Bumped this release? |
+|---|---|---|
+| `BOOT_PROTOCOL_VERSION` | 9 | yes |
+
+## Breaking Changes
+
+- None. The `BOOT_PROTOCOL_VERSION` bump (8 → 9) is an internal contract between the
+  bootloader and kernel, which ship together in a single disk image; image consumers
+  need no migration.
+
+## Known Issues
+
+- On RISC-V, the entropy pool is seeded from timing jitter alone — no S-mode hardware
+  entropy source is wired up yet, so early-boot entropy is thinner than on x86-64
+  (RDSEED/RDRAND). Steady-state jitter refill is adequate; the gap is at boot. Tracked
+  by [#393](https://github.com/kottlerg/seraph/issues/393).
+
+## Verification
+
+Disk images:
+
+- `seraph-v0.1.1-x86_64.img.zst`
+- `seraph-v0.1.1-riscv64.img.zst`
+
+Verify with `sha256sum -c SHA256SUMS` against the attached `SHA256SUMS` file.


### PR DESCRIPTION
## Summary

Release-prep for **v0.1.1**: bump the workspace version `0.1.0 → 0.1.1` and add the
per-tag release notes. This is the commit the `v0.1.1` tag must point at — `release.yml`
`preflight` verifies the workspace version equals the tag and that
`docs/releases/v0.1.1.md` follows `TEMPLATE.md`.

v0.1.1 is the Z-axis patch capturing the entropy/security-hardening cycle since v0.1.0
(plus a RISC-V UEFI boot fix and a syscalls docs resync). All cycle issues are assigned
to the `v0.1.1` GitHub milestone (8 closed, 0 open).

## Changes

- `Cargo.toml` — `[workspace.package] version = "0.1.1"`.
- `Cargo.lock` — propagated bump for every workspace-inherited crate (65 entries; no
  dependency changes).
- `docs/releases/v0.1.1.md` — new release notes (Highlights, Components Shipped, ABI &
  Protocol Versions, Breaking Changes, Known Issues, Verification).

`BOOT_PROTOCOL_VERSION` bumped `8 → 9` this cycle (EFI_RNG boot seed field); recorded in
the notes' ABI table. No other ABI/protocol constant changed.

## Linked issues (milestone v0.1.1, already closed by their own PRs)

#245, #246, #247, #248, #249, #174, #399, #394. This PR references them for the notes; it
does not close them.

## Acceptance

- [x] Workspace version bumped to `0.1.1`.
- [x] `docs/releases/v0.1.1.md` authored from `TEMPLATE.md`; contains all 6 required
  section headings as exact whole lines; no H1 title.
- [x] Local mirror of `release.yml` preflight passes (version-match + heading presence).
- [x] ABI table reflects the only changed constant (`BOOT_PROTOCOL_VERSION` 9).
- [x] Known Issues lists only shipped-build degradations (riscv64 jitter-only entropy,
  tracked by #393); no missing-feature entries.

## Test plan

Per CLAUDE.md validation (both arches, `clean` between arch switches):

| Arch | build | ktest marker |
|---|---|---|
| x86_64 | ✅ `cargo xtask build` | ✅ `[ktest] ALL TESTS PASSED` (run-parallel, 1 run) |
| riscv64 | ✅ `cargo xtask build --arch riscv64` | ✅ `[ktest] ALL TESTS PASSED` (run-parallel, 1 run) |

The bump changes the compiled-in `KERNEL_VERSION` (`abi/syscall/src/lib.rs:819`,
`pack_project_version(env!("CARGO_PKG_VERSION"))`), so the boot exercises the new value
and const-evaluates the parse.

The `v0.1.1` tag is pushed **after** this merges, triggering `release.yml` (image build +
draft Release) and `burnin.yml`; the draft is published manually after burn-in is green.