### PR TITLE
kernel, docs: audit cross-boundary surfaces for kernel-pointer leaks

### DIFF
--- a/core/kernel/README.md
+++ b/core/kernel/README.md
@@ -85,6 +85,7 @@ kernel/
     ├── arch-interface.md       # Architecture abstraction layer and dispatch surface
     ├── initialization.md       # Boot-to-init sequence, phase by phase
     ├── syscalls.md             # Syscall ABI and complete syscall table
+    ├── cross-boundary-disclosure.md # Kernel-pointer leak audit of cross-boundary outputs (KASLR prerequisite)
     ├── memory-internals.md     # Memory subsystem implementation details
     ├── capability-internals.md # Capability subsystem implementation details
     ├── entropy.md              # Entropy subsystem, CSPRNG, health tests, draw API
@@ -148,7 +149,9 @@ protocol.
 
 The syscall dispatch layer. Architecture-specific entry glue (in `arch/*/syscall.rs`)
 calls into this module's dispatch table, which routes to the appropriate subsystem
-implementation. See [`docs/syscalls.md`](docs/syscalls.md).
+implementation. See [`docs/syscalls.md`](docs/syscalls.md). The audit confirming no
+cross-boundary output (syscall, IPC, fault, exit) leaks a kernel virtual address is
+in [`docs/cross-boundary-disclosure.md`](docs/cross-boundary-disclosure.md).
 
 ---
 

--- a/core/kernel/docs/cross-boundary-disclosure.md
+++ b/core/kernel/docs/cross-boundary-disclosure.md
@@ -62,6 +62,7 @@ is in [docs/syscalls.md](syscalls.md).
 | Exit / death reason encoding + death payload `(correlator << 32) \| reason` | `syscall::encode_exit_code`, `EXIT_*` constants, `sched::post_one_death_event` | c/d |
 | Thread ID (random CSPRNG correlator; no `tid → TCB` table; never returned as data) | `sched::alloc_thread_id` | c |
 | `CSpaceId` (registry index, never returned to userspace); capability badges (caller-chosen) | `cap::alloc_cspace_id`, `cap::slot::CapabilitySlot::badge` | c |
+| Boot-time `InitInfo` handover — kernel writes a read-only struct into init's mapped region | `init_protocol::InitInfo`, `init_protocol::CapDescriptor` | b/c/d/e |
 
 Notes on the non-obvious entries:
 
@@ -79,10 +80,18 @@ Notes on the non-obvious entries:
 - **`SYS_SBI_CALL`** forwards caller-supplied arguments to M-mode firmware and
   returns the firmware result; neither the arguments the kernel forwards nor the
   value it returns is kernel-derived.
+- **`InitInfo` handover** is the boot-time kernel→init struct written into a
+  read-only region the kernel maps at the fixed *user* VA `INIT_INFO_VADDR`
+  (class **b** — a userspace address by ABI contract). Its `*_cap` / `*_base`
+  fields are CSpace slot indices (**c**); versions, counts, and byte-size
+  accounting facts including `kernel_reserved_bytes` are quantities, not
+  addresses (**d**); the only addresses it carries are physical — each
+  `CapDescriptor::aux0` for a Memory/Mmio cap and `InitFramebufferInfo::physical_base`
+  (**e**, see "Physical-address surfaces"). No field is a kernel VA.
 
 ## Physical-address surfaces
 
-Two surfaces return real addresses. Both are **physical**, not kernel virtual:
+Three surfaces emit real addresses. All are **physical**, not kernel virtual:
 
 - `SYS_ASPACE_QUERY` (`sysinfo::sys_aspace_query`) returns the leaf physical address
   backing a *user* page, gated on an `AddressSpace` capability with the `READ` right.
@@ -90,6 +99,10 @@ Two surfaces return real addresses. Both are **physical**, not kernel virtual:
 - `CAP_INFO_MEMORY_PHYS_BASE` (`cap::sys_cap_info`) returns `MemoryObject::base`, the
   physical base of a Memory object the caller holds a capability to. memmgr depends
   on it to track region contiguity.
+- The `InitInfo` handover publishes physical bases for the resources it hands init:
+  `CapDescriptor::aux0` (Memory / Mmio physical base) and
+  `InitFramebufferInfo::physical_base`. Each describes a resource init receives a
+  capability to.
 
 A physical address does not reveal the kernel's randomized virtual base, and each is
 gated behind a capability the caller already holds, so neither defeats KASLR. They

--- a/core/kernel/docs/cross-boundary-disclosure.md
+++ b/core/kernel/docs/cross-boundary-disclosure.md
@@ -1,0 +1,129 @@
+# Kernel Cross-Boundary Disclosure Inventory
+
+Enumerates every value the kernel emits across the user/kernel boundary and
+classifies it, establishing that no kernel virtual address or kernel pointer
+escapes to userspace — a prerequisite for kernel address-space layout
+randomization (KASLR).
+
+---
+
+## Threat model
+
+KASLR randomizes the kernel's virtual base. A single kernel virtual address (VA),
+kernel pointer, or value derived from one that reaches userspace defeats base
+randomization. This inventory audits the kernel's complete output surface and
+records, per surface, why it carries no kernel VA. It is the standing reference
+the coding-standards rule "Cross-Boundary Data Hygiene"
+([docs/coding-standards.md](../../../docs/coding-standards.md)) requires every new
+cross-boundary output to be added to.
+
+Scope is the *kernel-virtual-address* leak. Physical-address disclosure is a
+distinct, narrower concern handled in "Physical-address surfaces" below.
+
+## Classification
+
+Each surface is classified as one of:
+
+- **(a) kernel VA / pointer** — a kernel virtual address, kernel pointer, or value
+  derived from one. A leak. **None found.**
+- **(b) userspace VA** — an address in the caller's own (or a delegate's) address
+  space. The caller already owns it; not a disclosure.
+- **(c) opaque / randomized** — a kernel-minted identifier that is unguessable
+  (drawn from the entropy root) or a non-pointer registry index. Reveals no kernel
+  layout.
+- **(d) fixed-by-contract** — an enum discriminant, constant, count, or
+  firmware-originated value defined by the ABI.
+- **(e) physical address** — a physical address exposed by ABI contract, gated by a
+  capability the caller holds. Not a kernel VA. See "Physical-address surfaces".
+
+## Surface inventory
+
+Every syscall returns `Result<u64, SyscallError>` marshalled into a single return
+register (`rax` on x86-64, `a0` on RISC-V) by `TrapFrame::set_return`; multi-value
+IPC returns use the `set_ipc_*` family. No handler returns a raw pointer: the
+return type is uniformly integer, and the only address-valued returns are physical
+(class **e**). The dispatch table is `syscall::dispatch`; the full numbered table
+is in [docs/syscalls.md](syscalls.md).
+
+| Surface | Anchor (stable identifier) | Class |
+|---|---|---|
+| Syscall return convention; no raw-pointer return path | `syscall::dispatch`, `TrapFrame::set_return` | b/c/d |
+| `SYS_CAP_INFO` tag/rights, thread-state, TLB / cspace / memory counts | `cap::sys_cap_info` | c/d |
+| `CAP_INFO_MEMORY_PHYS_BASE` → `MemoryObject::base` | `cap::sys_cap_info`, `cap::object::MemoryObject` | **e** |
+| `SYS_SYSTEM_INFO` (version, cpu count, page size, elapsed µs, current cpu) | `sysinfo::sys_system_info` | c/d |
+| `SYS_ASPACE_QUERY` → leaf physical address of a user page | `sysinfo::sys_aspace_query`, `AddressSpace::query_page` | **e** |
+| `SYS_THREAD_READ_REGS` / `WRITE_REGS` → target thread's user `TrapFrame` | `thread::sys_thread_read_regs`, `TrapFrame::sanitize_for_user_resume` | b/d |
+| `SYS_GETRANDOM` → random bytes into a user buffer + byte count | `entropy::sys_getrandom` | d |
+| `SYS_SBI_CALL` → firmware `sbiret.value` + error code (RISC-V; args caller-supplied) | `sbi::sys_sbi_call` | d |
+| `SYS_IPC_BUFFER_SET` → status only (validates user-half, page-aligned VA) | `syscall::sys_ipc_buffer_set` | (no output) |
+| Cap split / create / derive handlers → opaque cap handles | `mem::sys_memory_split`, `hw::sys_mmio_split`, `cap::sys_cap_derive` | c |
+| IPC `Message` label / badge / data[] / cap_slots[] | `ipc::message::Message`, `ipc::{read_ipc_buf, write_ipc_buf, write_cap_results}` | b/c |
+| Fault message `kind` / `d1` / `d2` / `ip` (user VA or hardware code) + label / badge | `ipc::fault::FaultInfo`, `redirect_user_page_fault`, `redirect_user_exception`, `fault_info_for` | b/d |
+| Exit / death reason encoding + death payload `(correlator << 32) \| reason` | `syscall::encode_exit_code`, `EXIT_*` constants, `sched::post_one_death_event` | c/d |
+| Thread ID (random CSPRNG correlator; no `tid → TCB` table; never returned as data) | `sched::alloc_thread_id` | c |
+| `CSpaceId` (registry index, never returned to userspace); capability badges (caller-chosen) | `cap::alloc_cspace_id`, `cap::slot::CapabilitySlot::badge` | c |
+
+Notes on the non-obvious entries:
+
+- **IPC `cap_slots[]`** carry destination CSpace *indices* re-derived for the
+  receiver, not pointers; the per-slot generation is stripped on the send path
+  (`ipc::unpack_cap_slots`).
+- **Fault messages** source `d1`/`ip` from the live user `TrapFrame` — the faulting
+  user address and user instruction pointer. The forwarded/readable `TrapFrame`
+  holds only user-mode register state (no kernel stack pointer, kernel return
+  address, or `CR3`/`satp`); the write path re-validates through
+  `sanitize_for_user_resume`.
+- **Thread IDs** are random per `sched::alloc_thread_id` (issue #248) — a monotonic
+  id would leak thread creation counts/rates wherever logged. They are diagnostic
+  correlators only and never cross the boundary as syscall data.
+- **`SYS_SBI_CALL`** forwards caller-supplied arguments to M-mode firmware and
+  returns the firmware result; neither the arguments the kernel forwards nor the
+  value it returns is kernel-derived.
+
+## Physical-address surfaces
+
+Two surfaces return real addresses. Both are **physical**, not kernel virtual:
+
+- `SYS_ASPACE_QUERY` (`sysinfo::sys_aspace_query`) returns the leaf physical address
+  backing a *user* page, gated on an `AddressSpace` capability with the `READ` right.
+  The intermediate page-table addresses traversed during the walk are not returned.
+- `CAP_INFO_MEMORY_PHYS_BASE` (`cap::sys_cap_info`) returns `MemoryObject::base`, the
+  physical base of a Memory object the caller holds a capability to. memmgr depends
+  on it to track region contiguity.
+
+A physical address does not reveal the kernel's randomized virtual base, and each is
+gated behind a capability the caller already holds, so neither defeats KASLR. They
+are fixed-by-contract disclosures, not leaks.
+
+**Forward caveat for the KASLR work:** if KASLR is implemented such that the
+direct-map virtual offset becomes recoverable from a physical address (for example a
+fixed or low-entropy phys→virt relationship), these two surfaces must be re-reviewed,
+because a physical address would then be convertible to a kernel VA.
+
+## Kernel console diagnostics
+
+The kernel's `kprint!` / `kprintln!` macros (`console.rs`) and the register-dump,
+watchdog, and `KERNEL EXCEPTION` paths do format kernel pointers (`{:p}`, `{:#x}`).
+These are **not** a userspace-readable data channel: per the console-model contract
+([docs/console-model.md](../../../docs/console-model.md)), the kernel writes the UART
+directly and never becomes a client of the userspace serial or framebuffer driver,
+and no IPC channel delivers kernel log output to a userspace process as data. The
+always-on `USERSPACE FAULT` serial dumps print the faulting thread's *own* user
+registers, not kernel addresses. Kernel-pointer console output is therefore an
+operator-console diagnostic outside the KASLR threat model; it must not be routed to
+any userspace-reachable IPC or log channel.
+
+## Maintaining this inventory
+
+When a syscall, IPC field, fault message field, exit reason, or `cap_info` /
+`system_info` selector is added or changed, classify its output here in the same
+change, per the "Cross-Boundary Data Hygiene" rule in
+[docs/coding-standards.md](../../../docs/coding-standards.md). A kernel-minted
+identifier observed across the boundary is drawn from the entropy root
+(`entropy::next_u32` / `entropy::fill_bytes`); see [entropy.md](entropy.md).
+
+---
+
+## Summarized By
+
+[Kernel](../README.md)

--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -222,6 +222,34 @@ let value = unsafe { ptr.read() };
 
 ---
 
+### Cross-Boundary Data Hygiene
+
+Kernel virtual addresses, kernel pointers, and any value derived from one — a
+pointer cast to an integer, a fixed kernel VA, a kernel return address, a saved
+kernel stack pointer — MUST NOT cross into userspace. This covers every
+cross-boundary output: syscall return registers, IPC label/badge/data/cap-slot
+fields, fault and exception messages, exit and death reasons, and `SYS_CAP_INFO` /
+`SYS_SYSTEM_INFO` / `SYS_ASPACE_QUERY` selectors.
+
+- Kernel-minted identifiers observed across the boundary MUST be opaque and
+  unguessable — drawn from the entropy root (`entropy::next_u32` /
+  `entropy::fill_bytes`), never a monotonic counter that leaks creation counts or
+  rates.
+- A value that must cross and cannot be made opaque MUST be fixed by ABI contract
+  (an enum discriminant, a constant, or a count) and documented as such.
+- A physical address MAY cross only where an ABI contract requires it and the caller
+  already holds the capability the address describes; the kernel virtual mapping of
+  that physical address MUST NOT be exposed.
+- Kernel-pointer values MAY appear only in kernel-owned console diagnostics
+  (`kprint!` / `kprintln!`), which the console-model contract keeps off any
+  userspace-readable channel. They MUST NOT reach a userspace IPC or log channel.
+
+New or changed cross-boundary outputs MUST be classified in the kernel
+cross-boundary disclosure inventory (`core/kernel/docs/cross-boundary-disclosure.md`)
+in the same change.
+
+---
+
 ### Documentation
 
 - All public APIs MUST have rustdoc comments covering behaviour, arguments, return value,


### PR DESCRIPTION
## Summary

Audit of the kernel's complete cross-boundary output surface for kernel-pointer / kernel-VA leaks, a prerequisite for KASLR. Complements #248 (randomized epochs/correlators).

**Finding: no kernel-VA leak exists.** Every value crossing the user/kernel boundary — syscall returns, IPC payloads, fault/exception messages, exit/death reasons, `SYS_CAP_INFO`/`SYS_SYSTEM_INFO`/`SYS_ASPACE_QUERY` selectors — is a userspace VA, a caller-chosen opaque value, a randomized/counter ID, a fixed-by-contract constant, or a physical address. Thread IDs were already randomized by #248. The two address-bearing returns (`SYS_ASPACE_QUERY` leaf phys, `CAP_INFO_MEMORY_PHYS_BASE`) are physical (not kernel VAs), gated behind a caller-held cap, and required by memmgr by ABI contract. Kernel-pointer console prints reach only the kernel-owned UART, which the console-model contract keeps off any userspace-readable channel.

This makes the change documentation-only: the audit closed no leaks because none exist.

## Changes

- **New** `core/kernel/docs/cross-boundary-disclosure.md` — the standing inventory: every surface classified pointer-free or fixed-by-contract, with a forward caveat for the KASLR direct-map work.
- `docs/coding-standards.md` — new "Cross-Boundary Data Hygiene" rule under Part B so new kernel-pointer exposure is caught in review.
- `core/kernel/README.md` — register the new doc.

## Acceptance (closes #251)

- [x] Inventory of cross-boundary outputs; each confirmed pointer-free or fixed-by-contract — `core/kernel/docs/cross-boundary-disclosure.md`.
- [x] Any leak found is closed (opaque handle / redaction) — none found; recorded per-surface. Physical-address surfaces confirmed by-contract (not kernel VAs).
- [x] Standing rule documented so new kernel-pointer exposure is caught in review — "Cross-Boundary Data Hygiene" in `docs/coding-standards.md`.

## Test plan

Documentation-only; no compiled artifact changes, so QEMU boot validates nothing about this change.

- [x] Inventory cross-checked against all `SYS_*` constants (0–55) in `abi/syscall/src/lib.rs` and the `syscall::dispatch` arms — no syscall omitted.
- [x] Documentation-standards conformance: title, one-sentence purpose, `---`, content, trailing `## Summarized By`; code referenced by stable identifier, not `path:line`.
- [x] All relative links in the three edited files resolve.
- [x] CI `build-test` (both arches + host tests) green on the PR.

Closes #251

https://claude.ai/code/session_01Ryf2zhDBxLNQFortiNe1h2