### PR TITLE
abi/procmgr: demote layout-defining handover VAs to runtime fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,6 +519,7 @@ dependencies = [
  "namespace-protocol",
  "ns-client",
  "process-abi",
+ "process-layout",
  "syscall",
  "syscall-abi",
 ]
@@ -765,6 +766,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "process-layout"
+version = "0.1.1"
+
+[[package]]
 name = "procmgr"
 version = "0.1.1"
 dependencies = [
@@ -772,6 +777,7 @@ dependencies = [
  "ipc",
  "namespace-protocol",
  "process-abi",
+ "process-layout",
  "procmgr-process-table",
  "syscall",
  "syscall-abi",
@@ -1005,6 +1011,7 @@ version = "0.1.1"
 dependencies = [
  "ipc",
  "namespace-protocol",
+ "process-layout",
  "shmem",
  "syscall",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
     "shared/font",
     "shared/mmio",
     "shared/namespace-protocol",
+    "shared/process-layout",
     "shared/syscall",
     "shared/ipc",
     "shared/log",

--- a/abi/init-protocol/README.md
+++ b/abi/init-protocol/README.md
@@ -2,9 +2,11 @@
 
 Binary handover contract between the kernel and the init process.
 
-Defines [`InitInfo`] and all associated types placed in a read-only page at
-`INIT_INFO_VADDR` before init runs. Includes `INIT_PROTOCOL_VERSION`; init
-MUST check the version field before accessing any other fields.
+Defines [`InitInfo`] and all associated types placed in a read-only page before
+init runs. The kernel chooses the page's virtual address per-boot and delivers
+it to init in the entry register (`rdi`/`a0`), so the address is not an ABI
+constant. Includes `INIT_PROTOCOL_VERSION`; init MUST check the version field
+before accessing any other fields.
 
 **Constraints:** `no_std`, `#[repr(C)]` for all types, no dependencies outside
 `core`. Changes that alter `InitInfo` layout or CSpace population order MUST

--- a/abi/init-protocol/src/lib.rs
+++ b/abi/init-protocol/src/lib.rs
@@ -7,9 +7,9 @@
 //!
 //! This crate defines the binary interface between the kernel (Phase 7/9) and
 //! the init process. The kernel populates an [`InitInfo`] structure in a
-//! read-only page mapped into init's address space at [`INIT_INFO_VADDR`] and
-//! passes that address as init's sole entry argument (`rdi` on x86-64, `a0`
-//! on RISC-V).
+//! read-only page mapped into init's address space at a kernel-chosen virtual
+//! address (`choose_init_layout` in the kernel) and passes that address as
+//! init's sole entry argument (`rdi` on x86-64, `a0` on RISC-V).
 //!
 //! # Versioning
 //!
@@ -98,26 +98,12 @@ pub const INIT_MODULE_NAME_LEN: usize = 32;
 pub const INIT_MAX_NAMED_MODULES: usize = 12;
 
 // ── Address space constants ──────────────────────────────────────────────────
-
-/// Virtual address where the kernel maps the read-only [`InitInfo`] region.
-///
-/// The region spans one or more contiguous pages — enough for the header
-/// (which now includes the boot-module name table) followed by the
-/// variable-length [`CapDescriptor`] array. Sized so the full
-/// [`INIT_INFO_MAX_PAGES`] fit between this address and the init stack's guard
-/// page (`0x7FFF_FFFF_9000`): the
-/// region occupies `[0x7FFF_FFFF_5000, 0x7FFF_FFFF_9000)`, the guard sits at
-/// `0x7FFF_FFFF_9000`, and the stack runs `[0x7FFF_FFFF_A000, INIT_STACK_TOP)`.
-/// A larger array (3+ pages) must not collide with the stack — that silently
-/// remaps descriptor pages onto stack frames and drops the trailing caps.
-pub const INIT_INFO_VADDR: u64 = 0x7FFF_FFFF_5000;
-
-/// Virtual address of the top of init's user stack.
-///
-/// `INIT_STACK_PAGES` pages are mapped immediately below this address.
-/// One additional guard page (unmapped) sits below the stack, and the
-/// [`InitInfo`] region (up to [`INIT_INFO_MAX_PAGES`]) sits below that.
-pub const INIT_STACK_TOP: u64 = 0x7FFF_FFFF_E000;
+//
+// The `InitInfo` region and init stack virtual addresses are not ABI constants:
+// the kernel chooses them per-boot (see `choose_init_layout` in the kernel) and
+// delivers the `InitInfo` page address to init in the entry register, exactly as
+// procmgr does for `ProcessInfo` (#250). Only the page-count bounds below — which
+// both the kernel and init must agree on — remain part of the protocol.
 
 /// Number of 4 KiB pages in init's user stack (16 KiB total).
 pub const INIT_STACK_PAGES: usize = 4;
@@ -135,10 +121,10 @@ pub const INIT_INFO_MAX_PAGES: usize = 4;
 
 /// Kernel-to-init handover structure.
 ///
-/// Placed at [`INIT_INFO_VADDR`] (one or more pages, read-only). The fixed-size
-/// header is followed by a variable-length [`CapDescriptor`] array; the array
-/// starts at byte offset [`InitInfo::cap_descriptors_offset`] from the start
-/// of this struct.
+/// Placed in one or more read-only pages at a kernel-chosen virtual address,
+/// delivered to init in its entry register. The fixed-size header is followed by
+/// a variable-length [`CapDescriptor`] array; the array starts at byte offset
+/// [`InitInfo::cap_descriptors_offset`] from the start of this struct.
 ///
 /// All slot indices refer to init's root `CSpace` (`CSpace` ID 0).
 #[repr(C)]

--- a/abi/process-abi/README.md
+++ b/abi/process-abi/README.md
@@ -32,10 +32,11 @@ including init and ktest — share the same `main()` signature.
 
 ## ProcessInfo
 
-The procmgr-to-process handover struct. Placed by procmgr at
-`PROCESS_INFO_VADDR` (a fixed virtual address in every new process's address
-space) in a single read-only page, analogous to how the kernel places `InitInfo`
-for init at `INIT_INFO_VADDR`.
+The procmgr-to-process handover struct. Placed by procmgr in a single read-only
+page at a virtual address procmgr chooses per-process (via `process-layout`) and
+delivers in the entry register (`rdi`/`a0`), analogous to how the kernel places
+`InitInfo` for init. The address is not a fixed ABI constant — the process reads
+it as the argument to `_start`.
 
 The struct MUST be `#[repr(C)]` with stable layout. The process MUST check
 `version == PROCESS_ABI_VERSION` before accessing any other field.
@@ -43,11 +44,12 @@ The struct MUST be `#[repr(C)]` with stable layout. The process MUST check
 The authoritative field list, with per-field doc comments and exact order, is
 [`src/lib.rs`](src/lib.rs) (`struct ProcessInfo`). This README summarises the
 field groups rather than mirroring every field, so the two cannot drift. As of
-`PROCESS_ABI_VERSION` 19 the groups are:
+`PROCESS_ABI_VERSION` 21 the groups are:
 
 - **Process identity** — `version`, `self_thread_cap`, `self_aspace_cap`,
   `self_cspace_cap`, `sched_control_cap`.
-- **IPC / bootstrap** — `ipc_buffer_vaddr`, `creator_endpoint_cap`.
+- **IPC / bootstrap** — `ipc_buffer_vaddr` (creator-chosen per-process),
+  `creator_endpoint_cap`.
 - **Universal service endpoints** — `procmgr_endpoint_cap`, `memmgr_endpoint_cap`,
   `service_registry_cap` (the single system-wide service-discovery handle).
 - **Stdio rings** — `stdin_memory_cap`, `stdout_memory_cap`, `stderr_memory_cap`
@@ -59,7 +61,10 @@ field groups rather than mirroring every field, so the two cannot drift. As of
   after the fixed struct, bounded by the page remainder).
 - **Namespace** — `system_root_cap`, `current_dir_cap`.
 - **Logging** — `log_send_cap` (deprecated; migrating to `service_registry_cap`).
-- **Main-thread stack envelope** — `stack_top_vaddr`, `stack_pages`.
+- **Main-thread layout** — `stack_top_vaddr`, `stack_pages`, `main_tls_vaddr`
+  (TLS block base, zero when the process has no `PT_TLS`). The creator chooses
+  these VAs per-process (via `process-layout`), so they are runtime fields, not
+  ABI constants.
 - **Demand-paging pager** (v18, #34; default-on v19, #225) — `pager_endpoint_cap`,
   `pager_badge`. The `Endpoint` cap + badge of the process's pager (memmgr).
   Demand paging is the system-wide default, so these are nonzero for ordinary
@@ -104,8 +109,9 @@ The authoritative definition is [`src/lib.rs`](src/lib.rs) (`struct StartupInfo`
 the std overlay carries a `#[stable]`-attributed mirror at
 `runtime/ruststd/src/os/seraph.rs`. It exposes the same groups as `ProcessInfo`
 (identity, service endpoints, stdio rings + notifications, TLS template,
-argv/env as resolved `&[u8]` slices, namespace, stack envelope, and the v18
-`pager_endpoint_cap` / `pager_badge`), with cap slots delivered as `u32` values
+argv/env as resolved `&[u8]` slices, namespace, main-thread layout including
+`main_tls_vaddr`, and the v18 `pager_endpoint_cap` / `pager_badge`), with cap
+slots delivered as `u32` values
 and `args_blob` / `env_blob` resolved from the handover page into slices.
 
 Values are copied out of the handover page verbatim, so the struct does
@@ -130,7 +136,8 @@ safety net.
 `_start()` is provided by three distinct runtimes, chosen by build profile:
 
 - **std-built services** — `std::os::seraph::_start` (shipped via the
-  `ruststd/` overlay) reads `ProcessInfo`, registers the IPC buffer,
+  `ruststd/` overlay) takes the `ProcessInfo` page address as its argument
+  (entry register), reads `ProcessInfo`, registers the IPC buffer,
   bootstraps the heap against the `memmgr_endpoint` delivered in
   `ProcessInfo`, then jumps to `lang_start` → user `fn main`. procmgr
   is itself a std-built service and follows this path.
@@ -139,8 +146,10 @@ safety net.
   uses no `alloc` collections. It is the only std-less process spawned
   by init via raw syscalls besides init itself.
 - **init / ktest** — bespoke `_start` entries that consume `InitInfo`
-  from `INIT_INFO_VADDR` (defined in `abi/init-protocol`) rather than
-  `ProcessInfo`, because the kernel — not procmgr — is their producer.
+  (defined in `abi/init-protocol`) rather than `ProcessInfo`, because the
+  kernel — not procmgr — is their producer. The kernel chooses the
+  `InitInfo` page address and delivers it in the entry register, as procmgr
+  does for `ProcessInfo`.
 
 All variants produce the same `StartupInfo` shape and invoke `main()`,
 then call `sys_thread_exit` if `main()` returns (defensive — should not
@@ -155,7 +164,7 @@ happen).
 | Producer | Kernel (Phase 9) | procmgr |
 | Consumer | init, ktest | All other processes |
 | Handover struct | `InitInfo` | `ProcessInfo` |
-| Placed at | `INIT_INFO_VADDR` | `PROCESS_INFO_VADDR` |
+| Page address | Kernel-chosen, delivered in entry register | Creator-chosen, delivered in entry register |
 | Contains platform-global state | Yes (all memory caps, all HW caps, firmware tables) | No |
 | Contains parent endpoint | No (init has no parent) | Yes |
 | `main()` signature | Same (`&StartupInfo`) | Same (`&StartupInfo`) |

--- a/abi/process-abi/src/lib.rs
+++ b/abi/process-abi/src/lib.rs
@@ -56,19 +56,18 @@ use core::prelude::rust_2024::*;
 ///      never-recycled generation-0 slot, so the delivered values are
 ///      byte-identical; the semantic change is that the handle's high bits are
 ///      now meaningful and the kernel validates them on every use.
-pub const PROCESS_ABI_VERSION: u32 = 20;
+/// v21: Layout-defining handover VAs are creator-chosen runtime values, not ABI
+///      constants (#250). The `PROCESS_INFO_VADDR` / `PROCESS_STACK_TOP` /
+///      `PROCESS_MAIN_TLS_VADDR` constants are removed; the creator picks them
+///      per-process via `shared/process-layout`. The `ProcessInfo` page address
+///      is delivered in the entry register (`rdi`/`a0`) — `_start` takes it as
+///      its argument rather than reading a fixed address. Added
+///      [`ProcessInfo::main_tls_vaddr`], the chosen main-thread TLS block base
+///      (the stack top and IPC buffer already had runtime fields). The IPC
+///      buffer VA is also creator-chosen (it was already a runtime field).
+pub const PROCESS_ABI_VERSION: u32 = 21;
 
 // ── Address space constants ──────────────────────────────────────────────────
-
-/// Virtual address where procmgr maps the read-only [`ProcessInfo`] page in
-/// every new process's address space.
-pub const PROCESS_INFO_VADDR: u64 = 0x0000_7FFF_FFFF_0000;
-
-/// Virtual address of the top of a normal process's user stack.
-///
-/// `ProcessInfo.stack_pages` pages are mapped immediately below this
-/// address. One additional guard page (unmapped) sits below the stack.
-pub const PROCESS_STACK_TOP: u64 = 0x0000_7FFF_FFFF_E000;
 
 /// Default main-thread stack size in 4 KiB pages (32 KiB total).
 ///
@@ -182,14 +181,6 @@ macro_rules! stack_pages {
     };
 }
 
-/// Virtual address of the main thread's TLS block in a normal process.
-///
-/// Procmgr allocates and populates the block at creation time. For processes
-/// without a `PT_TLS` segment this region remains unmapped. Placed below
-/// [`CHILD_IPC_BUF_VADDR`] so it does not collide with the stack or the
-/// `ProcessInfo` page.
-pub const PROCESS_MAIN_TLS_VADDR: u64 = 0x0000_7FFF_FFFD_0000;
-
 /// Maximum number of 4 KiB pages reserved for the main thread's TLS block.
 ///
 /// Procmgr rejects binaries whose TLS block exceeds this size. Spawned
@@ -201,8 +192,11 @@ pub const PROCESS_MAIN_TLS_MAX_PAGES: u64 = 4;
 
 /// Creator-to-process handover structure.
 ///
-/// Placed at [`PROCESS_INFO_VADDR`] (one 4 KiB page, read-only) before the
-/// new process begins execution.
+/// One 4 KiB page, read-only, mapped before the new process begins execution.
+/// The creator chooses the page's virtual address per-process (via
+/// `process-layout`) and delivers it in the entry register (`rdi`/`a0`); the
+/// process receives it as the argument to `_start` rather than reading a fixed
+/// address.
 ///
 /// All slot indices refer to the process's own `CSpace`. Beyond the kernel-
 /// object self-caps, the creator endpoint, the procmgr endpoint, and the
@@ -499,6 +493,14 @@ pub struct ProcessInfo
     /// identifying this process to the pager. Zero when the process is pinned
     /// (no pager).
     pub pager_badge: u64,
+
+    /// Mapped base virtual address of the main thread's TLS block — the value
+    /// the creator placed the block at and from which the thread pointer is
+    /// derived. Zero when the process has no `PT_TLS` segment (mirrors
+    /// `tls_template_memsz == 0`). The creator chooses this per-process via
+    /// `process-layout`; the kernel installs the thread pointer, so `_start`
+    /// reads this only for introspection.
+    pub main_tls_vaddr: u64,
 }
 
 // ── StartupInfo ──────────────────────────────────────────────────────────────
@@ -619,6 +621,10 @@ pub struct StartupInfo
     /// Fault-message badge bound with [`Self::pager_endpoint_cap`]. Zero
     /// when not demand-paged.
     pub pager_badge: u64,
+
+    /// Mapped base virtual address of the main thread's TLS block, or zero when
+    /// the process has no TLS. See `ProcessInfo::main_tls_vaddr`.
+    pub main_tls_vaddr: u64,
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────

--- a/core/kernel/docs/initialization.md
+++ b/core/kernel/docs/initialization.md
@@ -406,21 +406,24 @@ calls `sched::enter()`.
       one at a time so each phys address is captured for the reclaim
       Memory cap minted alongside it
    b. Zero each frame
-   c. Map below INIT_STACK_TOP (0x7FFF_FFFF_E000) with read/write permissions
+   c. Map below the chosen init stack top (`choose_init_layout().init_stack_top`,
+      default 0x7FFF_FFFF_E000) with read/write permissions
    d. Mint a reclaimable Memory cap per stack page into the root CSpace
       so init can donate the pages to memmgr on reap
    e. Guard page (unmapped) sits immediately below the stack; stack overflows fault
 5. Create init's TCB:
    a. Allocate a kernel stack for init (KERNEL_STACK_PAGES = 4 pages = 16 KiB)
-   b. new_state(entry=init_image.entry_point, stack_top=kstack_top, arg=0, is_user=true)
-      stores entry_point in saved_state.rip (x86-64) or .ra (RISC-V)
+   b. new_state(entry=init_image.entry_point, stack_top=kstack_top,
+      arg=choose_init_layout().init_info_va, is_user=true) stores entry_point in
+      saved_state.rip (x86-64) or .ra (RISC-V) and the InitInfo VA as the arg
+      forwarded to init's a0/rdi on first entry
    c. Priority: INIT_PRIORITY (15)
    d. cspace: set to ROOT_CSPACE raw pointer (handed off at `sched::enter()` start)
 6. Enqueue the init TCB on the BSP's run queue at INIT_PRIORITY
 7. Call sched::enter() — does not return:
    a. Dequeue the highest-priority ready thread (init)
    b. Build an initial user-mode TrapFrame on init's kernel stack:
-      rip/sepc=entry_point, rsp/sp=INIT_STACK_TOP, cs=USER_CS, ss=USER_DS,
+      rip/sepc=entry_point, rsp/sp=chosen init stack top, cs=USER_CS, ss=USER_DS,
       rflags=0x202 (IF=1)
    c. x86-64: call switch_and_enter_user(root_phys, tf_ptr) — atomically
       switches RSP to init's kernel stack, writes CR3, builds iretq frame, iretq

--- a/core/kernel/src/main.rs
+++ b/core/kernel/src/main.rs
@@ -535,6 +535,11 @@ unsafe fn kernel_entry_post_rebase(
             init_image.entry_point
         );
 
+        // Choose init's bootstrap VA layout once; threaded through the InitInfo
+        // mapping, the stack mapping, and the entry-register arg below so all
+        // three agree even when ASLR (#39) makes the choice per-boot random.
+        let init_layout = mm::address_space::choose_init_layout();
+
         // Create init's user address space via the typed-memory boot path:
         // a slab is retyped from `SEED_FRAME` (page 0 = wrapper page holding
         // `AddressSpaceObject` + inlined `AddressSpace`; page 1 = root PT;
@@ -670,7 +675,7 @@ unsafe fn kernel_entry_post_rebase(
         // ── Populate InitInfo region ─────────────────────────────────────────
         // Allocate enough physical pages for InitInfo + CapDescriptor array +
         // command line, fill them via the direct map, then map read-only into
-        // init's address space starting at INIT_INFO_VADDR. Each backing page
+        // init's address space starting at the chosen InitInfo VA. Each backing page
         // also gets a reclaimable Memory cap minted into init's CSpace so the
         // pages flow into memmgr's pool through init's reap-handoff donate
         // path (see `services/init/src/service.rs` end-of-phase-3).
@@ -678,8 +683,7 @@ unsafe fn kernel_entry_post_rebase(
             use cap::object::{KernelObjectHeader, MemoryObject, ObjectType};
             use cap::slot::{CapTag, Rights};
             use init_protocol::{
-                INIT_INFO_VADDR, INIT_PROTOCOL_VERSION, InitFramebufferInfo, InitInfo,
-                InitPixelFormat,
+                INIT_PROTOCOL_VERSION, InitFramebufferInfo, InitInfo, InitPixelFormat,
             };
 
             // Re-read `BootInfo.framebuffer` via the direct physical map so
@@ -778,7 +782,7 @@ unsafe fn kernel_entry_post_rebase(
                 let phys = block_phys + (pg as u64) * mm::PAGE_SIZE as u64;
                 // SAFETY: pg < block_pages by construction (info_pages <= block_pages).
                 let virt = unsafe { block_virt.add(pg * mm::PAGE_SIZE) };
-                let map_va = INIT_INFO_VADDR + (pg as u64) * mm::PAGE_SIZE as u64;
+                let map_va = init_layout.init_info_va + (pg as u64) * mm::PAGE_SIZE as u64;
                 // SAFETY: init_as_ptr valid; phys is part of the contiguous extent.
                 unsafe { (*init_as_ptr).map_page(map_va, phys, flags) }
                     .unwrap_or_else(|()| fatal("Phase 9: failed to map InitInfo page"));
@@ -912,7 +916,7 @@ unsafe fn kernel_entry_post_rebase(
 
             kprintln!(
                 "init: info at {:#x} ({} cap descriptors, {} pages)",
-                INIT_INFO_VADDR,
+                init_layout.init_info_va,
                 desc_count,
                 info_pages,
             );
@@ -920,8 +924,8 @@ unsafe fn kernel_entry_post_rebase(
             info_base
         };
 
-        // Map init's user stack (INIT_STACK_PAGES pages below INIT_STACK_TOP)
-        // and mint a reclaimable Memory cap for each backing page. Inlined
+        // Map init's user stack (INIT_STACK_PAGES pages below the chosen stack
+        // top) and mint a reclaimable Memory cap for each backing page. Inlined
         // (rather than calling `map_stack`) so we capture each phys address
         // for cap minting; `register_owned_range` accounts for the pages in
         // the buddy's `total_pages` ledger. The caps route to memmgr via reap;
@@ -932,7 +936,7 @@ unsafe fn kernel_entry_post_rebase(
             use cap::slot::{CapTag, Rights};
 
             const STACK_PAGES: usize = mm::address_space::INIT_STACK_PAGES;
-            let stack_top = mm::address_space::INIT_STACK_TOP;
+            let stack_top = init_layout.init_stack_top;
             let rw_flags = mm::paging::PageFlags {
                 readable: true,
                 writable: true,
@@ -1092,7 +1096,7 @@ unsafe fn kernel_entry_post_rebase(
             let init_saved = arch::current::context::new_state(
                 init_image.entry_point,
                 kstack_top,
-                init_protocol::INIT_INFO_VADDR, // forwarded to init's a0/rdi on first entry
+                init_layout.init_info_va, // forwarded to init's a0/rdi on first entry
                 true,
             );
 

--- a/core/kernel/src/mm/address_space.rs
+++ b/core/kernel/src/mm/address_space.rs
@@ -9,8 +9,10 @@
 //! on RISC-V). Intermediate page table frames are allocated from the buddy
 //! allocator on demand.
 //!
-//! Init stack constants (`INIT_STACK_TOP`, `INIT_STACK_PAGES`) are defined in
-//! the `init-protocol` ABI crate and re-exported here for kernel use.
+//! `INIT_STACK_PAGES` is defined in the `init-protocol` ABI crate and
+//! re-exported here. Init's bootstrap virtual addresses (the `InitInfo` page and
+//! stack top) are the kernel's per-boot choice via [`choose_init_layout`], not
+//! ABI constants.
 //!
 //! ## Kernel mapping inheritance
 //! `new_user` copies kernel PML4 entries [256..512] from the currently active
@@ -73,8 +75,72 @@ use crate::cpu_mask::{AtomicCpuMask, CpuMask};
 use crate::mm::paging::phys_to_virt;
 use crate::mm::{BuddyAllocator, PAGE_SIZE};
 
-// Init stack constants are defined in the init protocol ABI crate.
-pub use init_protocol::{INIT_STACK_PAGES, INIT_STACK_TOP};
+// Init stack page count is part of the init protocol ABI; the init VA layout
+// (info page + stack top) is the kernel's per-boot choice, not an ABI constant.
+pub use init_protocol::INIT_STACK_PAGES;
+
+/// Default base of the read-only `InitInfo` region mapped into init.
+///
+/// The region spans up to `INIT_INFO_MAX_PAGES` contiguous pages from this
+/// address; with the default stack top it occupies
+/// `[0x7FFF_FFFF_5000, 0x7FFF_FFFF_9000)`, a guard sits at `0x7FFF_FFFF_9000`,
+/// and init's stack runs `[0x7FFF_FFFF_A000, DEFAULT_INIT_STACK_TOP)`.
+pub const DEFAULT_INIT_INFO_VA: u64 = 0x7FFF_FFFF_5000;
+
+/// Default top of init's user stack. `INIT_STACK_PAGES` pages map immediately
+/// below, with one unmapped guard page beneath them.
+pub const DEFAULT_INIT_STACK_TOP: u64 = 0x7FFF_FFFF_E000;
+
+/// Bootstrap virtual addresses the kernel chooses for the init process.
+///
+/// The `InitInfo` page address is delivered to init in its entry register; the
+/// stack top becomes init's initial stack pointer. Neither is an ABI constant,
+/// so the kernel may vary them per-boot.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct InitLayout
+{
+    /// Base VA of the read-only `InitInfo` region.
+    pub init_info_va: u64,
+    /// Top of init's user stack.
+    pub init_stack_top: u64,
+}
+
+/// Cached init layout for this boot. `init_info_va == 0` means not yet chosen
+/// (a real `InitInfo` VA is never 0). Init is a singleton, and two boot phases
+/// read its layout — the `InitInfo` mapping in Phase 9 and the user trap-frame
+/// build in `sched::enter` — so the choice is made once and cached to keep both
+/// readers in agreement once ASLR (#39) makes it random.
+static INIT_LAYOUT_INFO_VA: AtomicU64 = AtomicU64::new(0);
+static INIT_LAYOUT_STACK_TOP: AtomicU64 = AtomicU64::new(0);
+
+/// Return the init process's bootstrap VA layout for this boot, choosing it on
+/// the first call and returning the cached value thereafter.
+///
+/// Deterministic today: returns the `DEFAULT_INIT_*` addresses above. The first
+/// call is the single seam ASLR (#39) replaces with a per-boot entropy draw
+/// (`crate::entropy::fill_bytes`); the analogue of `process-layout`'s
+/// `choose_process_layout` for the kernel→init handover. Safe to call from the
+/// single boot thread across boot phases; not intended for concurrent use.
+#[must_use]
+pub fn choose_init_layout() -> InitLayout
+{
+    let cached = INIT_LAYOUT_INFO_VA.load(Ordering::Relaxed);
+    if cached != 0
+    {
+        return InitLayout {
+            init_info_va: cached,
+            init_stack_top: INIT_LAYOUT_STACK_TOP.load(Ordering::Relaxed),
+        };
+    }
+
+    let layout = InitLayout {
+        init_info_va: DEFAULT_INIT_INFO_VA,
+        init_stack_top: DEFAULT_INIT_STACK_TOP,
+    };
+    INIT_LAYOUT_STACK_TOP.store(layout.init_stack_top, Ordering::Relaxed);
+    INIT_LAYOUT_INFO_VA.store(layout.init_info_va, Ordering::Relaxed);
+    layout
+}
 
 // ── AddressSpace ──────────────────────────────────────────────────────────────
 

--- a/core/kernel/src/sched/mod.rs
+++ b/core/kernel/src/sched/mod.rs
@@ -4471,7 +4471,6 @@ pub(crate) unsafe extern "C" fn user_thread_trampoline() -> !
 pub fn enter() -> !
 {
     use crate::arch::current::trap_frame::TrapFrame;
-    use crate::mm::address_space::INIT_STACK_TOP;
 
     // Dequeue the highest-priority ready thread (init, at INIT_PRIORITY=15).
     // SAFETY: single-threaded boot; BSP scheduler slot exclusively owned; tcb is
@@ -4527,7 +4526,10 @@ pub fn enter() -> !
     // init_tcb is a valid TCB; saved_state and TrapFrame methods ensure correct field access.
     unsafe {
         core::ptr::write_bytes(tf_ptr.cast::<u8>(), 0, tf_size as usize);
-        (*tf_ptr).init_user(entry_point, INIT_STACK_TOP);
+        // init's user stack top comes from the same per-boot layout the Phase 9
+        // mapping used, so the SP matches the mapped stack even under ASLR (#39).
+        let init_stack_top = crate::mm::address_space::choose_init_layout().init_stack_top;
+        (*tf_ptr).init_user(entry_point, init_stack_top);
         // Forward the initial user argument (cap slot, etc.) stored in
         // saved_state at TCB creation via new_state(…, arg, …).
         let user_arg = init_tcb.saved_state.user_arg();

--- a/docs/process-lifecycle.md
+++ b/docs/process-lifecycle.md
@@ -60,8 +60,8 @@ applications) is std-built and bootstraps its heap via memmgr.
 
 The kernel hands init the maximal capability set in init's CSpace
 (see [`capability-model.md`](capability-model.md) §"Initial Capability
-Distribution") and the `InitInfo` page at `INIT_INFO_VADDR` describing
-it. `InitInfo.memory_base` and `InitInfo.memory_count`
+Distribution") and an `InitInfo` page — mapped at a kernel-chosen VA
+delivered in init's entry register — describing it. `InitInfo.memory_base` and `InitInfo.memory_count`
 identify the contiguous slot range in init's CSpace holding the RAM
 Memory caps. The kernel coalesces physically-adjacent drained RAM into the
 fewest contiguous extents and places the largest at `memory_base`, so the
@@ -230,6 +230,10 @@ at creation time. Examples:
 
 - `ProcessInfo.ipc_buffer_vaddr` — procmgr picks the IPC-buffer VA per
   child.
+- `ProcessInfo.stack_top_vaddr` / `ProcessInfo.main_tls_vaddr` — the
+  per-process stack top and main-thread TLS block base, chosen by the
+  creator via `shared/process-layout` (`main_tls_vaddr` is zero when the
+  binary has no `PT_TLS`).
 - `ProcessInfo.creator_endpoint_cap` — badged SEND back to the parent's
   bootstrap endpoint, distinct per child.
 - `ProcessInfo.memmgr_endpoint_cap` — badged SEND on memmgr's endpoint,
@@ -251,14 +255,18 @@ at creation time. Examples:
 - `InitInfo.memory_base`, `InitInfo.memory_count` — chosen
   by the kernel per init invocation.
 
-### ABI constants
+### Handover-page addresses (creator-chosen, register-delivered)
 
-Fields that are pinned at well-known virtual addresses
-(`PROCESS_INFO_VADDR`, `PROCESS_STACK_TOP`, `PROCESS_MAIN_TLS_VADDR`,
-`INIT_INFO_VADDR`). Each is declared in its respective ABI crate
-(`abi/process-abi`, `abi/init-protocol`) and consumed by both the
-parent-side populator and the child-side `_start` to find its handover
-page.
+The handover page itself (`ProcessInfo`, or `InitInfo` for init) cannot
+record its own address — that address is what locates the page. The
+creator chooses it per-process (procmgr/init via `shared/process-layout`;
+the kernel via `choose_init_layout` for init) and delivers it to the
+child in the entry register (`rdi`/`a0`); the child's `_start` takes it as
+its argument. The stack, TLS, and IPC-buffer VAs are likewise
+creator-chosen but travel as the runtime `ProcessInfo` fields above. No
+handover *address* is an ABI constant; the ABI crates declare only policy
+bounds (`DEFAULT_PROCESS_STACK_PAGES`, `MAX_PROCESS_STACK_PAGES`,
+`PROCESS_MAIN_TLS_MAX_PAGES`, `INIT_STACK_PAGES`, `INIT_INFO_MAX_PAGES`).
 
 ### CSpace slot conventions
 

--- a/docs/userspace-memory-model.md
+++ b/docs/userspace-memory-model.md
@@ -134,21 +134,27 @@ private VA constants for whatever scratch regions they need.
 The handover pages (`ProcessInfo`, `InitInfo`), the main-thread stack,
 the main-thread IPC buffer, and the main-thread TLS block must be
 mapped into the new process's address space *before* the process runs
-its first instruction. The creator picks the VAs and writes them where
-the child's `_start` will find them.
+its first instruction. The creator chooses every one of these virtual
+addresses per-process — none is a fixed ABI constant — and communicates
+them either through the handover struct or, for the handover page itself,
+through the entry register. Procmgr and init choose process layouts via
+[`shared/process-layout`](../shared/process-layout/)
+(`choose_process_layout`); the kernel chooses init's layout via its own
+`choose_init_layout`. Both are deterministic today and are the single
+seam ASLR ([#39](https://github.com/kottlerg/seraph/issues/39)) replaces
+with a per-process entropy draw.
 
-- **`ProcessInfo` page.** Procmgr maps a read-only page at
-  `PROCESS_INFO_VADDR` (today an ABI constant in
-  [`abi/process-abi`](../abi/process-abi/)) and writes the
-  `ProcessInfo` struct into it. The child's `_start` reads the
-  struct from this VA.
-- **`InitInfo` page.** The kernel maps a read-only page at
-  `INIT_INFO_VADDR` (today an ABI constant in
-  [`abi/init-protocol`](../abi/init-protocol/)) for init only.
+- **`ProcessInfo` page.** Procmgr maps a read-only page at the chosen
+  `process_info_va`, writes the `ProcessInfo` struct into it, and delivers
+  that address to the child in its entry register (`rdi`/`a0`). The
+  child's `_start` takes the address as its argument — it cannot read the
+  address from the struct, since the address is what locates the struct.
+- **`InitInfo` page.** The kernel maps a read-only page at its chosen
+  `init_info_va` for init only, and delivers the address in init's entry
+  register the same way.
 - **Main-thread stack.** The loader (procmgr or, for memmgr/procmgr,
-  init) maps `ProcessInfo.stack_pages` pages ending at
-  `ProcessInfo.stack_top_vaddr` (today equal to the
-  `PROCESS_STACK_TOP` ABI constant) with a guard page below. The page
+  init) maps `ProcessInfo.stack_pages` pages ending at the chosen
+  `ProcessInfo.stack_top_vaddr` with a guard page below. The page
   count comes from the binary's optional `.note.seraph.stack` ELF note
   (declared via the `process_abi::stack_pages!` / `seraph::stack_pages!`
   macro); binaries that omit the note inherit
@@ -156,18 +162,23 @@ the child's `_start` will find them.
   `MAX_PROCESS_STACK_PAGES`; the pool's available RAM is the remaining
   gate on the resulting `REQUEST_MEMORY_CAPS` calls (memmgr tracks
   per-process frames in a RAM-bound arena, not a fixed quota).
-- **Main-thread IPC buffer.** Procmgr picks a per-process VA and writes
-  it into `ProcessInfo.ipc_buffer_vaddr` — this is already a runtime
-  field, not an ABI constant.
-- **Main-thread TLS block.** Procmgr maps the block at
-  `PROCESS_MAIN_TLS_VADDR` (today an ABI constant); spawned threads
+- **Main-thread IPC buffer.** The creator picks a per-process VA and
+  writes it into `ProcessInfo.ipc_buffer_vaddr`.
+- **Main-thread TLS block.** The creator maps the block at the chosen
+  base and records it in `ProcessInfo.main_tls_vaddr` (zero when the
+  binary has no `PT_TLS`); the kernel installs the thread pointer, so
+  `_start` reads the field only for introspection. Spawned threads
   allocate their TLS blocks from the heap.
 
-The page locations are split between **runtime fields**
-(`ipc_buffer_vaddr`) and **ABI constants** (`PROCESS_INFO_VADDR`,
-`PROCESS_STACK_TOP`, `PROCESS_MAIN_TLS_VADDR`, `INIT_INFO_VADDR`).
-Each ABI constant is declared in its respective ABI crate
-(`abi/process-abi`, `abi/init-protocol`).
+These VAs are **runtime values**, not ABI constants: the handover-page
+addresses ride the entry register, and the stack/TLS/IPC VAs are
+`ProcessInfo` fields (`stack_top_vaddr`, `main_tls_vaddr`,
+`ipc_buffer_vaddr`). The only handover constants the ABI crates still
+declare are policy bounds — `DEFAULT_PROCESS_STACK_PAGES`,
+`MAX_PROCESS_STACK_PAGES`, `PROCESS_MAIN_TLS_MAX_PAGES`,
+`INIT_STACK_PAGES`, `INIT_INFO_MAX_PAGES` — not layout addresses. The
+default addresses the deterministic choosers return live in
+`shared/process-layout` (and the kernel's `choose_init_layout`).
 
 See [`process-lifecycle.md`](process-lifecycle.md) for the full
 handover discipline.

--- a/runtime/ruststd/src/os/seraph.rs
+++ b/runtime/ruststd/src/os/seraph.rs
@@ -31,7 +31,7 @@ use crate::sys::alloc::seraph as pal_alloc;
 use crate::sys::reserve as pal_reserve;
 use crate::sys::stdio::seraph as pal_stdio;
 
-use process_abi::{PROCESS_ABI_VERSION, PROCESS_INFO_VADDR, process_info_ref};
+use process_abi::{PROCESS_ABI_VERSION, process_info_ref};
 
 /// Re-export of [`process_abi::StackNote`]. Lets the [`stack_pages!`]
 /// macro emit a typed static through `std::os::seraph::StackNote`,
@@ -189,6 +189,10 @@ pub struct StartupInfo {
     /// when not demand-paged.
     #[stable(feature = "seraph_ext", since = "1.0.0")]
     pub pager_badge: u64,
+    /// Mapped base virtual address of the main thread's TLS block, or zero when
+    /// the process has no TLS. See `process_abi::ProcessInfo::main_tls_vaddr`.
+    #[stable(feature = "seraph_ext", since = "1.0.0")]
+    pub main_tls_vaddr: u64,
 }
 
 // SAFETY: `ipc_buffer` points at a process-global page mapped for the life of
@@ -309,27 +313,28 @@ const STARTUP_FAIL_HEAP: u32 = 0x0F02;
 /// Process entry point. Exported with the conventional ELF entry symbol name
 /// so the linker sets `e_entry` here and procmgr jumps directly in.
 ///
-/// Reads the read-only `ProcessInfo` page procmgr placed at
-/// [`PROCESS_INFO_VADDR`], registers the pre-mapped IPC buffer, stashes the
-/// derived [`StartupInfo`] in process-global storage, then hands off to the
-/// rustc-synthesised `extern "C" fn main` which in turn drives
-/// `std::rt::lang_start` and the user's `fn main`. When `main` returns, this
-/// function exits the process via `process_exit`, forwarding `main`'s `i32`
-/// return (the `ExitCode`/`lang_start` value) so the parent's `ExitStatus`
-/// carries it; the process never re-enters kernel entry code.
+/// `info_ptr` is the virtual address of the read-only `ProcessInfo` page,
+/// delivered by procmgr in the entry register (`rdi`/`a0`). Reads the page,
+/// registers the pre-mapped IPC buffer, stashes the derived [`StartupInfo`] in
+/// process-global storage, then hands off to the rustc-synthesised
+/// `extern "C" fn main` which in turn drives `std::rt::lang_start` and the
+/// user's `fn main`. When `main` returns, this function exits the process via
+/// `process_exit`, forwarding `main`'s `i32` return (the `ExitCode`/`lang_start`
+/// value) so the parent's `ExitStatus` carries it; the process never re-enters
+/// kernel entry code.
 ///
 /// # Safety
 ///
-/// Called by the kernel with a valid `ProcessInfo` page mapped at
-/// [`PROCESS_INFO_VADDR`] and a pre-mapped IPC buffer at the VA it records.
-/// The function itself is safe to export.
+/// Called by the kernel with `info_ptr` pointing at a valid `ProcessInfo` page
+/// and a pre-mapped IPC buffer at the VA it records. The function itself is safe
+/// to export.
 #[unsafe(no_mangle)]
 #[stable(feature = "seraph_ext", since = "1.0.0")]
-pub extern "C" fn _start() -> ! {
-    // SAFETY: procmgr maps a valid `ProcessInfo` page at `PROCESS_INFO_VADDR`
-    // before starting the first thread, and the page remains mapped for the
-    // process's lifetime.
-    let info = unsafe { process_info_ref(PROCESS_INFO_VADDR) };
+pub extern "C" fn _start(info_ptr: u64) -> ! {
+    // SAFETY: procmgr maps a valid `ProcessInfo` page and delivers its VA in
+    // `info_ptr` before starting the first thread; the page remains mapped for
+    // the process's lifetime.
+    let info = unsafe { process_info_ref(info_ptr) };
 
     if info.version != PROCESS_ABI_VERSION {
         syscall::process_exit(STARTUP_FAIL_BAD_ABI);
@@ -350,7 +355,7 @@ pub extern "C" fn _start() -> ! {
         && (info.args_offset as u64) < 4096
         && (info.args_offset as u64) + (info.args_bytes as u64) <= 4096
     {
-        let base = PROCESS_INFO_VADDR + info.args_offset as u64;
+        let base = info_ptr + info.args_offset as u64;
         // SAFETY: the ProcessInfo page is mapped read-only for the
         // process's lifetime and the bounds check above confines the
         // slice to the same page. Bytes are plain data.
@@ -366,7 +371,7 @@ pub extern "C" fn _start() -> ! {
         && (info.env_offset as u64) < 4096
         && (info.env_offset as u64) + (info.env_bytes as u64) <= 4096
     {
-        let base = PROCESS_INFO_VADDR + info.env_offset as u64;
+        let base = info_ptr + info.env_offset as u64;
         // SAFETY: ProcessInfo page is mapped read-only for the process's
         // lifetime; bounds check above confines the slice to the same page.
         unsafe { core::slice::from_raw_parts(base as *const u8, info.env_bytes as usize) }
@@ -408,6 +413,7 @@ pub extern "C" fn _start() -> ! {
         stack_pages: info.stack_pages,
         pager_endpoint_cap: info.pager_endpoint_cap,
         pager_badge: info.pager_badge,
+        main_tls_vaddr: info.main_tls_vaddr,
     };
 
     // SAFETY: single writer; we are the only code running at this point.
@@ -513,7 +519,7 @@ pub extern "C" fn _start() -> ! {
 // reference into `.data` and guarantees retention.
 #[used]
 #[cfg_attr(target_os = "seraph", unsafe(link_section = ".data.rel.ro"))]
-static _START_REF: unsafe extern "C" fn() -> ! = _start;
+static _START_REF: unsafe extern "C" fn(u64) -> ! = _start;
 
 // ── Public helpers surfaced on std::os::seraph ──────────────────────────────
 

--- a/runtime/ruststd/src/sys/stdio/seraph.rs
+++ b/runtime/ruststd/src/sys/stdio/seraph.rs
@@ -31,8 +31,12 @@ use crate::os::seraph::current_ipc_buf;
 
 // ── Child-side ring VAs ────────────────────────────────────────────────────
 //
-// One fixed VA per direction. Above PROCESS_MAIN_TLS_VADDR + max TLS pages
-// (0x7FFF_FFFD_4000) and below PROCMGR_IPC_BUF_VA (0x7FFF_FFFE_0000).
+// One fixed VA per direction, in the gap the default bootstrap layout leaves
+// between the main-thread TLS block and the IPC buffer: above
+// `process_layout::DEFAULT_MAIN_TLS_VA` + `PROCESS_MAIN_TLS_MAX_PAGES`
+// (0x7FFF_FFFD_4000) and below `process_layout::DEFAULT_IPC_BUFFER_VA`
+// (0x7FFF_FFFE_0000). These are the std runtime's own mapping choices, not
+// handover VAs; full per-process randomisation of them belongs to ASLR (#39).
 
 const STDIN_RING_VA: u64 = 0x0000_7FFF_FFFD_5000;
 const STDOUT_RING_VA: u64 = 0x0000_7FFF_FFFD_6000;

--- a/services/init/Cargo.toml
+++ b/services/init/Cargo.toml
@@ -12,6 +12,7 @@ test = false
 [dependencies]
 init-protocol = { path = "../../abi/init-protocol" }
 process-abi = { path = "../../abi/process-abi" }
+process-layout = { path = "../../shared/process-layout" }
 elf = { path = "../../shared/elf" }
 ipc = { path = "../../shared/ipc" }
 namespace-protocol = { path = "../../shared/namespace-protocol" }

--- a/services/init/src/bootstrap.rs
+++ b/services/init/src/bootstrap.rs
@@ -16,23 +16,18 @@
 use crate::logging::log;
 use crate::{MemoryAlloc, PAGE_SIZE, TEMP_MAP_BASE, arch};
 use init_protocol::{CapDescriptor, InitInfo};
-use process_abi::{
-    DEFAULT_PROCESS_STACK_PAGES, MAX_PROCESS_STACK_PAGES, PROCESS_ABI_VERSION, PROCESS_INFO_VADDR,
-    PROCESS_STACK_TOP,
-};
+use process_abi::{DEFAULT_PROCESS_STACK_PAGES, MAX_PROCESS_STACK_PAGES, PROCESS_ABI_VERSION};
+use process_layout::{ProcessLayout, choose_process_layout};
 
 // ── Constants ────────────────────────────────────────────────────────────────
 //
-// Both VAs are private to init's no_std bootstrap path. ELF_PAGE_TEMP_VA
-// sits inside init's TEMP_MAP_BASE scratch region (offset 256 MiB).
-// PROCMGR_IPC_BUF_VA is the IPC-buffer VA init writes into procmgr's
-// `ProcessInfo.ipc_buffer_vaddr` slot; procmgr reads it back at boot.
+// ELF_PAGE_TEMP_VA is private to init's no_std bootstrap path and sits inside
+// init's TEMP_MAP_BASE scratch region (offset 256 MiB). The per-child bootstrap
+// VAs (`ProcessInfo` page, stack top, TLS block, IPC buffer) are chosen via
+// `process-layout` rather than pinned here, mirroring procmgr.
 
 /// Per-page ELF write scratch during init's procmgr/memmgr bootstrap.
 const ELF_PAGE_TEMP_VA: u64 = TEMP_MAP_BASE + 0x1000_0000;
-
-/// procmgr's IPC buffer VA as seen from init while bootstrapping procmgr.
-const PROCMGR_IPC_BUF_VA: u64 = 0x0000_7FFF_FFFE_0000;
 
 // ── Bootstrap arena ────────────────────────────────────────────────────────────
 //
@@ -232,7 +227,7 @@ pub struct ChildTlsMeta
 
 /// Place the main thread's TLS block in `arena`: populate it from the
 /// in-memory `.tdata` template, install the TCB self-pointer, and map it
-/// read-write into `target_aspace` at `PROCESS_MAIN_TLS_VADDR`.
+/// read-write into `target_aspace` at the chosen `tls_base`.
 ///
 /// Returns `(tls_base_va, metadata)`. When the binary has no `PT_TLS`
 /// segment (or it is empty), returns `(0, ChildTlsMeta::default())` without
@@ -243,6 +238,7 @@ fn place_main_tls(
     ehdr: &elf::Elf64Ehdr,
     module_bytes: &[u8],
     target_aspace: u32,
+    tls_base: u64,
 ) -> Option<(u64, ChildTlsMeta)>
 {
     let Some(seg) = elf::tls_segment(ehdr, module_bytes).ok()?
@@ -278,10 +274,10 @@ fn place_main_tls(
         return None;
     }
 
-    let tls_base_va = process_abi::PROCESS_MAIN_TLS_VADDR + tls_base_offset;
+    let tls_base_va = tls_base + tls_base_offset;
     arena.place_page(
         target_aspace,
-        process_abi::PROCESS_MAIN_TLS_VADDR,
+        tls_base,
         syscall::MAP_WRITABLE,
         |scratch_va| {
             // SAFETY: scratch_va is mapped writable and zeroed; the copy
@@ -383,6 +379,12 @@ pub struct MemmgrBootstrap
     pub arena_cap: u32,
     /// Memmgr's ELF entry point.
     pub entry: u64,
+    /// Stack top init chose and mapped for memmgr; passed as the initial SP to
+    /// `thread_configure` in [`finalize_memmgr`].
+    pub stack_top_vaddr: u64,
+    /// VA of the `ProcessInfo` page init mapped for memmgr; delivered to memmgr
+    /// in its entry register by [`finalize_memmgr`].
+    pub process_info_va: u64,
 }
 
 /// One in-use bootstrap arena forwarded to memmgr for accounting. Its whole
@@ -455,6 +457,7 @@ fn populate_memmgr_info(
     target_aspace: u32,
     caps: &MemmgrCaps,
     stack_pages: u32,
+    layout: &ProcessLayout,
 ) -> Option<()>
 {
     let mm_thread_in_mm =
@@ -468,7 +471,7 @@ fn populate_memmgr_info(
 
     arena.place_page(
         target_aspace,
-        PROCESS_INFO_VADDR,
+        layout.process_info_va,
         syscall::MAP_READ,
         |scratch_va| {
             // SAFETY: scratch_va is mapped writable and zeroed, one page.
@@ -478,7 +481,7 @@ fn populate_memmgr_info(
             pi.self_aspace_cap = mm_aspace_in_mm;
             pi.self_cspace_cap = mm_cspace_in_mm;
             pi.sched_control_cap = mm_sched_in_mm;
-            pi.ipc_buffer_vaddr = PROCMGR_IPC_BUF_VA;
+            pi.ipc_buffer_vaddr = layout.ipc_buffer_va;
             pi.creator_endpoint_cap = caps.creator_endpoint_slot;
             pi.procmgr_endpoint_cap = 0;
             pi.memmgr_endpoint_cap = 0;
@@ -492,8 +495,10 @@ fn populate_memmgr_info(
             pi.stdout_space_notification_cap = 0;
             pi.stderr_data_notification_cap = 0;
             pi.stderr_space_notification_cap = 0;
-            pi.stack_top_vaddr = PROCESS_STACK_TOP;
+            pi.stack_top_vaddr = layout.stack_top;
             pi.stack_pages = stack_pages;
+            // memmgr's bespoke `_start` configures no TLS.
+            pi.main_tls_vaddr = 0;
             // Infrastructure is never demand-paged (would recurse on its own
             // faults); leave the pager unbound.
             pi.pager_endpoint_cap = 0;
@@ -564,6 +569,7 @@ pub fn bootstrap_memmgr(
     let stack_pages = elf::parse_stack_note(ehdr, module_bytes)
         .unwrap_or(DEFAULT_PROCESS_STACK_PAGES)
         .clamp(1, MAX_PROCESS_STACK_PAGES);
+    let layout = choose_process_layout();
 
     // memmgr's bespoke `_start` configures no TLS, so its arena reserves
     // only ELF segments + `ProcessInfo` + stack + IPC buffer.
@@ -600,8 +606,14 @@ pub fn bootstrap_memmgr(
         creator_endpoint_slot: mm_creator_slot,
         sched_baseline: baseline_sched,
     };
-    populate_memmgr_info(&mut arena, mm_aspace, &mm_caps, stack_pages)?;
-    place_stack_and_ipc(&mut arena, mm_aspace, PROCMGR_IPC_BUF_VA, stack_pages)?;
+    populate_memmgr_info(&mut arena, mm_aspace, &mm_caps, stack_pages, &layout)?;
+    place_stack_and_ipc(
+        &mut arena,
+        mm_aspace,
+        layout.ipc_buffer_va,
+        layout.stack_top,
+        stack_pages,
+    )?;
 
     // Mint procmgr's badged SEND cap on memmgr's endpoint. Memmgr will
     // recognise calls bearing this badge as authorised for the
@@ -622,6 +634,8 @@ pub fn bootstrap_memmgr(
         mm_thread,
         arena_cap: arena.cap,
         entry,
+        stack_top_vaddr: layout.stack_top,
+        process_info_va: layout.process_info_va,
     })
 }
 
@@ -881,8 +895,8 @@ pub fn finalize_memmgr(
     syscall::thread_configure(
         mm.mm_thread,
         mm.entry,
-        PROCESS_STACK_TOP,
-        PROCESS_INFO_VADDR,
+        mm.stack_top_vaddr,
+        mm.process_info_va,
     )
     .ok()?;
     syscall::thread_start(mm.mm_thread).ok()?;
@@ -993,6 +1007,7 @@ fn populate_procmgr_info(
     target_aspace: u32,
     caps: &ProcmgrCaps,
     stack_pages: u32,
+    layout: &ProcessLayout,
 ) -> Option<()>
 {
     let pm_thread_in_pm =
@@ -1007,7 +1022,7 @@ fn populate_procmgr_info(
 
     arena.place_page(
         target_aspace,
-        PROCESS_INFO_VADDR,
+        layout.process_info_va,
         syscall::MAP_READ,
         |scratch_va| {
             // SAFETY: scratch_va is mapped writable and zeroed, one page.
@@ -1017,7 +1032,7 @@ fn populate_procmgr_info(
             pi.self_aspace_cap = pm_aspace_in_pm;
             pi.self_cspace_cap = pm_cspace_in_pm;
             pi.sched_control_cap = pm_sched_in_pm;
-            pi.ipc_buffer_vaddr = PROCMGR_IPC_BUF_VA;
+            pi.ipc_buffer_vaddr = layout.ipc_buffer_va;
             pi.creator_endpoint_cap = caps.creator_endpoint_slot;
             // procmgr has no procmgr above it; leave zero.
             pi.procmgr_endpoint_cap = 0;
@@ -1042,8 +1057,17 @@ fn populate_procmgr_info(
             pi.tls_template_filesz = caps.tls.filesz;
             pi.tls_template_memsz = caps.tls.memsz;
             pi.tls_template_align = caps.tls.align;
-            pi.stack_top_vaddr = PROCESS_STACK_TOP;
+            pi.stack_top_vaddr = layout.stack_top;
             pi.stack_pages = stack_pages;
+            // TLS block base, or zero when procmgr's image carries no PT_TLS.
+            pi.main_tls_vaddr = if caps.tls.memsz != 0
+            {
+                layout.tls_base
+            }
+            else
+            {
+                0
+            };
             // Infrastructure is never demand-paged (would recurse on its own
             // faults); leave the pager unbound.
             pi.pager_endpoint_cap = 0;
@@ -1061,10 +1085,11 @@ fn place_stack_and_ipc(
     arena: &mut BootArena,
     target_aspace: u32,
     ipc_buf_va: u64,
+    stack_top: u64,
     stack_pages: u32,
 ) -> Option<()>
 {
-    let stack_base = PROCESS_STACK_TOP - u64::from(stack_pages) * PAGE_SIZE;
+    let stack_base = stack_top - u64::from(stack_pages) * PAGE_SIZE;
     for i in 0..stack_pages
     {
         arena.place_page(
@@ -1198,6 +1223,7 @@ pub fn bootstrap_procmgr(
     let stack_pages = elf::parse_stack_note(ehdr, module_bytes)
         .unwrap_or(DEFAULT_PROCESS_STACK_PAGES)
         .clamp(1, MAX_PROCESS_STACK_PAGES);
+    let layout = choose_process_layout();
 
     // procmgr is std-using: its arena reserves ELF segments + the main TLS
     // block + `ProcessInfo` + stack + IPC buffer.
@@ -1224,7 +1250,8 @@ pub fn bootstrap_procmgr(
     // std-using so the std runtime's `_start` accesses thread-local statics
     // (e.g. `IPC_BUF_TLS`) before user `main` runs; without a configured TLS
     // block, the first such access page-faults at NULL.
-    let (pm_tls_base_va, pm_tls_meta) = place_main_tls(&mut arena, ehdr, module_bytes, pm_aspace)?;
+    let (pm_tls_base_va, pm_tls_meta) =
+        place_main_tls(&mut arena, ehdr, module_bytes, pm_aspace, layout.tls_base)?;
 
     let _ = syscall::mem_unmap(init_aspace, TEMP_MAP_BASE, module_pages);
     let _ = syscall::cap_delete(module_ro);
@@ -1319,15 +1346,21 @@ pub fn bootstrap_procmgr(
         tls: pm_tls_meta,
         sched_baseline: baseline_sched,
     };
-    populate_procmgr_info(&mut arena, pm_aspace, &pm_caps, stack_pages)?;
+    populate_procmgr_info(&mut arena, pm_aspace, &pm_caps, stack_pages, &layout)?;
 
-    place_stack_and_ipc(&mut arena, pm_aspace, PROCMGR_IPC_BUF_VA, stack_pages)?;
+    place_stack_and_ipc(
+        &mut arena,
+        pm_aspace,
+        layout.ipc_buffer_va,
+        layout.stack_top,
+        stack_pages,
+    )?;
 
     syscall::thread_configure_with_tls(
         pm_thread,
         entry,
-        PROCESS_STACK_TOP,
-        PROCESS_INFO_VADDR,
+        layout.stack_top,
+        layout.process_info_va,
         pm_tls_base_va,
     )
     .ok()?;

--- a/services/init/src/main.rs
+++ b/services/init/src/main.rs
@@ -31,9 +31,8 @@ pub(crate) mod walk;
 //
 // init runs no_std with no `std::os::seraph::reserve_pages` allocator; its
 // scratch and IPC-buffer VAs are picked here as private constants. They
-// only need to be disjoint from each other and from the InitInfo page
-// (`INIT_INFO_VADDR` in `abi/init-protocol`) and the kernel-supplied
-// stack range — both of which live high in the lower-canonical half.
+// only need to be disjoint from each other and from the kernel-chosen InitInfo
+// page and stack range — both of which live high in the lower-canonical half.
 
 pub(crate) use syscall_abi::PAGE_SIZE;
 
@@ -100,20 +99,18 @@ pub(crate) fn descriptors(info: &InitInfo) -> &[CapDescriptor]
         return &[];
     }
 
-    // The kernel maps `INIT_INFO_MAX_PAGES` pages contiguously at
-    // `INIT_INFO_VADDR`; the InitInfo header lives at the start, and
-    // `cap_descriptors_offset` indexes into the same region. Construct
-    // the descriptor pointer from the integer address using
-    // `with_exposed_provenance` so the slice is not bounded by the
-    // narrower `&InitInfo` provenance — descriptors may span pages
-    // beyond the first one, and a pointer derived from `info`'s
-    // 112-byte allocation would let the optimiser assume out-of-bounds
-    // reads.
-    let base_addr = init_protocol::INIT_INFO_VADDR as usize + offset;
+    // The kernel maps the `InitInfo` region contiguously; the header lives at
+    // the start and `cap_descriptors_offset` indexes into the same region.
+    // Take the page address as a bare integer via `.addr()` (no provenance) and
+    // rebuild the pointer with `with_exposed_provenance` so the slice is not
+    // bounded by the narrower `&InitInfo` provenance — descriptors may span
+    // pages beyond the first one, and a pointer derived from `info`'s
+    // 112-byte allocation would let the optimiser assume out-of-bounds reads.
+    let base_addr = core::ptr::from_ref::<InitInfo>(info).addr() + offset;
     let ptr = core::ptr::with_exposed_provenance::<CapDescriptor>(base_addr);
-    // SAFETY: kernel has mapped `count * desc_size` valid CapDescriptor
-    // bytes starting at INIT_INFO_VADDR + offset. The exposed-provenance
-    // pointer carries provenance broad enough to cover that span.
+    // SAFETY: kernel has mapped `count * desc_size` valid CapDescriptor bytes
+    // starting at the InitInfo page + offset. The exposed-provenance pointer
+    // carries provenance broad enough to cover that span.
     unsafe { core::slice::from_raw_parts(ptr, count) }
 }
 
@@ -359,8 +356,8 @@ pub(crate) const BASELINE_PRIORITY_MAX: u8 = 20;
 #[allow(clippy::too_many_lines)]
 fn run(info_ptr: u64) -> !
 {
-    // SAFETY: kernel maps InitInfo at info_ptr (= INIT_INFO_VADDR).
-    // cast_ptr_alignment: INIT_INFO_VADDR is page-aligned.
+    // SAFETY: the kernel maps InitInfo at the kernel-chosen VA delivered in
+    // info_ptr. cast_ptr_alignment: that VA is page-aligned.
     #[allow(clippy::cast_ptr_alignment)]
     let info: &InitInfo = unsafe { &*(info_ptr as *const InitInfo) };
 

--- a/services/memmgr/src/main.rs
+++ b/services/memmgr/src/main.rs
@@ -17,9 +17,7 @@
 
 use free_pool::{DemandRegion, FreePool, FreeRun, chunk_for, region_contains, regions_overlap};
 use ipc::{IpcMessage, memmgr_errors, memmgr_labels};
-use process_abi::{
-    PROCESS_ABI_VERSION, PROCESS_INFO_VADDR, ProcessInfo, StartupInfo, process_info_ref,
-};
+use process_abi::{PROCESS_ABI_VERSION, ProcessInfo, StartupInfo, process_info_ref};
 use syscall_abi::{MAP_EXECUTABLE, MAP_READ, MAP_WRITABLE, PAGE_SIZE};
 
 // memmgr's bootstrap parser carries page-count buffers on stack and
@@ -34,12 +32,12 @@ process_abi::stack_pages!(12);
 // that call. The bespoke `_start` here runs on `core` + raw syscalls only.
 
 #[unsafe(no_mangle)]
-pub extern "C" fn _start(_info_ptr: u64) -> !
+pub extern "C" fn _start(info_ptr: u64) -> !
 {
-    // SAFETY: init's loader maps a valid ProcessInfo page at
-    // PROCESS_INFO_VADDR before starting this thread; the page remains
-    // mapped for the process's lifetime.
-    let info: &ProcessInfo = unsafe { process_info_ref(PROCESS_INFO_VADDR) };
+    // SAFETY: init's loader maps a valid ProcessInfo page and delivers its VA
+    // in `info_ptr` before starting this thread; the page remains mapped for the
+    // process's lifetime.
+    let info: &ProcessInfo = unsafe { process_info_ref(info_ptr) };
 
     if info.version != PROCESS_ABI_VERSION
     {
@@ -78,6 +76,7 @@ pub extern "C" fn _start(_info_ptr: u64) -> !
         stack_pages: info.stack_pages,
         pager_endpoint_cap: info.pager_endpoint_cap,
         pager_badge: info.pager_badge,
+        main_tls_vaddr: info.main_tls_vaddr,
     };
 
     main(&startup)

--- a/services/procmgr/Cargo.toml
+++ b/services/procmgr/Cargo.toml
@@ -13,6 +13,7 @@ test = false
 # Pure process-table + badge logic, extracted so it is host-testable.
 process_table = { path = "process-table", package = "procmgr-process-table" }
 process-abi = { path = "../../abi/process-abi" }
+process-layout = { path = "../../shared/process-layout" }
 elf = { path = "../../shared/elf" }
 ipc = { path = "../../shared/ipc" }
 namespace-protocol = { path = "../../shared/namespace-protocol" }

--- a/services/procmgr/process-table/src/lib.rs
+++ b/services/procmgr/process-table/src/lib.rs
@@ -76,6 +76,14 @@ pub struct ProcessEntry
     pub cwd_override: u32,
     pub entry_point: u64,
     pub tls_base_va: u64,
+    /// Top of the main-thread stack (SP at entry) the loader chose and mapped
+    /// for this child. Passed to `thread_configure_with_tls` at start so the
+    /// process is launched at the same VA its stack was mapped to.
+    pub stack_top_vaddr: u64,
+    /// VA of the read-only `ProcessInfo` page the loader mapped into the child.
+    /// Delivered to the child in its entry register at start, so the child reads
+    /// its handover struct from the address the loader chose.
+    pub process_info_va: u64,
     pub started: bool,
 }
 
@@ -309,6 +317,8 @@ mod tests
             cwd_override: 0,
             entry_point: 0,
             tls_base_va: 0,
+            stack_top_vaddr: 0,
+            process_info_va: 0,
             started: false,
         }
     }

--- a/services/procmgr/src/process.rs
+++ b/services/procmgr/src/process.rs
@@ -12,16 +12,11 @@
 use crate::loader::{self, ScratchMapping};
 use ipc::{IpcMessage, memmgr_errors, memmgr_labels, procmgr_errors};
 use process_abi::{
-    DEFAULT_PROCESS_STACK_PAGES, MAX_PROCESS_STACK_PAGES, PROCESS_ABI_VERSION, PROCESS_INFO_VADDR,
-    PROCESS_MAIN_TLS_MAX_PAGES, PROCESS_MAIN_TLS_VADDR, PROCESS_STACK_TOP,
+    DEFAULT_PROCESS_STACK_PAGES, MAX_PROCESS_STACK_PAGES, PROCESS_ABI_VERSION,
+    PROCESS_MAIN_TLS_MAX_PAGES,
 };
+use process_layout::{ProcessLayout, choose_process_layout};
 use syscall_abi::{FAULT_CLASS_ALL, PAGE_SIZE};
-
-// Bootstrap-cross-boundary VA: procmgr picks the per-child main-thread
-// IPC-buffer VA and writes it into `ProcessInfo.ipc_buffer_vaddr`. The
-// child's `_start` reads it back. Disjoint from the page-reservation
-// arena (above 0x1_0000_0000) and from the heap zone (0x4000_0000..0x8000_0000).
-const CHILD_IPC_BUF_VA: u64 = 0x0000_7FFF_FFFE_0000;
 
 /// Max file data bytes per VFS read IPC. Word 0 = `bytes_read`, words 1..63 = data.
 const VFS_CHUNK_SIZE: u64 = 63 * 8; // 504 bytes
@@ -478,6 +473,7 @@ fn populate_child_info(
     ipc_buf: *mut u64,
     stack_pages: u32,
     process_badge: u64,
+    layout: &ProcessLayout,
 ) -> Option<u32>
 {
     let pi_memory = crate::memmgr_alloc_page(universals.memmgr_endpoint, ipc_buf)?;
@@ -617,7 +613,7 @@ fn populate_child_info(
     pi.self_aspace_cap = child_aspace_in_child;
     pi.self_cspace_cap = child_cspace_in_child;
     pi.sched_control_cap = sched_in_child;
-    pi.ipc_buffer_vaddr = CHILD_IPC_BUF_VA;
+    pi.ipc_buffer_vaddr = layout.ipc_buffer_va;
     pi.creator_endpoint_cap = creator_ep_in_child;
     pi.procmgr_endpoint_cap = procmgr_ep_in_child;
     pi.memmgr_endpoint_cap = if universals.memmgr_endpoint != 0
@@ -671,8 +667,11 @@ fn populate_child_info(
     pi.tls_template_filesz = tls.filesz;
     pi.tls_template_memsz = tls.memsz;
     pi.tls_template_align = tls.align;
-    pi.stack_top_vaddr = PROCESS_STACK_TOP;
+    pi.stack_top_vaddr = layout.stack_top;
     pi.stack_pages = stack_pages;
+    // TLS block base, or zero when the binary has no PT_TLS (mirrors
+    // `tls_template_memsz == 0`); the block is mapped only in the TLS case.
+    pi.main_tls_vaddr = if tls.memsz != 0 { layout.tls_base } else { 0 };
     // Advertise the demand-paging pager so the runtime can inherit it onto
     // spawned threads. The child's badged memmgr endpoint is the pager
     // endpoint; the fault badge equals the child's memmgr badge so the
@@ -748,7 +747,7 @@ fn populate_child_info(
     drop(scratch);
 
     let pi_ro = syscall::cap_derive(pi_memory, syscall::RIGHTS_MAP_READ).ok()?;
-    syscall::mem_map(pi_ro, child_aspace, PROCESS_INFO_VADDR, 0, 1, 0).ok()?;
+    syscall::mem_map(pi_ro, child_aspace, layout.process_info_va, 0, 1, 0).ok()?;
     // pi_memory stays in procmgr's CSpace as the teardown handle (revoke
     // cascades to any descendants); the mapping doesn't need pi_ro to
     // outlive this call.
@@ -766,6 +765,9 @@ struct MainTlsAlloc
     memory_cap: u32,
     tls_base_offset: u64,
     tls_base_va: u64,
+    /// Mapped base VA of the TLS block (the chosen `layout.tls_base`); the block
+    /// is mapped here and `tls_base_va = tls_block_base + tls_base_offset`.
+    tls_block_base: u64,
     scratch: ScratchMapping,
 }
 
@@ -790,6 +792,7 @@ fn alloc_main_tls_memory(
     tls: &ChildTlsTemplate,
     child_memmgr_send: u32,
     ipc_buf: *mut u64,
+    layout: &ProcessLayout,
 ) -> Option<MainTlsAlloc>
 {
     let (block_size, block_align, tls_base_offset) =
@@ -813,14 +816,15 @@ fn alloc_main_tls_memory(
     Some(MainTlsAlloc {
         memory_cap: tls_memory,
         tls_base_offset,
-        tls_base_va: PROCESS_MAIN_TLS_VADDR + tls_base_offset,
+        tls_base_va: layout.tls_base + tls_base_offset,
+        tls_block_base: layout.tls_base,
         scratch,
     })
 }
 
 /// Install the TCB self-pointer at `scratch_va + tls_base_offset`, drop
 /// the scratch mapping from procmgr's aspace, derive an RW cap, and map
-/// the block into the child at [`PROCESS_MAIN_TLS_VADDR`].
+/// the block into the child at the chosen TLS block base.
 fn finalize_main_tls(alloc: MainTlsAlloc, _self_aspace: u32, child_aspace: u32) -> Option<MainTls>
 {
     // SAFETY: scratch_va is mapped writable for one page; the block fits.
@@ -835,7 +839,7 @@ fn finalize_main_tls(alloc: MainTlsAlloc, _self_aspace: u32, child_aspace: u32) 
     drop(alloc.scratch);
 
     let tls_rw = syscall::cap_derive(alloc.memory_cap, syscall::RIGHTS_MAP_RW).ok()?;
-    syscall::mem_map(tls_rw, child_aspace, PROCESS_MAIN_TLS_VADDR, 0, 1, 0).ok()?;
+    syscall::mem_map(tls_rw, child_aspace, alloc.tls_block_base, 0, 1, 0).ok()?;
     // alloc.memory_cap stays as the teardown handle; tls_rw is transient.
     let _ = syscall::cap_delete(tls_rw);
 
@@ -855,6 +859,7 @@ fn prepare_main_tls_from_bytes(
     template_bytes: &[u8],
     child_memmgr_send: u32,
     ipc_buf: *mut u64,
+    layout: &ProcessLayout,
 ) -> Option<MainTls>
 {
     if tls.memsz == 0
@@ -865,7 +870,7 @@ fn prepare_main_tls_from_bytes(
     {
         return None;
     }
-    let alloc = alloc_main_tls_memory(self_aspace, tls, child_memmgr_send, ipc_buf)?;
+    let alloc = alloc_main_tls_memory(self_aspace, tls, child_memmgr_send, ipc_buf, layout)?;
     let scratch_va = alloc.scratch_va();
     // SAFETY: scratch_va is mapped writable; length was bounded above.
     unsafe {
@@ -880,6 +885,9 @@ fn prepare_main_tls_from_bytes(
 
 /// Allocate, populate by streaming `.tdata` from an open VFS file handle,
 /// and map the main thread's TLS block.
+// too_many_arguments: each is a distinct creation input (caps, file handle,
+// IPC scratch, chosen layout); grouping them would not reduce coupling.
+#[allow(clippy::too_many_arguments)]
 fn prepare_main_tls_from_vfs(
     self_aspace: u32,
     child_aspace: u32,
@@ -888,13 +896,14 @@ fn prepare_main_tls_from_vfs(
     file_cap: u32,
     child_memmgr_send: u32,
     ipc_buf: *mut u64,
+    layout: &ProcessLayout,
 ) -> Option<MainTls>
 {
     if tls.memsz == 0
     {
         return Some(MainTls::default());
     }
-    let alloc = alloc_main_tls_memory(self_aspace, tls, child_memmgr_send, ipc_buf)?;
+    let alloc = alloc_main_tls_memory(self_aspace, tls, child_memmgr_send, ipc_buf, layout)?;
     let scratch_va = alloc.scratch_va();
 
     let mut read_pos: u64 = 0;
@@ -932,19 +941,19 @@ fn prepare_main_tls_from_vfs(
 /// Map stack and IPC buffer pages into a child address space.
 ///
 /// No explicit guard-page map. The page immediately below the stack
-/// (`PROCESS_STACK_TOP - PROCESS_STACK_PAGES * PAGE_SIZE - PAGE_SIZE`)
-/// stays unmapped by construction — `process-abi` lays out the stack and
-/// `ProcessInfo` page so the gap is always present. Stack overflow
-/// faults on the guard VA instead of silently writing into adjacent
-/// mappings.
+/// (`layout.stack_top - stack_pages * PAGE_SIZE - PAGE_SIZE`) stays unmapped by
+/// construction — `process-layout` chooses disjoint VAs for the stack and the
+/// other bootstrap surfaces so the gap is always present. Stack overflow faults
+/// on the guard VA instead of silently writing into adjacent mappings.
 fn map_child_stack_and_ipc(
     child_aspace: u32,
     child_memmgr_send: u32,
     ipc_buf: *mut u64,
     stack_pages: u32,
+    layout: &ProcessLayout,
 ) -> Option<()>
 {
-    let stack_base = PROCESS_STACK_TOP - u64::from(stack_pages) * PAGE_SIZE;
+    let stack_base = layout.stack_top - u64::from(stack_pages) * PAGE_SIZE;
     for i in 0..stack_pages
     {
         let memory_cap = crate::memmgr_alloc_page(child_memmgr_send, ipc_buf)?;
@@ -966,7 +975,7 @@ fn map_child_stack_and_ipc(
 
     let ipc_memory = crate::memmgr_alloc_page(child_memmgr_send, ipc_buf)?;
     let ipc_rw = syscall::cap_derive(ipc_memory, syscall::RIGHTS_MAP_RW).ok()?;
-    syscall::mem_map(ipc_rw, child_aspace, CHILD_IPC_BUF_VA, 0, 1, 0).ok()?;
+    syscall::mem_map(ipc_rw, child_aspace, layout.ipc_buffer_va, 0, 1, 0).ok()?;
     let _ = syscall::cap_delete(ipc_rw);
     let _ = syscall::cap_delete(ipc_memory);
 
@@ -1012,6 +1021,7 @@ fn finalize_creation(
     self_memmgr_ep: u32,
     parent_relay_cap: u32,
     ipc_buf: *mut u64,
+    layout: &ProcessLayout,
 ) -> Option<CreateResult>
 {
     let badge = process_badge;
@@ -1077,6 +1087,8 @@ fn finalize_creation(
         cwd_override: 0,
         entry_point,
         tls_base_va: main_tls.base_va,
+        stack_top_vaddr: layout.stack_top,
+        process_info_va: layout.process_info_va,
         started: false,
     })
     {
@@ -1167,6 +1179,7 @@ fn create_process_from_bytes(
     let stack_pages = elf::parse_stack_note(ehdr, module_bytes)
         .unwrap_or(DEFAULT_PROCESS_STACK_PAGES)
         .clamp(1, MAX_PROCESS_STACK_PAGES);
+    let layout = choose_process_layout();
 
     let aspace_slab = crate::memmgr_alloc_pages_contig(
         universals.memmgr_endpoint,
@@ -1250,6 +1263,7 @@ fn create_process_from_bytes(
             &module_bytes[start..end],
             child_memmgr_send,
             ipc_buf,
+            &layout,
         )?
     }
     else
@@ -1271,8 +1285,15 @@ fn create_process_from_bytes(
         ipc_buf,
         stack_pages,
         process_badge,
+        &layout,
     )?;
-    map_child_stack_and_ipc(child_aspace, child_memmgr_send, ipc_buf, stack_pages)?;
+    map_child_stack_and_ipc(
+        child_aspace,
+        child_memmgr_send,
+        ipc_buf,
+        stack_pages,
+        &layout,
+    )?;
 
     finalize_creation(
         child_aspace,
@@ -1293,6 +1314,7 @@ fn create_process_from_bytes(
         // relay terminal faults to; only CREATE_FROM_FILE carries a relay.
         0,
         ipc_buf,
+        &layout,
     )
 }
 
@@ -1903,6 +1925,7 @@ pub fn create_process_from_file(
     })
     .unwrap_or(DEFAULT_PROCESS_STACK_PAGES)
     .clamp(1, MAX_PROCESS_STACK_PAGES);
+    let layout = choose_process_layout();
 
     let aspace_slab =
         crate::memmgr_alloc_pages_contig(mms.cap(), crate::ASPACE_RETYPE_PAGES, ipc_buf)
@@ -2007,6 +2030,7 @@ pub fn create_process_from_file(
             file_cap.cap(),
             mms.cap(),
             ipc_buf,
+            &layout,
         )
         .ok_or(procmgr_errors::OUT_OF_MEMORY)?
     }
@@ -2046,12 +2070,19 @@ pub fn create_process_from_file(
         ipc_buf,
         stack_pages,
         process_badge,
+        &layout,
     )
     .ok_or(procmgr_errors::OUT_OF_MEMORY)?;
     let pi_memory_guard = CapGuard::new(pi_memory_cap);
 
-    map_child_stack_and_ipc(child_objs.aspace(), mms.cap(), ipc_buf, stack_pages)
-        .ok_or(procmgr_errors::OUT_OF_MEMORY)?;
+    map_child_stack_and_ipc(
+        child_objs.aspace(),
+        mms.cap(),
+        ipc_buf,
+        stack_pages,
+        &layout,
+    )
+    .ok_or(procmgr_errors::OUT_OF_MEMORY)?;
 
     // Commit point: hand the accumulated cap values to `finalize_creation`,
     // which records them in the process table on success. The guards stay
@@ -2081,6 +2112,7 @@ pub fn create_process_from_file(
         universals.self_memmgr_ep,
         parent_relay_cap,
         ipc_buf,
+        &layout,
     )
     .ok_or(procmgr_errors::OUT_OF_MEMORY);
     if result.is_ok()
@@ -2269,8 +2301,8 @@ pub fn start_process(badge: u64, table: &mut ProcessTable, self_aspace: u32) -> 
     syscall::thread_configure_with_tls(
         entry.thread_cap,
         entry.entry_point,
-        PROCESS_STACK_TOP,
-        PROCESS_INFO_VADDR,
+        entry.stack_top_vaddr,
+        entry.process_info_va,
         entry.tls_base_va,
     )
     .map_err(|_| 3u64)?;

--- a/services/svctest/Cargo.toml
+++ b/services/svctest/Cargo.toml
@@ -12,6 +12,7 @@ test = false
 [dependencies]
 ipc = { path = "../../shared/ipc" }
 namespace-protocol = { path = "../../shared/namespace-protocol" }
+process-layout = { path = "../../shared/process-layout" }
 syscall = { path = "../../shared/syscall" }
 shmem = { path = "../../shared/shmem" }
 

--- a/services/svctest/src/phases/startup.rs
+++ b/services/svctest/src/phases/startup.rs
@@ -134,8 +134,9 @@ pub fn stack_envelope_phase(_: &Caps)
         info.stack_pages
     );
     assert_eq!(
-        info.stack_top_vaddr, 0x0000_7FFF_FFFF_E000,
-        "stack_top_vaddr {:#x} does not match PROCESS_STACK_TOP",
+        info.stack_top_vaddr,
+        process_layout::DEFAULT_STACK_TOP,
+        "stack_top_vaddr {:#x} does not match the default process layout",
         info.stack_top_vaddr
     );
 
@@ -158,6 +159,22 @@ pub fn stack_envelope_phase(_: &Caps)
 
 pub fn tls_main_phase(_: &Caps)
 {
+    // svctest is a std binary with thread-locals, so the loader maps a main TLS
+    // block and reports its base. It must be nonzero and below the stack.
+    let info = startup_info();
+    assert_eq!(
+        info.main_tls_vaddr,
+        process_layout::DEFAULT_MAIN_TLS_VA,
+        "main_tls_vaddr {:#x} does not match the default process layout",
+        info.main_tls_vaddr
+    );
+    assert!(
+        info.main_tls_vaddr < info.stack_top_vaddr,
+        "main_tls_vaddr {:#x} must lie below the stack top {:#x}",
+        info.main_tls_vaddr,
+        info.stack_top_vaddr
+    );
+
     let init = TLS_INIT;
     let bss = TLS_BSS;
     std::os::seraph::log!("TLS_INIT ={init:#018x}");

--- a/shared/process-layout/Cargo.toml
+++ b/shared/process-layout/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "process-layout"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[lib]
+test = false
+doctest = false
+
+[lints]
+workspace = true

--- a/shared/process-layout/README.md
+++ b/shared/process-layout/README.md
@@ -1,0 +1,51 @@
+# shared/process-layout
+
+Per-process bootstrap virtual-address layout for Seraph process creators.
+
+`no_std`, no external dependencies, no allocation, no I/O. Owns the choice of
+where a new process's four bootstrap surfaces are placed — the `ProcessInfo`
+handover page, the main-thread stack, the main-thread TLS block, and the
+main-thread IPC buffer — so that choice lives in one place instead of being
+pinned as ABI constants in `process-abi`.
+
+Used by `init` (lays out memmgr and procmgr) and `procmgr` (lays out all other
+processes). The creator calls `choose_process_layout` once per process and
+writes the result into the handover surface and the entry register; the created
+process reads the addresses back rather than assuming fixed values.
+
+`choose_process_layout` is deterministic today. It is the single seam where
+per-process randomisation (ASLR, [#39](https://github.com/kottlerg/seraph/issues/39))
+substitutes an entropy draw for the default constants, mirroring the
+deterministic-first reservation arena in
+`runtime/ruststd/src/sys/reserve/seraph.rs`.
+
+---
+
+## Surface
+
+| Item | Purpose |
+|---|---|
+| `ProcessLayout` | The four bootstrap base VAs for one new process. |
+| `choose_process_layout() -> ProcessLayout` | Choose the layout; deterministic (the ASLR seam). |
+| `DEFAULT_PROCESS_INFO_VA`, `DEFAULT_STACK_TOP`, `DEFAULT_MAIN_TLS_VA`, `DEFAULT_IPC_BUFFER_VA` | Default addresses; the single source of truth for the values that were formerly ABI constants. |
+
+Page counts are not part of the layout: stack size comes from the binary's
+`.note.seraph.stack` ELF note and TLS size from its `PT_TLS` segment, both
+resolved by the creator.
+
+---
+
+## Relevant Design Documents
+
+| Document | Content |
+|---|---|
+| [docs/userspace-memory-model.md](../../docs/userspace-memory-model.md) | Three-surface VA model; "Bootstrap Cross-Boundary VAs" |
+| [docs/process-lifecycle.md](../../docs/process-lifecycle.md) | Handover discipline; `ProcessInfo`/`InitInfo` fields |
+| [abi/process-abi/](../../abi/process-abi/) | `ProcessInfo` handover struct that records the chosen VAs |
+| [docs/coding-standards.md](../../docs/coding-standards.md) | Formatting, naming, safety rules |
+
+---
+
+## Summarized By
+
+None

--- a/shared/process-layout/src/lib.rs
+++ b/shared/process-layout/src/lib.rs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 George Kottler <mail@kottlerg.com>
+
+// shared/process-layout/src/lib.rs
+
+//! Per-process bootstrap virtual-address layout.
+//!
+//! A process creator (procmgr for general processes, init for memmgr/procmgr)
+//! must place four bootstrap surfaces in a new process's address space before
+//! it runs: the `ProcessInfo` handover page, the main-thread stack, the
+//! main-thread TLS block, and the main-thread IPC buffer. This crate owns the
+//! choice of where those surfaces go, so the decision lives in one place rather
+//! than being pinned as ABI constants in `process-abi`.
+//!
+//! The creator is the chooser: it calls [`choose_process_layout`] once per
+//! process and writes the chosen VAs into the handover surface
+//! (`ProcessInfo.stack_top_vaddr`, `ProcessInfo.main_tls_vaddr`,
+//! `ProcessInfo.ipc_buffer_vaddr`) and into the entry register that delivers the
+//! `ProcessInfo` page address. The created process reads them back from the
+//! struct and the register — it does not assume any fixed address.
+//!
+//! [`choose_process_layout`] is deterministic: it returns the same VAs every
+//! time. It is the single seam where per-process randomisation (ASLR, #39) will
+//! substitute an entropy draw for the constants below, mirroring the
+//! deterministic-first reservation arena in
+//! `runtime/ruststd/src/sys/reserve/seraph.rs`.
+
+#![no_std]
+
+/// Default `ProcessInfo` handover-page virtual address.
+pub const DEFAULT_PROCESS_INFO_VA: u64 = 0x0000_7FFF_FFFF_0000;
+
+/// Default top of the main-thread user stack. `stack_pages` pages are mapped
+/// immediately below this, with one unmapped guard page beneath them.
+pub const DEFAULT_STACK_TOP: u64 = 0x0000_7FFF_FFFF_E000;
+
+/// Default base (region start) of the main-thread IPC buffer.
+pub const DEFAULT_IPC_BUFFER_VA: u64 = 0x0000_7FFF_FFFE_0000;
+
+/// Default base (region start) of the main-thread TLS block.
+pub const DEFAULT_MAIN_TLS_VA: u64 = 0x0000_7FFF_FFFD_0000;
+
+/// The bootstrap virtual addresses for one new process.
+///
+/// Page counts are not part of the layout: the stack size comes from the
+/// binary's `.note.seraph.stack` ELF note and the TLS block size from its
+/// `PT_TLS` segment, both resolved by the creator. This struct carries only the
+/// base addresses the creator places those regions at.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ProcessLayout
+{
+    /// Virtual address of the read-only `ProcessInfo` handover page. Delivered
+    /// to the new process in its entry register (`rdi`/`a0`), not stored in the
+    /// struct (which would be circular — the process needs this to find it).
+    pub process_info_va: u64,
+    /// Top of the main-thread user stack; written to `ProcessInfo.stack_top_vaddr`
+    /// and passed as the initial stack pointer.
+    pub stack_top: u64,
+    /// Base of the main-thread TLS block; written to `ProcessInfo.main_tls_vaddr`
+    /// (when the process has a `PT_TLS` segment) and used to derive the thread
+    /// pointer.
+    pub tls_base: u64,
+    /// Base of the main-thread IPC buffer; written to `ProcessInfo.ipc_buffer_vaddr`.
+    pub ipc_buffer_va: u64,
+}
+
+/// Choose the bootstrap VA layout for a new process.
+///
+/// Deterministic: returns the `DEFAULT_*` addresses above. This is the single
+/// seam ASLR (#39) replaces with a per-process entropy draw.
+#[must_use]
+pub fn choose_process_layout() -> ProcessLayout
+{
+    ProcessLayout {
+        process_info_va: DEFAULT_PROCESS_INFO_VA,
+        stack_top: DEFAULT_STACK_TOP,
+        tls_base: DEFAULT_MAIN_TLS_VA,
+        ipc_buffer_va: DEFAULT_IPC_BUFFER_VA,
+    }
+}


### PR DESCRIPTION
Closes #250.

## Problem

The process-handover surface pinned layout-defining virtual addresses as
compile-time ABI constants (`PROCESS_INFO_VADDR`, `PROCESS_STACK_TOP`,
`PROCESS_MAIN_TLS_VADDR` in `process-abi`; `INIT_INFO_VADDR`, `INIT_STACK_TOP` in
`init-protocol`). Fixed VAs structurally preclude per-process layout variation —
ASLR (#39) and lazy/large stacks (#46). `ProcessInfo.ipc_buffer_vaddr` was
already a runtime field; this extends that precedent to the rest of the surface,
making the **creator the chooser**. The first cut is deterministic (same VAs as
before, no behavior change); it removes the structural blocker and gives #39 a
single one-line RNG seam.

## Acceptance (#250)

- [x] **Each handover VA classified (runtime field vs genuinely-constant, with reason).** See below.
- [x] **Layout-defining VAs demoted; `_start` reads them at runtime.**
- [x] **`PROCESS_ABI_VERSION` bumped (20 → 21); `docs/userspace-memory-model.md` "Bootstrap Cross-Boundary VAs" updated.**
- [x] **Boot + run on both arches (pass markers).**

### VA classification

| VA | Disposition | Mechanism |
|---|---|---|
| `PROCESS_INFO_VADDR` / `INIT_INFO_VADDR` | Runtime, **anchor — cannot be a struct field** (it locates the struct) | Delivered in the entry register (`rdi`/`a0`); std/memmgr `_start` now read the arg, matching init/ktest |
| `PROCESS_STACK_TOP` | Runtime field (`ProcessInfo.stack_top_vaddr`, already existed) | Creator chooses; passed as SP |
| `PROCESS_MAIN_TLS_VADDR` | Runtime field (**new** `ProcessInfo.main_tls_vaddr`) | Creator chooses + maps; kernel installs the thread pointer |
| `INIT_STACK_TOP` | Runtime, kernel-internal | Kernel chooses |
| IPC-buffer VA (was duplicated `CHILD_IPC_BUF_VA` / `PROCMGR_IPC_BUF_VA`) | Runtime field (`ipc_buffer_vaddr`) | Creator chooses; duplicated consts removed |
| `DEFAULT/MAX_PROCESS_STACK_PAGES`, `PROCESS_MAIN_TLS_MAX_PAGES`, `INIT_STACK_PAGES`, `INIT_INFO_MAX_PAGES` | **Genuinely constant** (policy bounds) | Kept |

## Changes

- **New `no_std` crate `shared/process-layout`**: `ProcessLayout` +
  `choose_process_layout()` owns the default VAs (single source of truth;
  eliminates the duplicated IPC-buffer-VA constant) and is the deterministic seam
  #39 flips to an entropy draw. Kernel analogue `choose_init_layout()` in
  `mm::address_space` (memoized per-boot so Phase 9 and `sched::enter` agree).
- **Producers** (`procmgr`, `init`): thread the chosen layout through every
  map/write/configure site; `ProcessEntry` persists `stack_top`/`process_info_va`
  so start matches the mapping.
- **Consumers**: std and memmgr `_start` take the handover-page address as their
  argument; new `main_tls_vaddr` mirrored into both `StartupInfo` types.
- **ABI**: `process-abi` adds `main_tls_vaddr`, removes the three layout
  constants, bumps `PROCESS_ABI_VERSION` 20 → 21. `init-protocol` removes
  `INIT_INFO_VADDR`/`INIT_STACK_TOP`; `InitInfo` wire format is unchanged, so
  **no `INIT_PROTOCOL_VERSION` bump** (the register-delivered anchor convention
  and struct bytes are unchanged).
- **Docs**: `userspace-memory-model.md`, `process-lifecycle.md`, kernel
  `initialization.md`.

## Scope

Deterministic refactor only. ASLR (#39) is a separate, security-reviewed
follow-up that flips each chooser to an RNG draw — no further ABI bump, since the
fields land here.

## Test plan

Per `.claude/CLAUDE.md` / `docs/testing.md`, on **x86_64 and riscv64**:

- `cargo xtask build` — succeeds.
- `cargo xtask compose-bundle --harness ktest` + `run` — **ktest 196/196, ALL TESTS PASSED**.
- svctest recipe + `run` — **ALL TESTS PASSED**, including the new
  `main_tls_vaddr` assertion and the updated stack-envelope assertion.
- `cargo xtask test` — host tests pass.

> Note: this touches the boot / memory-init path and `core/kernel/src/mm/address_space.rs`,
> which per `docs/testing.md` "Coverage tiers" flags the high-`-smp` local boundary
> runs. The change is CPU-count-independent (deterministic init layout chosen once
> at single-threaded boot), so it has no SMP-scaling surface; the 4-vCPU canonical
> matrix + ktest/svctest already exercise the touched boot path. Flagging for the
> pre-merge decision.

https://claude.ai/code/session_01Q6qD9ZHGQTVoEZaiN2awah