### PR TITLE
kernel, docs: platform hardware-support baseline doc and boot-time feature-gate (#269)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Overall project design documents live in [`docs/`](docs/):
   GPT role-GUID discovery; mount lifecycle
 - [Device Management](docs/device-management.md) — platform enumeration, devmgr,
   driver binding, DMA safety
+- [Platform Requirements](docs/platform-requirements.md) — per-arch required/opportunistic/unsupported
+  CPU and platform feature baseline; boot-time feature-gate
 - [Console Model](docs/console-model.md) — serial/console output ownership across boot;
   serial-driver-mediated userspace output
 - [Build System](docs/build-system.md) — toolchain, workspace layout, sysroot, xtask commands

--- a/core/kernel/docs/arch-interface.md
+++ b/core/kernel/docs/arch-interface.md
@@ -165,11 +165,14 @@ pub unsafe fn flush_page_tagged(virt: u64, tag: u16);
 /// switched-away space accrued unmaps.
 pub unsafe fn flush_tag(tag: u16);
 
-/// Per-CPU enable of tagged TLBs; returns the number of hardware tags available
-/// (`0` when unsupported). x86-64 sets `CR4.PCIDE` and returns 4096; RISC-V
-/// probes the `satp` ASID width and returns `1 << width`. Called on the BSP
-/// (whose return seeds the tag pool) and on every AP (which must set its own
-/// `CR4.PCIDE` before any tagged CR3 load).
+/// Per-CPU enable of tagged TLBs; returns the number of hardware tags available.
+/// x86-64 sets `CR4.PCIDE` and returns 4096, or `0` where PCID/INVPCID are absent
+/// (the kernel keeps a full-flush fallback — see
+/// [platform-requirements.md](../../../docs/platform-requirements.md)). RISC-V
+/// probes the `satp` ASID width and returns `1 << width`; a hart with no ASID
+/// support is refused, since tagged TLBs are gated as required on RISC-V. Called
+/// on the BSP (whose return seeds the tag pool) and on every AP (which must set
+/// its own `CR4.PCIDE` before any tagged CR3 load).
 pub unsafe fn enable_tagged_tlb() -> usize;
 
 /// Classify a user page fault as spurious (the live PTE already permits the
@@ -342,6 +345,14 @@ pub fn current_cpu() -> u32;
 /// Read the current stack pointer (`rsp` / `sp`). Used by the panic-path
 /// backtrace scanner to bound the kernel-stack walk.
 pub fn current_stack_pointer() -> u64;
+
+/// Verify the platform hardware baseline and refuse unsupported hardware with a
+/// clear diagnostic. Run once in early boot after the console is live. x86-64
+/// checks the CPUID-detectable required features and sets `CR0.WP`; RISC-V probes
+/// the SBI substrate. The required/opportunistic/unsupported classification and
+/// what each arch gates are in
+/// [platform-requirements.md](../../../docs/platform-requirements.md).
+pub unsafe fn verify_baseline();
 
 /// Install the current CPU's per-CPU data block at `addr`. Call once per CPU
 /// before any per-CPU access.

--- a/core/kernel/src/arch/riscv64/cpu.rs
+++ b/core/kernel/src/arch/riscv64/cpu.rs
@@ -75,6 +75,45 @@ pub fn current_id() -> u32
     0
 }
 
+// ── Baseline feature gate ─────────────────────────────────────────────────────
+
+/// Verify the RISC-V platform baseline and refuse unsupported hardware.
+///
+/// This runs in early boot, where supervisor-mode detection is limited (`misa`
+/// is not S-mode-readable and `satp` cannot be safely probed before the kernel
+/// page tables are active). It probes the SBI HSM extension, which is required to
+/// start secondary harts (`sbi_get_spec_version` is unsuitable as a presence
+/// check — a compliant SBI always returns success, and a truly absent SBI traps
+/// on the `ecall`). The remaining required features are asserted where each is
+/// safely detectable: the Vector extension at `fpu::cache_vlenb`, and the
+/// ASID-tagged TLB at `paging::enable_tagged_tlb`. See
+/// [platform-requirements.md](../../../../docs/platform-requirements.md).
+///
+/// # Safety
+/// Must execute in supervisor mode during early boot, after the console is live
+/// so the diagnostic is visible.
+#[cfg(not(test))]
+pub unsafe fn verify_baseline()
+{
+    /// SBI Base extension ID.
+    const SBI_EXT_BASE: u64 = 0x10;
+    /// `sbi_probe_extension` function ID.
+    const SBI_PROBE_EXTENSION: u64 = 3;
+    /// HSM (Hart State Management) extension ID — ASCII "HSM".
+    const SBI_EXT_HSM: u64 = 0x0048_534D;
+
+    let probe = super::sbi::sbi_call(SBI_EXT_BASE, SBI_PROBE_EXTENSION, SBI_EXT_HSM, 0, 0);
+    if probe.error != 0 || probe.value == 0
+    {
+        crate::fatal("SBI HSM extension not present — required to start secondary harts");
+    }
+}
+
+/// Test-build stub: the baseline gate issues an SBI ecall and is a no-op in
+/// host unit tests.
+#[cfg(test)]
+pub unsafe fn verify_baseline() {}
+
 // ── ASID width probe ──────────────────────────────────────────────────────────
 
 /// Probe the number of implemented ASID bits in `satp[59:44]`.

--- a/core/kernel/src/arch/riscv64/paging.rs
+++ b/core/kernel/src/arch/riscv64/paging.rs
@@ -330,12 +330,17 @@ pub unsafe fn activate_tagged(root_phys: u64, tag: u16)
 }
 
 /// Per-CPU enable of ASID-tagged TLBs: report the number of hardware tags
-/// (ASIDs) this hart implements, or `0` when the `satp` ASID field is
-/// zero-width.
+/// (ASIDs) this hart implements.
 ///
 /// Called on the BSP and every AP. RISC-V needs no per-hart enable bit — the
 /// ASID is written directly into `satp` — so this only probes the implemented
 /// width. The BSP uses the returned count to seed the tag pool.
+///
+/// ASID-tagged TLBs are required by the platform baseline
+/// ([platform-requirements.md](../../../../docs/platform-requirements.md)); a
+/// hart with a zero-width `satp` ASID field is refused here. The check lives
+/// here, not in `cpu::verify_baseline`, because `satp` cannot be safely probed
+/// before the kernel page tables are active.
 ///
 /// # Safety
 /// Must execute in S-mode with `satp` holding a valid root (Phase 5 onward).
@@ -344,7 +349,11 @@ pub unsafe fn enable_tagged_tlb() -> usize
 {
     // SAFETY: caller's contract (S-mode, valid satp).
     let bits = unsafe { super::cpu::probe_asid_bits() };
-    if bits == 0 { 0 } else { 1usize << bits }
+    if bits == 0
+    {
+        crate::fatal("RISC-V ASID-tagged TLB unsupported — required by the platform baseline");
+    }
+    1usize << bits
 }
 
 /// No-op on RISC-V: the XN/NX mechanism is always available via PTE X bit.

--- a/core/kernel/src/arch/x86_64/cpu.rs
+++ b/core/kernel/src/arch/x86_64/cpu.rs
@@ -18,31 +18,17 @@
 
 // ── CPUID ─────────────────────────────────────────────────────────────────────
 
-/// Execute CPUID with leaf `leaf`. Returns `(eax, ebx, ecx, edx)`.
+/// Execute CPUID with leaf `leaf` (sub-leaf 0). Returns `(eax, ebx, ecx, edx)`.
 ///
-/// `rbx` is callee-saved and also used internally by LLVM, so it is
-/// preserved via a push/pop around the `cpuid` instruction.
+/// `rbx` is callee-saved and reserved by LLVM, so the EBX result must be
+/// shuttled out without leaving it in `rbx`. The `core` intrinsic does this
+/// correctly; a hand-rolled `push rbx` / `mov out, ebx` / `pop rbx` sequence is
+/// fragile because the chosen output register may itself alias `rbx`, in which
+/// case the `pop` clobbers the result.
 pub fn cpuid(leaf: u32) -> (u32, u32, u32, u32)
 {
-    let eax: u32;
-    let ebx: u32;
-    let ecx: u32;
-    let edx: u32;
-    // SAFETY: CPUID is a valid unprivileged instruction on all x86-64 CPUs; rbx preserved.
-    unsafe {
-        core::arch::asm!(
-            "push rbx",
-            "cpuid",
-            "mov {ebx_out:e}, ebx",
-            "pop rbx",
-            inout("eax") leaf => eax,
-            ebx_out = lateout(reg) ebx,
-            inout("ecx") 0u32 => ecx,
-            lateout("edx") edx,
-            // nostack omitted: push/pop modifies the stack pointer.
-        );
-    }
-    (eax, ebx, ecx, edx)
+    let r = core::arch::x86_64::__cpuid_count(leaf, 0);
+    (r.eax, r.ebx, r.ecx, r.edx)
 }
 
 // ── Stack pointer ───────────────────────────────────────────────────────────────
@@ -274,6 +260,146 @@ pub unsafe fn enable_pcid() -> bool
     }
     true
 }
+
+// ── Baseline feature gate ─────────────────────────────────────────────────────
+
+/// Verify the x86-64 platform baseline and refuse unsupported hardware.
+///
+/// Checks the required CPUID-detectable features that every supported run
+/// environment provides (see
+/// [platform-requirements.md](../../../../docs/platform-requirements.md)) and
+/// halts via [`crate::fatal`] naming the first missing feature, rather than
+/// faulting obscurely later. A few required features are deliberately excluded
+/// — see the note on the check table below. Also sets `CR0.WP`, without which
+/// ring-0 writes would bypass read-only page permissions and the kernel's own
+/// W^X would be unenforced on this CPU (UEFI may hand the BSP off with `CR0.WP`
+/// clear; the AP trampoline already sets it).
+///
+/// # Safety
+/// Must execute at ring 0 during early boot, after the console is live so the
+/// diagnostic is visible, and before any subsystem that assumes the baseline.
+// too_many_lines: a flat, exhaustive feature-check table; splitting it would
+// only obscure the one-line-per-required-feature structure.
+#[cfg(not(test))]
+#[allow(clippy::too_many_lines)]
+pub unsafe fn verify_baseline()
+{
+    /// `CR0.WP` (supervisor write-protect).
+    const CR0_WP: u64 = 1 << 16;
+
+    let max_leaf = cpuid(0).0;
+    let basic = cpuid(1).2; // leaf 1, ECX
+    let structured = cpuid(7).1; // leaf 7 sub-leaf 0, EBX
+    let ext = cpuid(0x8000_0001); // ext.2 = ECX, ext.3 = EDX
+
+    // (feature present, diagnostic). The kernel halts naming the first absent one.
+    //
+    // Some required platform features (see docs/platform-requirements.md) are
+    // deliberately not gated here because the emulator used for CI/dev (QEMU
+    // TCG) cannot provide them, and the kernel already degrades correctly:
+    // invariant TSC (a frequency-stability guarantee; the kernel calibrates the
+    // TSC against the PIT), PCID/INVPCID tagged TLBs (the kernel keeps a
+    // full-flush fallback), and the vendor-specific in-silicon mitigations.
+    let checks: [(bool, &str); 19] = [
+        // x86-64-v3 instruction baseline.
+        (
+            basic & (1 << 28) != 0,
+            "AVX not supported by CPU — required (x86-64-v3)",
+        ),
+        (
+            structured & (1 << 5) != 0,
+            "AVX2 not supported by CPU — required (x86-64-v3)",
+        ),
+        (
+            basic & (1 << 12) != 0,
+            "FMA not supported by CPU — required (x86-64-v3)",
+        ),
+        (
+            structured & (1 << 3) != 0,
+            "BMI1 not supported by CPU — required (x86-64-v3)",
+        ),
+        (
+            structured & (1 << 8) != 0,
+            "BMI2 not supported by CPU — required (x86-64-v3)",
+        ),
+        (
+            basic & (1 << 22) != 0,
+            "MOVBE not supported by CPU — required (x86-64-v3)",
+        ),
+        (
+            basic & (1 << 29) != 0,
+            "F16C not supported by CPU — required (x86-64-v3)",
+        ),
+        (
+            basic & (1 << 23) != 0,
+            "POPCNT not supported by CPU — required (x86-64-v3)",
+        ),
+        (
+            basic & (1 << 13) != 0,
+            "CMPXCHG16B not supported by CPU — required (x86-64-v3)",
+        ),
+        (
+            ext.2 & (1 << 5) != 0,
+            "LZCNT not supported by CPU — required (x86-64-v3)",
+        ),
+        (
+            basic & (1 << 26) != 0,
+            "XSAVE not supported by CPU — required (x86-64-v3)",
+        ),
+        // Privilege and W^X substrate.
+        (
+            ext.3 & (1 << 29) != 0,
+            "long mode not supported by CPU — required",
+        ),
+        (
+            ext.3 & (1 << 11) != 0,
+            "SYSCALL not supported by CPU — required",
+        ),
+        (ext.3 & (1 << 20) != 0, "NX not supported by CPU — required"),
+        // Supervisor isolation.
+        (
+            structured & (1 << 7) != 0,
+            "SMEP not supported by CPU — required",
+        ),
+        (
+            structured & (1 << 20) != 0,
+            "SMAP not supported by CPU — required",
+        ),
+        // Topology enumeration.
+        (
+            max_leaf >= 0x0B,
+            "CPUID topology leaf 0x0B not supported by CPU — required",
+        ),
+        // Hardware entropy sources.
+        (
+            basic & (1 << 30) != 0,
+            "RDRAND not supported by CPU — required",
+        ),
+        (
+            structured & (1 << 18) != 0,
+            "RDSEED not supported by CPU — required",
+        ),
+    ];
+    for (present, feature) in checks
+    {
+        if !present
+        {
+            crate::fatal(feature);
+        }
+    }
+
+    // SAFETY: ring 0 per the caller contract; setting WP only tightens
+    // supervisor write checks. Kernel code paths are WP-safe — the APs run with
+    // WP set from the trampoline through all of init.
+    unsafe {
+        super::fpu::write_cr0(super::fpu::read_cr0() | CR0_WP);
+    }
+}
+
+/// Test-build stub: the baseline gate performs privileged operations and is a
+/// no-op in host unit tests.
+#[cfg(test)]
+pub unsafe fn verify_baseline() {}
 
 // ── Misc ──────────────────────────────────────────────────────────────────────
 

--- a/core/kernel/src/main.rs
+++ b/core/kernel/src/main.rs
@@ -130,6 +130,15 @@ pub extern "C" fn kernel_entry(boot_info: *const BootInfo) -> !
     kprintln!("Phase 1: Early Console");
     kprintln!("boot protocol v{}", info.version);
 
+    // Platform feature-gate: refuse hardware missing a required baseline
+    // feature with a clear diagnostic, before any subsystem that assumes the
+    // baseline runs. See docs/platform-requirements.md.
+    // SAFETY: ring 0 / S-mode early-boot phase; console is live; called once.
+    unsafe {
+        arch::current::cpu::verify_baseline();
+    }
+    kprintln!("baseline ok");
+
     // ── Phase 2: physical memory ────────────────────────────────────────────
     // Parse the memory map, subtract reserved regions, populate the buddy
     // allocator. Halts with a FATAL message if no usable memory is found.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -237,9 +237,22 @@ Embedded or non-standard configurations are not targeted.
 
 Per-arch kernel and userspace target specifications (soft-float / FP
 profile, psABI feature floor, microarchitecture pins) are in
-[`build-system.md`](build-system.md#custom-targets). Architectural code
+[`build-system.md`](build-system.md#custom-targets). The
+required / opportunistic / unsupported CPU and platform feature
+classification per architecture, and the boot-time feature-gate that
+enforces it, are in
+[platform-requirements.md](platform-requirements.md). Architectural code
 isolation rules are in
 [coding-standards.md#c-architecture-invariants](coding-standards.md#c-architecture-invariants).
+
+---
+
+## Platform Requirements (summary — [platform-requirements.md](platform-requirements.md))
+
+Each architecture pins a two-layer floor — an instruction baseline (x86-64-v3 / RVA23U64) and a
+platform/silicon-era floor — and classifies every CPU and platform feature as required,
+opportunistic, or unsupported. A boot-time feature-gate refuses hardware missing a required feature
+with a clear diagnostic. The IOMMU is opportunistic with a degraded DMA-unconfined mode.
 
 ---
 

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -82,6 +82,11 @@ floor for userspace SIMD / Vector codegen:
   ratified 2024-10-21): IMAFDCV plus the Zba/Zbb/Zbs bitmanip set,
   hard-float LP64D ABI.
 
+These JSONs pin the *instruction baseline* (the psABI feature level the toolchain emits). The
+*runtime platform / silicon-era contract* — which CPU and platform features the kernel requires,
+uses opportunistically, or does not support, and the boot-time feature-gate that enforces it — is in
+[platform-requirements.md](platform-requirements.md).
+
 Userspace correctness under preemption is provided by eager FP/SIMD/V save
 on switch-out and lazy restore on first FP/V use after switch-in (`#NM`
 trap on x86-64, illegal-instruction trap on RISC-V). See

--- a/docs/memory-model.md
+++ b/docs/memory-model.md
@@ -115,14 +115,19 @@ level using the NX bit (x86-64) and the equivalent execute permission control on
 RISC-V. The kernel image itself follows W^X: text is executable but not writable;
 data and heap are writable but not executable.
 
+On x86-64, kernel-side W^X additionally depends on `CR0.WP` (supervisor write-protect);
+without it a ring-0 write would bypass a read-only page permission. `CR0.WP` is required by
+the platform baseline ([platform-requirements.md](platform-requirements.md)) and set on every CPU.
+
 ### TLB Management
 
-Where the hardware provides address-space tags (x86-64 PCID, RISC-V ASID), the kernel
-assigns a tag per address space so a context switch loads the outgoing space's page-table
-root **without** flushing the TLB — cached translations survive across switches. Support is
-detected at boot; where it is unavailable the kernel falls back to a full flush on every
-switch (writing CR3 with `CR4.PCIDE` clear, or `satp` with ASID 0 followed by `sfence.vma`).
-A switch between threads that share an address space requires no TLB operation either way.
+Address-space tags (x86-64 PCID, RISC-V ASID) are required by the platform baseline
+([platform-requirements.md](platform-requirements.md)). The kernel assigns a tag per address space
+so a context switch loads the outgoing space's page-table root **without** flushing the TLB —
+cached translations survive across switches. A switch between threads that share an address space
+requires no TLB operation either way. On RISC-V a hart without ASID support is refused at boot; on
+x86-64 the kernel retains a full-flush fallback for emulated environments that do not implement
+PCID.
 
 Eliding the per-switch flush requires keeping tagged entries coherent without it. Two
 generation counters do this:
@@ -152,8 +157,9 @@ emulation-independent measure of the optimization.
 ### Kernel Isolation — SMEP and SMAP
 
 On x86-64, SMEP (Supervisor Mode Execution Prevention) and SMAP (Supervisor Mode
-Access Prevention) are enabled unconditionally where available. SMEP prevents the
-kernel from executing userspace pages; SMAP prevents the kernel from reading or
+Access Prevention) are required by the platform baseline
+([platform-requirements.md](platform-requirements.md)) and enabled unconditionally. SMEP
+prevents the kernel from executing userspace pages; SMAP prevents the kernel from reading or
 writing userspace memory except through designated safe copy routines. Together these
 mitigate a class of privilege escalation exploits.
 

--- a/docs/platform-requirements.md
+++ b/docs/platform-requirements.md
@@ -1,0 +1,243 @@
+# Platform Requirements
+
+System-scope classification of the CPU and platform features each supported architecture
+requires, may use opportunistically, or does not support, and the boot-time gate that enforces
+the required set.
+
+---
+
+## Scope
+
+This document is authoritative for the **per-architecture hardware-support baseline**: which CPU,
+firmware, and platform features are required for Seraph to run, which are used only when present,
+and which are explicitly unsupported. It is also authoritative for the **boot-time feature-gate**
+contract — the early-boot check that refuses unsupported hardware with a clear diagnostic.
+
+In scope:
+
+- The targeting envelope and the rule that decides required-vs-opportunistic.
+- The two-layer floor: the instruction baseline and the platform/silicon-era floor.
+- The required / opportunistic / unsupported classification of each feature, per architecture.
+- The explicit IOMMU and in-silicon-mitigation policy.
+- The boot-time feature-gate's responsibility and diagnostic contract.
+
+Out of scope (owned elsewhere, referenced here):
+
+- The psABI / toolchain feature level and target JSONs — [build-system.md](build-system.md#custom-targets).
+- The mechanism of W^X, NX, SMEP/SMAP, SUM/PMP, and tagged-TLB tagging — [memory-model.md](memory-model.md).
+- IOMMU discovery and the DMA safety model — [device-management.md](device-management.md).
+- Console / serial ownership across boot — [console-model.md](console-model.md).
+- The UEFI handoff, firmware tables, and `BootInfo` surface — [bootstrap.md](bootstrap.md) and
+  [`abi/boot-protocol/`](../abi/boot-protocol/).
+
+---
+
+## Targeting Envelope
+
+Seraph targets mainstream **workstation, laptop, and server** machines, plus future-facing
+**handheld** devices with compatible silicon. Minimal and embedded platforms are not targeted.
+
+The decision rule for every feature below:
+
+> Require a feature if and only if it is present across that mainstream envelope at the floor
+> generation. Never require a server-exclusive or bleeding-edge feature.
+
+x86-64-v4 / AVX-512 is unsupported as a *requirement* precisely because it is essentially
+server-class at this generation — the wrong target for the envelope above.
+
+---
+
+## Floor Definition
+
+The floor has two layers. A platform MUST satisfy both.
+
+### Instruction baseline
+
+The psABI feature level the userspace toolchain emits, owned by the target JSONs
+([build-system.md](build-system.md#custom-targets)):
+
+- **x86-64**: x86-64-v3 (AVX2, BMI1/2, FMA, MOVBE, F16C, LZCNT, POPCNT, plus XSAVE) — Haswell-class
+  instruction selection.
+- **riscv64**: RVA23U64 (RV64GCV plus Zba/Zbb/Zbs).
+
+### Platform / silicon-era floor
+
+The instruction baseline alone does not pin a platform generation. The platform floor does:
+
+- **x86-64**: approximately the **2019–2020** mainstream generation (Intel ~10th-generation
+  Comet/Ice Lake, AMD Zen 2). This is the generation at which in-silicon transient-execution
+  mitigations, an invariant TSC, `RDSEED`, and PCID/INVPCID are uniformly present. The x86-64-v3
+  instruction floor (2013) is necessary but not sufficient; the platform floor is the binding
+  requirement.
+- **riscv64**: RVA23 silicon, which is inherently modern (post-2024). No separate era pin is
+  needed; the RVA23 mandatory set defines the floor.
+
+---
+
+## Feature Classes
+
+Each feature is classified per architecture as one of:
+
+- **Required** — the kernel MUST have it; the boot-time feature-gate (or a subsystem's own boot
+  assertion) refuses hardware that lacks it. W^X, isolation, and the floor depend on these.
+- **Opportunistic** — used when present, not required. Absence degrades performance or a
+  non-essential capability, never correctness.
+- **Unsupported** — not used, and in some cases actively refused. Listed so absence is never
+  mistaken for an oversight, and so a future requirement is a deliberate floor change.
+
+---
+
+## x86-64 Classification
+
+### Required
+
+- **Instruction baseline** — the x86-64-v3 set above (AVX2, BMI1/2, FMA, MOVBE, F16C, LZCNT,
+  POPCNT, CMPXCHG16B) and `XSAVE`.
+- **Long mode, `SYSCALL`/`SYSRET`, `NX` (`EFER.NXE`)** — the privilege and W^X substrate. The
+  kernel sets bit 63 on non-executable PTEs; `NX` is mandatory.
+- **`CR0.WP`** — supervisor write-protect. Without it, ring-0 writes bypass read-only page
+  permissions and the kernel's own W^X is unenforced. The kernel sets and requires it on every CPU.
+- **SMEP and SMAP** — supervisor execution and access prevention. See [memory-model.md](memory-model.md).
+- **PCID and INVPCID** — address-space-tagged TLBs. The kernel assigns a tag per address space and
+  elides the per-switch flush; see [memory-model.md](memory-model.md).
+- **Invariant TSC** — a constant-rate timestamp counter, the basis of timekeeping.
+- **8254 PIT** — used to calibrate the local-APIC timer and the TSC at boot.
+- **Local APIC and an I/O APIC** — interrupt delivery and routing.
+- **CPUID extended-topology leaf 0x0B** — SMT/topology enumeration.
+- **`RDRAND` and `RDSEED`** — hardware entropy sources seeded into the kernel CSPRNG.
+- **In-silicon transient-execution mitigations** (MDS, L1TF, and the rest of the ~2019 set) — a
+  consequence of the platform floor. Their per-vulnerability enforcement is a hardening concern and
+  is vendor-specific (Intel enumerates via `IA32_ARCH_CAPABILITIES`; AMD differs), so it is not part
+  of the cross-vendor boot-gate.
+- **2 MiB large pages** — used for the kernel direct map.
+- **UEFI firmware and ACPI 2.0+ (XSDT, MADT)** — the boot and hardware-discovery path. There is no
+  BIOS or RSDT fallback.
+- **COM1 16550 UART at I/O port `0x3F8`** — the boot/console serial device.
+
+### Opportunistic
+
+- **x2APIC mode** — used when present (and required to address more than 255 CPUs); the kernel
+  falls back to xAPIC MMIO.
+- **AES-NI and SHA-NI** — crypto acceleration.
+- **CET (shadow stack / IBT)** — control-flow integrity, when enabled.
+- **TSC-deadline timer mode** — an alternative to the periodic APIC timer.
+- **EFI_RNG_PROTOCOL** — an additional boot entropy seed.
+- **GOP framebuffer** — graphical console; a headless serial-only boot is valid.
+- **PCIe ECAM (MCFG)** — discovered when firmware publishes it; not required by the kernel.
+
+### Unsupported
+
+- **AVX-512 / x86-64-v4** — server-class; never required, never depended upon.
+- **LA57 (5-level paging)** — the kernel uses 4-level paging.
+- **1 GiB huge pages, global pages (`PGE`), `FSGSBASE`/`SWAPGS`, MTRR reprogramming, HPET, the legacy
+  8259 PIC** — not used. (The kernel sets per-CPU GS through `IA32_GS_BASE` and never swaps; it
+  relies on firmware's default PAT and leaves the 8259 masked.)
+- **Legacy BIOS / multiboot** — boot is UEFI-only.
+- **Secure Boot, TPM, RTC** — not boot dependencies.
+
+---
+
+## riscv64 Classification
+
+### Required
+
+- **Instruction baseline** — RV64GCV plus Zba/Zbb/Zbs. The Vector extension is a hard requirement;
+  the kernel refuses a hart reporting `vlenb == 0`.
+- **Supervisor isolation — `SUM` and PMP** — supervisor-user access control and physical-memory
+  protection (PMP is established by M-mode firmware). See [memory-model.md](memory-model.md).
+- **ASID-tagged TLBs** — the `satp` ASID field, the RISC-V counterpart of PCID; see
+  [memory-model.md](memory-model.md).
+- **AIA — Ssaia, with APLIC and IMSIC** — the interrupt controller. PLIC is unsupported.
+- **Sstc — `stimecmp`** — the supervisor timer.
+- **Svpbmt, Svinval, Svnapot** — page-based memory types, fine-grained fence invalidation, and
+  NAPOT page encodings. Svade is the baseline A/D-bit model.
+- **Ssstateen / Smstateen** — state-enable CSRs, required for the hardening posture.
+- **Zkr seed CSR** — the supervisor-accessible hardware entropy source.
+- **`time` CSR (Zicntr)** — the timestamp source.
+- **Address translation: Sv48** is the kernel operating mode. Sv39 is the RVA23 mandatory minimum.
+- **UEFI firmware over an SBI (M-mode) implementation; a device tree or ACPI** — the boot and
+  discovery path. SBI HSM is required to start secondary harts.
+- **MMIO ns16550a UART** — the boot/console serial device (base discovered via firmware tables,
+  with a platform fallback).
+
+### Opportunistic
+
+- **Svadu** — hardware A/D-bit updates (Svade is the required baseline).
+- **Sv57** — a larger-VA expansion above the Sv48 operating mode.
+- **Zvk vector crypto** — crypto acceleration.
+- **EFI_RNG_PROTOCOL, GOP framebuffer, PCIe ECAM** — as on x86-64.
+
+### Unsupported
+
+- **PLIC** — replaced by AIA, no fallback.
+- **Legacy / embedded RISC-V profiles** — outside the RVA23 floor.
+- **Port-mapped I/O** — RISC-V has no port I/O; all device access is MMIO.
+- **Cache-block-management instructions (Zicbom/Zicboz/Zicbop)** — not used; the kernel assumes
+  cache-coherent DMA.
+- **Secure Boot, TPM, RTC** — not boot dependencies.
+
+---
+
+## IOMMU and DMA Confinement
+
+The IOMMU (Intel VT-d, the RISC-V IOMMU extension) is **opportunistic** on both architectures. It
+is a platform/chipset feature whose presence and usability vary across the envelope — firmware may
+disable it, fuse it off, or omit it on consumer boards and handhelds — so requiring it would exclude
+in-envelope hardware.
+
+The IOMMU is discovered and programmed by the userspace device manager, not the kernel. When an
+IOMMU is present and configured, device DMA is confined to explicitly mapped frames; when it is
+absent or unconfigured, DMA is unconfined (a degraded mode). The authoritative DMA safety model is
+in [device-management.md](device-management.md).
+
+---
+
+## Boot-Time Feature Gate
+
+The kernel verifies the required set during early boot — after the console is live so a diagnostic
+can be printed, and before any subsystem that assumes a required feature initializes. On a missing
+feature it halts with a message naming the specific feature, rather than failing obscurely later.
+
+- **x86-64**: a single `cpu::verify_baseline()` checks the cross-vendor, CPUID-detectable required
+  features (the v3 instruction set, long mode / `SYSCALL` / `NX`, SMEP/SMAP, `XSAVE`,
+  extended-topology leaf 0x0B, `RDRAND`/`RDSEED`) and ensures `CR0.WP` is set. Three required
+  features are deliberately not gated because the software emulator used for continuous integration
+  (QEMU TCG) cannot provide them and the kernel degrades correctly: PCID/INVPCID tagged TLBs (the
+  kernel retains a full-flush fallback), invariant TSC (a frequency-stability guarantee; the kernel
+  calibrates the TSC against the PIT), and the vendor-specific in-silicon mitigations.
+- **riscv64**: required features are asserted where each is safely detectable from supervisor mode —
+  SBI presence at the gate, and the Vector extension and the ASID-tagged TLB at their initialization
+  sites (a hart lacking either is refused; emulated RISC-V provides ASID, so unlike x86-64 PCID this
+  is gated). Extension requirements introduced by a subsystem (the interrupt controller, the timer,
+  the paging extensions) are asserted by that subsystem at its own initialization.
+
+Platform features that are not CPU-detectable (the PIT, UEFI, ACPI/DTB, the UART) are not probed by
+the gate; their absence manifests as a boot failure on the discovery path they feed.
+
+---
+
+## Platform Limits
+
+Independent of the feature classification, the kernel imposes two fixed platform limits on both
+architectures:
+
+- **Page size** is 4 KiB.
+- **Maximum RAM** is approximately 248 GiB. The kernel's boot-time direct-map pool is a fixed-size
+  table sized for that ceiling; a platform with more RAM is refused at boot
+  (`core/kernel/src/mm/paging.rs`).
+
+---
+
+## Future Architectures
+
+The classification is structured to extend to a third architecture (for example aarch64) without
+reshaping the existing sections: the new architecture adds its own `## <arch> Classification`
+section with the same Required / Opportunistic / Unsupported subsections, an entry in the floor
+definition, and an arch-local `cpu::verify_baseline()`. The targeting envelope and the
+required-vs-opportunistic rule are architecture-neutral and unchanged.
+
+---
+
+## Summarized By
+
+[README.md](../README.md), [Architecture Overview](architecture.md), [Memory Model](memory-model.md)


### PR DESCRIPTION
## Summary

Closes #269. Defines and enforces the platform hardware-support floor.

**(a) `docs/platform-requirements.md`** — new system-scope authoritative doc classifying every CPU and platform feature as **required / opportunistic / unsupported** per architecture, structured so a future aarch64 slots in cleanly. It pins a two-layer floor (x86-64-v3 *instruction* baseline + ~2019–2020 *platform/silicon-era* floor; RVA23U64 / RVA23 silicon for riscv64) and makes the two open calls explicit:
- **IOMMU** — opportunistic, with a flagged DMA-unconfined degraded mode (discovered by userspace devmgr; #37 owns confinement).
- **In-silicon transient-execution mitigations** — required at the era floor; per-vulnerability enforcement is vendor-specific and out of the cross-vendor boot-gate (the #270 scoping knob).

riscv64 is classified RVA23-only in the target voice (AIA required / PLIC unsupported; Sstc; Svpbmt/Svinval/Svnapot; Ssstateen/Smstateen; Zkr) — the doc leads the code where roadmap issues #325/#326/#327/#245/#270 land the consuming asserts.

**(b) Boot-time feature-gate** — `cpu::verify_baseline()` per arch (added to the arch-interface `cpu` dispatch surface), run in early boot after the console is live, halting with a clear diagnostic naming the first missing feature:
- **x86-64**: v3 instruction set, long mode / `SYSCALL` / `NX`, SMEP/SMAP, `XSAVE`, CPUID topology leaf 0x0B, `RDRAND`/`RDSEED`; also sets `CR0.WP`.
- **riscv64**: SBI HSM-extension probe at the gate; the Vector extension and the ASID-tagged TLB at their init sites.

Cross-doc: README, architecture.md, build-system.md, arch-interface.md link the new doc; memory-model.md promotes SMEP/SMAP, tagged TLB, and `CR0.WP` from "where available" to required.

## Notable findings / decisions

- **Latent cpuid wrapper bug fixed.** The shared x86 `cpuid()` used a hand-rolled `push rbx / mov out,ebx / pop rbx` where the compiler could allocate the EBX output to `rbx`, which the `pop` then clobbered — yielding garbage leaf-7 EBX (AVX2/SMEP/...) under register pressure. The gate's multiple CPUID calls surfaced it (nondeterministic AVX2-absent reports). Replaced with `core::arch::x86_64::__cpuid_count`, hardening every existing caller (`enable_smep_smap`, `fpu`, `entropy`, `interrupts`).
- **CR0.WP gap fixed.** The BSP inherited UEFI's `CR0.WP=0`, leaving kernel-side W^X unenforced on the BSP (the AP trampoline already set it). The gate now sets it.
- **Tagged TLB is gated on riscv64 but not x86-64.** Emulated RISC-V provides ASID, so ASID-required is enforced (a hart without it is refused). x86-64 PCID/INVPCID, invariant TSC, x2APIC, and the vendor-specific mitigations are required-on-hardware but **not boot-gated**, because the QEMU TCG emulator used for CI (GitHub runners have no `/dev/kvm`) cannot provide them and the kernel degrades correctly (full-flush fallback / PIT calibration / xAPIC fallback). This is a forced deviation from the literal "drop the full-flush fallback" wording: the fallback must remain live for the x86 CI substrate, and is documented as such.

## Scope notes (no new follow-ups needed)

- riscv `timebase-frequency` hardcoded to 10 MHz (`timer.rs`) is already tracked by **#326** (timer modernization — Sstc / TSC-deadline).
- Sv48-operating vs Sv39-RVA23-floor reconciliation (`mmu-type` negotiation) is already tracked by **#63** (parameterize RISC-V paging mode).
- The full-flush fallback machinery is shared and is retained because the x86 TCG CI substrate requires it; the riscv ASID-0 return path is replaced by a boot refusal, so no separate removal follow-up is warranted.

## Test plan

- [x] `cargo xtask build` (x86_64) + `cargo xtask run` ktest under QEMU TCG and KVM — `[ktest] ALL TESTS PASSED` (196/196).
- [x] `cargo xtask build --arch riscv64` + `cargo xtask run --arch riscv64` ktest — `baseline ok`, `tagged-tlb ok`, `[ktest] ALL TESTS PASSED` (196/196).
- [x] `cargo xtask test` (host-side workspace tests).
- [x] Gate diagnostic path observed firing (`FATAL: <feature> ... — required`) during bring-up.

https://claude.ai/code/session_01TsurvMSxcdeTBx3Q1cNs8V
