### PR TITLE
kernel: recover from user-copy faults instead of panicking (#398)

### DIFF
--- a/core/kernel/docs/arch-interface.md
+++ b/core/kernel/docs/arch-interface.md
@@ -362,9 +362,17 @@ pub unsafe fn disable_interrupts();
 pub fn halt_until_interrupt();
 pub fn halt_loop() -> !;
 
-/// Bracket a copy to/from user memory (SMAP/SUM toggle).
-pub unsafe fn user_access_begin();
-pub unsafe fn user_access_end();
+/// Copy `len` bytes between kernel and user memory across the SMAP/SUM access
+/// window with in-kernel fault recovery: a fault on an unmapped or read-only
+/// user span returns a non-zero sentinel (recovered by the page-fault handler's
+/// user-copy fixup) instead of panicking. The sole sanctioned path for kernel
+/// access to user pointers; the typed `crate::uaccess::copy_to_user` /
+/// `copy_from_user` wrappers turn the sentinel into `SyscallError::InvalidAddress`.
+pub unsafe fn copy_user(dst: *mut u8, src: *const u8, len: usize) -> usize;
+
+/// Map a faulting PC to the `copy_user` recovery fixup, or `None`. Consulted by
+/// the page-fault handler on a kernel-mode fault to redirect into the fixup.
+pub fn user_copy_fixup(pc: u64) -> Option<u64>;
 ```
 
 Arch-private CPU helpers (CPUID/MSR/CR access on x86-64, SMEP/SMAP/SUM enablement) are not

--- a/core/kernel/src/arch/riscv64/cpu.rs
+++ b/core/kernel/src/arch/riscv64/cpu.rs
@@ -212,57 +212,104 @@ pub unsafe fn set_kernel_trap_stack(stack_top: u64)
     }
 }
 
-// ── SUM user-access bracket ───────────────────────────────────────────────────
+// ── User-copy primitive (fault-recoverable) ───────────────────────────────────
 
-/// Allow supervisor-mode access to user pages (sets sstatus.SUM, bit 18).
-///
-/// Must be paired with a matching `user_access_end` call.
-///
-/// # Safety
-/// Must execute in supervisor mode. Leaves SUM set until `user_access_end`.
-///
-/// # Compiler barrier
-/// `nomem` is intentionally absent so the compiler treats this CSR write as a
-/// memory operation. This prevents the compiler from reordering user-memory
-/// loads to before the csrrs at opt-level ≥ 1, matching Linux's "memory"
-/// clobber on equivalent operations.
+// `copy_user` is the sole sanctioned path for kernel access to user memory. It
+// owns the SUM access window (sstatus.SUM, bit 18) and is covered by the trap
+// dispatcher's user-copy fixup: a fault on an unmapped or read-only user span
+// inside the copy redirects to `__copy_user_fixup` (which clears SUM and returns
+// a non-zero sentinel) instead of panicking. See `crate::uaccess` for the typed
+// `copy_to_user`/`copy_from_user` wrappers and `interrupts::trap_dispatch` for
+// the fixup hook.
 #[cfg(not(test))]
-#[inline]
-pub unsafe fn user_access_begin()
-{
-    // SAFETY: csrrs sets bit 18 (SUM) in sstatus; safe in supervisor mode.
-    // csrsi/csrci only accept 5-bit immediates (0-31); bit 18 must use a register.
-    // nostack: CSR write does not modify sp.
-    // (no nomem): compiler memory barrier — prevents hoisting user-memory loads
-    // above this instruction at opt-level ≥ 1.
-    unsafe {
-        core::arch::asm!(
-            "csrrs zero, sstatus, {sum}",
-            sum = in(reg) (1u64 << 18),
-            options(nostack),
-        );
-    }
+core::arch::global_asm!(
+    ".section .text.copy_user, \"ax\"",
+    ".global __copy_user",
+    ".global __copy_user_fault_start",
+    ".global __copy_user_fault_end",
+    ".global __copy_user_fixup",
+    // fn __copy_user(dst: a0, src: a1, len: a2) -> a0 (0 = ok, 1 = faulted)
+    "__copy_user:",
+    "    li    t0, 0x40000",       // SUM = bit 18
+    "    csrrs zero, sstatus, t0", // open the access window
+    "1:",
+    "    beqz  a2, 2f",
+    "__copy_user_fault_start:",
+    "    lb    t1, 0(a1)", // load from src (user side may fault)
+    "    sb    t1, 0(a0)", // store to dst (user side may fault)
+    "__copy_user_fault_end:",
+    "    addi  a0, a0, 1",
+    "    addi  a1, a1, 1",
+    "    addi  a2, a2, -1",
+    "    j     1b",
+    "2:",
+    "    csrrc zero, sstatus, t0", // close the access window
+    "    li    a0, 0",
+    "    ret",
+    "__copy_user_fixup:",
+    "    li    t0, 0x40000",
+    "    csrrc zero, sstatus, t0", // close the access window (recovery path)
+    "    li    a0, 1",
+    "    ret",
+);
+
+#[cfg(not(test))]
+unsafe extern "C" {
+    /// Raw user-copy routine (`dst=a0, src=a1, len=a2`); returns 0 on success or
+    /// 1 if a fault on the user span was recovered.
+    fn __copy_user(dst: *mut u8, src: *const u8, len: usize) -> usize;
+    /// First byte of the faultable copy region (the `lb`/`sb` pair).
+    static __copy_user_fault_start: u8;
+    /// First byte past the faultable copy region.
+    static __copy_user_fault_end: u8;
+    /// Recovery landing pad: closes the SUM window and returns the fault sentinel.
+    static __copy_user_fixup: u8;
 }
 
-/// Revoke supervisor-mode access to user pages (clears sstatus.SUM, bit 18).
+/// Copy `len` bytes from `src` to `dst` across the SUM window with fault
+/// recovery. Returns 0 on success, non-zero if a user-span fault was recovered.
 ///
 /// # Safety
-/// Must be called after a matching `user_access_begin`.
-///
-/// # Compiler barrier
-/// Like `user_access_begin`, `nomem` is absent to prevent the compiler from
-/// sinking user-memory stores to after the csrrc.
+/// Must execute in supervisor mode. The operands must be arranged so the user
+/// pointer is the only one that may fault; the non-user side must be valid for
+/// `len` bytes.
 #[cfg(not(test))]
 #[inline]
-pub unsafe fn user_access_end()
+pub unsafe fn copy_user(dst: *mut u8, src: *const u8, len: usize) -> usize
 {
-    // SAFETY: csrrc clears bit 18 (SUM) in sstatus; restores user-page isolation.
+    // SAFETY: forwarded to the asm routine; a fault on the user span is recovered
+    // by the trap dispatcher via __copy_user_fixup.
+    unsafe { __copy_user(dst, src, len) }
+}
+
+/// Host-test stub: the SUM CSR write is privileged and the test pointers never
+/// fault, so perform a plain copy and report success.
+#[cfg(test)]
+pub unsafe fn copy_user(dst: *mut u8, src: *const u8, len: usize) -> usize
+{
+    // SAFETY: caller guarantees src/dst valid for len bytes.
     unsafe {
-        core::arch::asm!(
-            "csrrc zero, sstatus, {sum}",
-            sum = in(reg) (1u64 << 18),
-            options(nostack),
-        );
+        core::ptr::copy_nonoverlapping(src, dst, len);
+    }
+    0
+}
+
+/// If `pc` lies within `copy_user`'s faultable region, return the address of the
+/// recovery fixup; otherwise `None`. Consulted by the trap dispatcher on an
+/// S-mode page fault to convert an unmapped/read-only user access into an error
+/// return instead of a panic.
+#[cfg(not(test))]
+pub fn user_copy_fixup(pc: u64) -> Option<u64>
+{
+    let lo = core::ptr::addr_of!(__copy_user_fault_start) as u64;
+    let hi = core::ptr::addr_of!(__copy_user_fault_end) as u64;
+    if pc >= lo && pc < hi
+    {
+        Some(core::ptr::addr_of!(__copy_user_fixup) as u64)
+    }
+    else
+    {
+        None
     }
 }
 

--- a/core/kernel/src/arch/riscv64/interrupts.rs
+++ b/core/kernel/src/arch/riscv64/interrupts.rs
@@ -628,6 +628,18 @@ extern "C" fn trap_dispatch(frame: &mut TrapFrame)
         }
         else
         {
+            // In-kernel user-copy fault recovery: an S-mode page fault (load=13,
+            // store=15, instruction=12) whose sepc lies in the `copy_user` faultable
+            // region is an unmapped or read-only user buffer. Redirect to the fixup
+            // — which clears SUM and returns an error sentinel — instead of
+            // panicking.
+            if matches!(cause_code, 12 | 13 | 15)
+                && let Some(fixup) = super::cpu::user_copy_fixup(frame.sepc)
+            {
+                frame.sepc = fixup;
+                return;
+            }
+
             crate::kprintln!(
                 "KERNEL EXCEPTION: cpu={} cause={} (scause={:#x})",
                 cpu,

--- a/core/kernel/src/arch/x86_64/cpu.rs
+++ b/core/kernel/src/arch/x86_64/cpu.rs
@@ -133,52 +133,95 @@ pub unsafe fn write_msr(msr: u32, val: u64)
     }
 }
 
-// ── SMAP user-access bracket ──────────────────────────────────────────────────
+// ── User-copy primitive (fault-recoverable) ───────────────────────────────────
 
-/// Allow supervisor-mode access to user pages (sets AC flag via `stac`).
-///
-/// Must be paired with a matching `user_access_end` call. Nesting is not
-/// supported. Call immediately before reading/writing user memory, and call
-/// `user_access_end` immediately after.
-///
-/// # Safety
-/// Must execute at ring 0. Leaves AC set until `user_access_end` is called,
-/// so any faulting user-pointer dereference between the two calls will not
-/// produce a SMAP fault (but may still fault for other reasons).
-///
-/// # Compiler barrier
-/// `nomem` is intentionally absent so the compiler treats this as a memory
-/// operation. This prevents the compiler from reordering user-memory accesses
-/// (loads OR stores) to before the stac at opt-level ≥ 1. Mirrors Linux's
-/// `stac()` which uses an asm "memory" clobber for the same reason.
+// `copy_user` is the sole sanctioned path for kernel access to user memory. It
+// owns the SMAP access window (`stac`/`clac`) and is covered by the page-fault
+// handler's user-copy fixup: a fault on an unmapped or read-only user span
+// inside the copy redirects to `__copy_user_fixup` (which executes `clac` and
+// returns a non-zero sentinel) instead of panicking. See `crate::uaccess` for
+// the typed `copy_to_user`/`copy_from_user` wrappers and `idt::page_fault_handler`
+// for the fixup hook. The DF=0 ABI invariant makes `rep movsb` copy forward.
 #[cfg(not(test))]
-#[inline]
-pub unsafe fn user_access_begin()
-{
-    // SAFETY: stac sets AC in RFLAGS; safe at ring 0 when SMAP is enabled.
-    // nostack: stac does not modify RSP.
-    // (no nomem): acts as a compiler memory barrier — prevents the optimizer
-    // from hoisting user-memory accesses above this instruction.
-    unsafe {
-        core::arch::asm!("stac", options(nostack));
-    }
+core::arch::global_asm!(
+    ".section .text.copy_user, \"ax\"",
+    ".global __copy_user",
+    ".global __copy_user_fault_start",
+    ".global __copy_user_fault_end",
+    ".global __copy_user_fixup",
+    // fn __copy_user(dst: rdi, src: rsi, len: rdx) -> rax (0 = ok, 1 = faulted)
+    "__copy_user:",
+    "    stac",
+    "    mov rcx, rdx",
+    "__copy_user_fault_start:",
+    "    rep movsb",
+    "__copy_user_fault_end:",
+    "    clac",
+    "    xor eax, eax",
+    "    ret",
+    "__copy_user_fixup:",
+    "    clac",
+    "    mov eax, 1",
+    "    ret",
+);
+
+#[cfg(not(test))]
+unsafe extern "C" {
+    /// Raw user-copy routine (`dst=rdi, src=rsi, len=rdx`); returns 0 on success
+    /// or 1 if a fault on the user span was recovered.
+    fn __copy_user(dst: *mut u8, src: *const u8, len: usize) -> usize;
+    /// First byte of the faultable copy instruction.
+    static __copy_user_fault_start: u8;
+    /// First byte past the faultable copy instruction.
+    static __copy_user_fault_end: u8;
+    /// Recovery landing pad: closes the SMAP window and returns the fault sentinel.
+    static __copy_user_fixup: u8;
 }
 
-/// Revoke supervisor-mode access to user pages (clears AC flag via `clac`).
+/// Copy `len` bytes from `src` to `dst` across the SMAP window with fault
+/// recovery. Returns 0 on success, non-zero if a user-span fault was recovered.
 ///
 /// # Safety
-/// Must be called after a matching `user_access_begin`.
-///
-/// # Compiler barrier
-/// Like `user_access_begin`, `nomem` is absent to prevent the compiler from
-/// sinking user-memory accesses to after the clac.
+/// Must execute at ring 0 with SMAP enabled. The operands must be arranged so the
+/// user pointer is the only one that may fault; the non-user side must be valid
+/// for `len` bytes.
 #[cfg(not(test))]
 #[inline]
-pub unsafe fn user_access_end()
+pub unsafe fn copy_user(dst: *mut u8, src: *const u8, len: usize) -> usize
 {
-    // SAFETY: clac clears AC in RFLAGS; restores SMAP protection.
+    // SAFETY: forwarded to the asm routine; a fault on the user span is recovered
+    // by the page-fault handler via __copy_user_fixup.
+    unsafe { __copy_user(dst, src, len) }
+}
+
+/// Host-test stub: `stac`/`clac` are privileged and the test pointers never
+/// fault, so perform a plain copy and report success.
+#[cfg(test)]
+pub unsafe fn copy_user(dst: *mut u8, src: *const u8, len: usize) -> usize
+{
+    // SAFETY: caller guarantees src/dst valid for len bytes.
     unsafe {
-        core::arch::asm!("clac", options(nostack));
+        core::ptr::copy_nonoverlapping(src, dst, len);
+    }
+    0
+}
+
+/// If `pc` lies within `copy_user`'s faultable region, return the address of the
+/// recovery fixup; otherwise `None`. Consulted by the page-fault handler on a
+/// kernel-mode fault to convert an unmapped/read-only user access into an error
+/// return instead of a panic.
+#[cfg(not(test))]
+pub fn user_copy_fixup(pc: u64) -> Option<u64>
+{
+    let lo = core::ptr::addr_of!(__copy_user_fault_start) as u64;
+    let hi = core::ptr::addr_of!(__copy_user_fault_end) as u64;
+    if pc >= lo && pc < hi
+    {
+        Some(core::ptr::addr_of!(__copy_user_fixup) as u64)
+    }
+    else
+    {
+        None
     }
 }
 

--- a/core/kernel/src/arch/x86_64/idt.rs
+++ b/core/kernel/src/arch/x86_64/idt.rs
@@ -1034,6 +1034,22 @@ extern "C" fn page_fault_handler(tf: *mut TrapFrame, error_code: u64)
         }
     }
 
+    // In-kernel user-copy fault recovery: a fault taken at CPL 0 whose RIP lies in
+    // the `copy_user` faultable region is an unmapped or read-only user buffer.
+    // Redirect to the fixup — which closes the SMAP window and returns an error
+    // sentinel — instead of panicking. Genuine userspace faults already returned
+    // above; their RIP is never inside the kernel copy region, so this is a no-op
+    // for them.
+    // SAFETY: tf is valid; rip is read-only here.
+    if let Some(fixup) = super::cpu::user_copy_fixup(unsafe { (*tf).rip })
+    {
+        // SAFETY: tf is the live frame; rewriting rip redirects iretq to the fixup.
+        unsafe {
+            (*tf).rip = fixup;
+        }
+        return;
+    }
+
     // Not a recoverable spurious fault and not resumed by a handler — kill
     // (userspace) or fatal (kernel).
     // SAFETY: tf is valid; common_exception_handler never returns.

--- a/core/kernel/src/main.rs
+++ b/core/kernel/src/main.rs
@@ -60,6 +60,7 @@ mod platform;
 mod sched;
 mod sync;
 mod syscall;
+mod uaccess;
 mod validate;
 
 /// Kernel entry point.

--- a/core/kernel/src/syscall/entropy.rs
+++ b/core/kernel/src/syscall/entropy.rs
@@ -67,20 +67,18 @@ pub fn sys_getrandom(tf: &mut TrapFrame) -> Result<u64, SyscallError>
         return Err(SyscallError::WouldBlock);
     }
 
-    // Draw into a kernel buffer *before* opening the user-access window: the
-    // draw disables/re-enables interrupts internally, which must not happen
-    // inside the SMAP/SUM (AC/SUM) bracket. The bracket then wraps only the
-    // plain copy, mirroring `sys_thread_read_regs`.
+    // Draw into a kernel buffer *before* the user copy: the draw disables/
+    // re-enables interrupts internally, which must not happen inside the SMAP/SUM
+    // access window that `copy_to_user` opens. Mirrors `sys_thread_read_regs`.
     let mut scratch = [0u8; MAX_GETRANDOM_LEN];
     crate::entropy::fill_bytes(&mut scratch[..len]);
 
-    // SAFETY: the span was validated to lie wholly in the user half above;
-    // user_access_begin/end bracket the copy to permit the user-memory write.
+    // The span was range-validated above; the copy is additionally fault-recovered,
+    // so an in-range-but-unmapped/read-only buffer returns InvalidAddress rather
+    // than faulting the kernel.
+    // SAFETY: scratch is valid for `len` reads; buf_ptr is the validated user span.
     unsafe {
-        let dst = buf_ptr as *mut u8;
-        crate::arch::current::cpu::user_access_begin();
-        core::ptr::copy_nonoverlapping(scratch.as_ptr(), dst, len);
-        crate::arch::current::cpu::user_access_end();
+        crate::uaccess::copy_to_user(buf_ptr, scratch.as_ptr(), len)?;
     }
 
     Ok(len as u64)

--- a/core/kernel/src/syscall/ipc.rs
+++ b/core/kernel/src/syscall/ipc.rs
@@ -35,12 +35,13 @@ use syscall::{MSG_CAP_SLOTS_MAX, MSG_DATA_WORDS_MAX};
 
 /// Read up to `count` data words from the thread's IPC buffer into `dst`.
 ///
-/// Returns `Err(InvalidArgument)` if the buffer is not registered.
+/// Returns `Err(InvalidArgument)` if the buffer is not registered, or
+/// `Err(InvalidAddress)` if the buffer is unmapped at copy time.
 ///
 /// # Safety
-/// `buf` must be a valid user-mode IPC buffer VA or 0. Brackets the access
-/// with `user_access_begin`/`user_access_end` to satisfy SMAP (x86-64) /
-/// SUM (RISC-V).
+/// `buf` must be a user-mode IPC buffer VA or 0. The read goes through
+/// `copy_from_user`, so an unmapped span is recovered as `InvalidAddress`
+/// rather than faulting the kernel.
 #[cfg(not(test))]
 unsafe fn read_ipc_buf(
     buf: u64,
@@ -52,30 +53,33 @@ unsafe fn read_ipc_buf(
     {
         return Err(SyscallError::InvalidArgument);
     }
-    // cast_possible_truncation: Seraph targets 64-bit only; usize == u64 on all supported targets.
-    #[allow(clippy::cast_possible_truncation)]
-    let ptr = buf as *const u64;
-    // SAFETY: buf validated non-zero and user-mapped by caller; SMAP/SUM enabled.
+    let n = count.min(MSG_DATA_WORDS_MAX);
+    // Read the first `n` words from the user IPC buffer with fault recovery: a
+    // buffer unmapped after SYS_IPC_BUFFER_SET returns InvalidAddress instead of
+    // faulting the kernel.
+    // SAFETY: dst holds MSG_DATA_WORDS_MAX words, so it is valid for n*8 bytes; buf
+    //         is the user source span (validated non-zero / page-aligned at
+    //         registration).
     unsafe {
-        crate::arch::current::cpu::user_access_begin();
-        for (i, item) in dst.iter_mut().enumerate().take(count)
-        {
-            // SAFETY: buf is page-aligned and user-mapped; count <= MSG_DATA_WORDS_MAX.
-            *item = core::ptr::read_volatile(ptr.add(i));
-        }
-        // SAFETY: paired with user_access_begin above; clears AC flag.
-        crate::arch::current::cpu::user_access_end();
+        crate::uaccess::copy_from_user(
+            dst.as_mut_ptr().cast::<u8>(),
+            buf,
+            n * core::mem::size_of::<u64>(),
+        )?;
     }
     Ok(())
 }
 
 /// Write up to `count` data words from `src` to the thread's IPC buffer.
 ///
-/// Silently skips if buffer is not registered (caller may not want data).
+/// Silently skips if the buffer is not registered (caller may not want data) and
+/// silently tolerates a faulting (unmapped) buffer — see the body for why a fault
+/// here is swallowed rather than propagated.
 ///
 /// # Safety
-/// `buf` must be a valid user-mode IPC buffer VA or 0. Brackets the access
-/// with `user_access_begin`/`user_access_end` to satisfy SMAP / SUM.
+/// `buf` must be a user-mode IPC buffer VA or 0. The write goes through
+/// `copy_to_user`, so an unmapped span is recovered rather than faulting the
+/// kernel.
 #[cfg(not(test))]
 unsafe fn write_ipc_buf(buf: u64, count: usize, src: &[u64; MSG_DATA_WORDS_MAX])
 {
@@ -83,19 +87,20 @@ unsafe fn write_ipc_buf(buf: u64, count: usize, src: &[u64; MSG_DATA_WORDS_MAX])
     {
         return;
     }
-    // cast_possible_truncation: Seraph targets 64-bit only; usize == u64 on all supported targets.
-    #[allow(clippy::cast_possible_truncation)]
-    let ptr = buf as *mut u64;
-    // SAFETY: buf validated non-zero and user-mapped by caller; SMAP/SUM enabled.
+    let n = count.min(MSG_DATA_WORDS_MAX);
+    // Write the first `n` words to the user IPC buffer with fault recovery. A fault
+    // (the owner unmapped its own buffer) is swallowed rather than propagated: this
+    // runs during reply delivery in the owner's address space where the IPC has
+    // already committed, so the only consequence is that the owner reads stale
+    // words from a buffer it broke — never a kernel panic.
+    // SAFETY: src holds MSG_DATA_WORDS_MAX words, valid for n*8 bytes; buf is the
+    //         user destination span.
     unsafe {
-        crate::arch::current::cpu::user_access_begin();
-        for (i, item) in src.iter().enumerate().take(count)
-        {
-            // SAFETY: buf is page-aligned and user-mapped; count <= MSG_DATA_WORDS_MAX.
-            core::ptr::write_volatile(ptr.add(i), *item);
-        }
-        // SAFETY: paired with user_access_begin above; clears AC flag.
-        crate::arch::current::cpu::user_access_end();
+        let _ = crate::uaccess::copy_to_user(
+            buf,
+            src.as_ptr().cast::<u8>(),
+            n * core::mem::size_of::<u64>(),
+        );
     }
 }
 
@@ -124,20 +129,26 @@ unsafe fn write_cap_results(buf: u64, cap_count: usize, indices: &[u32; MSG_CAP_
     // Always write the cap_count word, even when 0: stale values from a prior
     // IPC round would otherwise be read by `read_recv_caps` and mismatch the
     // declared cap count, tripping `debug_assert_eq!` on the caller side.
-    // cast_possible_truncation: Seraph targets 64-bit only; usize == u64 on all supported targets.
-    #[allow(clippy::cast_possible_truncation)]
-    let ptr = buf as *mut u64;
-    // SAFETY: IPC buffer is at least 4 KiB; MSG_DATA_WORDS_MAX + 1 + MSG_CAP_SLOTS_MAX
-    // words = at most 11 words = 88 bytes, well within the page. Brackets the
-    // access with user_access_begin/end to satisfy SMAP (x86-64) / SUM (RISC-V).
+    let n = cap_count.min(MSG_CAP_SLOTS_MAX);
+    // Assemble the result block [cap_count, idx0, idx1, ...] (indices widened
+    // u32 -> u64) in a kernel buffer, then copy it to the user IPC buffer at word
+    // offset MSG_DATA_WORDS_MAX.
+    let mut block = [0u64; MSG_CAP_SLOTS_MAX + 1];
+    block[0] = cap_count as u64;
+    for (slot, &idx) in block[1..].iter_mut().zip(indices.iter()).take(n)
+    {
+        *slot = u64::from(idx);
+    }
+    let dst = buf + (MSG_DATA_WORDS_MAX * core::mem::size_of::<u64>()) as u64;
+    // SAFETY: block is valid for (n+1)*8 bytes; the IPC buffer is page-sized, far
+    //         larger than MSG_DATA_WORDS_MAX + 1 + MSG_CAP_SLOTS_MAX words. A fault
+    //         is swallowed (see write_ipc_buf) rather than panicking.
     unsafe {
-        crate::arch::current::cpu::user_access_begin();
-        core::ptr::write_volatile(ptr.add(MSG_DATA_WORDS_MAX), cap_count as u64);
-        for (i, &idx) in indices.iter().enumerate().take(cap_count)
-        {
-            core::ptr::write_volatile(ptr.add(MSG_DATA_WORDS_MAX + 1 + i), u64::from(idx));
-        }
-        crate::arch::current::cpu::user_access_end();
+        let _ = crate::uaccess::copy_to_user(
+            dst,
+            block.as_ptr().cast::<u8>(),
+            (n + 1) * core::mem::size_of::<u64>(),
+        );
     }
 }
 

--- a/core/kernel/src/syscall/mod.rs
+++ b/core/kernel/src/syscall/mod.rs
@@ -717,8 +717,9 @@ fn sys_ipc_buffer_set(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     let virt = tf.arg(0);
     // A non-zero buffer must be page-aligned AND in the user half. Without the
     // user-half check a page-aligned kernel or non-canonical VA would be stored
-    // and later dereferenced by the IPC fast paths under user_access_begin/end,
-    // faulting in the kernel instead of failing the (mis)registration here.
+    // and later copied by the IPC fast paths; SMAP/SUM do not gate kernel-half
+    // pages, so it must be rejected here rather than relying on copy-fault
+    // recovery (which only catches user-page faults).
     if virt != 0 && ((virt & 0xFFF) != 0 || virt >= USER_HALF_TOP)
     {
         return Err(SyscallError::InvalidAddress);

--- a/core/kernel/src/syscall/thread.rs
+++ b/core/kernel/src/syscall/thread.rs
@@ -18,6 +18,10 @@
 use crate::arch::current::trap_frame::TrapFrame;
 use syscall::SyscallError;
 
+/// User-half ceiling: virtual addresses at or above this are kernel/non-canonical.
+#[cfg(not(test))]
+const USER_HALF_TOP: u64 = 0x0000_8000_0000_0000;
+
 /// `SYS_THREAD_CONFIGURE` (23): set entry point, stack, argument, and TLS base
 /// for a thread.
 ///
@@ -1346,16 +1350,23 @@ pub fn sys_thread_read_regs(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     {
         return Err(SyscallError::InvalidArgument);
     }
+    // The destination must lie wholly in the user half: SMAP/SUM gate only
+    // accesses to user pages, so without this a kernel-half buf_ptr would let the
+    // copy write the target's register frame into kernel memory at an
+    // attacker-chosen VA. (`buf_ptr >= USER_HALF_TOP` short-circuits before the
+    // sum, so `buf_ptr + copy_size` cannot overflow.)
+    if buf_ptr >= USER_HALF_TOP || buf_ptr + copy_size as u64 > USER_HALF_TOP
+    {
+        return Err(SyscallError::InvalidAddress);
+    }
 
-    // Copy TrapFrame to user buffer under SMAP/SUM bracket.
-    // SAFETY: trap_frame validated non-null; buf_ptr user VA; copy_size bounded;
-    //         user_access_begin/end bracket enables SMAP bypass.
+    // Copy the target's TrapFrame to the user buffer with fault recovery: an
+    // unmapped or read-only buffer returns InvalidAddress instead of faulting.
+    // SAFETY: trap_frame validated non-null; src is valid for copy_size reads;
+    //         buf_ptr is the validated user destination span.
     unsafe {
         let src = (*target_tcb).trap_frame as *const u8;
-        let dst = buf_ptr as *mut u8;
-        crate::arch::current::cpu::user_access_begin();
-        core::ptr::copy_nonoverlapping(src, dst, copy_size);
-        crate::arch::current::cpu::user_access_end();
+        crate::uaccess::copy_to_user(buf_ptr, src, copy_size)?;
     }
 
     Ok(copy_size as u64)
@@ -1435,22 +1446,26 @@ pub fn sys_thread_write_regs(tf: &mut TrapFrame) -> Result<u64, SyscallError>
     {
         return Err(SyscallError::InvalidArgument);
     }
-
-    // Copy from user into a stack-local TrapFrame, then validate.
-    // Never write directly to the target's trap_frame before validation.
-    let mut tmp: MaybeUninit<ArchTF> = MaybeUninit::zeroed();
-    // SAFETY: buf_ptr is a non-null user VA; copy_size matches the struct.
-    unsafe {
-        crate::arch::current::cpu::user_access_begin();
-        core::ptr::copy_nonoverlapping(
-            buf_ptr as *const u8,
-            tmp.as_mut_ptr().cast::<u8>(),
-            copy_size,
-        );
-        crate::arch::current::cpu::user_access_end();
+    // The source must lie wholly in the user half: SMAP/SUM gate only accesses to
+    // user pages, so without this a kernel-half buf_ptr would let the copy read
+    // kernel memory at an attacker-chosen VA into the register frame.
+    if buf_ptr >= USER_HALF_TOP || buf_ptr + copy_size as u64 > USER_HALF_TOP
+    {
+        return Err(SyscallError::InvalidAddress);
     }
 
-    // SAFETY: all bytes just written by copy_nonoverlapping above.
+    // Copy from user into a stack-local TrapFrame, then validate. Never write
+    // directly to the target's trap_frame before validation. The copy is
+    // fault-recovered: an unmapped or read-only source returns InvalidAddress.
+    let mut tmp: MaybeUninit<ArchTF> = MaybeUninit::zeroed();
+    // SAFETY: tmp is valid for copy_size writes; buf_ptr is the validated user
+    //         source span.
+    unsafe {
+        crate::uaccess::copy_from_user(tmp.as_mut_ptr().cast::<u8>(), buf_ptr, copy_size)?;
+    }
+
+    // SAFETY: tmp was zero-initialized, so every byte is a valid bit pattern for
+    // ArchTF regardless of how much copy_from_user wrote before any fault.
     let mut regs = unsafe { tmp.assume_init() };
 
     // Architecture-specific register safety validation.

--- a/core/kernel/src/uaccess.rs
+++ b/core/kernel/src/uaccess.rs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// kernel/src/uaccess.rs
+
+//! Fault-recoverable user-memory copies.
+//!
+//! All kernel access to user-supplied pointers goes through these helpers. They
+//! forward to the arch `copy_user` primitive, which owns the SMAP (x86-64) / SUM
+//! (RISC-V) access window and is covered by the page-fault handlers' user-copy
+//! fixup: a fault on an unmapped or read-only user span returns
+//! [`SyscallError::InvalidAddress`] instead of panicking the kernel.
+//!
+//! Callers SHOULD still range-validate the user pointer (user half, alignment,
+//! length) before copying — that rejects the common bad-pointer case cheaply
+//! without taking a fault, and (critically) keeps the copy from touching a
+//! kernel-half VA, which SMAP/SUM do not protect. Fault recovery is the backstop
+//! for an in-range span that is unmapped or read-only, including a TOCTOU unmap
+//! after validation.
+
+#[cfg(not(test))]
+use syscall::SyscallError;
+
+/// Copy `len` bytes from kernel `src` into user `dst`. Returns
+/// [`SyscallError::InvalidAddress`] if the user span faults during the copy.
+///
+/// # Safety
+/// `src` must be valid for `len` bytes of reads. `dst` is a user VA in the
+/// caller's address space; it need not be mapped (a fault is recovered), but the
+/// caller must have range-validated it lies in the user half.
+#[cfg(not(test))]
+pub unsafe fn copy_to_user(dst: u64, src: *const u8, len: usize) -> Result<(), SyscallError>
+{
+    // SAFETY: forwarded to the arch primitive; a fault on the user destination is
+    // recovered and reported as a non-zero return.
+    let faulted = unsafe { crate::arch::current::cpu::copy_user(dst as *mut u8, src, len) };
+    if faulted == 0
+    {
+        Ok(())
+    }
+    else
+    {
+        Err(SyscallError::InvalidAddress)
+    }
+}
+
+/// Copy `len` bytes from user `src` into kernel `dst`. Returns
+/// [`SyscallError::InvalidAddress`] if the user span faults during the copy.
+///
+/// On success the entire `len` bytes were copied; on `Err` an unspecified prefix
+/// may have been written before the fault.
+///
+/// # Safety
+/// `dst` must be valid for `len` bytes of writes. `src` is a user VA in the
+/// caller's address space; it need not be mapped (a fault is recovered), but the
+/// caller must have range-validated it lies in the user half.
+#[cfg(not(test))]
+pub unsafe fn copy_from_user(dst: *mut u8, src: u64, len: usize) -> Result<(), SyscallError>
+{
+    // SAFETY: forwarded to the arch primitive; a fault on the user source is
+    // recovered and reported as a non-zero return.
+    let faulted = unsafe { crate::arch::current::cpu::copy_user(dst, src as *const u8, len) };
+    if faulted == 0
+    {
+        Ok(())
+    }
+    else
+    {
+        Err(SyscallError::InvalidAddress)
+    }
+}

--- a/core/ktest/src/unit/entropy.rs
+++ b/core/ktest/src/unit/entropy.rs
@@ -11,6 +11,10 @@ use syscall_abi::SyscallError;
 /// A canonical user-half virtual address that ktest never maps.
 const UNMAPPED_USER_VA: u64 = 0x6000_0000_0000;
 
+/// Safe test VA (1 GiB), well above ktest's load address and stack. Mapped and
+/// unmapped within a single test, so it is free between tests.
+const RO_TEST_VA: u64 = 0x4000_0000;
+
 /// `getrandom` into a valid buffer fills the whole span with non-zero entropy.
 pub fn getrandom_fills_buffer(_ctx: &TestContext) -> TestResult
 {
@@ -45,6 +49,33 @@ pub fn getrandom_unmapped_ptr_invalid_address(_ctx: &TestContext) -> TestResult
     {
         Err("getrandom on an unmapped user buffer must return InvalidAddress, not panic/succeed")
     }
+}
+
+/// `getrandom` into a read-only buffer returns `InvalidAddress` instead of
+/// panicking the kernel (#398, the read-only arm). The page is mapped, so it
+/// passes the user-half range check, but it is read-only: the kernel's copy
+/// store faults at CPL 0 / SPP=1 (write-protection is enforced independently of
+/// SMAP/SUM) and must be recovered by the same user-copy fixup.
+pub fn getrandom_readonly_ptr_invalid_address(ctx: &TestContext) -> TestResult
+{
+    let mut frame = crate::frame_pool::FrameGuard::new(ctx.aspace_cap)
+        .ok_or("getrandom RO: frame pool exhausted")?;
+    frame
+        .map(RO_TEST_VA)
+        .map_err(|_| "getrandom RO: mem_map failed")?;
+    // prot = 0: read-only (no WRITE/EXECUTE). Drops the W bit on the live PTE.
+    syscall::mem_protect(frame.cap(), ctx.aspace_cap, RO_TEST_VA, 1, 0)
+        .map_err(|_| "getrandom RO: mem_protect to read-only failed")?;
+
+    let r = syscall::getrandom(RO_TEST_VA as *mut u8, 16);
+    if r != Err(SyscallError::InvalidAddress as i64)
+    {
+        return Err(
+            "getrandom into a read-only buffer must return InvalidAddress, not panic/succeed",
+        );
+    }
+    // FrameGuard drop unmaps RO_TEST_VA and returns the frame to the pool.
+    Ok(())
 }
 
 /// `getrandom` with `len > MAX_GETRANDOM_LEN` returns `InvalidArgument`.

--- a/core/ktest/src/unit/entropy.rs
+++ b/core/ktest/src/unit/entropy.rs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// ktest/src/unit/entropy.rs
+
+//! Tier 1 tests for the entropy syscall surface (`SYS_GETRANDOM`).
+
+use crate::{TestContext, TestResult};
+use syscall_abi::SyscallError;
+
+/// A canonical user-half virtual address that ktest never maps.
+const UNMAPPED_USER_VA: u64 = 0x6000_0000_0000;
+
+/// `getrandom` into a valid buffer fills the whole span with non-zero entropy.
+pub fn getrandom_fills_buffer(_ctx: &TestContext) -> TestResult
+{
+    let mut buf = [0u8; 32];
+    let n = syscall::getrandom(buf.as_mut_ptr(), buf.len())
+        .map_err(|_| "getrandom failed on a valid buffer")?;
+    if n != buf.len() as u64
+    {
+        return Err("getrandom returned a short count");
+    }
+    // A seeded CSPRNG producing 32 zero bytes has probability ~2^-256.
+    if buf.iter().all(|&b| b == 0)
+    {
+        return Err("getrandom left the buffer all-zero");
+    }
+    Ok(())
+}
+
+/// `getrandom` into an unmapped user buffer returns `InvalidAddress` instead of
+/// panicking the kernel (#398). The buffer passes the handler's user-half range
+/// check but is unmapped, so the kernel's copy faults at CPL 0 / SPP=1 and must
+/// be redirected to the error path by the user-copy fixup rather than reaching
+/// the fatal kernel-exception handler.
+pub fn getrandom_unmapped_ptr_invalid_address(_ctx: &TestContext) -> TestResult
+{
+    let r = syscall::getrandom(UNMAPPED_USER_VA as *mut u8, 16);
+    if r == Err(SyscallError::InvalidAddress as i64)
+    {
+        Ok(())
+    }
+    else
+    {
+        Err("getrandom on an unmapped user buffer must return InvalidAddress, not panic/succeed")
+    }
+}
+
+/// `getrandom` with `len > MAX_GETRANDOM_LEN` returns `InvalidArgument`.
+pub fn getrandom_over_max_len_invalid_arg(_ctx: &TestContext) -> TestResult
+{
+    let mut buf = [0u8; 8];
+    let r = syscall::getrandom(buf.as_mut_ptr(), syscall::MAX_GETRANDOM_LEN + 1);
+    if r == Err(SyscallError::InvalidArgument as i64)
+    {
+        Ok(())
+    }
+    else
+    {
+        Err("getrandom with len > MAX_GETRANDOM_LEN must return InvalidArgument")
+    }
+}

--- a/core/ktest/src/unit/mod.rs
+++ b/core/ktest/src/unit/mod.rs
@@ -25,7 +25,8 @@
 //! - `retype.rs`   — retype primitive: aspace/cspace augment, PT budget, kernel PT pool
 //! - `mm.rs`       — memory map/unmap/protect, memory split, address space query
 //! - `entropy.rs`  — userspace randomness (`SYS_GETRANDOM`), incl. the user-copy
-//!   fault-recovery regression (unmapped buffer ⇒ `InvalidAddress`, not panic)
+//!   fault-recovery regression (unmapped or read-only buffer ⇒ `InvalidAddress`,
+//!   not panic)
 //! - `notification.rs`   — notification send and wait (blocking and timeout)
 //! - `event.rs`    — event queue post and receive (blocking, try, timeout)
 //! - `wait_set.rs` — wait set add, remove, wait
@@ -521,6 +522,10 @@ pub fn run_all(ctx: &TestContext)
     run_test!(
         "entropy::getrandom_unmapped_ptr_invalid_address",
         entropy::getrandom_unmapped_ptr_invalid_address(ctx)
+    );
+    run_test!(
+        "entropy::getrandom_readonly_ptr_invalid_address",
+        entropy::getrandom_readonly_ptr_invalid_address(ctx)
     );
     run_test!(
         "entropy::getrandom_over_max_len_invalid_arg",

--- a/core/ktest/src/unit/mod.rs
+++ b/core/ktest/src/unit/mod.rs
@@ -24,6 +24,8 @@
 //! - `cap_info.rs` — read-only capability state inspection (`SYS_CAP_INFO`)
 //! - `retype.rs`   — retype primitive: aspace/cspace augment, PT budget, kernel PT pool
 //! - `mm.rs`       — memory map/unmap/protect, memory split, address space query
+//! - `entropy.rs`  — userspace randomness (`SYS_GETRANDOM`), incl. the user-copy
+//!   fault-recovery regression (unmapped buffer ⇒ `InvalidAddress`, not panic)
 //! - `notification.rs`   — notification send and wait (blocking and timeout)
 //! - `event.rs`    — event queue post and receive (blocking, try, timeout)
 //! - `wait_set.rs` — wait set add, remove, wait
@@ -39,6 +41,7 @@
 pub mod cap;
 pub mod cap_info;
 pub mod crypto;
+pub mod entropy;
 pub mod event;
 pub mod fpu;
 pub mod hw;
@@ -509,6 +512,20 @@ pub fn run_all(ctx: &TestContext)
     run_test!("sysinfo::elapsed_us", sysinfo::elapsed_us(ctx));
     run_test!("sysinfo::current_cpu", sysinfo::current_cpu(ctx));
     run_test!("sysinfo::cpu_count_smp", sysinfo::cpu_count_smp(ctx));
+
+    // ── Entropy syscalls ──────────────────────────────────────────────────────
+    run_test!(
+        "entropy::getrandom_fills_buffer",
+        entropy::getrandom_fills_buffer(ctx)
+    );
+    run_test!(
+        "entropy::getrandom_unmapped_ptr_invalid_address",
+        entropy::getrandom_unmapped_ptr_invalid_address(ctx)
+    );
+    run_test!(
+        "entropy::getrandom_over_max_len_invalid_arg",
+        entropy::getrandom_over_max_len_invalid_arg(ctx)
+    );
 
     // ── Shared crypto primitives ──────────────────────────────────────────────
     run_test!("crypto::sha512_kats", crypto::sha512_kats(ctx));


### PR DESCRIPTION
## Summary

Closes #398. The kernel accessed user-supplied pointers under the SMAP/SUM access
window with **no fault recovery**: a copy to/from an in-range but **unmapped or
read-only** user VA faulted at CPL 0 / SPP=1 and fell through to
`fatal("unhandled kernel exception")`. `SYS_GETRANDOM` is ambient (no capability),
so any unprivileged process could panic the kernel — a kernel-wide DoS.

This adds a kernel-wide PC-based exception-table/fixup, reduced to its minimal
form by funnelling every user copy through one arch primitive:

- **`copy_user`** (`global_asm!`, per arch) owns the access window (`stac`/`clac`,
  `sstatus.SUM`) and brackets the faultable copy with start/end/fixup labels.
- The page-fault handlers (`x86_64::page_fault_handler`, `riscv64::trap_dispatch`)
  consult **`user_copy_fixup(pc)`** on a kernel-mode fault and, on a hit, redirect
  the saved `rip`/`sepc` to the fixup — which closes the window and returns a
  non-zero sentinel — instead of panicking.
- Typed **`uaccess::copy_to_user`/`copy_from_user`** wrappers map the sentinel to
  `SyscallError::InvalidAddress`.

All six user-copy sites migrate to the wrappers: `getrandom`, `thread_read_regs`,
`thread_write_regs`, and the three IPC buffer helpers (`read_ipc_buf`,
`write_ipc_buf`, `write_cap_results`). The bare `user_access_begin`/
`user_access_end` brackets are removed so the fault-recoverable path is the only
sanctioned one (prevents reintroducing the bug).

### Incidental security fix (same audited surface)

`thread_read_regs`/`thread_write_regs` validated the buffer only for non-null. A
kernel-half `buf_ptr` (which SMAP/SUM do **not** gate) let the bracketed copy
read/write **kernel memory at an attacker-chosen VA** — gated only by a Thread cap
with OBSERVE/CONTROL. Both now reject buffers outside the user half before copying.

## Acceptance (#398)

- [x] A user-copy syscall (`SYS_GETRANDOM`) given an unmapped user pointer returns
  `InvalidAddress`, not a kernel panic — new ktest regression on both arches.
- [x] The mechanism covers existing user-copy handlers (`thread_read_regs`/
  `thread_write_regs` + IPC helpers) on both arches — all routed through the single
  `copy_user` primitive.

Read-only buffers are covered by the same mechanism (a write to a read-only
mapping is a `#PF` / store page-fault, identical recovery path).

## Test plan

Both arches (`cargo xtask clean` between):

- `cargo xtask build` / `--arch riscv64` — green (clippy `-D warnings`).
- `cargo xtask compose-bundle --harness ktest` + `cargo xtask run` — ktest
  **199 passed, 0 failed** on x86_64 and riscv64, including:
  - `entropy::getrandom_unmapped_ptr_invalid_address` (the #398 regression),
  - `entropy::getrandom_fills_buffer`, `entropy::getrandom_over_max_len_invalid_arg`.
- `cargo xtask test` — host workspace tests green, incl. kernel
  `trap_frame_layout_matches_asm`.

Pre-change, the regression test instead triggers `unhandled kernel exception`.